### PR TITLE
Handle empty territory list in victory check

### DIFF
--- a/game.js
+++ b/game.js
@@ -207,7 +207,9 @@ class Game {
   }
 
   checkVictory() {
+    if (this.territories.length === 0) return null;
     const owner = this.territories[0].owner;
+    if (owner === undefined) return null;
     const win = this.territories.every(t => t.owner === owner);
     if (win) {
       this.phase = GAME_OVER;

--- a/game.test.js
+++ b/game.test.js
@@ -84,6 +84,12 @@ test('gameover phase when one player owns all territories', () => {
   expect(game.winner).toBe(0);
 });
 
+test('checkVictory returns null when there are no territories', () => {
+  const g = new Game(null, [], [], [], false);
+  expect(() => g.checkVictory()).not.toThrow();
+  expect(g.checkVictory()).toBeNull();
+});
+
 test('calculateReinforcements enforces minimum of three armies', () => {
   const territories = [
     { id: 'a', neighbors: [], owner: 0, armies: 1 },


### PR DESCRIPTION
## Summary
- Avoid accessing first territory when list is empty
- Skip declaring victory when no territories exist
- Add regression test for checkVictory with no territories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad600d14c8832caffe6136fe950d56