### PR TITLE
Skip eliminated players during turn rotation

### DIFF
--- a/game.js
+++ b/game.js
@@ -185,7 +185,10 @@ class Game {
     } else if (this.phase === 'fortify') {
       const prev = this.currentPlayer;
       this.selectedFrom = null;
-      this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
+      // Move to the next player, skipping any who have been eliminated
+      do {
+        this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
+      } while (!this.territories.some(t => t.owner === this.currentPlayer));
       if (this.conqueredThisTurn) {
         this.drawCard(prev);
         this.conqueredThisTurn = false;

--- a/game.test.js
+++ b/game.test.js
@@ -164,3 +164,27 @@ test('playing valid card set grants reinforcements', () => {
   expect(game.reinforcements).toBe(5);
   expect(game.hands[0].length).toBe(0);
 });
+
+test('players with no territories are skipped on turn rotation', () => {
+  // Setup: player 1 has a single territory that will be conquered
+  const t2 = game.territoryById('t2');
+  const t3 = game.territoryById('t3');
+  const t4 = game.territoryById('t4');
+  t2.armies = 5; // attacker
+  t3.owner = 1; t3.armies = 1; // defender's last territory
+  t4.owner = 2; // ensure player 1 has no other territories
+  game.setPhase('attack');
+  // Ensure deterministic conquest
+  jest.spyOn(Math, 'random').mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.1);
+  game.attack(t2, t3);
+  Math.random.mockRestore();
+  // End current player's turn completely
+  game.endTurn(); // to fortify
+  game.endTurn(); // to next player
+  // Player 1 had no territories, so it should now be player 2's turn
+  expect(game.getCurrentPlayer()).toBe(2);
+  expect(game.getPhase()).toBe('reinforce');
+});


### PR DESCRIPTION
## Summary
- Skip over players with no territories when advancing turns
- Test that eliminated players are not given a turn

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acdb2e8354832cb70f3ab71b147c2b