### PR TITLE
Improve mobile layout and touch support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <link rel="stylesheet" href="./style.css" />

--- a/main.js
+++ b/main.js
@@ -238,7 +238,7 @@ function attachAIActionLogging() {
 
 function attachTerritoryHandlers() {
   document.querySelectorAll(".territory").forEach((el) => {
-    el.addEventListener("click", async () => {
+    el.addEventListener("pointerdown", async () => {
       if (typeof logger !== "undefined") {
         logger.info(`Territory clicked: ${el.dataset.id}`);
       }

--- a/main.test.js
+++ b/main.test.js
@@ -33,10 +33,10 @@ describe('main DOM interactions', () => {
     global.logger = { info: jest.fn(), error: jest.fn() };
     main = require('./main.js');
     ui = require('./ui.js');
-    await Promise.resolve();
-    main.attachTerritoryHandlers();
-    jest.useFakeTimers();
-  });
+      await Promise.resolve();
+      main.attachTerritoryHandlers();
+      jest.useFakeTimers();
+    });
 
   afterEach(() => {
     jest.useRealTimers();
@@ -45,17 +45,21 @@ describe('main DOM interactions', () => {
     }
   });
 
+  function pointerDown(el) {
+    el.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
+  }
+
   test('reinforcement updates status and log', () => {
     const t1 = document.getElementById('t1');
     const status = document.getElementById('status');
     const log = document.getElementById('actionLog');
 
-    t1.click();
+    pointerDown(t1);
     expect(log.textContent).toContain('reinforces t1');
     expect(status.textContent).toContain(REINFORCE);
 
-    t1.click();
-    t1.click();
+    pointerDown(t1);
+    pointerDown(t1);
     expect(status.textContent).toContain(ATTACK);
   });
 
@@ -64,14 +68,14 @@ describe('main DOM interactions', () => {
     const t4 = document.getElementById('t4');
     const log = document.getElementById('actionLog');
 
-    t1.click();
-    t1.click();
-    t1.click();
+    pointerDown(t1);
+    pointerDown(t1);
+    pointerDown(t1);
 
-    t1.click();
+    pointerDown(t1);
     expect(t1.classList.contains('selected')).toBe(true);
 
-    t4.click();
+    pointerDown(t4);
     expect(log.textContent).toContain('attacks t4 from t1');
     expect(t1.classList.contains('attack')).toBe(true);
     expect(t4.classList.contains('attack')).toBe(true);
@@ -85,16 +89,16 @@ describe('main DOM interactions', () => {
     const { game } = main;
     const { updateUI } = ui;
 
-    t1.click();
-    t1.click();
-    t1.click();
+    pointerDown(t1);
+    pointerDown(t1);
+    pointerDown(t1);
 
     game.endTurn();
     updateUI();
 
-    t1.click();
+    pointerDown(t1);
     expect(t1.classList.contains('selected')).toBe(true);
-    t2.click();
+    pointerDown(t2);
     await Promise.resolve();
     expect(log.textContent).toContain('moves 1 from t1 to t2');
     expect(status.textContent).toContain(REINFORCE);
@@ -107,9 +111,9 @@ describe('main DOM interactions', () => {
     const status = document.getElementById('status');
     const log = document.getElementById('actionLog');
 
-    t1.click();
-    t1.click();
-    t1.click();
+    pointerDown(t1);
+    pointerDown(t1);
+    pointerDown(t1);
 
     endTurnBtn.click();
     expect(status.textContent).toContain(FORTIFY);
@@ -122,9 +126,9 @@ describe('main DOM interactions', () => {
 
   test('state is saved and restored from localStorage', async () => {
     const t1 = document.getElementById('t1');
-    t1.click();
-    t1.click();
-    t1.click();
+    pointerDown(t1);
+    pointerDown(t1);
+    pointerDown(t1);
     const armies = main.game.territoryById('t1').armies;
     const phase = main.game.getPhase();
     const saved = localStorage.getItem('netriskGame');

--- a/style.css
+++ b/style.css
@@ -21,6 +21,20 @@ body {
   }
 }
 
+@media (max-width: 480px) {
+  #uiPanel {
+    margin: 5px;
+    padding: 5px;
+  }
+  .board {
+    margin: 10px 0;
+  }
+  button {
+    padding: 10px;
+    font-size: 16px;
+  }
+}
+
 #uiPanel {
   max-width: 600px;
   width: 100%;

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -105,32 +105,32 @@ export default function initTerritorySelection({
         tokenEl.style.left = `${gameState.tokenPosition.x * scale.x}px`;
         tokenEl.style.top = `${gameState.tokenPosition.y * scale.y}px`;
       }
-      const map = boardEl.querySelector("#map");
-      map.addEventListener("click", (e) => {
-        const target = e.target.closest(".map-territory");
-        if (target) {
-          selectTerritory(target);
-        } else {
-          selectTerritory(null);
-        }
-        e.stopPropagation();
+        const map = boardEl.querySelector("#map");
+        map.addEventListener("pointerdown", (e) => {
+          const target = e.target.closest(".map-territory");
+          if (target) {
+            selectTerritory(target);
+          } else {
+            selectTerritory(null);
+          }
+          e.stopPropagation();
+        });
+        map.addEventListener("dblclick", (e) => {
+          const target = e.target.closest(".map-territory");
+          if (target) {
+            selectTerritory(target);
+            moveToken(target);
+          }
+          e.stopPropagation();
+        });
+        document.addEventListener("pointerdown", (e) => {
+          if (!map.contains(e.target)) {
+            selectTerritory(null);
+          }
+        });
+      })
+      .catch((err) => {
+        logger?.error(err);
       });
-      map.addEventListener("dblclick", (e) => {
-        const target = e.target.closest(".map-territory");
-        if (target) {
-          selectTerritory(target);
-          moveToken(target);
-        }
-        e.stopPropagation();
-      });
-      document.addEventListener("click", (e) => {
-        if (!map.contains(e.target)) {
-          selectTerritory(null);
-        }
-      });
-    })
-    .catch((err) => {
-      logger?.error(err);
-    });
-}
+  }
 


### PR DESCRIPTION
## Summary
- Add viewport meta tag and mobile styling for better layout on phones
- Use pointer events for territory selection to improve touch responsiveness
- Switch map and document listeners to pointer events and update tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad9485fa20832c884132ada31871c8