### PR TITLE
feat: require fortify step before ending turn

### DIFF
--- a/script.js
+++ b/script.js
@@ -279,9 +279,10 @@ function attachTerritoryHandlers() {
         logger.info(`Territory clicked: ${el.dataset.id}`);
       }
       try {
+        const prevPlayer = game.currentPlayer;
         const result = game.handleTerritoryClick(el.dataset.id);
         if (result) {
-          const playerName = game.players[game.currentPlayer].name;
+          const playerName = game.players[prevPlayer].name;
           if (result.type === "attack") {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} attacks ${result.to} from ${result.from}`);
@@ -314,6 +315,14 @@ function attachTerritoryHandlers() {
             }
             addLogEntry(`${playerName} sposta da ${result.from} a ${result.to}`);
             animateMove(result.from, result.to);
+            const nextName = game.players[game.currentPlayer].name;
+            gameState.turnNumber += 1;
+            addLogEntry(
+              `${playerName} termina il turno. Ora tocca a ${nextName}`,
+            );
+            if (typeof logger !== "undefined") {
+              logger.info(`${playerName} ends turn. Next: ${nextName}`);
+            }
           }
         }
         updateUI();
@@ -341,19 +350,22 @@ document.getElementById("endTurn").addEventListener("click", () => {
     logger.info("End turn clicked");
   }
   try {
-    const prev = game.currentPlayer;
+    const prevPlayer = game.currentPlayer;
+    const prevPhase = game.getPhase();
     game.endTurn();
-    if (game.getPhase() !== "reinforce") {
-      game.endTurn();
-    }
-    if (prev !== game.currentPlayer) {
+    if (prevPhase === "attack" && game.getPhase() === "fortify") {
+      addLogEntry(`${game.players[prevPlayer].name} passa alla fase fortificazioni`);
+      if (typeof logger !== "undefined") {
+        logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
+      }
+    } else if (prevPhase === "fortify" && game.getPhase() === "reinforce") {
       gameState.turnNumber += 1;
       addLogEntry(
-        `${game.players[prev].name} termina il turno. Ora tocca a ${game.players[game.currentPlayer].name}`,
+        `${game.players[prevPlayer].name} termina il turno. Ora tocca a ${game.players[game.currentPlayer].name}`,
       );
       if (typeof logger !== "undefined") {
         logger.info(
-          `${game.players[prev].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
+          `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
         );
       }
     }

--- a/script.test.js
+++ b/script.test.js
@@ -93,7 +93,7 @@ describe('script DOM interactions', () => {
     expect(t1.classList.contains('selected')).toBe(false);
   });
 
-  test('end turn updates to next player reinforce', () => {
+  test('end turn now requires fortify step', () => {
     const t1 = document.getElementById('t1');
     const endTurnBtn = document.getElementById('endTurn');
     const status = document.getElementById('status');
@@ -102,6 +102,9 @@ describe('script DOM interactions', () => {
     t1.click();
     t1.click();
     t1.click();
+
+    endTurnBtn.click();
+    expect(status.textContent).toContain('fortify');
 
     endTurnBtn.click();
     expect(log.textContent).toContain('termina il turno');


### PR DESCRIPTION
## Summary
- allow end turn button to enter fortify phase before passing to next player
- log and advance turn after fortify moves or second end-turn click
- update DOM tests for two-step end turn flow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace57dcba4832ca711b1ed0a9d81aa