### PR TITLE
feat: add continents and card mechanics

### DIFF
--- a/game.js
+++ b/game.js
@@ -40,12 +40,39 @@ class Game {
     this.phase = 'reinforce';
     this.selectedFrom = null;
     this.reinforcements = 0;
+    this.continents = [
+      { name: 'north', territories: ['t1', 't2', 't3'], bonus: 2 },
+      { name: 'south', territories: ['t4', 't5', 't6'], bonus: 2 }
+    ];
+    this.deck = [
+      { territory: 't1', type: 'infantry' },
+      { territory: 't2', type: 'cavalry' },
+      { territory: 't3', type: 'artillery' },
+      { territory: 't4', type: 'infantry' },
+      { territory: 't5', type: 'cavalry' },
+      { territory: 't6', type: 'artillery' }
+    ];
+    this.shuffle(this.deck);
+    this.hands = Array.from({ length: this.players.length }, () => []);
+    this.discard = [];
+    this.conqueredThisTurn = false;
     this.calculateReinforcements();
   }
 
   calculateReinforcements() {
     const owned = this.territories.filter(t => t.owner === this.currentPlayer).length;
-    this.reinforcements = Math.max(3, Math.floor(owned / 3));
+    let reinf = Math.max(3, Math.floor(owned / 3));
+    this.continents.forEach(c => {
+      if (
+        c.territories.every(id => {
+          const terr = this.territoryById(id);
+          return terr && terr.owner === this.currentPlayer;
+        })
+      ) {
+        reinf += c.bonus;
+      }
+    });
+    this.reinforcements = reinf;
   }
 
   territoryById(id) {
@@ -133,6 +160,7 @@ class Game {
       to.armies = 1;
       from.armies -= 1;
       conquered = true;
+      this.conqueredThisTurn = true;
       this.checkVictory();
     }
     return { attackRolls, defendRolls, conquered };
@@ -155,11 +183,45 @@ class Game {
       this.selectedFrom = null;
       this.phase = 'fortify';
     } else if (this.phase === 'fortify') {
+      const prev = this.currentPlayer;
       this.selectedFrom = null;
       this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
+      if (this.conqueredThisTurn) {
+        this.drawCard(prev);
+        this.conqueredThisTurn = false;
+      }
       this.phase = 'reinforce';
       this.calculateReinforcements();
     }
+  }
+
+  drawCard(player) {
+    if (this.deck.length === 0) return null;
+    const card = this.deck.shift();
+    this.hands[player].push(card);
+    return card;
+  }
+
+  playCards(indices) {
+    const hand = this.hands[this.currentPlayer];
+    if (indices.length !== 3) return false;
+    const cards = indices.map(i => hand[i]);
+    if (cards.some(c => !c)) return false;
+    const types = cards.map(c => c.type);
+    const allSame = types.every(t => t === types[0]);
+    const allDiff = new Set(types).size === 3;
+    if (!allSame && !allDiff) return false;
+    indices.sort((a, b) => b - a).forEach(i => this.discard.push(hand.splice(i, 1)[0]));
+    this.reinforcements += 5;
+    return true;
+  }
+
+  shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
   }
 
   performAITurn() {

--- a/game.test.js
+++ b/game.test.js
@@ -126,3 +126,41 @@ test('AI fortifies at end of turn', () => {
   expect(game.getPhase()).toBe('reinforce');
   attack.mockRestore();
 });
+
+test('continent bonus is added to reinforcements', () => {
+  ['t1', 't2', 't3'].forEach(id => { game.territoryById(id).owner = 0; });
+  game.calculateReinforcements();
+  expect(game.reinforcements).toBe(5); // 3 base +2 continent
+});
+
+test('player draws a card after conquering a territory', () => {
+  game.setPhase('attack');
+  const from = game.territoryById('t2');
+  const to = game.territoryById('t3');
+  from.armies = 5;
+  to.armies = 1; to.owner = 1;
+  jest.spyOn(Math, 'random')
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.8)
+    .mockReturnValueOnce(0.7)
+    .mockReturnValueOnce(0.1);
+  game.handleTerritoryClick('t2');
+  game.handleTerritoryClick('t3');
+  Math.random.mockRestore();
+  game.endTurn();
+  game.endTurn();
+  expect(game.hands[0].length).toBe(1);
+});
+
+test('playing valid card set grants reinforcements', () => {
+  game.hands[0] = [
+    { territory: 'a', type: 'infantry' },
+    { territory: 'b', type: 'cavalry' },
+    { territory: 'c', type: 'artillery' }
+  ];
+  game.reinforcements = 0;
+  const played = game.playCards([0, 1, 2]);
+  expect(played).toBe(true);
+  expect(game.reinforcements).toBe(5);
+  expect(game.hands[0].length).toBe(0);
+});

--- a/script.js
+++ b/script.js
@@ -21,6 +21,7 @@ if (typeof navigator !== "undefined" && navigator.serviceWorker) {
 
 let game;
 let territoryPositions = {};
+let selectedCards = [];
 
 const gameState = {
   turnNumber: 1,
@@ -104,6 +105,42 @@ function playConquerSound() {
   playTone(600, 0.3);
 }
 
+function updateBonusInfo() {
+  const bonusEl = document.getElementById("bonusInfo");
+  if (!bonusEl) return;
+  const bonuses = game.continents
+    .filter((c) =>
+      c.territories.every((id) => game.territoryById(id).owner === game.currentPlayer),
+    )
+    .map((c) => `${c.name} +${c.bonus}`);
+  bonusEl.textContent = bonuses.length ? `Bonus: ${bonuses.join(", ")}` : "";
+}
+
+function updateCardsUI() {
+  const container = document.getElementById("cards");
+  if (!container) return;
+  container.innerHTML = "";
+  const hand = game.hands[game.currentPlayer] || [];
+  selectedCards = [];
+  hand.forEach((card, idx) => {
+    const el = document.createElement("span");
+    el.textContent = card.type;
+    el.dataset.idx = idx;
+    el.className = "card";
+    if (selectedCards.includes(idx)) el.classList.add("selected-card");
+    el.addEventListener("click", () => {
+      if (selectedCards.includes(idx)) {
+        selectedCards = selectedCards.filter((i) => i !== idx);
+        el.classList.remove("selected-card");
+      } else if (selectedCards.length < 3) {
+        selectedCards.push(idx);
+        el.classList.add("selected-card");
+      }
+    });
+    container.appendChild(el);
+  });
+}
+
 function updateUI() {
   game.territories.forEach((t) => {
     const el = document.getElementById(t.id);
@@ -122,6 +159,8 @@ function updateUI() {
     status += ` (${game.reinforcements} reinforcements)`;
   }
   document.getElementById("status").textContent = status;
+  updateBonusInfo();
+  updateCardsUI();
 }
 
 function runAI() {
@@ -237,6 +276,25 @@ if (forceErrorBtn) {
 
 async function init() {
   await loadGame();
+  const ui = document.getElementById("uiPanel");
+  const cardPanel = document.createElement("div");
+  cardPanel.id = "cardPanel";
+  cardPanel.innerHTML =
+    '<div><strong>Carte:</strong> <span id="cards"></span></div>' +
+    '<button id="playCardsBtn">Gioca carte</button>' +
+    '<div id="bonusInfo"></div>';
+  ui.appendChild(cardPanel);
+  document.getElementById("playCardsBtn").addEventListener("click", () => {
+    if (selectedCards.length === 3) {
+      if (game.playCards(selectedCards)) {
+        addLogEntry(`${game.players[game.currentPlayer].name} gioca carte`);
+        selectedCards = [];
+        game.calculateReinforcements();
+        updateUI();
+        updateCardsUI();
+      }
+    }
+  });
   initTerritorySelection({
     logger,
     game,


### PR DESCRIPTION
## Summary
- define continent and card data structures
- compute continent bonuses and allow card trades
- expose UI for card play and bonus display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd2f35630832c9dea5f9a1c9e35ae