### PR TITLE
Read continent and deck data from map configuration

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,26 +1,30 @@
 class Game {
-  constructor(players, territories) {
+  constructor(players, territories, continents, deck) {
     this.players = players || [
       { name: 'Player 1', color: '#e74c3c' },
       { name: 'Player 2', color: '#3498db' },
       { name: 'AI', color: '#2ecc71', ai: true }
     ];
 
-    if (!territories) {
+    let map;
+    if (!territories || !continents || !deck) {
       try {
-        // Load default territory data from JSON when none provided
-        const map = require('./src/data/map.json');
-        territories = map.territories.map((t, i) => ({
-          id: t.id,
-          neighbors: t.neighbors,
-          x: t.x,
-          y: t.y,
-          owner: Math.floor((i * this.players.length) / map.territories.length),
-          armies: 3,
-        }));
+        map = require('./src/data/map.json');
       } catch (err) {
-        territories = [];
+        map = { territories: [], continents: [], deck: [] };
       }
+    }
+
+    if (!territories) {
+      // Load default territory data from JSON when none provided
+      territories = map.territories.map((t, i) => ({
+        id: t.id,
+        neighbors: t.neighbors,
+        x: t.x,
+        y: t.y,
+        owner: Math.floor((i * this.players.length) / map.territories.length),
+        armies: 3,
+      }));
     } else {
       territories = territories.map((t, i) => ({
         id: t.id,
@@ -40,18 +44,8 @@ class Game {
     this.phase = 'reinforce';
     this.selectedFrom = null;
     this.reinforcements = 0;
-    this.continents = [
-      { name: 'north', territories: ['t1', 't2', 't3'], bonus: 2 },
-      { name: 'south', territories: ['t4', 't5', 't6'], bonus: 2 }
-    ];
-    this.deck = [
-      { territory: 't1', type: 'infantry' },
-      { territory: 't2', type: 'cavalry' },
-      { territory: 't3', type: 'artillery' },
-      { territory: 't4', type: 'infantry' },
-      { territory: 't5', type: 'cavalry' },
-      { territory: 't6', type: 'artillery' }
-    ];
+    this.continents = continents || (map ? map.continents : []) || [];
+    this.deck = (deck || (map ? map.deck : []) || []).map(c => ({ ...c }));
     this.shuffle(this.deck);
     this.hands = Array.from({ length: this.players.length }, () => []);
     this.discard = [];

--- a/game.test.js
+++ b/game.test.js
@@ -1,7 +1,31 @@
 let Game, game;
 
+const mapMock = {
+  territories: [
+    { id: 't1', neighbors: ['t2', 't4'], x: 120, y: 100 },
+    { id: 't2', neighbors: ['t1', 't3', 't5'], x: 340, y: 110 },
+    { id: 't3', neighbors: ['t2', 't6'], x: 500, y: 140 },
+    { id: 't4', neighbors: ['t1', 't5'], x: 150, y: 260 },
+    { id: 't5', neighbors: ['t2', 't4', 't6'], x: 360, y: 220 },
+    { id: 't6', neighbors: ['t3', 't5'], x: 520, y: 300 },
+  ],
+  continents: [
+    { name: 'north', territories: ['t1', 't2', 't3'], bonus: 2 },
+    { name: 'south', territories: ['t4', 't5', 't6'], bonus: 2 },
+  ],
+  deck: [
+    { territory: 't1', type: 'infantry' },
+    { territory: 't2', type: 'cavalry' },
+    { territory: 't3', type: 'artillery' },
+    { territory: 't4', type: 'infantry' },
+    { territory: 't5', type: 'cavalry' },
+    { territory: 't6', type: 'artillery' },
+  ],
+};
+
 beforeEach(() => {
   jest.resetModules();
+  jest.doMock('./src/data/map.json', () => mapMock, { virtual: true });
   Game = require('./game');
   game = new Game();
 });

--- a/script.js
+++ b/script.js
@@ -140,7 +140,7 @@ async function loadGame() {
       players = null;
     }
   }
-  game = new GameClass(players, map.territories);
+  game = new GameClass(players, map.territories, map.continents, map.deck);
   if (typeof logger !== "undefined") {
     logger.info("Game initialised");
   }

--- a/src/data/map.json
+++ b/src/data/map.json
@@ -6,5 +6,17 @@
     { "id": "t4", "neighbors": ["t1", "t5"], "x": 150, "y": 260 },
     { "id": "t5", "neighbors": ["t2", "t4", "t6"], "x": 360, "y": 220 },
     { "id": "t6", "neighbors": ["t3", "t5"], "x": 520, "y": 300 }
+  ],
+  "continents": [
+    { "name": "north", "territories": ["t1", "t2", "t3"], "bonus": 2 },
+    { "name": "south", "territories": ["t4", "t5", "t6"], "bonus": 2 }
+  ],
+  "deck": [
+    { "territory": "t1", "type": "infantry" },
+    { "territory": "t2", "type": "cavalry" },
+    { "territory": "t3", "type": "artillery" },
+    { "territory": "t4", "type": "infantry" },
+    { "territory": "t5", "type": "cavalry" },
+    { "territory": "t6", "type": "artillery" }
   ]
 }


### PR DESCRIPTION
## Summary
- Extend map data with continent and deck sections
- Update Game to consume continents and deck from map instead of hard-coded arrays
- Adjust client loading logic and tests for new map structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acdfbbf148832ca899d4c5b8fb2f41