### PR TITLE
refactor: migrate AI helpers to ES modules

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -1,4 +1,4 @@
-function attackSuccessProbability(from, to) {
+export function attackSuccessProbability(from, to) {
   const attack = from.armies - 1;
   const defend = to.armies;
   if (attack <= 0) return 0;
@@ -7,7 +7,7 @@ function attackSuccessProbability(from, to) {
   return attackPower / (attackPower + defensePower);
 }
 
-function territoryPriority(game, territory) {
+export function territoryPriority(game, territory) {
   const enemyNeighbors = territory.neighbors.filter(id => {
     const neighbor = game.territoryById(id);
     return neighbor && neighbor.owner !== territory.owner;
@@ -15,4 +15,3 @@ function territoryPriority(game, territory) {
   return enemyNeighbors * 10 - territory.armies;
 }
 
-module.exports = { attackSuccessProbability, territoryPriority };

--- a/ai.test.js
+++ b/ai.test.js
@@ -1,4 +1,4 @@
-const { attackSuccessProbability, territoryPriority } = require('./ai');
+import { attackSuccessProbability, territoryPriority } from './ai.js';
 
 class MockGame {
   constructor(map) { this.map = map; }


### PR DESCRIPTION
## Summary
- refactor ai helper functions to use ES module named exports
- update ai tests to import helpers with ESM syntax

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3f1b2704832c88345382ff68313b