### PR TITLE
fix: include map data in build output

### DIFF
--- a/build.js
+++ b/build.js
@@ -31,8 +31,14 @@ for (const asset of assets) {
 }
 
 for (const asset of plainAssets) {
-  fs.copyFileSync(path.join(root, asset), path.join(dist, asset));
+  const srcPath = path.join(root, asset);
+  const destPath = path.join(dist, asset);
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  fs.copyFileSync(srcPath, destPath);
 }
+
+// Copy additional data files (e.g., map.json)
+fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });
 
 let indexHtml = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 

--- a/build.test.js
+++ b/build.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment node
+ */
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+describe('build script', () => {
+  beforeAll(() => {
+    execSync('node build.js');
+  });
+
+  afterAll(() => {
+    fs.rmSync(path.join(__dirname, 'dist'), { recursive: true, force: true });
+  });
+
+  test('copies map data file', () => {
+    const mapPath = path.join(__dirname, 'dist', 'src', 'data', 'map.json');
+    expect(fs.existsSync(mapPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- copy `src` directory into build output so map data is included
- add test ensuring map data is bundled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad54526aa8832caba49abca16ab192