### PR TITLE
feat: improve card system visuals

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -175,6 +175,8 @@ test('continent bonus is added to reinforcements', () => {
 });
 
 test('player draws a card after conquering a territory', () => {
+  const awarded = jest.fn();
+  game.on('cardAwarded', awarded);
   game.setPhase(ATTACK);
   const from = game.territoryById('t2');
   const to = game.territoryById('t3');
@@ -191,6 +193,7 @@ test('player draws a card after conquering a territory', () => {
   game.endTurn();
   game.endTurn();
   expect(game.hands[0].length).toBe(1);
+  expect(awarded).toHaveBeenCalled();
 });
 
 test('playing valid card set grants reinforcements', () => {

--- a/main.js
+++ b/main.js
@@ -210,6 +210,15 @@ function attachAIActionLogging() {
     }
   });
 
+  game.on("cardAwarded", ({ player, card }) => {
+    const name = game.players[player].name;
+    const icons = { infantry: "🪖", cavalry: "🐎", artillery: "💣" };
+    addLogEntry(`${name} receives a card ${icons[card.type] || card.type}`);
+    if (typeof logger !== "undefined") {
+      logger.info(`${name} receives card ${card.type}`);
+    }
+  });
+
   game.on("turnStart", ({ player }) => {
     const prev = lastPlayer;
     const prevName = game.players[prev].name;

--- a/style.css
+++ b/style.css
@@ -162,3 +162,32 @@ body {
   max-width: 300px;
   text-align: center;
 }
+
+.card {
+  display: inline-block;
+  width: 32px;
+  height: 40px;
+  line-height: 40px;
+  margin: 0 4px;
+  border: 1px solid #333;
+  border-radius: 4px;
+  font-size: 24px;
+  cursor: pointer;
+  background: #fff;
+}
+
+.card.infantry {
+  background: #e8f5e9;
+}
+
+.card.cavalry {
+  background: #e3f2fd;
+}
+
+.card.artillery {
+  background: #ffebee;
+}
+
+.selected-card {
+  outline: 2px solid #f00;
+}

--- a/ui.js
+++ b/ui.js
@@ -137,11 +137,12 @@ function updateCardsUI() {
   while (container.firstChild) container.removeChild(container.firstChild);
   const hand = game.hands[game.currentPlayer] || [];
   selectedCards = [];
+  const icons = { infantry: "🪖", cavalry: "🐎", artillery: "💣" };
   hand.forEach((card, idx) => {
     const el = document.createElement("span");
-    el.textContent = card.type;
+    el.innerHTML = icons[card.type] || card.type;
     el.dataset.idx = idx;
-    el.className = "card";
+    el.className = `card ${card.type}`;
     if (selectedCards.includes(idx)) el.classList.add("selected-card");
     el.addEventListener("click", () => {
       if (selectedCards.includes(idx)) {


### PR DESCRIPTION
## Summary
- display card icons with emojis and styling
- log and expose awarded cards after conquering territories
- test card awarding when conquering a territory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad76949d3c832c893deda1571af689