### PR TITLE
feat: use real dice odds for attack

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -1,10 +1,74 @@
+const battleCache = {};
+
+function enumerateRolls(dice) {
+  const rolls = [];
+  const recur = (arr, depth) => {
+    if (depth === dice) {
+      rolls.push([...arr]);
+      return;
+    }
+    for (let i = 1; i <= 6; i++) {
+      arr[depth] = i;
+      recur(arr, depth + 1);
+    }
+  };
+  recur([], 0);
+  return rolls;
+}
+
+function battleOutcomeProbs(attDice, defDice) {
+  const key = `${attDice}v${defDice}`;
+  if (battleCache[key]) return battleCache[key];
+  const aRolls = enumerateRolls(attDice);
+  const dRolls = enumerateRolls(defDice);
+  const outcomes = {};
+  for (const a of aRolls) {
+    const aSorted = [...a].sort((x, y) => y - x);
+    for (const d of dRolls) {
+      const dSorted = [...d].sort((x, y) => y - x);
+      const comparisons = Math.min(attDice, defDice);
+      let attLoss = 0;
+      let defLoss = 0;
+      for (let i = 0; i < comparisons; i++) {
+        if (aSorted[i] > dSorted[i]) defLoss++;
+        else attLoss++;
+      }
+      const outcomeKey = `${attLoss}-${defLoss}`;
+      outcomes[outcomeKey] = (outcomes[outcomeKey] || 0) + 1;
+    }
+  }
+  const total = Math.pow(6, attDice + defDice);
+  const result = Object.entries(outcomes).map(([k, count]) => {
+    const [attLoss, defLoss] = k.split('-').map(Number);
+    return { attLoss, defLoss, prob: count / total };
+  });
+  battleCache[key] = result;
+  return result;
+}
+
 export function attackSuccessProbability(from, to) {
   const attack = from.armies - 1;
   const defend = to.armies;
   if (attack <= 0) return 0;
-  const attackPower = attack;
-  const defensePower = defend * 1.5; // defense advantage
-  return attackPower / (attackPower + defensePower);
+
+  const memo = new Map();
+  const winProb = (att, def) => {
+    if (def <= 0) return 1;
+    if (att <= 0) return 0;
+    const key = `${att},${def}`;
+    if (memo.has(key)) return memo.get(key);
+    const attDice = Math.min(3, att);
+    const defDice = Math.min(2, def);
+    let prob = 0;
+    for (const outcome of battleOutcomeProbs(attDice, defDice)) {
+      prob +=
+        outcome.prob * winProb(att - outcome.attLoss, def - outcome.defLoss);
+    }
+    memo.set(key, prob);
+    return prob;
+  };
+
+  return winProb(attack, defend);
 }
 
 export function territoryPriority(game, territory) {

--- a/ai.test.js
+++ b/ai.test.js
@@ -11,6 +11,11 @@ test('attackSuccessProbability favors larger armies', () => {
   expect(high).toBeGreaterThan(low);
 });
 
+test('attackSuccessProbability matches simple dice odds', () => {
+  const prob = attackSuccessProbability({ armies: 2 }, { armies: 1 });
+  expect(prob).toBeCloseTo(5 / 12, 5);
+});
+
 test('territoryPriority increases with enemy neighbors', () => {
   const map = {
     b: { owner: 1 },


### PR DESCRIPTION
## Summary
- replace linear attack success estimate with recursive simulation of Risk dice outcomes
- add unit test validating odds for a simple 1v1 battle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad61f9541c832ca1efe6286d995fd8