### PR TITLE
Improve AI strategy and card handling

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -1,0 +1,96 @@
+// AI utility functions for decision making
+
+// Estimate probability of successful attack based on army counts.
+// Uses a simple heuristic: proportion of attacking armies (minus one) over total armies involved.
+function successProbability(from, to) {
+  const attackers = from.armies - 1;
+  const defenders = to.armies;
+  if (attackers <= 0) return 0;
+  return attackers / (attackers + defenders);
+}
+
+// Determine priority of reinforcing a territory based on number of enemy neighbors.
+function territoryPriority(game, territory) {
+  const enemyNeighbors = territory.neighbors.filter(id => {
+    const n = game.territoryById(id);
+    return n.owner !== territory.owner;
+  }).length;
+  return enemyNeighbors;
+}
+
+// Choose the best territory to reinforce for the current player.
+function chooseReinforcement(game) {
+  const owned = game.territories.filter(t => t.owner === game.currentPlayer);
+  let best = null;
+  owned.forEach(t => {
+    const score = territoryPriority(game, t);
+    if (!best || score > best.score) {
+      best = { territory: t, score };
+    }
+  });
+  return best ? best.territory : null;
+}
+
+// Choose the most promising attack based on success probability.
+function chooseAttack(game) {
+  let best = null;
+  game.territories
+    .filter(t => t.owner === game.currentPlayer && t.armies > 1)
+    .forEach(from => {
+      from.neighbors.forEach(id => {
+        const to = game.territoryById(id);
+        if (to.owner !== game.currentPlayer) {
+          const prob = successProbability(from, to);
+          if (!best || prob > best.prob) {
+            best = { from, to, prob };
+          }
+        }
+      });
+    });
+  return best;
+}
+
+// Choose a fortification move to balance armies across friendly territories.
+function chooseFortification(game) {
+  let best = null;
+  game.territories
+    .filter(t => t.owner === game.currentPlayer && t.armies > 1)
+    .forEach(from => {
+      from.neighbors.forEach(id => {
+        const to = game.territoryById(id);
+        if (to.owner === game.currentPlayer) {
+          const diff = from.armies - to.armies;
+          if (diff > 1 && (!best || diff > best.diff)) {
+            best = { from, to, diff };
+          }
+        }
+      });
+    });
+  return best;
+}
+
+// Find a valid set of cards to play (three of a kind or all different types).
+function findValidCardSet(hand) {
+  if (!hand || hand.length < 3) return null;
+  for (let i = 0; i < hand.length - 2; i++) {
+    for (let j = i + 1; j < hand.length - 1; j++) {
+      for (let k = j + 1; k < hand.length; k++) {
+        const types = [hand[i].type, hand[j].type, hand[k].type];
+        const allSame = types[0] === types[1] && types[1] === types[2];
+        const allDiff = new Set(types).size === 3;
+        if (allSame || allDiff) return [i, j, k];
+      }
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  successProbability,
+  territoryPriority,
+  chooseReinforcement,
+  chooseAttack,
+  chooseFortification,
+  findValidCardSet,
+};
+

--- a/game.js
+++ b/game.js
@@ -1,3 +1,5 @@
+const ai = require('./ai');
+
 class Game {
   constructor(players, territories, continents, deck) {
     this.players = players || [
@@ -223,57 +225,40 @@ class Game {
 
   performAITurn() {
     if (!this.players[this.currentPlayer].ai || this.phase === 'gameover') return;
-    // Reinforce randomly
-    const owned = this.territories.filter(t => t.owner === this.currentPlayer);
-    while (this.reinforcements > 0 && owned.length > 0) {
-      const t = owned[Math.floor(Math.random() * owned.length)];
-      t.armies += 1;
+
+    // Play cards if a valid set is available
+    const hand = this.hands[this.currentPlayer];
+    const cardSet = ai.findValidCardSet(hand);
+    if (cardSet) {
+      this.playCards(cardSet);
+    }
+
+    // Reinforce using territory priorities
+    while (this.reinforcements > 0) {
+      const target = ai.chooseReinforcement(this);
+      if (!target) break;
+      target.armies += 1;
       this.reinforcements -= 1;
     }
     if (this.phase === 'reinforce' && this.reinforcements === 0) {
       this.phase = 'attack';
     }
-    // Keep attacking while advantageous targets exist
+
+    // Attack while a favorable target exists
     while (this.phase === 'attack') {
-      const options = [];
-      this.territories
-        .filter(t => t.owner === this.currentPlayer)
-        .forEach(from => {
-          if (from.armies > 1) {
-            from.neighbors.forEach(n => {
-              const to = this.territoryById(n);
-              if (to.owner !== this.currentPlayer && from.armies > to.armies) {
-                options.push({ from, to });
-              }
-            });
-          }
-        });
-      if (options.length === 0) break;
-      const { from, to } = options[Math.floor(Math.random() * options.length)];
-      this.attack(from, to);
+      const best = ai.chooseAttack(this);
+      if (!best || best.prob < 0.6) break;
+      this.attack(best.from, best.to);
       if (this.phase === 'gameover') return;
     }
-    // Move to fortify phase and automatically fortify one army
+
+    // Fortify towards weaker friendly territories
     this.endTurn();
     if (this.phase === 'fortify') {
-      const aiOwned = this.territories.filter(t => t.owner === this.currentPlayer);
-      let best = null;
-      aiOwned.forEach(from => {
-        if (from.armies > 1) {
-          from.neighbors.forEach(n => {
-            const to = this.territoryById(n);
-            if (to.owner === this.currentPlayer) {
-              const diff = from.armies - to.armies;
-              if (diff > 1 && (!best || diff > best.diff)) {
-                best = { from, to, diff };
-              }
-            }
-          });
-        }
-      });
-      if (best) {
-        best.from.armies -= 1;
-        best.to.armies += 1;
+      const move = ai.chooseFortification(this);
+      if (move) {
+        move.from.armies -= 1;
+        move.to.armies += 1;
       }
       this.endTurn();
     }

--- a/game.test.js
+++ b/game.test.js
@@ -151,6 +151,66 @@ test('AI fortifies at end of turn', () => {
   attack.mockRestore();
 });
 
+test('AI plays cards and reinforces most threatened territory', () => {
+  game.setCurrentPlayer(2);
+  game.hands[2] = [
+    { territory: 'a', type: 'infantry' },
+    { territory: 'b', type: 'cavalry' },
+    { territory: 'c', type: 'artillery' }
+  ];
+  const t5 = game.territoryById('t5');
+  const t6 = game.territoryById('t6');
+  const t2 = game.territoryById('t2'); t2.armies = 10;
+  const t4 = game.territoryById('t4'); t4.armies = 10;
+  const t3 = game.territoryById('t3'); t3.armies = 10;
+  const playSpy = jest.spyOn(game, 'playCards');
+  game.performAITurn();
+  expect(playSpy).toHaveBeenCalled();
+  expect(game.hands[2].length).toBe(0);
+  expect(t5.armies).toBeGreaterThan(t6.armies);
+  playSpy.mockRestore();
+});
+
+test('AI chooses attack with highest success probability', () => {
+  game.setCurrentPlayer(2);
+  game.reinforcements = 0;
+  game.setPhase('reinforce');
+  const t5 = game.territoryById('t5');
+  const t6 = game.territoryById('t6');
+  const t2 = game.territoryById('t2');
+  const t3 = game.territoryById('t3');
+  t5.armies = 5;
+  t6.armies = 3;
+  t2.armies = 1; t2.owner = 0;
+  t3.armies = 2; t3.owner = 1;
+  const attack = jest.spyOn(game, 'attack').mockImplementation((from, to) => {
+    to.owner = from.owner;
+    to.armies = 1;
+    from.armies -= 1;
+    return { conquered: true, attackRolls: [], defendRolls: [] };
+  });
+  game.performAITurn();
+  expect(attack).toHaveBeenCalled();
+  expect(attack.mock.calls[0][0].id).toBe('t5');
+  expect(attack.mock.calls[0][1].id).toBe('t2');
+  attack.mockRestore();
+});
+
+test('AI fortifies weaker border territory when no attack is favorable', () => {
+  game.setCurrentPlayer(2);
+  game.setPhase('reinforce');
+  game.reinforcements = 0;
+  const t5 = game.territoryById('t5');
+  const t6 = game.territoryById('t6');
+  const t2 = game.territoryById('t2'); t2.armies = 10;
+  const t3 = game.territoryById('t3'); t3.armies = 10;
+  t5.armies = 5;
+  t6.armies = 1;
+  game.performAITurn();
+  expect(t5.armies).toBe(4);
+  expect(t6.armies).toBe(2);
+});
+
 test('continent bonus is added to reinforcements', () => {
   ['t1', 't2', 't3'].forEach(id => { game.territoryById(id).owner = 0; });
   game.calculateReinforcements();


### PR DESCRIPTION
## Summary
- add AI evaluation utilities for attack odds, territory priority, fortification and card sets
- use these utilities in `performAITurn` to reinforce borders, select attacks, fortify intelligently and play card sets
- cover new decision logic with targeted tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace9e2faa8832c87351e7d89b39905