### PR TITLE
Refactor startNewGame navigation for testability

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import Game from "./game.js";
 import initTerritorySelection from "./territory-selection.js";
 import { playAttackSound, playConquerSound } from "./audio.js";
 import askArmiesToMove from "./move-prompt.js";
+import { navigateTo } from "./navigation.js";
 import {
   initUI,
   updateInfoPanel,
@@ -77,13 +78,7 @@ async function startNewGame() {
     localStorage.removeItem("netriskGame");
     localStorage.removeItem("netriskPlayers");
   }
-  if (typeof window !== "undefined") {
-    if (typeof window.location.assign === "function") {
-      window.location.assign("setup.html");
-    } else {
-      window.location.href = "setup.html";
-    }
-  }
+  navigateTo("setup.html");
 }
 
 async function loadGame() {

--- a/main.test.js
+++ b/main.test.js
@@ -2,6 +2,7 @@ const mapData = require('./src/data/map.json');
 
 jest.mock('./territory-selection.js', () => jest.fn());
 jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
+jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
 
 describe('main DOM interactions', () => {
   let main;
@@ -179,6 +180,8 @@ describe('main DOM interactions', () => {
     expect(() => main.startNewGame()).not.toThrow();
     expect(localStorage.getItem('netriskPlayers')).toBeNull();
     expect(localStorage.getItem('netriskGame')).toBeNull();
+    const navigation = require('./navigation.js');
+    expect(navigation.navigateTo).toHaveBeenCalledWith('setup.html');
   });
 
   test('runAI processes AI turns', () => {

--- a/navigation.js
+++ b/navigation.js
@@ -1,0 +1,11 @@
+export function navigateTo(url) {
+  if (typeof window !== "undefined") {
+    if (typeof window.location.assign === "function") {
+      window.location.assign(url);
+    } else {
+      window.location.href = url;
+    }
+  }
+}
+
+export default { navigateTo };


### PR DESCRIPTION
## Summary
- Add navigation wrapper module to handle redirects
- Refactor `startNewGame` to use navigation wrapper
- Mock navigation in tests to avoid unwanted page redirects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad58a29408832c8e1564152dc994ed