### PR TITLE
Add configurable human and AI player setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 A simple browser-based strategy game inspired by the classic game of Risk.
 
-The game now supports three players by default, with the third controlled by a
-basic AI to enable solo play. Reinforcements are calculated based on the number
+The setup interface allows choosing how many human players and AI opponents
+participate in each match, making both solo and multiplayer games possible.
+Reinforcements are calculated based on the number
 of territories a player owns and the fortify phase allows moving troops between
 adjacent friendly territories.
 

--- a/game.test.js
+++ b/game.test.js
@@ -200,6 +200,32 @@ test('playing valid card set grants reinforcements', () => {
   expect(game.hands[0].length).toBe(0);
 });
 
+test('initialises with 1 human and 2 AI players and executes AI turn', () => {
+  const players = [
+    { name: 'Human', color: '#000000' },
+    { name: 'AI 1', color: '#2ecc71', ai: true },
+    { name: 'AI 2', color: '#2ecc71', ai: true }
+  ];
+  const g = new Game(players, mapMock.territories, mapMock.continents, mapMock.deck);
+  expect(g.players.filter(p => p.ai).length).toBe(2);
+  g.setCurrentPlayer(1);
+  g.performAITurn();
+  expect(g.getCurrentPlayer()).toBe(2);
+});
+
+test('initialises with three human players and no AI', () => {
+  const players = [
+    { name: 'P1', color: '#000000' },
+    { name: 'P2', color: '#111111' },
+    { name: 'P3', color: '#222222' }
+  ];
+  const g = new Game(players, mapMock.territories, mapMock.continents, mapMock.deck);
+  expect(g.players.every(p => !p.ai)).toBe(true);
+  const current = g.getCurrentPlayer();
+  g.performAITurn();
+  expect(g.getCurrentPlayer()).toBe(current);
+});
+
 test('players with no territories are skipped on turn rotation', () => {
   // Setup: player 1 has a single territory that will be conquered
   const t2 = game.territoryById('t2');

--- a/main.js
+++ b/main.js
@@ -121,15 +121,20 @@ async function loadGame() {
     }
   }
   if (!game) {
-    let players = null;
+    let players = [];
     if (typeof localStorage !== "undefined") {
       try {
-        players = JSON.parse(localStorage.getItem("netriskPlayers"));
+        players = JSON.parse(localStorage.getItem("netriskPlayers")) || [];
       } catch (err) {
-        players = null;
+        players = [];
       }
     }
-    game = new GameClass(players, map.territories, map.continents, map.deck);
+    game = new GameClass(
+      players.length ? players : null,
+      map.territories,
+      map.continents,
+      map.deck,
+    );
     if (typeof logger !== "undefined") {
       logger.info("Game initialised");
     }

--- a/setup.html
+++ b/setup.html
@@ -8,8 +8,12 @@
     <h1>Setup Giocatori</h1>
     <form id="setupForm">
       <label>
-        Numero giocatori:
-        <input type="number" id="playerCount" min="2" max="6" />
+        Numero giocatori umani:
+        <input type="number" id="humanCount" min="1" max="6" />
+      </label>
+      <label>
+        Numero giocatori IA:
+        <input type="number" id="aiCount" min="0" max="5" />
       </label>
       <div id="players"></div>
       <button type="submit">Start</button>

--- a/setup.js
+++ b/setup.js
@@ -1,10 +1,11 @@
 const form = document.getElementById("setupForm");
-const playerCountInput = document.getElementById("playerCount");
+const humanCountInput = document.getElementById("humanCount");
+const aiCountInput = document.getElementById("aiCount");
 const playersContainer = document.getElementById("players");
 
-function renderPlayerInputs(count) {
+function renderPlayerInputs(humanCount) {
   playersContainer.innerHTML = "";
-  for (let i = 0; i < count; i += 1) {
+  for (let i = 0; i < humanCount; i += 1) {
     const wrapper = document.createElement("div");
     wrapper.innerHTML = `
       <label>Nome Giocatore ${i + 1}: <input type="text" id="name${i}" /></label>
@@ -21,11 +22,17 @@ function loadFromStorage() {
   } catch (err) {
     saved = null;
   }
-  const count = saved ? saved.length : 3;
-  playerCountInput.value = count;
-  renderPlayerInputs(count);
+  let humanCount = 2;
+  let aiCount = 1;
+  if (saved && Array.isArray(saved)) {
+    humanCount = saved.filter((p) => !p.ai).length;
+    aiCount = saved.filter((p) => p.ai).length;
+  }
+  humanCountInput.value = humanCount;
+  aiCountInput.value = aiCount;
+  renderPlayerInputs(humanCount);
   if (saved) {
-    saved.forEach((p, i) => {
+    saved.filter((p) => !p.ai).forEach((p, i) => {
       const nameInput = document.getElementById(`name${i}`);
       const colorInput = document.getElementById(`color${i}`);
       if (nameInput) nameInput.value = p.name;
@@ -34,20 +41,24 @@ function loadFromStorage() {
   }
 }
 
-playerCountInput.addEventListener("change", () => {
-  const count = parseInt(playerCountInput.value, 10);
-  if (Number.isNaN(count) || count < 2) return;
+humanCountInput.addEventListener("change", () => {
+  const count = parseInt(humanCountInput.value, 10);
+  if (Number.isNaN(count) || count < 1) return;
   renderPlayerInputs(count);
 });
 
 form.addEventListener("submit", (e) => {
   e.preventDefault();
-  const count = parseInt(playerCountInput.value, 10);
+  const humanCount = parseInt(humanCountInput.value, 10) || 0;
+  const aiCount = parseInt(aiCountInput.value, 10) || 0;
   const players = [];
-  for (let i = 0; i < count; i += 1) {
+  for (let i = 0; i < humanCount; i += 1) {
     const name = document.getElementById(`name${i}`).value || `Player ${i + 1}`;
     const color = document.getElementById(`color${i}`).value || "#000000";
     players.push({ name, color });
+  }
+  for (let i = 0; i < aiCount; i += 1) {
+    players.push({ name: `AI ${i + 1}`, color: "#2ecc71", ai: true });
   }
   try {
     localStorage.setItem("netriskPlayers", JSON.stringify(players));


### PR DESCRIPTION
## Summary
- Allow selecting human and AI player counts in setup screen
- Load saved player types and initialize game accordingly
- Test game starts with different human/AI mixes and AI turns run

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf0db4fb4832c96d823c65c945faf