### PR TITLE
refactor: switch Game to ES module

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-const { attackSuccessProbability, territoryPriority } = require("./ai");
+import { attackSuccessProbability, territoryPriority } from "./ai.js";
 
 class Game {
   constructor(players, territories, continents, deck) {
@@ -357,8 +357,4 @@ class Game {
   setSelectedFrom(s) { this.selectedFrom = s; }
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = Game;
-} else {
-  window.Game = Game;
-}
+export default Game;

--- a/game.test.js
+++ b/game.test.js
@@ -26,7 +26,7 @@ const mapMock = {
 beforeEach(() => {
   jest.resetModules();
   jest.doMock('./src/data/map.json', () => mapMock, { virtual: true });
-  Game = require('./game');
+  Game = require('./game.js').default;
   game = new Game();
 });
 


### PR DESCRIPTION
## Summary
- refactor game.js to use ES module imports and default export
- update tests to consume new default export

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf43950c8832caa854336707ccb3a