### PR TITLE
Add high contrast theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
+    <button id="themeToggle">High Contrast</button>
     <h1>NetRisk</h1>
     <div id="mainMenu">
       <button id="startGame">Start Game</button>

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ import {
   FORTIFY,
   GAME_OVER,
 } from "./phases.js";
+import { initThemeToggle } from "./theme.js";
 import {
   initUI,
   updateInfoPanel,
@@ -461,6 +462,7 @@ function init() {
 }
 
 init();
+initThemeToggle();
 
 export {
   game,

--- a/setup.html
+++ b/setup.html
@@ -8,6 +8,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
   </head>
   <body>
+    <button id="themeToggle">High Contrast</button>
     <h1>Player Setup</h1>
     <form id="setupForm">
       <label>

--- a/setup.js
+++ b/setup.js
@@ -1,4 +1,5 @@
 import { colorPalette } from "./colors.js";
+import { initThemeToggle } from "./theme.js";
 
 const form = document.getElementById("setupForm");
 const humanCountInput = document.getElementById("humanCount");
@@ -98,3 +99,4 @@ form.addEventListener("submit", (e) => {
 });
 
 loadFromStorage();
+initThemeToggle();

--- a/style.css
+++ b/style.css
@@ -231,3 +231,48 @@ button:hover {
 .selected-card {
   outline: 2px solid #f00;
 }
+
+/* High contrast theme */
+body.high-contrast {
+  background: #000;
+  color: #fff;
+}
+
+body.high-contrast h1 {
+  color: #ff0;
+  text-shadow: none;
+}
+
+body.high-contrast button {
+  background: #000;
+  color: #ff0;
+  border: 2px solid #ff0;
+}
+
+body.high-contrast #uiPanel {
+  background: #000;
+  color: #fff;
+  border-color: #fff;
+}
+
+body.high-contrast .log {
+  background: #000;
+  color: #fff;
+}
+
+body.high-contrast .board {
+  background: #000;
+  border-color: #fff;
+}
+
+body.high-contrast .territory {
+  background: #555;
+  border-color: #fff;
+  color: #fff;
+}
+
+body.high-contrast .modal-content {
+  background: #000;
+  color: #fff;
+  border: 2px solid #fff;
+}

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,23 @@
+export function initThemeToggle() {
+  const body = document.body;
+  if (!body) return;
+  const btn = document.getElementById('themeToggle');
+  const stored = (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) || 'default';
+  if (stored === 'high-contrast') {
+    body.classList.add('high-contrast');
+    if (btn) btn.textContent = 'Standard Theme';
+  }
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    body.classList.toggle('high-contrast');
+    const high = body.classList.contains('high-contrast');
+    btn.textContent = high ? 'Standard Theme' : 'High Contrast';
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem('theme', high ? 'high-contrast' : 'default');
+      } catch (err) {
+        // ignore storage errors
+      }
+    }
+  });
+}

--- a/theme.test.js
+++ b/theme.test.js
@@ -1,0 +1,29 @@
+import { initThemeToggle } from './theme.js';
+
+describe('theme toggle', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<button id="themeToggle">High Contrast</button>';
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  test('toggles high contrast and stores preference', () => {
+    initThemeToggle();
+    const btn = document.getElementById('themeToggle');
+    btn.click();
+    expect(document.body.classList.contains('high-contrast')).toBe(true);
+    expect(btn.textContent).toBe('Standard Theme');
+    expect(localStorage.getItem('theme')).toBe('high-contrast');
+    btn.click();
+    expect(document.body.classList.contains('high-contrast')).toBe(false);
+    expect(btn.textContent).toBe('High Contrast');
+    expect(localStorage.getItem('theme')).toBe('default');
+  });
+
+  test('loads stored preference', () => {
+    localStorage.setItem('theme', 'high-contrast');
+    initThemeToggle();
+    expect(document.body.classList.contains('high-contrast')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add toggle button to switch a high contrast theme
- apply theme selection on main and setup pages
- test theme toggle behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d50a648832cb9ac233685111074