### PR TITLE
Improve How to play panel accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,15 @@
         <div id="howToPlayBox">
           <div>
             <strong>How to play (alpha)</strong>
-            <a href="#" id="toggleHowToPlay">Show details</a>
+            <button
+              id="toggleHowToPlay"
+              aria-expanded="false"
+              aria-controls="howToPlaySteps"
+            >
+              Show details
+            </button>
           </div>
-          <ol id="howToPlaySteps" style="display: none">
+          <ol id="howToPlaySteps" hidden>
             <li>Click a territory</li>
             <li>Choose an action</li>
             <li>Press "End Turn"</li>

--- a/main.js
+++ b/main.js
@@ -431,15 +431,14 @@ async function initGame() {
 
   const toggleHowToPlay = document.getElementById("toggleHowToPlay");
   if (toggleHowToPlay) {
-    toggleHowToPlay.addEventListener("click", (e) => {
-      e.preventDefault();
+    toggleHowToPlay.addEventListener("click", () => {
       const steps = document.getElementById("howToPlaySteps");
       if (!steps) return;
-      const hidden = steps.style.display === "none";
-      steps.style.display = hidden ? "block" : "none";
-      toggleHowToPlay.textContent = hidden
-        ? "Hide details"
-        : "Show details";
+      const nowHidden = steps.toggleAttribute("hidden");
+      toggleHowToPlay.setAttribute("aria-expanded", (!nowHidden).toString());
+      toggleHowToPlay.textContent = nowHidden
+        ? "Show details"
+        : "Hide details";
     });
   }
 }


### PR DESCRIPTION
## Summary
- Replace link with ARIA-enabled button for "How to play" instructions
- Toggle instructional steps using hidden attribute and aria-expanded state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d000118832ca6254a0f23a62fdd