### PR TITLE
Add tests for audio and UI helpers

### DIFF
--- a/audio.test.js
+++ b/audio.test.js
@@ -1,0 +1,45 @@
+import * as audio from './audio.js';
+
+describe('audio helpers', () => {
+  test('playTone returns without error when window is undefined', () => {
+    const originalWindow = global.window;
+    // Simulate environment without window
+    // eslint-disable-next-line no-undefined
+    global.window = undefined;
+    expect(() => audio.playTone(440)).not.toThrow();
+    global.window = originalWindow;
+  });
+
+  test('playAttackSound does not throw', () => {
+    expect(() => audio.playAttackSound()).not.toThrow();
+  });
+
+  test('playConquerSound does not throw', () => {
+    expect(() => audio.playConquerSound()).not.toThrow();
+  });
+
+  test('playTone creates audio nodes when AudioContext is available', () => {
+    const originalWindow = global.window;
+    const mockCtx = {
+      createOscillator: () => ({
+        type: '',
+        frequency: { value: 0 },
+        connect: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn(),
+      }),
+      createGain: () => ({
+        connect: jest.fn(),
+        gain: {
+          setValueAtTime: jest.fn(),
+          exponentialRampToValueAtTime: jest.fn(),
+        },
+      }),
+      destination: {},
+      currentTime: 0,
+    };
+    global.window = { AudioContext: function () { return mockCtx; } };
+    expect(() => audio.playTone(440, 0.1)).not.toThrow();
+    global.window = originalWindow;
+  });
+});

--- a/main.test.js
+++ b/main.test.js
@@ -169,5 +169,20 @@ describe('main DOM interactions', () => {
     expect(localStorage.getItem('netriskPlayers')).toBeNull();
     expect(localStorage.getItem('netriskGame')).toBeNull();
   });
+
+  test('runAI processes AI turns', () => {
+    main.game.setCurrentPlayer(2); // ensure AI player
+    const perform = jest
+      .spyOn(main.game, 'performAITurn')
+      .mockImplementation(() => {
+        main.game.setPhase('gameover');
+      });
+    const uiSpy = jest.spyOn(ui, 'updateUI').mockImplementation(() => {});
+    main.runAI();
+    expect(perform).toHaveBeenCalled();
+    expect(uiSpy).toHaveBeenCalled();
+    perform.mockRestore();
+    uiSpy.mockRestore();
+  });
 });
 

--- a/ui.test.js
+++ b/ui.test.js
@@ -1,0 +1,79 @@
+import {
+  initUI,
+  getSelectedCards,
+  resetSelectedCards,
+  animateMove,
+  showVictoryModal,
+  updateBonusInfo,
+  updateCardsUI,
+} from './ui.js';
+
+describe('ui utilities', () => {
+  let game;
+  let gameState;
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="board"></div>
+      <div id="victoryModal"><div id="victoryTitle"></div><div id="victoryStats"></div></div>
+      <div id="bonusInfo"></div>
+      <div id="cards"></div>
+    `;
+    game = {
+      players: [
+        { name: 'P1', color: '#f00' },
+        { name: 'P2', color: '#0f0' }
+      ],
+      currentPlayer: 0,
+      territories: [
+        { id: 'from', owner: 0, armies: 1 },
+        { id: 'to', owner: 0, armies: 1 }
+      ],
+      hands: [[
+        { territory: 'x', type: 'infantry' },
+        { territory: 'y', type: 'cavalry' },
+        { territory: 'z', type: 'artillery' }
+      ]],
+      continents: [
+        { name: 'c1', territories: ['from'], bonus: 2 }
+      ],
+      territoryById: (id) => game.territories.find(t => t.id === id)
+    };
+    gameState = { currentPlayer: 0, turnNumber: 1, log: [] };
+    const territoryPositions = { from: { x: 0, y: 0 }, to: { x: 10, y: 10 } };
+    initUI({ game, gameState, territoryPositions });
+  });
+
+  test('getSelectedCards and resetSelectedCards', () => {
+    resetSelectedCards();
+    expect(getSelectedCards()).toEqual([]);
+  });
+
+  test('animateMove creates a token element', () => {
+    global.requestAnimationFrame = (cb) => cb();
+    animateMove('from', 'to');
+    const token = document.querySelector('.move-token');
+    expect(token).not.toBeNull();
+  });
+
+  test('showVictoryModal displays winner info', () => {
+    showVictoryModal(0);
+    const modal = document.getElementById('victoryModal');
+    expect(modal.classList.contains('show')).toBe(true);
+    expect(document.getElementById('victoryTitle').textContent).toContain('P1 ha vinto');
+  });
+
+  test('updateBonusInfo shows continent bonus', () => {
+    updateBonusInfo();
+    expect(document.getElementById('bonusInfo').textContent).toBe('Bonus: c1 +2');
+  });
+
+  test('updateCardsUI renders hand and tracks selection', () => {
+    updateCardsUI();
+    const cards = document.querySelectorAll('#cards .card');
+    expect(cards.length).toBe(3);
+    cards[0].dispatchEvent(new window.Event('click'));
+    expect(getSelectedCards()).toEqual([0]);
+    resetSelectedCards();
+    expect(getSelectedCards()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for audio helpers including playTone
- test UI utilities for cards, bonus, animations, and victory modal
- verify runAI handles AI turns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad497f849c832ca192b561120475e7