### PR TITLE
Replace prompt with custom move modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 import Game from "./game.js";
 import initTerritorySelection from "./territory-selection.js";
 import { playAttackSound, playConquerSound } from "./audio.js";
+import askArmiesToMove from "./move-prompt.js";
 import {
   initUI,
   updateInfoPanel,
@@ -60,18 +61,6 @@ function updateGameState(selected = null) {
       }
     }
   }
-}
-
-function askArmiesToMove(max, min = 0) {
-  if (max <= 0) return 0;
-  let input = null;
-  if (typeof window !== "undefined" && typeof window.prompt === "function") {
-    input = window.prompt(`Quante armate spostare? (${min}-${max})`, String(max));
-  }
-  let count = parseInt(input, 10);
-  if (isNaN(count)) count = min;
-  count = Math.max(min, Math.min(max, count));
-  return count;
 }
 
 function checkForVictory() {
@@ -159,7 +148,7 @@ function runAI() {
 
 function attachTerritoryHandlers() {
   document.querySelectorAll(".territory").forEach((el) => {
-    el.addEventListener("click", () => {
+    el.addEventListener("click", async () => {
       if (typeof logger !== "undefined") {
         logger.info(`Territory clicked: ${el.dataset.id}`);
       }
@@ -187,7 +176,7 @@ function attachTerritoryHandlers() {
               playConquerSound();
               toEl.classList.add("conquer");
               setTimeout(() => toEl.classList.remove("conquer"), 1000);
-              const move = askArmiesToMove(result.movableArmies, 0);
+              const move = await askArmiesToMove(result.movableArmies, 0);
               if (move > 0) {
                 game.moveArmies(result.from, result.to, move);
                 addLogEntry(`${playerName} sposta ${move} da ${result.from} a ${result.to}`);
@@ -204,7 +193,7 @@ function attachTerritoryHandlers() {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
             }
-            const move = askArmiesToMove(result.movableArmies, 1);
+            const move = await askArmiesToMove(result.movableArmies, 1);
             if (move > 0) {
               game.moveArmies(result.from, result.to, move);
               addLogEntry(`${playerName} sposta ${move} da ${result.from} a ${result.to}`);

--- a/main.test.js
+++ b/main.test.js
@@ -1,6 +1,7 @@
 const mapData = require('./src/data/map.json');
 
 jest.mock('./territory-selection.js', () => jest.fn());
+jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
 
 describe('main DOM interactions', () => {
   let main;
@@ -28,7 +29,6 @@ describe('main DOM interactions', () => {
       Promise.resolve({ json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
-    global.prompt = jest.fn(() => '1');
     main = require('./main.js');
     ui = require('./ui.js');
     await Promise.resolve();
@@ -75,7 +75,7 @@ describe('main DOM interactions', () => {
     expect(t4.classList.contains('attack')).toBe(true);
   });
 
-  test('fortify moves army and updates status/log', () => {
+  test('fortify moves army and updates status/log', async () => {
     const t1 = document.getElementById('t1');
     const t2 = document.getElementById('t2');
     const log = document.getElementById('actionLog');
@@ -93,6 +93,7 @@ describe('main DOM interactions', () => {
     t1.click();
     expect(t1.classList.contains('selected')).toBe(true);
     t2.click();
+    await Promise.resolve();
     expect(log.textContent).toContain('sposta 1 da t1 a t2');
     expect(status.textContent).toContain('reinforce');
     expect(t1.classList.contains('selected')).toBe(false);

--- a/move-prompt.js
+++ b/move-prompt.js
@@ -1,0 +1,30 @@
+function askArmiesToMove(max, min = 0) {
+  return new Promise((resolve) => {
+    if (max <= 0) {
+      resolve(0);
+      return;
+    }
+    const modal = document.createElement('div');
+    modal.id = 'moveArmiesModal';
+    modal.className = 'modal';
+    modal.innerHTML = `
+      <div class="modal-content">
+        <label>Quante armate spostare? (${min}-${max})</label>
+        <input type="number" id="moveArmiesInput" min="${min}" max="${max}" value="${max}" />
+        <button id="moveArmiesOk">OK</button>
+      </div>`;
+    document.body.appendChild(modal);
+    modal.classList.add('show');
+    const input = modal.querySelector('#moveArmiesInput');
+    const btn = modal.querySelector('#moveArmiesOk');
+    btn.addEventListener('click', () => {
+      let count = parseInt(input.value, 10);
+      if (isNaN(count)) count = min;
+      count = Math.max(min, Math.min(max, count));
+      modal.remove();
+      resolve(count);
+    });
+  });
+}
+
+export default askArmiesToMove;


### PR DESCRIPTION
## Summary
- replace blocking `window.prompt` with custom modal for selecting armies to move
- adjust territory click handler to await modal response
- mock new modal in tests and handle async flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad57568960832ca97d6573ece6c5f2