### PR TITLE
Add world map background with attack animations and sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The game now calculates reinforcements based on the number of territories a
 player owns and includes a fortify phase for moving troops between adjacent
 friendly territories.
 
+The interface features a simple world map background in place of the old grid,
+and attack or conquest actions trigger short animations and audio cues for
+better feedback.
+
 Combat uses multiple dice rolls for both attacker and defender, with roll results displayed on screen for more strategic play.
 
 ## Development

--- a/game.test.js
+++ b/game.test.js
@@ -7,6 +7,7 @@ beforeEach(() => {
   jest.resetModules();
   document.body.innerHTML = `
     <div id="status"></div>
+    <div id="diceResults"></div>
     <div id="board" class="board">
       <div class="territory" id="t1" data-id="t1"></div>
       <div class="territory" id="t2" data-id="t2"></div>
@@ -24,7 +25,9 @@ test('reinforce phase allows adding army and moves to attack', () => {
   const t1 = document.getElementById('t1');
   const initial = game.territories[0].armies;
   game.handleTerritoryClick({ currentTarget: t1 });
-  expect(game.territories[0].armies).toBe(initial + 1);
+  game.handleTerritoryClick({ currentTarget: t1 });
+  game.handleTerritoryClick({ currentTarget: t1 });
+  expect(game.territories[0].armies).toBe(initial + 3);
   expect(game.getPhase()).toBe('attack');
 });
 
@@ -32,7 +35,14 @@ test('attack phase resolves battle between territories', () => {
   const t1 = document.getElementById('t1');
   const t4 = document.getElementById('t4');
   game.handleTerritoryClick({ currentTarget: t1 });
-  jest.spyOn(Math, 'random').mockReturnValueOnce(0.9).mockReturnValueOnce(0.1);
+  game.handleTerritoryClick({ currentTarget: t1 });
+  game.handleTerritoryClick({ currentTarget: t1 });
+  jest.spyOn(Math, 'random')
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.5)
+    .mockReturnValueOnce(0.2)
+    .mockReturnValueOnce(0.8)
+    .mockReturnValueOnce(0.6);
   game.handleTerritoryClick({ currentTarget: t1 });
   game.handleTerritoryClick({ currentTarget: t4 });
   expect(game.territories[3].armies).toBe(2);

--- a/map.svg
+++ b/map.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="400" fill="#87ceeb"/>
+  <!-- North America -->
+  <path d="M50 60 L150 40 L200 100 L160 140 L120 160 L80 120 Z" fill="#c8e6c9"/>
+  <!-- South America -->
+  <path d="M120 160 L160 180 L180 260 L140 350 L100 300 Z" fill="#c8e6c9"/>
+  <!-- Europe/Asia -->
+  <path d="M220 60 L560 60 L580 140 L520 180 L400 160 L300 140 L250 100 Z" fill="#c8e6c9"/>
+  <!-- Africa -->
+  <path d="M300 140 L360 180 L380 260 L340 340 L300 280 L280 200 Z" fill="#c8e6c9"/>
+  <!-- Australia -->
+  <path d="M470 260 L540 260 L560 300 L520 340 L460 320 Z" fill="#c8e6c9"/>
+</svg>

--- a/script.js
+++ b/script.js
@@ -4,18 +4,39 @@ const players = [
 ];
 
 const territories = [
-  { id: 't1', neighbors: ['t2', 't4'], owner: 0, armies: 3 },
-  { id: 't2', neighbors: ['t1', 't3', 't5'], owner: 0, armies: 3 },
-  { id: 't3', neighbors: ['t2', 't6'], owner: 0, armies: 3 },
-  { id: 't4', neighbors: ['t1', 't5'], owner: 1, armies: 3 },
-  { id: 't5', neighbors: ['t2', 't4', 't6'], owner: 1, armies: 3 },
-  { id: 't6', neighbors: ['t3', 't5'], owner: 1, armies: 3 }
+  { id: 't1', neighbors: ['t2', 't4'], owner: 0, armies: 3, x: 120, y: 100 },
+  { id: 't2', neighbors: ['t1', 't3', 't5'], owner: 0, armies: 3, x: 340, y: 110 },
+  { id: 't3', neighbors: ['t2', 't6'], owner: 0, armies: 3, x: 500, y: 140 },
+  { id: 't4', neighbors: ['t1', 't5'], owner: 1, armies: 3, x: 150, y: 260 },
+  { id: 't5', neighbors: ['t2', 't4', 't6'], owner: 1, armies: 3, x: 360, y: 220 },
+  { id: 't6', neighbors: ['t3', 't5'], owner: 1, armies: 3, x: 520, y: 300 }
 ];
 
 let currentPlayer = 0;
 let phase = 'reinforce'; // reinforce, attack, fortify, gameover
 let selectedFrom = null;
 let reinforcements = 0;
+
+let audioCtx;
+function playTone(freq, duration = 0.2) {
+  if (typeof window === 'undefined') return;
+  const AudioContext = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContext) return;
+  if (!audioCtx) audioCtx = new AudioContext();
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = 'sine';
+  osc.frequency.value = freq;
+  osc.connect(gain);
+  gain.connect(audioCtx.destination);
+  osc.start();
+  gain.gain.setValueAtTime(0.2, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + duration);
+  osc.stop(audioCtx.currentTime + duration);
+}
+
+function playAttackSound() { playTone(300); }
+function playConquerSound() { playTone(600, 0.3); }
 
 function calculateReinforcements() {
   const owned = territories.filter(t => t.owner === currentPlayer).length;
@@ -27,6 +48,8 @@ function updateUI() {
     const el = document.getElementById(t.id);
     el.style.background = players[t.owner].color;
     el.textContent = t.armies;
+    el.style.left = t.x + 'px';
+    el.style.top = t.y + 'px';
     el.classList.remove('selected');
   });
   let status = `${players[currentPlayer].name} - ${phase}`;
@@ -101,6 +124,16 @@ function handleTerritoryClick(e) {
 }
 
 function attack(from, to) {
+  playAttackSound();
+  const fromEl = document.getElementById(from.id);
+  const toEl = document.getElementById(to.id);
+  if (fromEl) fromEl.classList.add('attack');
+  if (toEl) toEl.classList.add('attack');
+  setTimeout(() => {
+    if (fromEl) fromEl.classList.remove('attack');
+    if (toEl) toEl.classList.remove('attack');
+  }, 500);
+
   const attackDice = Math.min(3, from.armies - 1);
   const defendDice = Math.min(2, to.armies);
 
@@ -120,6 +153,11 @@ function attack(from, to) {
   document.getElementById('diceResults').textContent = resultText;
 
   if (to.armies <= 0) {
+    playConquerSound();
+    if (toEl) {
+      toEl.classList.add('conquer');
+      setTimeout(() => toEl.classList.remove('conquer'), 1000);
+    }
     to.owner = from.owner;
     to.armies = 1;
     from.armies -= 1;

--- a/style.css
+++ b/style.css
@@ -4,29 +4,53 @@ body {
   text-align: center;
 }
 
+
 .board {
-  display: grid;
-  grid-template-columns: repeat(3, 150px);
-  grid-template-rows: repeat(2, 150px);
-  gap: 5px;
-  justify-content: center;
+  position: relative;
+  width: 600px;
+  height: 400px;
+  background: url('map.svg') no-repeat center/cover;
   margin: 20px auto;
 }
 
 .territory {
-  position: relative;
+  position: absolute;
+  width: 40px;
+  height: 40px;
   border: 2px solid #333;
+  border-radius: 50%;
   background: #ddd;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
+  font-size: 18px;
   user-select: none;
+  transition: transform 0.3s;
+  transform: translate(-50%, -50%);
 }
 
 .territory.selected {
   outline: 4px solid #ff0;
+}
+
+.territory.attack {
+  animation: attackPulse 0.5s ease-in-out;
+}
+
+.territory.conquer {
+  animation: conquerFlash 1s ease-in-out;
+}
+
+@keyframes attackPulse {
+  0% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.2); }
+  100% { transform: translate(-50%, -50%) scale(1); }
+}
+
+@keyframes conquerFlash {
+  0% { box-shadow: 0 0 0 0 rgba(255,255,0,1); }
+  100% { box-shadow: 0 0 20px 10px rgba(255,255,0,0); }
 }
 
 #status {


### PR DESCRIPTION
## Summary
- Replace grid board with simple SVG world map and reposition territories accordingly
- Highlight attacks and conquests with CSS animations and generated audio cues
- Update tests for multi-reinforcement flow and include dice result container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac836fc524832cbfcb7b8e6d90c9d2