### PR TITLE
Cleanup player color styles

### DIFF
--- a/main.test.js
+++ b/main.test.js
@@ -168,6 +168,25 @@ describe('main DOM interactions', () => {
     expect(colorClasses).toHaveLength(0);
   });
 
+  test('unused player color classes are cleaned up', () => {
+    const getSheet = () =>
+      Array.from(document.styleSheets).find((s) =>
+        Array.from(s.cssRules).some(
+          (r) => r.selectorText && r.selectorText.startsWith('.player-color-'),
+        ),
+      );
+    const t1 = document.getElementById('t1');
+    const sheet = getSheet();
+    const initialCount = sheet ? sheet.cssRules.length : 0;
+    expect(t1.classList.contains('player-color-e6194b')).toBe(true);
+    main.game.players[0].color = '#00ff00';
+    ui.updateUI();
+    expect(t1.classList.contains('player-color-00ff00')).toBe(true);
+    expect(t1.classList.contains('player-color-e6194b')).toBe(false);
+    const sheetAfter = getSheet();
+    expect(sheetAfter.cssRules.length).toBe(initialCount);
+  });
+
   test('army count text contrasts with player color', () => {
     const t1 = document.getElementById('t1');
     main.game.players[0].color = '#000000';

--- a/ui.js
+++ b/ui.js
@@ -181,13 +181,31 @@ function getColorClass(color) {
   return className;
 }
 
+function cleanupColorClasses(activeClasses) {
+  if (!colorStyleSheet) return;
+  const allowed = new Set(activeClasses.map((c) => `.${c}`));
+  for (let i = colorStyleSheet.cssRules.length - 1; i >= 0; i--) {
+    const rule = colorStyleSheet.cssRules[i];
+    const sel = rule.selectorText;
+    if (sel && sel.startsWith(".player-color-") && !allowed.has(sel)) {
+      colorStyleSheet.deleteRule(i);
+    }
+  }
+  if (colorStyleSheet.cssRules.length === 0) {
+    colorStyleSheet.ownerNode.remove();
+    colorStyleSheet = null;
+  }
+}
+
 function updateUI() {
   const scale = getBoardScale();
+  const playerColorClasses = game.players.map((p) => getColorClass(p.color));
+  cleanupColorClasses(playerColorClasses.filter(Boolean));
   game.territories.forEach((t) => {
     const el = getElement(t.id);
     if (!el) return;
 
-    const colorClass = getColorClass(game.players[t.owner].color);
+    const colorClass = playerColorClasses[t.owner];
     const colorClasses = Array.from(el.classList).filter((c) =>
       c.startsWith("player-color-"),
     );


### PR DESCRIPTION
## Summary
- remove old player-color style rules when updating the board
- reuse per-player color classes during UI updates to prevent stylesheet bloat
- test player color class cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad67f9325c832c8354e24fda896e07