### PR TITLE
feat: add token movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <div id="diceResults"></div>
     <div id="selectedTerritory"></div>
     <div id="board" class="board"></div>
+    <button id="moveToken">Move Token</button>
     <button id="endTurn">End Turn</button>
     <button id="forceError">Force Error</button>
     <script src="./logger.js?v=2"></script>

--- a/script.js
+++ b/script.js
@@ -32,7 +32,6 @@ function updateGameState(selected = null) {
   gameState.territories = game.territories;
   gameState.phase = game.getPhase();
   gameState.selectedTerritory = selected;
-  gameState.tokenPosition = selected ? territoryPositions[selected] : null;
 }
 
 function updateInfoPanel() {

--- a/style.css
+++ b/style.css
@@ -52,6 +52,17 @@ body {
   stroke-width: 3;
 }
 
+.token {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #000;
+  background: #fff;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+
 .territory {
   position: absolute;
   width: 40px;

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -20,17 +20,71 @@ function selectTerritory(el) {
   }
 }
 
+function moveToken(el) {
+  if (!el) return;
+  const phase = typeof game !== 'undefined' ? game.getPhase() : null;
+  if (phase && !['attack', 'fortify'].includes(phase)) {
+    if (typeof addLogEntry !== 'undefined') {
+      addLogEntry(`Movimento non consentito nella fase ${phase}`);
+    }
+    return;
+  }
+  const box = el.getBBox();
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  const token = document.getElementById('token');
+  if (token) {
+    token.style.left = `${x}px`;
+    token.style.top = `${y}px`;
+  }
+  if (typeof gameState !== 'undefined') {
+    gameState.tokenPosition = { x, y };
+  }
+  if (typeof addLogEntry !== 'undefined' && typeof game !== 'undefined') {
+    const name = el.dataset.name || el.id;
+    addLogEntry(`${game.players[game.currentPlayer].name} muove il segnalino su ${name}`);
+  }
+}
+
+const moveBtn = document.getElementById('moveToken');
+if (moveBtn) {
+  moveBtn.addEventListener('click', () => {
+    if (selectedTerritory) {
+      moveToken(selectedTerritory.el);
+    } else if (typeof addLogEntry !== 'undefined') {
+      addLogEntry('Nessun territorio selezionato');
+    }
+  });
+}
+
 fetch('map.svg')
   .then((r) => r.text())
   .then((svg) => {
-    document.getElementById('board').innerHTML = svg;
-    const map = document.getElementById('board').querySelector('#map');
+    const boardEl = document.getElementById('board');
+    boardEl.innerHTML = svg;
+    const tokenEl = document.createElement('div');
+    tokenEl.id = 'token';
+    tokenEl.className = 'token';
+    boardEl.appendChild(tokenEl);
+    if (typeof gameState !== 'undefined' && gameState.tokenPosition) {
+      tokenEl.style.left = `${gameState.tokenPosition.x}px`;
+      tokenEl.style.top = `${gameState.tokenPosition.y}px`;
+    }
+    const map = boardEl.querySelector('#map');
     map.addEventListener('click', (e) => {
       const target = e.target.closest('.map-territory');
       if (target) {
         selectTerritory(target);
       } else {
         selectTerritory(null);
+      }
+      e.stopPropagation();
+    });
+    map.addEventListener('dblclick', (e) => {
+      const target = e.target.closest('.map-territory');
+      if (target) {
+        selectTerritory(target);
+        moveToken(target);
       }
       e.stopPropagation();
     });


### PR DESCRIPTION
## Summary
- enable moving a token to a territory's centroid via double click or button
- add style and state handling for token position with phase validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9a4b5180832cbed989046b8b2a9d