### PR TITLE
feat: deploy build to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/build.js
+++ b/build.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const root = __dirname;
+const dist = path.join(root, 'dist');
+
+if (fs.existsSync(dist)) {
+  fs.rmSync(dist, { recursive: true, force: true });
+}
+fs.mkdirSync(dist);
+
+function hashContent(content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8);
+}
+
+const assets = ['map.svg', 'style.css', 'logger.js', 'game.js', 'script.js', 'territory-selection.js'];
+const hashed = {};
+
+// First process map.svg to know its hashed name
+for (const asset of assets) {
+  let filePath = path.join(root, asset);
+  let content = fs.readFileSync(filePath, 'utf8');
+
+  if (asset === 'territory-selection.js') {
+    // replace map.svg reference with hashed name
+    content = content.replace(/map\.svg/g, hashed['map.svg']);
+  }
+
+  const hash = hashContent(content);
+  const ext = path.extname(asset);
+  const base = path.basename(asset, ext);
+  const newName = `${base}.${hash}${ext}`;
+  fs.writeFileSync(path.join(dist, newName), content);
+  hashed[asset] = newName;
+}
+
+let indexHtml = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+
+for (const [orig, hashedName] of Object.entries(hashed)) {
+  indexHtml = indexHtml.replace(new RegExp(orig, 'g'), hashedName);
+}
+
+fs.writeFileSync(path.join(dist, 'index.html'), indexHtml);
+

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>NetRisk</title>
-    <link rel="stylesheet" href="./style.css?v=2" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+    <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
     <h1>NetRisk</h1>
@@ -31,9 +32,9 @@
     <button id="moveToken">Move Token</button>
     <button id="endTurn">End Turn</button>
     <button id="forceError">Force Error</button>
-    <script src="./logger.js?v=2"></script>
-    <script src="./game.js?v=2"></script>
-    <script src="./script.js?v=2"></script>
-    <script src="./territory-selection.js?v=1"></script>
+    <script src="./logger.js"></script>
+    <script src="./game.js"></script>
+    <script src="./script.js"></script>
+    <script src="./territory-selection.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "lint": "eslint .",
     "start": "http-server .",
-    "test": "jest"
+    "test": "jest",
+    "build": "node build.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
- deploy deterministic site to gh-pages on every push
- hash static assets and copy to dist for caching
- add no-cache/no-transform meta for index.html

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68accbbce3a4832cb75cd7f19500bb90