### PR TITLE
Add start menu before launching game

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,11 @@
   </head>
   <body>
     <h1>NetRisk</h1>
-    <div><a href="setup.html">Set up players</a></div>
-    <div id="gameContainer">
+    <div id="mainMenu">
+      <button id="startGame">Start Game</button>
+      <div><a href="setup.html">Set up players</a></div>
+    </div>
+    <div id="gameContainer" style="display: none">
       <div id="uiPanel">
         <div>Current turn: <span id="turnNumber">1</span></div>
         <div>Current player: <span id="currentPlayer"></span></div>

--- a/main.js
+++ b/main.js
@@ -363,7 +363,7 @@ if (forceErrorBtn) {
   });
 }
 
-async function init() {
+async function initGame() {
   if (
     typeof window !== "undefined" &&
     typeof localStorage !== "undefined" &&
@@ -438,6 +438,22 @@ async function init() {
         : "Show details";
     });
   }
+}
+
+function init() {
+  const menu = document.getElementById("mainMenu");
+  const startBtn = document.getElementById("startGame");
+  const container = document.getElementById("gameContainer");
+  if (!menu || !startBtn || !container) {
+    initGame();
+    return;
+  }
+  container.style.display = "none";
+  startBtn.addEventListener("click", async () => {
+    menu.style.display = "none";
+    container.style.display = "";
+    await initGame();
+  });
 }
 
 init();

--- a/menu.test.js
+++ b/menu.test.js
@@ -1,0 +1,43 @@
+const mapData = require('./src/data/map.json');
+jest.mock('./territory-selection.js', () => jest.fn());
+jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
+jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
+
+describe('main menu', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+    document.body.innerHTML = `
+      <div id="mainMenu"><button id="startGame"></button></div>
+      <div id="gameContainer">
+        <div id="status"></div>
+        <div id="currentPlayer"></div>
+        <div id="turnNumber"></div>
+        <div id="actionLog"></div>
+        <div id="diceResults"></div>
+        <div id="uiPanel"></div>
+        <button id="endTurn"></button>
+        <div id="t1" class="territory" data-id="t1"></div>
+        <div id="t2" class="territory" data-id="t2"></div>
+        <div id="t3" class="territory" data-id="t3"></div>
+        <div id="t4" class="territory" data-id="t4"></div>
+        <div id="t5" class="territory" data-id="t5"></div>
+        <div id="t6" class="territory" data-id="t6"></div>
+      </div>`;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
+    );
+    global.logger = { info: jest.fn(), error: jest.fn() };
+  });
+
+  test('initializes game after start button clicked', async () => {
+    const main = require('./main.js');
+    expect(main.game).toBeUndefined();
+    document.getElementById('startGame').click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(main.game).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add start menu with Start Game button and player setup link
- Refactor initialization to run only after menu start
- Test game initialization triggered via start menu

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad935cb9a4832cb4f58b99c764143c