### PR TITLE
Enforce unique player colors and readable army counts

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -1,0 +1,28 @@
+const colorPalette = [
+  '#e6194b',
+  '#3cb44b',
+  '#ffe119',
+  '#0082c8',
+  '#f58231',
+  '#911eb4',
+  '#46f0f0',
+  '#f032e6',
+  '#d2f53c',
+  '#fabebe',
+  '#008080',
+  '#e6beff'
+];
+
+function getContrastingColor(hex) {
+  let c = hex.replace('#', '');
+  if (c.length === 3) {
+    c = c.split('').map((ch) => ch + ch).join('');
+  }
+  const r = parseInt(c.substring(0, 2), 16);
+  const g = parseInt(c.substring(2, 4), 16);
+  const b = parseInt(c.substring(4, 6), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 125 ? '#000000' : '#ffffff';
+}
+
+export { colorPalette, getContrastingColor };

--- a/game.js
+++ b/game.js
@@ -1,4 +1,5 @@
 import { attackSuccessProbability, territoryPriority } from "./ai.js";
+import { colorPalette } from "./colors.js";
 
 async function loadMapData() {
   try {
@@ -18,11 +19,12 @@ async function loadMapData() {
 
 class Game {
   constructor(players, territories = [], continents = [], deck = [], shuffleDeck = true) {
-    this.players = players || [
-      { name: 'Player 1', color: '#e74c3c' },
-      { name: 'Player 2', color: '#3498db' },
-      { name: 'AI', color: '#2ecc71', ai: true }
-    ];
+    this.players =
+      players || [
+        { name: 'Player 1', color: colorPalette[0] },
+        { name: 'Player 2', color: colorPalette[1] },
+        { name: 'AI', color: colorPalette[2], ai: true },
+      ];
 
     const total = territories.length || 1;
     territories = territories.map((t, i) => ({

--- a/main.test.js
+++ b/main.test.js
@@ -162,6 +162,16 @@ describe('main DOM interactions', () => {
     expect(t1.style.background).toBe('');
   });
 
+  test('army count text contrasts with player color', () => {
+    const t1 = document.getElementById('t1');
+    main.game.players[0].color = '#000000';
+    ui.updateUI();
+    expect(t1.style.color).toBe('rgb(255, 255, 255)');
+    main.game.players[0].color = '#ffffff';
+    ui.updateUI();
+    expect(t1.style.color).toBe('rgb(0, 0, 0)');
+  });
+
   test('startNewGame clears saved data', () => {
     localStorage.setItem('netriskPlayers', JSON.stringify([{ name: 'P1', color: '#000' }]));
     localStorage.setItem('netriskGame', 'dummy');

--- a/setup.js
+++ b/setup.js
@@ -1,3 +1,5 @@
+import { colorPalette } from "./colors.js";
+
 const form = document.getElementById("setupForm");
 const humanCountInput = document.getElementById("humanCount");
 const aiCountInput = document.getElementById("aiCount");
@@ -7,9 +9,15 @@ function renderPlayerInputs(humanCount) {
   playersContainer.innerHTML = "";
   for (let i = 0; i < humanCount; i += 1) {
     const wrapper = document.createElement("div");
+    const options = colorPalette
+      .map(
+        (c, idx) =>
+          `<option value="${c}" ${idx === i ? "selected" : ""}>${c}</option>`
+      )
+      .join("");
     wrapper.innerHTML = `
       <label>Nome Giocatore ${i + 1}: <input type="text" id="name${i}" /></label>
-      <label>Colore: <input type="color" id="color${i}" /></label>
+      <label>Colore: <select id="color${i}">${options}</select></label>
     `;
     playersContainer.appendChild(wrapper);
   }
@@ -52,13 +60,21 @@ form.addEventListener("submit", (e) => {
   const humanCount = parseInt(humanCountInput.value, 10) || 0;
   const aiCount = parseInt(aiCountInput.value, 10) || 0;
   const players = [];
+  const usedColors = new Set();
   for (let i = 0; i < humanCount; i += 1) {
     const name = document.getElementById(`name${i}`).value || `Player ${i + 1}`;
-    const color = document.getElementById(`color${i}`).value || "#000000";
+    const color = document.getElementById(`color${i}`).value || colorPalette[0];
+    if (usedColors.has(color)) {
+      window.alert("I colori dei giocatori devono essere unici");
+      return;
+    }
+    usedColors.add(color);
     players.push({ name, color });
   }
   for (let i = 0; i < aiCount; i += 1) {
-    players.push({ name: `AI ${i + 1}`, color: "#2ecc71", ai: true });
+    const color = colorPalette.find((c) => !usedColors.has(c)) || colorPalette[0];
+    usedColors.add(color);
+    players.push({ name: `AI ${i + 1}`, color, ai: true });
   }
   try {
     localStorage.setItem("netriskPlayers", JSON.stringify(players));

--- a/ui.js
+++ b/ui.js
@@ -1,3 +1,5 @@
+import { getContrastingColor } from "./colors.js";
+
 let game;
 let gameState;
 let territoryPositions = {};
@@ -117,18 +119,12 @@ function updateUI() {
     if (!el) return;
 
     const color = game.players[t.owner].color;
-    try {
-      if (
-        typeof CSS !== "undefined" &&
-        CSS.supports &&
-        CSS.supports("color", color)
-      ) {
-        el.style.background = color;
-      } else {
-        el.style.background = "";
-      }
-    } catch {
-      el.style.background = "";
+    el.style.background = "";
+    el.style.background = color;
+    if (el.style.background) {
+      el.style.color = getContrastingColor(color);
+    } else {
+      el.style.color = "";
     }
 
     el.textContent = t.armies;


### PR DESCRIPTION
## Summary
- provide a predefined color palette and enforce unique player colors
- color AI players from the same palette
- adjust army count text for contrast on territory backgrounds
- add test ensuring army numbers remain readable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad50c25c80832c80795a4bcd240afb