### PR TITLE
refactor: centralize phase constants

### DIFF
--- a/event-bus.test.js
+++ b/event-bus.test.js
@@ -1,4 +1,5 @@
 import Game from "./game.js";
+import { REINFORCE } from "./phases.js";
 
 describe('Event bus', () => {
   const mapMock = {
@@ -14,7 +15,7 @@ describe('Event bus', () => {
     const game = new Game(null, mapMock.territories, mapMock.continents, mapMock.deck, false);
     let called = false;
     const plugin = (g) => {
-      g.on('reinforce', () => {
+      g.on(REINFORCE, () => {
         called = true;
       });
     };

--- a/game.js
+++ b/game.js
@@ -1,4 +1,10 @@
 import { attackSuccessProbability, territoryPriority } from "./ai.js";
+import {
+  REINFORCE,
+  ATTACK,
+  FORTIFY,
+  GAME_OVER,
+} from "./phases.js";
 import { colorPalette } from "./colors.js";
 import EventBus from "./src/core/event-bus.js";
 
@@ -44,7 +50,7 @@ class Game {
 
     this.territories = territories;
     this.currentPlayer = 0;
-    this.phase = 'reinforce';
+    this.phase = REINFORCE;
     this.selectedFrom = null;
     this.reinforcements = 0;
     this.continents = continents;
@@ -97,18 +103,18 @@ class Game {
     const territory = this.territoryById(id);
     if (!territory) return null;
 
-    if (this.phase === 'reinforce') {
+    if (this.phase === REINFORCE) {
       if (territory.owner === this.currentPlayer && this.reinforcements > 0) {
         territory.armies += 1;
         this.reinforcements -= 1;
-        this.emit('reinforce', { territory: id, player: this.currentPlayer });
+        this.emit(REINFORCE, { territory: id, player: this.currentPlayer });
         if (this.reinforcements === 0) {
-          this.phase = 'attack';
+          this.phase = ATTACK;
           this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
         }
-        return { type: 'reinforce', territory: id };
+        return { type: REINFORCE, territory: id };
       }
-    } else if (this.phase === 'attack') {
+    } else if (this.phase === ATTACK) {
       if (!this.selectedFrom) {
         if (territory.owner === this.currentPlayer && territory.armies > 1) {
           this.selectedFrom = territory;
@@ -123,12 +129,12 @@ class Game {
         }
         if (from.owner === this.currentPlayer && to.owner !== this.currentPlayer && from.neighbors.includes(to.id)) {
           const result = this.attack(from, to);
-          this.emit('attack', { from: from.id, to: to.id, result });
+          this.emit(ATTACK, { from: from.id, to: to.id, result });
           this.selectedFrom = null;
-          return Object.assign({ type: 'attack', from: from.id, to: to.id }, result);
+          return Object.assign({ type: ATTACK, from: from.id, to: to.id }, result);
         }
       }
-    } else if (this.phase === 'fortify') {
+    } else if (this.phase === FORTIFY) {
       if (!this.selectedFrom) {
         if (territory.owner === this.currentPlayer && territory.armies > 1) {
           this.selectedFrom = territory;
@@ -148,7 +154,7 @@ class Game {
         ) {
           const movable = from.armies - 1;
           this.selectedFrom = null;
-          return { type: 'fortify', from: from.id, to: to.id, movableArmies: movable };
+          return { type: FORTIFY, from: from.id, to: to.id, movableArmies: movable };
         }
       }
     }
@@ -204,7 +210,7 @@ class Game {
     const owner = this.territories[0].owner;
     const win = this.territories.every(t => t.owner === owner);
     if (win) {
-      this.phase = 'gameover';
+      this.phase = GAME_OVER;
       this.winner = owner;
       return owner;
     }
@@ -212,12 +218,12 @@ class Game {
   }
 
   endTurn() {
-    if (this.phase === 'gameover') return;
-    if (this.phase === 'attack') {
+    if (this.phase === GAME_OVER) return;
+    if (this.phase === ATTACK) {
       this.selectedFrom = null;
-      this.phase = 'fortify';
+      this.phase = FORTIFY;
       this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
-    } else if (this.phase === 'fortify') {
+    } else if (this.phase === FORTIFY) {
       const prev = this.currentPlayer;
       this.selectedFrom = null;
       // Move to the next player, skipping any who have been eliminated
@@ -231,7 +237,7 @@ class Game {
           this.emit('cardAwarded', { player: prev, card });
         }
       }
-      this.phase = 'reinforce';
+      this.phase = REINFORCE;
       this.calculateReinforcements();
       this.emit('turnStart', { player: this.currentPlayer });
       this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
@@ -284,7 +290,7 @@ class Game {
   }
 
   performAITurn() {
-    if (!this.players[this.currentPlayer].ai || this.phase === 'gameover') return;
+    if (!this.players[this.currentPlayer].ai || this.phase === GAME_OVER) return;
     // Play cards if possible
     const hand = this.hands[this.currentPlayer];
     const set = this.findValidSet(hand);
@@ -301,12 +307,12 @@ class Game {
       target.armies += 1;
       this.reinforcements -= 1;
     }
-    if (this.phase === 'reinforce' && this.reinforcements === 0) {
-      this.phase = 'attack';
+    if (this.phase === REINFORCE && this.reinforcements === 0) {
+      this.phase = ATTACK;
     }
 
     // Attack while probabilities favorable
-    while (this.phase === 'attack') {
+    while (this.phase === ATTACK) {
       const options = [];
       this.territories
         .filter(t => t.owner === this.currentPlayer && t.armies > 1)
@@ -324,12 +330,12 @@ class Game {
       const best = options[0];
       if (best.prob < 0.6) break;
       this.attack(best.from, best.to);
-      if (this.phase === 'gameover') return;
+      if (this.phase === GAME_OVER) return;
     }
 
     // Fortify one army from strong to weak border
     this.endTurn();
-    if (this.phase === 'fortify') {
+    if (this.phase === FORTIFY) {
       let best = null;
       const aiOwned = this.territories.filter(t => t.owner === this.currentPlayer);
       aiOwned.forEach(from => {

--- a/game.test.js
+++ b/game.test.js
@@ -1,4 +1,5 @@
 import Game from "./game.js";
+import { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "./phases.js";
 
 let game;
 
@@ -35,7 +36,7 @@ test('reinforce phase allows adding army and moves to attack', () => {
   game.handleTerritoryClick('t1');
   game.handleTerritoryClick('t1');
   expect(game.territories[0].armies).toBe(initial + 3);
-  expect(game.getPhase()).toBe('attack');
+  expect(game.getPhase()).toBe(ATTACK);
 });
 
 test('attack phase resolves battle between territories', () => {
@@ -51,12 +52,12 @@ test('attack phase resolves battle between territories', () => {
   game.handleTerritoryClick('t1');
   game.handleTerritoryClick('t4');
   expect(game.territories[3].armies).toBe(2);
-  expect(game.getPhase()).toBe('attack');
+  expect(game.getPhase()).toBe(ATTACK);
   Math.random.mockRestore();
 });
 
 test('attack returns movable armies after conquest and moveArmies transfers them', () => {
-  game.setPhase('attack');
+  game.setPhase(ATTACK);
   const from = game.territoryById('t2');
   const to = game.territoryById('t3');
   from.armies = 5;
@@ -79,7 +80,7 @@ test('attack returns movable armies after conquest and moveArmies transfers them
 test('gameover phase when one player owns all territories', () => {
   game.territories.forEach(t => { t.owner = 0; });
   game.checkVictory();
-  expect(game.getPhase()).toBe('gameover');
+  expect(game.getPhase()).toBe(GAME_OVER);
   expect(game.winner).toBe(0);
 });
 
@@ -97,11 +98,11 @@ test('endTurn moves from attack to fortify then to next player', () => {
   game.handleTerritoryClick('t1');
   game.handleTerritoryClick('t1');
   game.handleTerritoryClick('t1');
-  expect(game.getPhase()).toBe('attack');
+  expect(game.getPhase()).toBe(ATTACK);
   game.endTurn();
-  expect(game.getPhase()).toBe('fortify');
+  expect(game.getPhase()).toBe(FORTIFY);
   game.endTurn();
-  expect(game.getPhase()).toBe('reinforce');
+  expect(game.getPhase()).toBe(REINFORCE);
   expect(game.getCurrentPlayer()).toBe(1);
 });
 
@@ -134,7 +135,7 @@ test('AI plays cards before reinforcing', () => {
 
 test('AI chooses attacks with highest probability', () => {
   game.setCurrentPlayer(2);
-  game.setPhase('attack');
+  game.setPhase(ATTACK);
   game.reinforcements = 0;
   const t5 = game.territoryById('t5'); t5.owner = 2; t5.armies = 5;
   const t2 = game.territoryById('t2'); t2.owner = 0; t2.armies = 1;
@@ -150,7 +151,7 @@ test('AI chooses attacks with highest probability', () => {
 
 test('AI fortifies toward strategic territory', () => {
   game.setCurrentPlayer(2);
-  game.setPhase('attack');
+  game.setPhase(ATTACK);
   game.reinforcements = 0;
   const t5 = game.territoryById('t5'); t5.owner = 2; t5.armies = 3;
   const t6 = game.territoryById('t6'); t6.owner = 2; t6.armies = 3;
@@ -168,7 +169,7 @@ test('continent bonus is added to reinforcements', () => {
 });
 
 test('player draws a card after conquering a territory', () => {
-  game.setPhase('attack');
+  game.setPhase(ATTACK);
   const from = game.territoryById('t2');
   const to = game.territoryById('t3');
   from.armies = 5;
@@ -233,7 +234,7 @@ test('players with no territories are skipped on turn rotation', () => {
   t2.armies = 5; // attacker
   t3.owner = 1; t3.armies = 1; // defender's last territory
   t4.owner = 2; // ensure player 1 has no other territories
-  game.setPhase('attack');
+  game.setPhase(ATTACK);
   // Ensure deterministic conquest
   jest.spyOn(Math, 'random').mockReturnValueOnce(0.9)
     .mockReturnValueOnce(0.9)
@@ -246,7 +247,7 @@ test('players with no territories are skipped on turn rotation', () => {
   game.endTurn(); // to next player
   // Player 1 had no territories, so it should now be player 2's turn
   expect(game.getCurrentPlayer()).toBe(2);
-  expect(game.getPhase()).toBe('reinforce');
+  expect(game.getPhase()).toBe(REINFORCE);
 });
 
 test('serialize and deserialize restores game state', () => {

--- a/main.js
+++ b/main.js
@@ -5,6 +5,12 @@ import { playAttackSound, playConquerSound } from "./audio.js";
 import askArmiesToMove from "./move-prompt.js";
 import { navigateTo } from "./navigation.js";
 import {
+  REINFORCE,
+  ATTACK,
+  FORTIFY,
+  GAME_OVER,
+} from "./phases.js";
+import {
   initUI,
   updateInfoPanel,
   addLogEntry,
@@ -43,7 +49,7 @@ const gameState = {
   territories: [],
   selectedTerritory: null,
   tokenPosition: null,
-  phase: "reinforce",
+  phase: REINFORCE,
   log: [],
 };
 
@@ -134,7 +140,7 @@ async function loadGame() {
 function runAI() {
   if (
     game.players[game.currentPlayer].ai &&
-    game.getPhase() !== "gameover"
+    game.getPhase() !== GAME_OVER
   ) {
     setTimeout(() => {
       game.performAITurn();
@@ -155,7 +161,7 @@ function attachTerritoryHandlers() {
         const result = game.handleTerritoryClick(el.dataset.id);
         if (result) {
           const playerName = game.players[prevPlayer].name;
-          if (result.type === "attack") {
+          if (result.type === ATTACK) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} attacks ${result.to} from ${result.from}`);
             }
@@ -182,12 +188,12 @@ function attachTerritoryHandlers() {
               }
             }
             addLogEntry(`${playerName} attacca ${result.to} da ${result.from}`);
-          } else if (result.type === "reinforce") {
+          } else if (result.type === REINFORCE) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} reinforces ${result.territory}`);
             }
             addLogEntry(`${playerName} rinforza ${result.territory}`);
-          } else if (result.type === "fortify") {
+          } else if (result.type === FORTIFY) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
             }
@@ -236,12 +242,12 @@ document.getElementById("endTurn").addEventListener("click", () => {
     const prevPlayer = game.currentPlayer;
     const prevPhase = game.getPhase();
     game.endTurn();
-    if (prevPhase === "attack" && game.getPhase() === "fortify") {
+    if (prevPhase === ATTACK && game.getPhase() === FORTIFY) {
       addLogEntry(`${game.players[prevPlayer].name} passa alla fase fortificazioni`);
       if (typeof logger !== "undefined") {
         logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
       }
-    } else if (prevPhase === "fortify" && game.getPhase() === "reinforce") {
+    } else if (prevPhase === FORTIFY && game.getPhase() === REINFORCE) {
       gameState.turnNumber += 1;
       addLogEntry(
         `${game.players[prevPlayer].name} termina il turno. Ora tocca a ${game.players[game.currentPlayer].name}`,

--- a/main.test.js
+++ b/main.test.js
@@ -1,4 +1,5 @@
 const mapData = require('./src/data/map.json');
+const { REINFORCE, ATTACK, FORTIFY, GAME_OVER } = require('./phases.js');
 
 jest.mock('./territory-selection.js', () => jest.fn());
 jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
@@ -51,11 +52,11 @@ describe('main DOM interactions', () => {
 
     t1.click();
     expect(log.textContent).toContain('rinforza t1');
-    expect(status.textContent).toContain('reinforce');
+    expect(status.textContent).toContain(REINFORCE);
 
     t1.click();
     t1.click();
-    expect(status.textContent).toContain('attack');
+    expect(status.textContent).toContain(ATTACK);
   });
 
   test('attack updates log and highlights', () => {
@@ -96,7 +97,7 @@ describe('main DOM interactions', () => {
     t2.click();
     await Promise.resolve();
     expect(log.textContent).toContain('sposta 1 da t1 a t2');
-    expect(status.textContent).toContain('reinforce');
+    expect(status.textContent).toContain(REINFORCE);
     expect(t1.classList.contains('selected')).toBe(false);
   });
 
@@ -111,12 +112,12 @@ describe('main DOM interactions', () => {
     t1.click();
 
     endTurnBtn.click();
-    expect(status.textContent).toContain('fortify');
+    expect(status.textContent).toContain(FORTIFY);
 
     endTurnBtn.click();
     expect(log.textContent).toContain('termina il turno');
     expect(status.textContent).toContain('Player 2');
-    expect(status.textContent).toContain('reinforce');
+    expect(status.textContent).toContain(REINFORCE);
   });
 
   test('state is saved and restored from localStorage', async () => {
@@ -189,7 +190,7 @@ describe('main DOM interactions', () => {
     const perform = jest
       .spyOn(main.game, 'performAITurn')
       .mockImplementation(() => {
-        main.game.setPhase('gameover');
+        main.game.setPhase(GAME_OVER);
       });
     const uiSpy = jest.spyOn(ui, 'updateUI').mockImplementation(() => {});
     main.runAI();

--- a/phases.js
+++ b/phases.js
@@ -1,0 +1,15 @@
+export const PHASES = Object.freeze({
+  REINFORCE: 'reinforce',
+  ATTACK: 'attack',
+  FORTIFY: 'fortify',
+  GAME_OVER: 'gameover',
+});
+
+export const {
+  REINFORCE,
+  ATTACK,
+  FORTIFY,
+  GAME_OVER,
+} = PHASES;
+
+export default PHASES;

--- a/src/plugins/logger-plugin.js
+++ b/src/plugins/logger-plugin.js
@@ -1,5 +1,7 @@
+import { REINFORCE } from "../../phases.js";
+
 export default function loggerPlugin(game, logger = console) {
-  game.on('reinforce', ({ territory, player }) => {
+  game.on(REINFORCE, ({ territory, player }) => {
     logger.log(`Player ${player} reinforces ${territory}`);
   });
   game.on('attackResolved', ({ from, to, result }) => {

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -1,3 +1,5 @@
+import { ATTACK, FORTIFY } from "./phases.js";
+
 export default function initTerritorySelection({
   logger,
   game,
@@ -33,7 +35,7 @@ export default function initTerritorySelection({
   function moveToken(el) {
     if (!el) return;
     const phase = game?.getPhase();
-    if (phase && !["attack", "fortify"].includes(phase)) {
+    if (phase && ![ATTACK, FORTIFY].includes(phase)) {
       addLogEntry?.(`Movimento non consentito nella fase ${phase}`);
       return;
     }

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,5 @@
 import { getContrastingColor } from "./colors.js";
+import { REINFORCE } from "./phases.js";
 
 let game;
 let gameState;
@@ -136,7 +137,7 @@ function updateUI() {
     el.classList.remove("selected");
   });
   let status = `${game.players[game.currentPlayer].name} - ${game.getPhase()}`;
-  if (game.getPhase() === "reinforce") {
+  if (game.getPhase() === REINFORCE) {
     status += ` (${game.reinforcements} reinforcements)`;
   }
   document.getElementById("status").textContent = status;


### PR DESCRIPTION
## Summary
- consolidate phase strings into shared constants
- replace magic phase strings across codebase and tests
- update imports and event listeners to use new constants

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5ae49914832c912a1487fd3e33e4