### PR TITLE
feat: enhance AI attack and fortify

### DIFF
--- a/game.js
+++ b/game.js
@@ -151,23 +151,50 @@ class Game {
     if (this.phase === 'reinforce' && this.reinforcements === 0) {
       this.phase = 'attack';
     }
-    // Attempt a single random attack
-    const options = [];
-    owned.forEach(from => {
-      if (from.armies > 1) {
-        from.neighbors.forEach(n => {
-          const to = this.territoryById(n);
-          if (to.owner !== this.currentPlayer) options.push({ from, to });
+    // Keep attacking while advantageous targets exist
+    while (this.phase === 'attack') {
+      const options = [];
+      this.territories
+        .filter(t => t.owner === this.currentPlayer)
+        .forEach(from => {
+          if (from.armies > 1) {
+            from.neighbors.forEach(n => {
+              const to = this.territoryById(n);
+              if (to.owner !== this.currentPlayer && from.armies > to.armies) {
+                options.push({ from, to });
+              }
+            });
+          }
         });
-      }
-    });
-    if (options.length > 0) {
+      if (options.length === 0) break;
       const { from, to } = options[Math.floor(Math.random() * options.length)];
       this.attack(from, to);
+      if (this.phase === 'gameover') return;
     }
-    // End turn
+    // Move to fortify phase and automatically fortify one army
     this.endTurn();
-    if (this.phase === 'fortify') this.endTurn();
+    if (this.phase === 'fortify') {
+      const aiOwned = this.territories.filter(t => t.owner === this.currentPlayer);
+      let best = null;
+      aiOwned.forEach(from => {
+        if (from.armies > 1) {
+          from.neighbors.forEach(n => {
+            const to = this.territoryById(n);
+            if (to.owner === this.currentPlayer) {
+              const diff = from.armies - to.armies;
+              if (diff > 1 && (!best || diff > best.diff)) {
+                best = { from, to, diff };
+              }
+            }
+          });
+        }
+      });
+      if (best) {
+        best.from.armies -= 1;
+        best.to.armies += 1;
+      }
+      this.endTurn();
+    }
   }
 
   getPhase() { return this.phase; }

--- a/game.test.js
+++ b/game.test.js
@@ -70,3 +70,59 @@ test('AI player performs its turn and passes play', () => {
   expect(game.getCurrentPlayer()).toBe(0);
   expect(game.getPhase()).toBe('reinforce');
 });
+
+test('AI performs multiple advantageous attacks', () => {
+  game.setCurrentPlayer(2);
+  game.setPhase('attack');
+  game.reinforcements = 0;
+  const t5 = game.territoryById('t5');
+  const t6 = game.territoryById('t6');
+  const t2 = game.territoryById('t2');
+  const t3 = game.territoryById('t3');
+  const t4 = game.territoryById('t4');
+  t5.armies = 5;
+  t6.armies = 4;
+  t2.armies = 1;
+  t3.armies = 1;
+  t4.armies = 1;
+  const attack = jest.spyOn(game, 'attack').mockImplementation((from, to) => {
+    to.owner = from.owner;
+    to.armies = 1;
+    from.armies -= 1;
+    return { conquered: true, attackRolls: [], defendRolls: [] };
+  });
+  jest.spyOn(Math, 'random').mockReturnValue(0);
+  game.performAITurn();
+  expect(attack).toHaveBeenCalledTimes(3);
+  expect(t2.owner).toBe(2);
+  expect(t3.owner).toBe(2);
+  expect(t4.owner).toBe(2);
+  Math.random.mockRestore();
+  attack.mockRestore();
+});
+
+test('AI fortifies at end of turn', () => {
+  game.setCurrentPlayer(2);
+  game.setPhase('attack');
+  game.reinforcements = 0;
+  const t5 = game.territoryById('t5');
+  const t6 = game.territoryById('t6');
+  const t2 = game.territoryById('t2');
+  const t3 = game.territoryById('t3');
+  const t4 = game.territoryById('t4');
+  t5.armies = 3;
+  t6.armies = 1;
+  t2.armies = 3; t2.owner = 0;
+  t3.armies = 3; t3.owner = 1;
+  t4.armies = 3; t4.owner = 1;
+  const attack = jest.spyOn(game, 'attack');
+  jest.spyOn(Math, 'random').mockReturnValue(0);
+  game.performAITurn();
+  Math.random.mockRestore();
+  expect(attack).not.toHaveBeenCalled();
+  expect(t5.armies).toBe(2);
+  expect(t6.armies).toBe(2);
+  expect(game.getCurrentPlayer()).toBe(0);
+  expect(game.getPhase()).toBe('reinforce');
+  attack.mockRestore();
+});


### PR DESCRIPTION
## Summary
- Extend AI turn to repeatedly attack while advantageous targets remain
- Automatically fortify AI positions by shifting armies within its territory
- Add unit tests covering multi-attack behavior and auto-fortification

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acd00fca28832cb24813407e09df12