### PR TITLE
feat: introduce plugin system with event bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ npm test
 npm run lint
 ```
 
+## Extensibility
+
+The core `Game` class exposes a lightweight event bus and plugin system to
+support game expansions. Plugins are simple functions that receive the game
+instance and can register handlers for events such as `reinforce`,
+`attackResolved` or `phaseChange`.
+
+```javascript
+import Game from './game.js';
+import loggerPlugin from './src/plugins/logger-plugin.js';
+
+const game = new Game();
+game.use(loggerPlugin);
+```
+
+This structure keeps the engine small while making it straightforward to add
+new behaviours or UI integrations without touching the core logic.
+
 ## UAT Debug
 
 The client exposes a basic logger wrapping the browser console with `info`, `warn` and `error` levels. An error overlay appears at the top of the page when an uncaught exception or unhandled promise rejection occurs.

--- a/event-bus.test.js
+++ b/event-bus.test.js
@@ -1,0 +1,25 @@
+import Game from "./game.js";
+
+describe('Event bus', () => {
+  const mapMock = {
+    territories: [
+      { id: 'a', neighbors: [], owner: 0, x: 0, y: 0 },
+      { id: 'b', neighbors: [], owner: 0, x: 0, y: 0 },
+    ],
+    continents: [],
+    deck: [],
+  };
+
+  test('plugin receives reinforce event', () => {
+    const game = new Game(null, mapMock.territories, mapMock.continents, mapMock.deck, false);
+    let called = false;
+    const plugin = (g) => {
+      g.on('reinforce', () => {
+        called = true;
+      });
+    };
+    game.use(plugin);
+    game.handleTerritoryClick('a');
+    expect(called).toBe(true);
+  });
+});

--- a/game.js
+++ b/game.js
@@ -1,5 +1,6 @@
 import { attackSuccessProbability, territoryPriority } from "./ai.js";
 import { colorPalette } from "./colors.js";
+import EventBus from "./src/core/event-bus.js";
 
 async function loadMapData() {
   try {
@@ -25,6 +26,8 @@ class Game {
         { name: 'Player 2', color: colorPalette[1] },
         { name: 'AI', color: colorPalette[2], ai: true },
       ];
+
+    this.events = new EventBus();
 
     const total = territories.length || 1;
     territories = territories.map((t, i) => ({
@@ -80,6 +83,10 @@ class Game {
       }
     });
     this.reinforcements = reinf;
+    this.emit('reinforcementsCalculated', {
+      player: this.currentPlayer,
+      amount: this.reinforcements,
+    });
   }
 
   territoryById(id) {
@@ -94,8 +101,10 @@ class Game {
       if (territory.owner === this.currentPlayer && this.reinforcements > 0) {
         territory.armies += 1;
         this.reinforcements -= 1;
+        this.emit('reinforce', { territory: id, player: this.currentPlayer });
         if (this.reinforcements === 0) {
           this.phase = 'attack';
+          this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
         }
         return { type: 'reinforce', territory: id };
       }
@@ -114,6 +123,7 @@ class Game {
         }
         if (from.owner === this.currentPlayer && to.owner !== this.currentPlayer && from.neighbors.includes(to.id)) {
           const result = this.attack(from, to);
+          this.emit('attack', { from: from.id, to: to.id, result });
           this.selectedFrom = null;
           return Object.assign({ type: 'attack', from: from.id, to: to.id }, result);
         }
@@ -172,7 +182,9 @@ class Game {
       this.conqueredThisTurn = true;
       this.checkVictory();
     }
-    return { attackRolls, defendRolls, conquered, movableArmies };
+    const result = { attackRolls, defendRolls, conquered, movableArmies };
+    this.emit('attackResolved', { from: from.id, to: to.id, result });
+    return result;
   }
 
   moveArmies(fromId, toId, count) {
@@ -184,6 +196,7 @@ class Game {
     if (count < 1 || from.armies <= count) return false;
     from.armies -= count;
     to.armies += count;
+    this.emit('move', { from: fromId, to: toId, count });
     return true;
   }
 
@@ -203,6 +216,7 @@ class Game {
     if (this.phase === 'attack') {
       this.selectedFrom = null;
       this.phase = 'fortify';
+      this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
     } else if (this.phase === 'fortify') {
       const prev = this.currentPlayer;
       this.selectedFrom = null;
@@ -211,11 +225,16 @@ class Game {
         this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
       } while (!this.territories.some(t => t.owner === this.currentPlayer));
       if (this.conqueredThisTurn) {
-        this.drawCard(prev);
+        const card = this.drawCard(prev);
         this.conqueredThisTurn = false;
+        if (card) {
+          this.emit('cardAwarded', { player: prev, card });
+        }
       }
       this.phase = 'reinforce';
       this.calculateReinforcements();
+      this.emit('turnStart', { player: this.currentPlayer });
+      this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
     }
   }
 
@@ -223,6 +242,7 @@ class Game {
     if (this.deck.length === 0) return null;
     const card = this.deck.shift();
     this.hands[player].push(card);
+    this.emit('cardDrawn', { player, card });
     return card;
   }
 
@@ -237,6 +257,7 @@ class Game {
     if (!allSame && !allDiff) return false;
     indices.sort((a, b) => b - a).forEach(i => this.discard.push(hand.splice(i, 1)[0]));
     this.reinforcements += 5;
+    this.emit('cardsPlayed', { player: this.currentPlayer, cards });
     return true;
   }
 
@@ -372,6 +393,24 @@ class Game {
   setCurrentPlayer(p) { this.currentPlayer = p; }
   getSelectedFrom() { return this.selectedFrom; }
   setSelectedFrom(s) { this.selectedFrom = s; }
+
+  on(event, handler) {
+    return this.events.on(event, handler);
+  }
+
+  off(event, handler) {
+    this.events.off(event, handler);
+  }
+
+  emit(event, payload) {
+    this.events.emit(event, payload);
+  }
+
+  use(plugin) {
+    if (typeof plugin === 'function') {
+      plugin(this);
+    }
+  }
 }
 
 export default Game;

--- a/src/core/event-bus.js
+++ b/src/core/event-bus.js
@@ -1,0 +1,36 @@
+class EventBus {
+  constructor() {
+    this.listeners = {};
+  }
+
+  on(event, handler) {
+    if (!this.listeners[event]) {
+      this.listeners[event] = new Set();
+    }
+    this.listeners[event].add(handler);
+    return () => this.off(event, handler);
+  }
+
+  off(event, handler) {
+    if (!this.listeners[event]) return;
+    this.listeners[event].delete(handler);
+    if (this.listeners[event].size === 0) {
+      delete this.listeners[event];
+    }
+  }
+
+  emit(event, payload) {
+    if (!this.listeners[event]) return;
+    for (const handler of [...this.listeners[event]]) {
+      try {
+        handler(payload);
+      } catch (err) {
+        // isolate handler errors
+        // eslint-disable-next-line no-console
+        console.error('Event handler error', err);
+      }
+    }
+  }
+}
+
+export default EventBus;

--- a/src/plugins/logger-plugin.js
+++ b/src/plugins/logger-plugin.js
@@ -1,0 +1,11 @@
+export default function loggerPlugin(game, logger = console) {
+  game.on('reinforce', ({ territory, player }) => {
+    logger.log(`Player ${player} reinforces ${territory}`);
+  });
+  game.on('attackResolved', ({ from, to, result }) => {
+    logger.log(`Attack from ${from} to ${to}`, result);
+  });
+  game.on('phaseChange', ({ phase, player }) => {
+    logger.log(`Player ${player} enters phase ${phase}`);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable `EventBus` utility and sample logger plugin
- integrate plugin-based event bus into `Game` for extensibility
- document plugin usage and verify events via new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad53cd0a20832c8471aca5322d3df1