### PR TITLE
Add error handling for map fetch in loadGame

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,8 +88,22 @@ async function startNewGame() {
 }
 
 async function loadGame() {
-  const res = await fetch("./src/data/map.json");
-  const map = await res.json();
+  let map;
+  try {
+    const res = await fetch("./src/data/map.json");
+    if (!res.ok) {
+      throw new Error(`Failed to fetch map data: ${res.status}`);
+    }
+    map = await res.json();
+  } catch (err) {
+    if (typeof logger !== "undefined") {
+      logger.error("Failed to load map data", err);
+    }
+    if (typeof alert !== "undefined") {
+      alert("Unable to load game data. Please try again later.");
+    }
+    return;
+  }
   territoryPositions = map.territories.reduce((acc, t) => {
     acc[t.id] = { x: t.x, y: t.y };
     return acc;

--- a/main.test.js
+++ b/main.test.js
@@ -28,7 +28,7 @@ describe('main DOM interactions', () => {
       <div id="t5" class="territory" data-id="t5"></div>
       <div id="t6" class="territory" data-id="t6"></div>`;
     global.fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve(mapData) })
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
     main = require('./main.js');
@@ -147,7 +147,7 @@ describe('main DOM interactions', () => {
       <div id="t5" class="territory" data-id="t5"></div>
       <div id="t6" class="territory" data-id="t6"></div>`;
     global.fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve(mapData) })
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
     const main2 = require('./main.js');


### PR DESCRIPTION
## Summary
- Handle map data fetch failures in `loadGame` with try/catch and user notification
- Update tests to mock successful fetch responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5f23bd04832c8f4c7eb88827355b