### PR TITLE
refactor: import Game module directly

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 /* global logger */
+import Game from "./game.js";
 import initTerritorySelection from "./territory-selection.js";
 import { playAttackSound, playConquerSound } from "./audio.js";
 import {
@@ -107,7 +108,11 @@ async function loadGame() {
     acc[t.id] = { x: t.x, y: t.y };
     return acc;
   }, {});
-  const GameClass = window.Game;
+  const GameClass =
+    (typeof window !== "undefined" && window.Game) || Game;
+  if (typeof GameClass !== "function") {
+    throw new Error("Game class not available");
+  }
   if (typeof localStorage !== "undefined") {
     try {
       const saved = localStorage.getItem("netriskGame");

--- a/main.test.js
+++ b/main.test.js
@@ -1,5 +1,4 @@
 const mapData = require('./src/data/map.json');
-const Game = require('./game');
 
 jest.mock('./territory-selection.js', () => jest.fn());
 
@@ -30,7 +29,6 @@ describe('main DOM interactions', () => {
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
     global.prompt = jest.fn(() => '1');
-    window.Game = Game;
     main = require('./main.js');
     ui = require('./ui.js');
     await Promise.resolve();
@@ -146,7 +144,6 @@ describe('main DOM interactions', () => {
       Promise.resolve({ json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
-    window.Game = Game;
     const main2 = require('./main.js');
     require('./ui.js');
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- import Game module in main script instead of relying on global
- add safe fallback if Game class is unavailable
- remove window.Game test assignments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf22b6210832c936877c51112dea9