### PR TITLE
Fix new game not starting

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,6 +88,18 @@ async function startNewGame() {
     localStorage.removeItem("netriskGame");
   }
   await loadGame();
+  // Re-render the board and reset any selection state so a fresh
+  // match begins. The territory selection module will recreate the
+  // SVG map, attach click handlers and call updateUI when done.
+  initTerritorySelection({
+    logger,
+    game,
+    territories: game.territories,
+    addLogEntry,
+    gameState,
+    attachTerritoryHandlers,
+    updateUI,
+  });
   gameState.turnNumber = 1;
   gameState.log = [];
   const logEl = document.getElementById("actionLog");


### PR DESCRIPTION
## Summary
- Reload territory selection and handlers when starting a new game so the board resets correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad43cd3e20832c95faedcfd4d01a6c