### PR TITLE
Add basic AI player and multi-player support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A simple browser-based strategy game inspired by the classic game of Risk.
 
-The game now calculates reinforcements based on the number of territories a
-player owns and includes a fortify phase for moving troops between adjacent
-friendly territories.
+The game now supports three players by default, with the third controlled by a
+basic AI to enable solo play. Reinforcements are calculated based on the number
+of territories a player owns and the fortify phase allows moving troops between
+adjacent friendly territories.
 
 The interface features a simple world map background in place of the old grid,
 and attack or conquest actions trigger short animations and audio cues for

--- a/game.js
+++ b/game.js
@@ -2,15 +2,16 @@ class Game {
   constructor(players, territories) {
     this.players = players || [
       { name: 'Player 1', color: '#e74c3c' },
-      { name: 'Player 2', color: '#3498db' }
+      { name: 'Player 2', color: '#3498db' },
+      { name: 'AI', color: '#2ecc71', ai: true }
     ];
     this.territories = territories || [
       { id: 't1', neighbors: ['t2', 't4'], owner: 0, armies: 3 },
       { id: 't2', neighbors: ['t1', 't3', 't5'], owner: 0, armies: 3 },
-      { id: 't3', neighbors: ['t2', 't6'], owner: 0, armies: 3 },
+      { id: 't3', neighbors: ['t2', 't6'], owner: 1, armies: 3 },
       { id: 't4', neighbors: ['t1', 't5'], owner: 1, armies: 3 },
-      { id: 't5', neighbors: ['t2', 't4', 't6'], owner: 1, armies: 3 },
-      { id: 't6', neighbors: ['t3', 't5'], owner: 1, armies: 3 }
+      { id: 't5', neighbors: ['t2', 't4', 't6'], owner: 2, armies: 3 },
+      { id: 't6', neighbors: ['t3', 't5'], owner: 2, armies: 3 }
     ];
     this.currentPlayer = 0;
     this.phase = 'reinforce';
@@ -136,6 +137,37 @@ class Game {
       this.phase = 'reinforce';
       this.calculateReinforcements();
     }
+  }
+
+  performAITurn() {
+    if (!this.players[this.currentPlayer].ai || this.phase === 'gameover') return;
+    // Reinforce randomly
+    const owned = this.territories.filter(t => t.owner === this.currentPlayer);
+    while (this.reinforcements > 0 && owned.length > 0) {
+      const t = owned[Math.floor(Math.random() * owned.length)];
+      t.armies += 1;
+      this.reinforcements -= 1;
+    }
+    if (this.phase === 'reinforce' && this.reinforcements === 0) {
+      this.phase = 'attack';
+    }
+    // Attempt a single random attack
+    const options = [];
+    owned.forEach(from => {
+      if (from.armies > 1) {
+        from.neighbors.forEach(n => {
+          const to = this.territoryById(n);
+          if (to.owner !== this.currentPlayer) options.push({ from, to });
+        });
+      }
+    });
+    if (options.length > 0) {
+      const { from, to } = options[Math.floor(Math.random() * options.length)];
+      this.attack(from, to);
+    }
+    // End turn
+    this.endTurn();
+    if (this.phase === 'fortify') this.endTurn();
   }
 
   getPhase() { return this.phase; }

--- a/game.test.js
+++ b/game.test.js
@@ -60,3 +60,13 @@ test('endTurn moves from attack to fortify then to next player', () => {
   expect(game.getPhase()).toBe('reinforce');
   expect(game.getCurrentPlayer()).toBe(1);
 });
+
+test('AI player performs its turn and passes play', () => {
+  game.setCurrentPlayer(2);
+  game.calculateReinforcements();
+  jest.spyOn(Math, 'random').mockReturnValue(0.1);
+  game.performAITurn();
+  Math.random.mockRestore();
+  expect(game.getCurrentPlayer()).toBe(0);
+  expect(game.getPhase()).toBe('reinforce');
+});

--- a/script.js
+++ b/script.js
@@ -48,6 +48,13 @@ function updateUI() {
   document.getElementById('status').textContent = status;
 }
 
+function runAI() {
+  while (game.players[game.currentPlayer].ai && game.getPhase() !== 'gameover') {
+    game.performAITurn();
+    updateUI();
+  }
+}
+
 document.querySelectorAll('.territory').forEach(el => {
   el.addEventListener('click', () => {
     const result = game.handleTerritoryClick(el.dataset.id);
@@ -74,16 +81,19 @@ document.querySelectorAll('.territory').forEach(el => {
     if (result && result.type === 'select') {
       document.getElementById(result.territory).classList.add('selected');
     }
+    runAI();
   });
 });
 
 document.getElementById('endTurn').addEventListener('click', () => {
   game.endTurn();
   updateUI();
+  runAI();
 });
 
 updateUI();
+runAI();
 
 if (typeof module !== 'undefined') {
-  module.exports = { game, updateUI, territoryPositions };
+  module.exports = { game, updateUI, territoryPositions, runAI };
 }


### PR DESCRIPTION
## Summary
- Support three players by default and introduce a basic AI player
- Run AI turns automatically in the browser client
- Add tests for AI turn handling and document the new single-player capability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac879cd470832cafe2a394f2ef12fc