### PR TITLE
feat: prompt army movement after conquest

### DIFF
--- a/game.js
+++ b/game.js
@@ -118,14 +118,14 @@ class Game {
           this.selectedFrom = null;
           return { type: 'deselect', territory: id };
         }
-        if (from.owner === this.currentPlayer && to.owner === this.currentPlayer && from.neighbors.includes(to.id)) {
-          from.armies -= 1;
-          to.armies += 1;
+        if (
+          from.owner === this.currentPlayer &&
+          to.owner === this.currentPlayer &&
+          from.neighbors.includes(to.id)
+        ) {
+          const movable = from.armies - 1;
           this.selectedFrom = null;
-          this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
-          this.phase = 'reinforce';
-          this.calculateReinforcements();
-          return { type: 'fortify', from: from.id, to: to.id };
+          return { type: 'fortify', from: from.id, to: to.id, movableArmies: movable };
         }
       }
     }
@@ -149,15 +149,29 @@ class Game {
     }
 
     let conquered = false;
+    let movableArmies = 0;
     if (to.armies <= 0) {
       to.owner = from.owner;
       to.armies = 1;
-      from.armies -= 1;
+      from.armies -= 1; // mandatory move
       conquered = true;
+      movableArmies = from.armies - 1;
       this.conqueredThisTurn = true;
       this.checkVictory();
     }
-    return { attackRolls, defendRolls, conquered };
+    return { attackRolls, defendRolls, conquered, movableArmies };
+  }
+
+  moveArmies(fromId, toId, count) {
+    const from = this.territoryById(fromId);
+    const to = this.territoryById(toId);
+    if (!from || !to) return false;
+    if (from.owner !== this.currentPlayer || to.owner !== this.currentPlayer) return false;
+    if (!from.neighbors.includes(to.id)) return false;
+    if (count < 1 || from.armies <= count) return false;
+    from.armies -= count;
+    to.armies += count;
+    return true;
   }
 
   checkVictory() {
@@ -272,8 +286,7 @@ class Game {
         }
       });
       if (best) {
-        best.from.armies -= 1;
-        best.to.armies += 1;
+        this.moveArmies(best.from.id, best.to.id, 1);
       }
       this.endTurn();
     }

--- a/game.test.js
+++ b/game.test.js
@@ -56,6 +56,27 @@ test('attack phase resolves battle between territories', () => {
   Math.random.mockRestore();
 });
 
+test('attack returns movable armies after conquest and moveArmies transfers them', () => {
+  game.setPhase('attack');
+  const from = game.territoryById('t2');
+  const to = game.territoryById('t3');
+  from.armies = 5;
+  to.owner = 1; to.armies = 1;
+  jest.spyOn(Math, 'random')
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.8)
+    .mockReturnValueOnce(0.7)
+    .mockReturnValueOnce(0.1);
+  const res = game.attack(from, to);
+  Math.random.mockRestore();
+  expect(res.conquered).toBe(true);
+  expect(res.movableArmies).toBe(3);
+  const moved = game.moveArmies('t2', 't3', 2);
+  expect(moved).toBe(true);
+  expect(from.armies).toBe(2);
+  expect(to.armies).toBe(3);
+});
+
 test('gameover phase when one player owns all territories', () => {
   game.territories.forEach(t => { t.owner = 0; });
   game.checkVictory();

--- a/script.js
+++ b/script.js
@@ -93,6 +93,18 @@ function animateMove(from, to) {
   );
 }
 
+function askArmiesToMove(max, min = 0) {
+  if (max <= 0) return 0;
+  let input = null;
+  if (typeof window !== "undefined" && typeof window.prompt === "function") {
+    input = window.prompt(`Quante armate spostare? (${min}-${max})`, String(max));
+  }
+  let count = parseInt(input, 10);
+  if (isNaN(count)) count = min;
+  count = Math.max(min, Math.min(max, count));
+  return count;
+}
+
 function showVictoryModal(winnerIdx) {
   const modal = document.getElementById("victoryModal");
   if (!modal) return;
@@ -302,6 +314,12 @@ function attachTerritoryHandlers() {
               playConquerSound();
               toEl.classList.add("conquer");
               setTimeout(() => toEl.classList.remove("conquer"), 1000);
+              const move = askArmiesToMove(result.movableArmies, 0);
+              if (move > 0) {
+                game.moveArmies(result.from, result.to, move);
+                addLogEntry(`${playerName} sposta ${move} da ${result.from} a ${result.to}`);
+                animateMove(result.from, result.to);
+              }
             }
             addLogEntry(`${playerName} attacca ${result.to} da ${result.from}`);
           } else if (result.type === "reinforce") {
@@ -313,8 +331,13 @@ function attachTerritoryHandlers() {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
             }
-            addLogEntry(`${playerName} sposta da ${result.from} a ${result.to}`);
-            animateMove(result.from, result.to);
+            const move = askArmiesToMove(result.movableArmies, 1);
+            if (move > 0) {
+              game.moveArmies(result.from, result.to, move);
+              addLogEntry(`${playerName} sposta ${move} da ${result.from} a ${result.to}`);
+              animateMove(result.from, result.to);
+            }
+            game.endTurn();
             const nextName = game.players[game.currentPlayer].name;
             gameState.turnNumber += 1;
             addLogEntry(

--- a/script.test.js
+++ b/script.test.js
@@ -28,6 +28,7 @@ describe('script DOM interactions', () => {
       Promise.resolve({ json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
+    global.prompt = jest.fn(() => '1');
     window.Game = Game;
     mod = require('./script.js');
     await Promise.resolve();
@@ -88,7 +89,7 @@ describe('script DOM interactions', () => {
     t1.click();
     expect(t1.classList.contains('selected')).toBe(true);
     t2.click();
-    expect(log.textContent).toContain('sposta da t1 a t2');
+    expect(log.textContent).toContain('sposta 1 da t1 a t2');
     expect(status.textContent).toContain('reinforce');
     expect(t1.classList.contains('selected')).toBe(false);
   });


### PR DESCRIPTION
## Summary
- return remaining movable armies from `Game.attack`
- add `Game.moveArmies` for post-attack and fortify moves
- prompt players for army counts when conquering or fortifying
- update UI and tests for new movement flow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace81815b8832cadf6458c2464527b