### PR TITLE
Make desktop map responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -87,7 +87,6 @@ button:hover {
 
 .board {
   position: relative;
-  max-width: 600px;
   width: 100%;
   aspect-ratio: 3 / 2;
   margin: 20px;


### PR DESCRIPTION
## Summary
- remove fixed `max-width` on the game board so the map can scale to the available screen space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9d73131c832cbbf662a61df3b031