### PR TITLE
fix: use relative paths and bust caches

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>NetRisk</title>
-    <link rel="stylesheet" href="./style.css?v=1" />
+    <link rel="stylesheet" href="./style.css?v=2" />
   </head>
   <body>
     <h1>NetRisk</h1>
@@ -19,8 +19,8 @@
     </div>
     <button id="endTurn">End Turn</button>
     <button id="forceError">Force Error</button>
-    <script src="./logger.js?v=1"></script>
-    <script src="./game.js?v=1"></script>
-    <script src="./script.js?v=1"></script>
+    <script src="./logger.js?v=2"></script>
+    <script src="./game.js?v=2"></script>
+    <script src="./script.js?v=2"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,11 @@
 /* global logger */
+// Remove any previously registered service workers to avoid stale caches
+if (typeof navigator !== "undefined" && navigator.serviceWorker) {
+  navigator.serviceWorker
+    .getRegistrations()
+    .then((regs) => regs.forEach((reg) => reg.unregister()));
+}
+
 const Game =
   typeof window !== "undefined" && window.Game
     ? window.Game

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ body {
   position: relative;
   width: 600px;
   height: 400px;
-  background: url('map.svg') no-repeat center/cover;
+  background: url('./map.svg?v=2') no-repeat center/cover;
   margin: 20px auto;
 }
 


### PR DESCRIPTION
## Summary
- use versioned relative paths for scripts and styles
- bust CSS background image cache
- unregister obsolete service workers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8f570214832c89295d012f1a1ab6