### PR TITLE
Switch UI to English for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple browser-based strategy game inspired by the classic game of Risk.
 
-Use the setup interface (`setup.html` or the "Imposta giocatori" link on the
+Use the setup interface (`setup.html` or the "Set up players" link on the
 main page) to choose how many human players and AI opponents participate in
 each match, making both solo and multiplayer games possible.
 Reinforcements are calculated based on the number

--- a/index.html
+++ b/index.html
@@ -8,22 +8,22 @@
   </head>
   <body>
     <h1>NetRisk</h1>
-    <div><a href="setup.html">Imposta giocatori</a></div>
+    <div><a href="setup.html">Set up players</a></div>
     <div id="uiPanel">
-      <div>Turno corrente: <span id="turnNumber">1</span></div>
-      <div>Giocatore corrente: <span id="currentPlayer"></span></div>
+      <div>Current turn: <span id="turnNumber">1</span></div>
+      <div>Current player: <span id="currentPlayer"></span></div>
       <div id="howToPlayBox">
         <div>
-          <strong>Come si gioca (alpha)</strong>
-          <a href="#" id="toggleHowToPlay">Mostra dettagli</a>
+          <strong>How to play (alpha)</strong>
+          <a href="#" id="toggleHowToPlay">Show details</a>
         </div>
         <ol id="howToPlaySteps" style="display: none">
-          <li>Clicca un territorio / Click a territory</li>
-          <li>Scegli l'azione / Choose action</li>
-          <li>Premi "End Turn" / Press "End Turn"</li>
+          <li>Click a territory</li>
+          <li>Choose an action</li>
+          <li>Press "End Turn"</li>
         </ol>
       </div>
-      <div><strong>Log azioni:</strong></div>
+      <div><strong>Action log:</strong></div>
       <div id="actionLog" class="log"></div>
     </div>
     <div id="status"></div>

--- a/main.js
+++ b/main.js
@@ -197,16 +197,16 @@ function attachTerritoryHandlers() {
               const move = await askArmiesToMove(result.movableArmies, 0);
               if (move > 0) {
                 game.moveArmies(result.from, result.to, move);
-                addLogEntry(`${playerName} sposta ${move} da ${result.from} a ${result.to}`);
+                addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`);
                 animateMove(result.from, result.to);
               }
             }
-            addLogEntry(`${playerName} attacca ${result.to} da ${result.from}`);
+            addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`);
           } else if (result.type === REINFORCE) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} reinforces ${result.territory}`);
             }
-            addLogEntry(`${playerName} rinforza ${result.territory}`);
+            addLogEntry(`${playerName} reinforces ${result.territory}`);
           } else if (result.type === FORTIFY) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
@@ -214,14 +214,14 @@ function attachTerritoryHandlers() {
             const move = await askArmiesToMove(result.movableArmies, 1);
             if (move > 0) {
               game.moveArmies(result.from, result.to, move);
-              addLogEntry(`${playerName} sposta ${move} da ${result.from} a ${result.to}`);
+              addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`);
               animateMove(result.from, result.to);
             }
             game.endTurn();
             const nextName = game.players[game.currentPlayer].name;
             gameState.turnNumber += 1;
             addLogEntry(
-              `${playerName} termina il turno. Ora tocca a ${nextName}`,
+              `${playerName} ends turn. Next: ${nextName}`,
             );
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} ends turn. Next: ${nextName}`);
@@ -257,14 +257,14 @@ document.getElementById("endTurn").addEventListener("click", () => {
     const prevPhase = game.getPhase();
     game.endTurn();
     if (prevPhase === ATTACK && game.getPhase() === FORTIFY) {
-      addLogEntry(`${game.players[prevPlayer].name} passa alla fase fortificazioni`);
+      addLogEntry(`${game.players[prevPlayer].name} enters fortify phase`);
       if (typeof logger !== "undefined") {
         logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
       }
     } else if (prevPhase === FORTIFY && game.getPhase() === REINFORCE) {
       gameState.turnNumber += 1;
       addLogEntry(
-        `${game.players[prevPlayer].name} termina il turno. Ora tocca a ${game.players[game.currentPlayer].name}`,
+        `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
       );
       if (typeof logger !== "undefined") {
         logger.info(
@@ -304,14 +304,14 @@ async function init() {
   await loadGame();
   const resetBtn = document.createElement("button");
   resetBtn.id = "resetGame";
-  resetBtn.textContent = "Nuova partita";
+  resetBtn.textContent = "New Game";
   resetBtn.addEventListener("click", startNewGame);
   document.body.appendChild(resetBtn);
   const modal = document.createElement("div");
   modal.id = "victoryModal";
   modal.className = "modal";
   modal.innerHTML =
-    '<div class="modal-content"><h2 id="victoryTitle"></h2><div id="victoryStats"></div><button id="newGameBtn">Nuova partita</button></div>';
+    '<div class="modal-content"><h2 id="victoryTitle"></h2><div id="victoryStats"></div><button id="newGameBtn">New Game</button></div>';
   document.body.appendChild(modal);
   document
     .getElementById("newGameBtn")
@@ -320,15 +320,15 @@ async function init() {
   const cardPanel = document.createElement("div");
   cardPanel.id = "cardPanel";
   cardPanel.innerHTML =
-    '<div><strong>Carte:</strong> <span id="cards"></span></div>' +
-    '<button id="playCardsBtn">Gioca carte</button>' +
+    '<div><strong>Cards:</strong> <span id="cards"></span></div>' +
+    '<button id="playCardsBtn">Play cards</button>' +
     '<div id="bonusInfo"></div>';
   ui.appendChild(cardPanel);
   document.getElementById("playCardsBtn").addEventListener("click", () => {
     const cards = getSelectedCards();
     if (cards.length === 3) {
       if (game.playCards(cards)) {
-        addLogEntry(`${game.players[game.currentPlayer].name} gioca carte`);
+        addLogEntry(`${game.players[game.currentPlayer].name} plays cards`);
         resetSelectedCards();
         game.calculateReinforcements();
         updateUI();
@@ -351,7 +351,7 @@ async function init() {
 
   updateGameState();
   updateInfoPanel();
-  addLogEntry(`Turno ${gameState.turnNumber}: ${game.players[game.currentPlayer].name}`);
+  addLogEntry(`Turn ${gameState.turnNumber}: ${game.players[game.currentPlayer].name}`);
 
   const toggleHowToPlay = document.getElementById("toggleHowToPlay");
   if (toggleHowToPlay) {
@@ -362,8 +362,8 @@ async function init() {
       const hidden = steps.style.display === "none";
       steps.style.display = hidden ? "block" : "none";
       toggleHowToPlay.textContent = hidden
-        ? "Nascondi dettagli"
-        : "Mostra dettagli";
+        ? "Hide details"
+        : "Show details";
     });
   }
 }

--- a/main.test.js
+++ b/main.test.js
@@ -51,7 +51,7 @@ describe('main DOM interactions', () => {
     const log = document.getElementById('actionLog');
 
     t1.click();
-    expect(log.textContent).toContain('rinforza t1');
+    expect(log.textContent).toContain('reinforces t1');
     expect(status.textContent).toContain(REINFORCE);
 
     t1.click();
@@ -72,7 +72,7 @@ describe('main DOM interactions', () => {
     expect(t1.classList.contains('selected')).toBe(true);
 
     t4.click();
-    expect(log.textContent).toContain('attacca t4 da t1');
+    expect(log.textContent).toContain('attacks t4 from t1');
     expect(t1.classList.contains('attack')).toBe(true);
     expect(t4.classList.contains('attack')).toBe(true);
   });
@@ -96,7 +96,7 @@ describe('main DOM interactions', () => {
     expect(t1.classList.contains('selected')).toBe(true);
     t2.click();
     await Promise.resolve();
-    expect(log.textContent).toContain('sposta 1 da t1 a t2');
+    expect(log.textContent).toContain('moves 1 from t1 to t2');
     expect(status.textContent).toContain(REINFORCE);
     expect(t1.classList.contains('selected')).toBe(false);
   });
@@ -115,7 +115,7 @@ describe('main DOM interactions', () => {
     expect(status.textContent).toContain(FORTIFY);
 
     endTurnBtn.click();
-    expect(log.textContent).toContain('termina il turno');
+    expect(log.textContent).toContain('ends turn');
     expect(status.textContent).toContain('Player 2');
     expect(status.textContent).toContain(REINFORCE);
   });

--- a/move-prompt.js
+++ b/move-prompt.js
@@ -9,7 +9,7 @@ function askArmiesToMove(max, min = 0) {
     modal.className = 'modal';
     modal.innerHTML = `
       <div class="modal-content">
-        <label>Quante armate spostare? (${min}-${max})</label>
+        <label>How many armies to move? (${min}-${max})</label>
         <input type="number" id="moveArmiesInput" min="${min}" max="${max}" value="${max}" />
         <button id="moveArmiesOk">OK</button>
       </div>`;

--- a/setup.html
+++ b/setup.html
@@ -5,14 +5,14 @@
     <title>Setup NetRisk</title>
   </head>
   <body>
-    <h1>Setup Giocatori</h1>
+    <h1>Player Setup</h1>
     <form id="setupForm">
       <label>
-        Numero giocatori umani:
+        Number of human players:
         <input type="number" id="humanCount" min="1" max="6" />
       </label>
       <label>
-        Numero giocatori IA:
+        Number of AI players:
         <input type="number" id="aiCount" min="0" max="5" />
       </label>
       <div id="players"></div>

--- a/setup.js
+++ b/setup.js
@@ -16,8 +16,8 @@ function renderPlayerInputs(humanCount) {
       )
       .join("");
     wrapper.innerHTML = `
-      <label>Nome Giocatore ${i + 1}: <input type="text" id="name${i}" /></label>
-      <label>Colore: <select id="color${i}">${options}</select></label>
+      <label>Player Name ${i + 1}: <input type="text" id="name${i}" /></label>
+      <label>Color: <select id="color${i}">${options}</select></label>
     `;
     playersContainer.appendChild(wrapper);
   }
@@ -65,7 +65,7 @@ form.addEventListener("submit", (e) => {
     const name = document.getElementById(`name${i}`).value || `Player ${i + 1}`;
     const color = document.getElementById(`color${i}`).value || colorPalette[0];
     if (usedColors.has(color)) {
-      window.alert("I colori dei giocatori devono essere unici");
+      window.alert("Player colors must be unique");
       return;
     }
     usedColors.add(color);

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -36,7 +36,7 @@ export default function initTerritorySelection({
     if (!el) return;
     const phase = game?.getPhase();
     if (phase && ![ATTACK, FORTIFY].includes(phase)) {
-      addLogEntry?.(`Movimento non consentito nella fase ${phase}`);
+      addLogEntry?.(`Move not allowed during ${phase} phase`);
       return;
     }
     const box = el.getBBox();
@@ -53,7 +53,7 @@ export default function initTerritorySelection({
     if (addLogEntry && game) {
       const name = el.dataset.name || el.id;
       addLogEntry(
-        `${game.players[game.currentPlayer].name} muove il segnalino su ${name}`,
+        `${game.players[game.currentPlayer].name} moves token to ${name}`,
       );
       logger?.info(
         `${game.players[game.currentPlayer].name} moves token to ${name}`,
@@ -69,7 +69,7 @@ export default function initTerritorySelection({
         if (selectedTerritory) {
           moveToken(selectedTerritory.el);
         } else {
-          addLogEntry?.("Nessun territorio selezionato");
+          addLogEntry?.("No territory selected");
         }
       } catch (err) {
         logger?.error(err);

--- a/ui.js
+++ b/ui.js
@@ -67,13 +67,13 @@ function showVictoryModal(winnerIdx) {
   if (!modal) return;
   const title = document.getElementById("victoryTitle");
   const stats = document.getElementById("victoryStats");
-  if (title) title.textContent = `${game.players[winnerIdx].name} ha vinto!`;
+  if (title) title.textContent = `${game.players[winnerIdx].name} has won!`;
   if (stats) {
     const terr = game.players.map((p, idx) => {
       const count = game.territories.filter((t) => t.owner === idx).length;
-      return `<li>${p.name}: ${count} territori</li>`;
+      return `<li>${p.name}: ${count} territories</li>`;
     });
-    stats.innerHTML = `<p>Turni: ${gameState.turnNumber}</p><ul>${terr.join("")}</ul>`;
+    stats.innerHTML = `<p>Turns: ${gameState.turnNumber}</p><ul>${terr.join("")}</ul>`;
   }
   modal.classList.add("show");
 }

--- a/ui.test.js
+++ b/ui.test.js
@@ -59,7 +59,7 @@ describe('ui utilities', () => {
     showVictoryModal(0);
     const modal = document.getElementById('victoryModal');
     expect(modal.classList.contains('show')).toBe(true);
-    expect(document.getElementById('victoryTitle').textContent).toContain('P1 ha vinto');
+    expect(document.getElementById('victoryTitle').textContent).toContain('P1 has won');
   });
 
   test('updateBonusInfo shows continent bonus', () => {


### PR DESCRIPTION
## Summary
- translate mixed Italian/English UI text to English for a consistent interface
- adjust logging and prompts to use English phrasing
- update tests and docs for new messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad64035ba4832cb9877a687d71f7a4