### PR TITLE
Handle invalid player colors in UI

### DIFF
--- a/main.test.js
+++ b/main.test.js
@@ -151,5 +151,12 @@ describe('main DOM interactions', () => {
     expect(main2.game.territoryById('t1').armies).toBe(armies);
     expect(main2.game.getPhase()).toBe(phase);
   });
+
+  test('invalid player color does not crash updateUI', () => {
+    const t1 = document.getElementById('t1');
+    main.game.players[0].color = '#notacolor';
+    expect(() => ui.updateUI()).not.toThrow();
+    expect(t1.style.background).toBe('');
+  });
 });
 

--- a/ui.js
+++ b/ui.js
@@ -115,7 +115,22 @@ function updateUI() {
   game.territories.forEach((t) => {
     const el = document.getElementById(t.id);
     if (!el) return;
-    el.style.background = game.players[t.owner].color;
+
+    const color = game.players[t.owner].color;
+    try {
+      if (
+        typeof CSS !== "undefined" &&
+        CSS.supports &&
+        CSS.supports("color", color)
+      ) {
+        el.style.background = color;
+      } else {
+        el.style.background = "";
+      }
+    } catch {
+      el.style.background = "";
+    }
+
     el.textContent = t.armies;
     const pos = territoryPositions[t.id];
     if (pos) {


### PR DESCRIPTION
## Summary
- avoid crashes when applying player colors by validating CSS color values before setting the background
- cover invalid-color scenario in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad41b6d380832ca33bf060eac89d12