### PR TITLE
Make game layout responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,30 +9,32 @@
   <body>
     <h1>NetRisk</h1>
     <div><a href="setup.html">Set up players</a></div>
-    <div id="uiPanel">
-      <div>Current turn: <span id="turnNumber">1</span></div>
-      <div>Current player: <span id="currentPlayer"></span></div>
-      <div id="howToPlayBox">
-        <div>
-          <strong>How to play (alpha)</strong>
-          <a href="#" id="toggleHowToPlay">Show details</a>
+    <div id="gameContainer">
+      <div id="uiPanel">
+        <div>Current turn: <span id="turnNumber">1</span></div>
+        <div>Current player: <span id="currentPlayer"></span></div>
+        <div id="howToPlayBox">
+          <div>
+            <strong>How to play (alpha)</strong>
+            <a href="#" id="toggleHowToPlay">Show details</a>
+          </div>
+          <ol id="howToPlaySteps" style="display: none">
+            <li>Click a territory</li>
+            <li>Choose an action</li>
+            <li>Press "End Turn"</li>
+          </ol>
         </div>
-        <ol id="howToPlaySteps" style="display: none">
-          <li>Click a territory</li>
-          <li>Choose an action</li>
-          <li>Press "End Turn"</li>
-        </ol>
+        <div><strong>Action log:</strong></div>
+        <div id="actionLog" class="log"></div>
+        <div id="status"></div>
+        <div id="diceResults"></div>
+        <div id="selectedTerritory"></div>
+        <button id="moveToken">Move Token</button>
+        <button id="endTurn">End Turn</button>
+        <button id="forceError">Force Error</button>
       </div>
-      <div><strong>Action log:</strong></div>
-      <div id="actionLog" class="log"></div>
+      <div id="board" class="board"></div>
     </div>
-    <div id="status"></div>
-    <div id="diceResults"></div>
-    <div id="selectedTerritory"></div>
-    <div id="board" class="board"></div>
-    <button id="moveToken">Move Token</button>
-    <button id="endTurn">End Turn</button>
-    <button id="forceError">Force Error</button>
     <script src="./logger.js"></script>
     <script type="module" src="./main.js"></script>
   </body>

--- a/style.css
+++ b/style.css
@@ -6,9 +6,25 @@ body {
   text-align: center;
 }
 
+#gameContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+@media (min-width: 768px) {
+  #gameContainer {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+  }
+}
+
 #uiPanel {
-  width: 600px;
-  margin: 10px auto;
+  max-width: 600px;
+  width: 100%;
+  margin: 10px;
   text-align: left;
   background: #fff;
   padding: 10px;
@@ -34,9 +50,10 @@ body {
 
 .board {
   position: relative;
-  width: 600px;
-  height: 400px;
-  margin: 20px auto;
+  max-width: 600px;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  margin: 20px;
 }
 
 #map {

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -1,4 +1,5 @@
 import { ATTACK, FORTIFY } from "./phases.js";
+import { getBoardScale } from "./ui.js";
 
 export default function initTerritorySelection({
   logger,
@@ -43,9 +44,10 @@ export default function initTerritorySelection({
     const x = box.x + box.width / 2;
     const y = box.y + box.height / 2;
     const token = document.getElementById("token");
+    const scale = getBoardScale();
     if (token) {
-      token.style.left = `${x}px`;
-      token.style.top = `${y}px`;
+      token.style.left = `${x * scale.x}px`;
+      token.style.top = `${y * scale.y}px`;
     }
     if (gameState) {
       gameState.tokenPosition = { x, y };
@@ -99,8 +101,9 @@ export default function initTerritorySelection({
         updateUI?.();
       }
       if (gameState?.tokenPosition) {
-        tokenEl.style.left = `${gameState.tokenPosition.x}px`;
-        tokenEl.style.top = `${gameState.tokenPosition.y}px`;
+        const scale = getBoardScale();
+        tokenEl.style.left = `${gameState.tokenPosition.x * scale.x}px`;
+        tokenEl.style.top = `${gameState.tokenPosition.y * scale.y}px`;
       }
       const map = boardEl.querySelector("#map");
       map.addEventListener("click", (e) => {

--- a/ui.js
+++ b/ui.js
@@ -1,6 +1,18 @@
 import { getContrastingColor } from "./colors.js";
 import { REINFORCE } from "./phases.js";
 
+const BOARD_WIDTH = 600;
+const BOARD_HEIGHT = 400;
+
+function getBoardScale() {
+  const board = document.getElementById("board");
+  if (!board) return { x: 1, y: 1 };
+  const rect = board.getBoundingClientRect();
+  const x = rect.width ? rect.width / BOARD_WIDTH : 1;
+  const y = rect.height ? rect.height / BOARD_HEIGHT : 1;
+  return { x, y };
+}
+
 let game;
 let gameState;
 let territoryPositions = {};
@@ -10,6 +22,7 @@ function initUI({ game: g, gameState: gs, territoryPositions: tp }) {
   game = g;
   gameState = gs;
   territoryPositions = tp;
+  window.addEventListener("resize", updateUI);
 }
 
 function getSelectedCards() {
@@ -45,12 +58,13 @@ function animateMove(from, to) {
   if (!fromPos || !toPos) return;
   const token = document.createElement("div");
   token.className = "token move-token";
-  token.style.left = fromPos.x + "px";
-  token.style.top = fromPos.y + "px";
+  const scale = getBoardScale();
+  token.style.left = fromPos.x * scale.x + "px";
+  token.style.top = fromPos.y * scale.y + "px";
   board.appendChild(token);
   requestAnimationFrame(() => {
-    token.style.left = toPos.x + "px";
-    token.style.top = toPos.y + "px";
+    token.style.left = toPos.x * scale.x + "px";
+    token.style.top = toPos.y * scale.y + "px";
   });
   token.addEventListener(
     "transitionend",
@@ -140,6 +154,7 @@ function getColorClass(color) {
 }
 
 function updateUI() {
+  const scale = getBoardScale();
   game.territories.forEach((t) => {
     const el = document.getElementById(t.id);
     if (!el) return;
@@ -156,11 +171,18 @@ function updateUI() {
     el.textContent = t.armies;
     const pos = territoryPositions[t.id];
     if (pos) {
-      el.style.left = pos.x + "px";
-      el.style.top = pos.y + "px";
+      el.style.left = pos.x * scale.x + "px";
+      el.style.top = pos.y * scale.y + "px";
     }
     el.classList.remove("selected");
   });
+  if (gameState.tokenPosition) {
+    const token = document.getElementById("token");
+    if (token) {
+      token.style.left = gameState.tokenPosition.x * scale.x + "px";
+      token.style.top = gameState.tokenPosition.y * scale.y + "px";
+    }
+  }
   let status = `${game.players[game.currentPlayer].name} - ${game.getPhase()}`;
   if (game.getPhase() === REINFORCE) {
     status += ` (${game.reinforcements} reinforcements)`;
@@ -181,4 +203,5 @@ export {
   updateUI,
   getSelectedCards,
   resetSelectedCards,
+  getBoardScale,
 };


### PR DESCRIPTION
## Summary
- Replace fixed-width layout with flexbox container and responsive CSS
- Scale token and territory positions to match resized game board
- Adjust territory selection to account for board scaling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad65b054cc832c9ad3f1bcfbab3bab