### PR TITLE
feat: add setup screen and player preferences

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,7 +67,15 @@ async function loadGame() {
     return acc;
   }, {});
   const GameClass = window.Game;
-  game = new GameClass(null, map.territories);
+  let players = null;
+  if (typeof localStorage !== "undefined") {
+    try {
+      players = JSON.parse(localStorage.getItem("netriskPlayers"));
+    } catch (err) {
+      players = null;
+    }
+  }
+  game = new GameClass(players, map.territories);
   if (typeof logger !== "undefined") {
     logger.info("Game initialised");
   }

--- a/setup.html
+++ b/setup.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Setup NetRisk</title>
+  </head>
+  <body>
+    <h1>Setup Giocatori</h1>
+    <form id="setupForm">
+      <label>
+        Numero giocatori:
+        <input type="number" id="playerCount" min="2" max="6" />
+      </label>
+      <div id="players"></div>
+      <button type="submit">Start</button>
+    </form>
+    <script type="module" src="./setup.js"></script>
+  </body>
+</html>

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,60 @@
+const form = document.getElementById("setupForm");
+const playerCountInput = document.getElementById("playerCount");
+const playersContainer = document.getElementById("players");
+
+function renderPlayerInputs(count) {
+  playersContainer.innerHTML = "";
+  for (let i = 0; i < count; i += 1) {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `
+      <label>Nome Giocatore ${i + 1}: <input type="text" id="name${i}" /></label>
+      <label>Colore: <input type="color" id="color${i}" /></label>
+    `;
+    playersContainer.appendChild(wrapper);
+  }
+}
+
+function loadFromStorage() {
+  let saved = null;
+  try {
+    saved = JSON.parse(localStorage.getItem("netriskPlayers"));
+  } catch (err) {
+    saved = null;
+  }
+  const count = saved ? saved.length : 3;
+  playerCountInput.value = count;
+  renderPlayerInputs(count);
+  if (saved) {
+    saved.forEach((p, i) => {
+      const nameInput = document.getElementById(`name${i}`);
+      const colorInput = document.getElementById(`color${i}`);
+      if (nameInput) nameInput.value = p.name;
+      if (colorInput) colorInput.value = p.color;
+    });
+  }
+}
+
+playerCountInput.addEventListener("change", () => {
+  const count = parseInt(playerCountInput.value, 10);
+  if (Number.isNaN(count) || count < 2) return;
+  renderPlayerInputs(count);
+});
+
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const count = parseInt(playerCountInput.value, 10);
+  const players = [];
+  for (let i = 0; i < count; i += 1) {
+    const name = document.getElementById(`name${i}`).value || `Player ${i + 1}`;
+    const color = document.getElementById(`color${i}`).value || "#000000";
+    players.push({ name, color });
+  }
+  try {
+    localStorage.setItem("netriskPlayers", JSON.stringify(players));
+  } catch (err) {
+    // ignore storage errors
+  }
+  window.location.href = "index.html";
+});
+
+loadFromStorage();


### PR DESCRIPTION
## Summary
- add setup page to pick player number, names, and colors
- initialize Game from saved player settings instead of hardcoded values
- persist player preferences using `localStorage`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acd8111dd8832ca20a8b3b7e3f8020