### PR TITLE
Refactor Game to receive map data

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,58 +1,67 @@
 import { attackSuccessProbability, territoryPriority } from "./ai.js";
 
+async function loadMapData() {
+  try {
+    if (typeof fetch === "function") {
+      const res = await fetch("./src/data/map.json");
+      if (res.ok) return await res.json();
+    }
+    const fs = await import("fs/promises");
+    const pathMod = await import("path");
+    const filePath = pathMod.resolve("src/data/map.json");
+    const data = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(data);
+  } catch {
+    return { territories: [], continents: [], deck: [] };
+  }
+}
+
 class Game {
-  constructor(players, territories, continents, deck) {
+  constructor(players, territories = [], continents = [], deck = [], shuffleDeck = true) {
     this.players = players || [
       { name: 'Player 1', color: '#e74c3c' },
       { name: 'Player 2', color: '#3498db' },
       { name: 'AI', color: '#2ecc71', ai: true }
     ];
 
-    let map;
-    if (!territories || !continents || !deck) {
-      try {
-        map = require('./src/data/map.json');
-      } catch (err) {
-        map = { territories: [], continents: [], deck: [] };
-      }
-    }
-
-    if (!territories) {
-      // Load default territory data from JSON when none provided
-      territories = map.territories.map((t, i) => ({
-        id: t.id,
-        neighbors: t.neighbors,
-        x: t.x,
-        y: t.y,
-        owner: Math.floor((i * this.players.length) / map.territories.length),
-        armies: 3,
-      }));
-    } else {
-      territories = territories.map((t, i) => ({
-        id: t.id,
-        neighbors: t.neighbors,
-        x: t.x,
-        y: t.y,
-        owner:
-          typeof t.owner === 'number'
-            ? t.owner
-            : Math.floor((i * this.players.length) / territories.length),
-        armies: t.armies || 3,
-      }));
-    }
+    const total = territories.length || 1;
+    territories = territories.map((t, i) => ({
+      id: t.id,
+      neighbors: t.neighbors,
+      x: t.x,
+      y: t.y,
+      owner:
+        typeof t.owner === "number"
+          ? t.owner
+          : Math.floor((i * this.players.length) / total),
+      armies: t.armies || 3,
+    }));
 
     this.territories = territories;
     this.currentPlayer = 0;
     this.phase = 'reinforce';
     this.selectedFrom = null;
     this.reinforcements = 0;
-    this.continents = continents || (map ? map.continents : []) || [];
-    this.deck = (deck || (map ? map.deck : []) || []).map(c => ({ ...c }));
-    if (!deck) this.shuffle(this.deck);
+    this.continents = continents;
+    this.deck = (deck || []).map((c) => ({ ...c }));
+    if (shuffleDeck) this.shuffle(this.deck);
     this.hands = Array.from({ length: this.players.length }, () => []);
     this.discard = [];
     this.conqueredThisTurn = false;
     this.calculateReinforcements();
+  }
+
+  static async create(players, territories, continents, deck) {
+    if (territories && continents && deck) {
+      return new Game(players, territories, continents, deck);
+    }
+    const map = await loadMapData();
+    return new Game(
+      players,
+      territories || map.territories,
+      continents || map.continents,
+      deck || map.deck
+    );
   }
 
   calculateReinforcements() {
@@ -337,7 +346,13 @@ class Game {
 
   static deserialize(str) {
     const data = typeof str === 'string' ? JSON.parse(str) : str;
-    const game = new Game(data.players, data.territories, data.continents, data.deck);
+    const game = new Game(
+      data.players,
+      data.territories,
+      data.continents,
+      data.deck,
+      false
+    );
     game.hands = data.hands;
     game.discard = data.discard || [];
     game.currentPlayer = data.currentPlayer;

--- a/game.test.js
+++ b/game.test.js
@@ -1,4 +1,6 @@
-let Game, game;
+import Game from "./game.js";
+
+let game;
 
 const mapMock = {
   territories: [
@@ -24,10 +26,7 @@ const mapMock = {
 };
 
 beforeEach(() => {
-  jest.resetModules();
-  jest.doMock('./src/data/map.json', () => mapMock, { virtual: true });
-  Game = require('./game.js').default;
-  game = new Game();
+  game = new Game(null, mapMock.territories, mapMock.continents, mapMock.deck, false);
 });
 
 test('reinforce phase allows adding army and moves to attack', () => {
@@ -90,7 +89,7 @@ test('calculateReinforcements enforces minimum of three armies', () => {
     { id: 'b', neighbors: [], owner: 0, armies: 1 },
     { id: 'c', neighbors: [], owner: 0, armies: 1 }
   ];
-  const g = new Game(null, territories);
+  const g = new Game(null, territories, [], [], false);
   expect(g.reinforcements).toBe(3);
 });
 
@@ -206,7 +205,7 @@ test('initialises with 1 human and 2 AI players and executes AI turn', () => {
     { name: 'AI 1', color: '#2ecc71', ai: true },
     { name: 'AI 2', color: '#2ecc71', ai: true }
   ];
-  const g = new Game(players, mapMock.territories, mapMock.continents, mapMock.deck);
+  const g = new Game(players, mapMock.territories, mapMock.continents, mapMock.deck, false);
   expect(g.players.filter(p => p.ai).length).toBe(2);
   g.setCurrentPlayer(1);
   g.performAITurn();
@@ -219,7 +218,7 @@ test('initialises with three human players and no AI', () => {
     { name: 'P2', color: '#111111' },
     { name: 'P3', color: '#222222' }
   ];
-  const g = new Game(players, mapMock.territories, mapMock.continents, mapMock.deck);
+  const g = new Game(players, mapMock.territories, mapMock.continents, mapMock.deck, false);
   expect(g.players.every(p => !p.ai)).toBe(true);
   const current = g.getCurrentPlayer();
   g.performAITurn();


### PR DESCRIPTION
## Summary
- load map data via parameters or dynamic import, eliminating `require`
- adjust tests to supply territory, continent, and deck data

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acff8be61c832c8c30f5510ac7741d