### PR TITLE
Add game state persistence

### DIFF
--- a/game.js
+++ b/game.js
@@ -46,7 +46,7 @@ class Game {
     this.reinforcements = 0;
     this.continents = continents || (map ? map.continents : []) || [];
     this.deck = (deck || (map ? map.deck : []) || []).map(c => ({ ...c }));
-    this.shuffle(this.deck);
+    if (!deck) this.shuffle(this.deck);
     this.hands = Array.from({ length: this.players.length }, () => []);
     this.discard = [];
     this.conqueredThisTurn = false;
@@ -277,6 +277,37 @@ class Game {
       }
       this.endTurn();
     }
+  }
+
+  serialize() {
+    return JSON.stringify({
+      players: this.players,
+      territories: this.territories,
+      continents: this.continents,
+      deck: this.deck,
+      hands: this.hands,
+      discard: this.discard,
+      currentPlayer: this.currentPlayer,
+      phase: this.phase,
+      reinforcements: this.reinforcements,
+      selectedFrom: this.selectedFrom ? this.selectedFrom.id : null,
+      conqueredThisTurn: this.conqueredThisTurn,
+      winner: this.winner,
+    });
+  }
+
+  static deserialize(str) {
+    const data = typeof str === 'string' ? JSON.parse(str) : str;
+    const game = new Game(data.players, data.territories, data.continents, data.deck);
+    game.hands = data.hands;
+    game.discard = data.discard || [];
+    game.currentPlayer = data.currentPlayer;
+    game.phase = data.phase;
+    game.reinforcements = data.reinforcements;
+    game.selectedFrom = data.selectedFrom ? game.territoryById(data.selectedFrom) : null;
+    game.conqueredThisTurn = data.conqueredThisTurn || false;
+    game.winner = data.winner;
+    return game;
   }
 
   getPhase() { return this.phase; }

--- a/game.test.js
+++ b/game.test.js
@@ -212,3 +212,16 @@ test('players with no territories are skipped on turn rotation', () => {
   expect(game.getCurrentPlayer()).toBe(2);
   expect(game.getPhase()).toBe('reinforce');
 });
+
+test('serialize and deserialize restores game state', () => {
+  game.handleTerritoryClick('t1');
+  game.handleTerritoryClick('t1');
+  game.handleTerritoryClick('t1');
+  const saved = game.serialize();
+  const restored = Game.deserialize(saved);
+  expect(restored.territoryById('t1').armies).toBe(
+    game.territoryById('t1').armies
+  );
+  expect(restored.getPhase()).toBe(game.getPhase());
+  expect(restored.getCurrentPlayer()).toBe(game.getCurrentPlayer());
+});

--- a/script.js
+++ b/script.js
@@ -40,6 +40,15 @@ function updateGameState(selected = null) {
   gameState.territories = game.territories;
   gameState.phase = game.getPhase();
   gameState.selectedTerritory = selected;
+  if (typeof localStorage !== "undefined") {
+    try {
+      localStorage.setItem("netriskGame", game.serialize());
+    } catch (err) {
+      if (typeof logger !== "undefined") {
+        logger.error("Failed to save game", err);
+      }
+    }
+  }
 }
 
 function updateInfoPanel() {
@@ -110,6 +119,9 @@ function checkForVictory() {
 async function startNewGame() {
   const modal = document.getElementById("victoryModal");
   if (modal) modal.classList.remove("show");
+  if (typeof localStorage !== "undefined") {
+    localStorage.removeItem("netriskGame");
+  }
   await loadGame();
   gameState.turnNumber = 1;
   gameState.log = [];
@@ -132,17 +144,31 @@ async function loadGame() {
     return acc;
   }, {});
   const GameClass = window.Game;
-  let players = null;
   if (typeof localStorage !== "undefined") {
     try {
-      players = JSON.parse(localStorage.getItem("netriskPlayers"));
+      const saved = localStorage.getItem("netriskGame");
+      if (saved) {
+        game = GameClass.deserialize(saved);
+      }
     } catch (err) {
-      players = null;
+      if (typeof logger !== "undefined") {
+        logger.error("Failed to load saved game", err);
+      }
     }
   }
-  game = new GameClass(players, map.territories, map.continents, map.deck);
-  if (typeof logger !== "undefined") {
-    logger.info("Game initialised");
+  if (!game) {
+    let players = null;
+    if (typeof localStorage !== "undefined") {
+      try {
+        players = JSON.parse(localStorage.getItem("netriskPlayers"));
+      } catch (err) {
+        players = null;
+      }
+    }
+    game = new GameClass(players, map.territories, map.continents, map.deck);
+    if (typeof logger !== "undefined") {
+      logger.info("Game initialised");
+    }
   }
   gameState.currentPlayer = game.currentPlayer;
   gameState.players = game.players;
@@ -352,6 +378,11 @@ if (forceErrorBtn) {
 
 async function init() {
   await loadGame();
+  const resetBtn = document.createElement("button");
+  resetBtn.id = "resetGame";
+  resetBtn.textContent = "Nuova partita";
+  resetBtn.addEventListener("click", startNewGame);
+  document.body.appendChild(resetBtn);
   const modal = document.createElement("div");
   modal.id = "victoryModal";
   modal.className = "modal";
@@ -422,4 +453,5 @@ export {
   runAI,
   attachTerritoryHandlers,
   addLogEntry,
+  startNewGame,
 };

--- a/script.test.js
+++ b/script.test.js
@@ -7,6 +7,9 @@ describe('script DOM interactions', () => {
   let mod;
   beforeEach(async () => {
     jest.resetModules();
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
     document.body.innerHTML = `
       <div id="status"></div>
       <div id="currentPlayer"></div>
@@ -104,6 +107,44 @@ describe('script DOM interactions', () => {
     expect(log.textContent).toContain('termina il turno');
     expect(status.textContent).toContain('Player 2');
     expect(status.textContent).toContain('reinforce');
+  });
+
+  test('state is saved and restored from localStorage', async () => {
+    const t1 = document.getElementById('t1');
+    t1.click();
+    t1.click();
+    t1.click();
+    const armies = mod.game.territoryById('t1').armies;
+    const phase = mod.game.getPhase();
+    const saved = localStorage.getItem('netriskGame');
+    expect(saved).toBeTruthy();
+
+    // simulate reload
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="status"></div>
+      <div id="currentPlayer"></div>
+      <div id="turnNumber"></div>
+      <div id="actionLog"></div>
+      <div id="diceResults"></div>
+      <div id="uiPanel"></div>
+      <button id="endTurn"></button>
+      <div id="t1" class="territory" data-id="t1"></div>
+      <div id="t2" class="territory" data-id="t2"></div>
+      <div id="t3" class="territory" data-id="t3"></div>
+      <div id="t4" class="territory" data-id="t4"></div>
+      <div id="t5" class="territory" data-id="t5"></div>
+      <div id="t6" class="territory" data-id="t6"></div>`;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(mapData) })
+    );
+    global.logger = { info: jest.fn(), error: jest.fn() };
+    window.Game = Game;
+    const mod2 = require('./script.js');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mod2.game.territoryById('t1').armies).toBe(armies);
+    expect(mod2.game.getPhase()).toBe(phase);
   });
 });
 


### PR DESCRIPTION
## Summary
- allow Game to serialize/deserialize full state and keep deck order when restoring
- save and reload game state via localStorage with new "Nuova partita" reset button
- test game state serialization and browser reload persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace242eae0832ca55f55aea2eeaf37