### PR TITLE
refactor: run AI asynchronously

### DIFF
--- a/main.js
+++ b/main.js
@@ -132,12 +132,15 @@ async function loadGame() {
 }
 
 function runAI() {
-  while (
+  if (
     game.players[game.currentPlayer].ai &&
     game.getPhase() !== "gameover"
   ) {
-    game.performAITurn();
-    updateUI();
+    setTimeout(() => {
+      game.performAITurn();
+      updateUI();
+      runAI();
+    }, 0);
   }
 }
 

--- a/main.test.js
+++ b/main.test.js
@@ -193,6 +193,7 @@ describe('main DOM interactions', () => {
       });
     const uiSpy = jest.spyOn(ui, 'updateUI').mockImplementation(() => {});
     main.runAI();
+    jest.runOnlyPendingTimers();
     expect(perform).toHaveBeenCalled();
     expect(uiSpy).toHaveBeenCalled();
     perform.mockRestore();


### PR DESCRIPTION
## Summary
- make `runAI` process turns asynchronously to prevent long blocking loops
- adjust tests to handle async AI execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad59e290e8832ca232cf8ccf178f80