### PR TITLE
refactor: use ES modules for front-end scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
     <button id="forceError">Force Error</button>
     <script src="./logger.js"></script>
     <script src="./game.js"></script>
-    <script src="./script.js"></script>
-    <script src="./territory-selection.js"></script>
+    <script type="module" src="./script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
 /* global logger */
+import initTerritorySelection from "./territory-selection.js";
+
 // Remove any previously registered service workers to avoid stale caches
 // and log their status so that we know if any were present.
 if (typeof navigator !== "undefined" && navigator.serviceWorker) {
@@ -17,8 +19,7 @@ if (typeof navigator !== "undefined" && navigator.serviceWorker) {
     });
 }
 
-const GameClass =
-  typeof module !== "undefined" ? require("./game") : window.Game;
+const GameClass = window.Game;
 const game = new GameClass();
 if (typeof logger !== "undefined") {
   logger.info("Game initialised");
@@ -228,6 +229,15 @@ if (forceErrorBtn) {
   });
 }
 
+initTerritorySelection({
+  logger,
+  game,
+  addLogEntry,
+  gameState,
+  attachTerritoryHandlers,
+  updateUI,
+});
+
 updateUI();
 runAI();
 
@@ -248,7 +258,11 @@ if (toggleHowToPlay) {
       : "Mostra dettagli";
   });
 }
-
-if (typeof module !== "undefined") {
-  module.exports = { game, updateUI, territoryPositions, runAI, attachTerritoryHandlers };
-}
+export {
+  game,
+  updateUI,
+  territoryPositions,
+  runAI,
+  attachTerritoryHandlers,
+  addLogEntry,
+};

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -1,128 +1,129 @@
-/* global logger game addLogEntry gameState attachTerritoryHandlers updateUI */
-let selectedTerritory = null;
-const infoPanel = document.getElementById('selectedTerritory');
+export default function initTerritorySelection({
+  logger,
+  game,
+  addLogEntry,
+  gameState,
+  attachTerritoryHandlers,
+  updateUI,
+}) {
+  let selectedTerritory = null;
+  const infoPanel = document.getElementById("selectedTerritory");
 
-function selectTerritory(el) {
-  if (selectedTerritory && selectedTerritory.el) {
-    selectedTerritory.el.classList.remove('selected');
-  }
-  if (el) {
-    const name = el.dataset.name || el.id;
-    el.classList.add('selected');
-    selectedTerritory = { id: el.id, name, el };
-    infoPanel.textContent = name;
-    if (typeof logger !== 'undefined') {
-      logger.info(`Selected territory: ${selectedTerritory.id} (${selectedTerritory.name})`);
+  function selectTerritory(el) {
+    if (selectedTerritory && selectedTerritory.el) {
+      selectedTerritory.el.classList.remove("selected");
     }
-  } else {
-    selectedTerritory = null;
-    infoPanel.textContent = '';
-  }
-}
-
-function moveToken(el) {
-  if (!el) return;
-  const phase = typeof game !== 'undefined' ? game.getPhase() : null;
-  if (phase && !['attack', 'fortify'].includes(phase)) {
-    if (typeof addLogEntry !== 'undefined') {
-      addLogEntry(`Movimento non consentito nella fase ${phase}`);
-    }
-    return;
-  }
-  const box = el.getBBox();
-  const x = box.x + box.width / 2;
-  const y = box.y + box.height / 2;
-  const token = document.getElementById('token');
-  if (token) {
-    token.style.left = `${x}px`;
-    token.style.top = `${y}px`;
-  }
-  if (typeof gameState !== 'undefined') {
-    gameState.tokenPosition = { x, y };
-  }
-  if (typeof addLogEntry !== 'undefined' && typeof game !== 'undefined') {
-    const name = el.dataset.name || el.id;
-    addLogEntry(`${game.players[game.currentPlayer].name} muove il segnalino su ${name}`);
-    if (typeof logger !== 'undefined') {
-      logger.info(`${game.players[game.currentPlayer].name} moves token to ${name}`);
-    }
-  }
-}
-
-const moveBtn = document.getElementById('moveToken');
-if (moveBtn) {
-  moveBtn.addEventListener('click', () => {
-    if (typeof logger !== 'undefined') {
-      logger.info('Move token clicked');
-    }
-    try {
-      if (selectedTerritory) {
-        moveToken(selectedTerritory.el);
-      } else if (typeof addLogEntry !== 'undefined') {
-        addLogEntry('Nessun territorio selezionato');
+    if (el) {
+      const name = el.dataset.name || el.id;
+      el.classList.add("selected");
+      selectedTerritory = { id: el.id, name, el };
+      infoPanel.textContent = name;
+      if (logger) {
+        logger.info(
+          `Selected territory: ${selectedTerritory.id} (${selectedTerritory.name})`,
+        );
       }
-    } catch (err) {
-      if (typeof logger !== 'undefined') {
-        logger.error(err);
-      }
+    } else {
+      selectedTerritory = null;
+      infoPanel.textContent = "";
     }
-  });
-}
+  }
 
-fetch('map.svg')
-  .then((r) => r.text())
-  .then((svg) => {
-    const boardEl = document.getElementById('board');
-    boardEl.innerHTML = svg;
-    const tokenEl = document.createElement('div');
-    tokenEl.id = 'token';
-    tokenEl.className = 'token';
-    boardEl.appendChild(tokenEl);
-    if (typeof game !== 'undefined') {
-      game.territories.forEach((t) => {
-        const terrEl = document.createElement('div');
-        terrEl.id = t.id;
-        terrEl.className = 'territory';
-        terrEl.dataset.id = t.id;
-        boardEl.appendChild(terrEl);
+  function moveToken(el) {
+    if (!el) return;
+    const phase = game?.getPhase();
+    if (phase && !["attack", "fortify"].includes(phase)) {
+      addLogEntry?.(`Movimento non consentito nella fase ${phase}`);
+      return;
+    }
+    const box = el.getBBox();
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    const token = document.getElementById("token");
+    if (token) {
+      token.style.left = `${x}px`;
+      token.style.top = `${y}px`;
+    }
+    if (gameState) {
+      gameState.tokenPosition = { x, y };
+    }
+    if (addLogEntry && game) {
+      const name = el.dataset.name || el.id;
+      addLogEntry(
+        `${game.players[game.currentPlayer].name} muove il segnalino su ${name}`,
+      );
+      logger?.info(
+        `${game.players[game.currentPlayer].name} moves token to ${name}`,
+      );
+    }
+  }
+
+  const moveBtn = document.getElementById("moveToken");
+  if (moveBtn) {
+    moveBtn.addEventListener("click", () => {
+      logger?.info("Move token clicked");
+      try {
+        if (selectedTerritory) {
+          moveToken(selectedTerritory.el);
+        } else {
+          addLogEntry?.("Nessun territorio selezionato");
+        }
+      } catch (err) {
+        logger?.error(err);
+      }
+    });
+  }
+
+  fetch("map.svg")
+    .then((r) => r.text())
+    .then((svg) => {
+      const boardEl = document.getElementById("board");
+      boardEl.innerHTML = svg;
+      const tokenEl = document.createElement("div");
+      tokenEl.id = "token";
+      tokenEl.className = "token";
+      boardEl.appendChild(tokenEl);
+      if (game) {
+        game.territories.forEach((t) => {
+          const terrEl = document.createElement("div");
+          terrEl.id = t.id;
+          terrEl.className = "territory";
+          terrEl.dataset.id = t.id;
+          boardEl.appendChild(terrEl);
+        });
+        attachTerritoryHandlers?.();
+        updateUI?.();
+      }
+      if (gameState?.tokenPosition) {
+        tokenEl.style.left = `${gameState.tokenPosition.x}px`;
+        tokenEl.style.top = `${gameState.tokenPosition.y}px`;
+      }
+      const map = boardEl.querySelector("#map");
+      map.addEventListener("click", (e) => {
+        const target = e.target.closest(".map-territory");
+        if (target) {
+          selectTerritory(target);
+        } else {
+          selectTerritory(null);
+        }
+        e.stopPropagation();
       });
-      if (typeof attachTerritoryHandlers === 'function') {
-        attachTerritoryHandlers();
-      }
-      if (typeof updateUI === 'function') {
-        updateUI();
-      }
-    }
-    if (typeof gameState !== 'undefined' && gameState.tokenPosition) {
-      tokenEl.style.left = `${gameState.tokenPosition.x}px`;
-      tokenEl.style.top = `${gameState.tokenPosition.y}px`;
-    }
-    const map = boardEl.querySelector('#map');
-    map.addEventListener('click', (e) => {
-      const target = e.target.closest('.map-territory');
-      if (target) {
-        selectTerritory(target);
-      } else {
-        selectTerritory(null);
-      }
-      e.stopPropagation();
+      map.addEventListener("dblclick", (e) => {
+        const target = e.target.closest(".map-territory");
+        if (target) {
+          selectTerritory(target);
+          moveToken(target);
+        }
+        e.stopPropagation();
+      });
+      document.addEventListener("click", (e) => {
+        if (!map.contains(e.target)) {
+          selectTerritory(null);
+        }
+      });
+    })
+    .catch((err) => {
+      logger?.error(err);
     });
-    map.addEventListener('dblclick', (e) => {
-      const target = e.target.closest('.map-territory');
-      if (target) {
-        selectTerritory(target);
-        moveToken(target);
-      }
-      e.stopPropagation();
-    });
-    document.addEventListener('click', (e) => {
-      if (!map.contains(e.target)) {
-        selectTerritory(null);
-      }
-    });
-  })
-  .catch((err) => {
-    if (typeof logger !== 'undefined') {
-      logger.error(err);
-    }
-  });
+}
+


### PR DESCRIPTION
## Summary
- convert browser scripts to ES modules with explicit imports/exports
- inject game context into territory selection setup
- load main script as a module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68accf109f20832c950a33a5db1bac20