### PR TITLE
Improve keyboard accessibility for territory selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -242,7 +242,7 @@ function attachAIActionLogging() {
 
 function attachTerritoryHandlers() {
   document.querySelectorAll(".territory").forEach((el) => {
-    el.addEventListener("pointerdown", async () => {
+    el.addEventListener("click", async () => {
       if (typeof logger !== "undefined") {
         logger.info(`Territory clicked: ${el.dataset.id}`);
       }

--- a/main.test.js
+++ b/main.test.js
@@ -21,12 +21,12 @@ describe('main DOM interactions', () => {
       <div id="diceResults"></div>
       <div id="uiPanel"></div>
       <button id="endTurn"></button>
-      <div id="t1" class="territory" data-id="t1"></div>
-      <div id="t2" class="territory" data-id="t2"></div>
-      <div id="t3" class="territory" data-id="t3"></div>
-      <div id="t4" class="territory" data-id="t4"></div>
-      <div id="t5" class="territory" data-id="t5"></div>
-      <div id="t6" class="territory" data-id="t6"></div>`;
+      <button type="button" id="t1" class="territory" data-id="t1"></button>
+      <button type="button" id="t2" class="territory" data-id="t2"></button>
+      <button type="button" id="t3" class="territory" data-id="t3"></button>
+      <button type="button" id="t4" class="territory" data-id="t4"></button>
+      <button type="button" id="t5" class="territory" data-id="t5"></button>
+      <button type="button" id="t6" class="territory" data-id="t6"></button>`;
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
@@ -45,8 +45,8 @@ describe('main DOM interactions', () => {
     }
   });
 
-  function pointerDown(el) {
-    el.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
+  function clickTerritory(el) {
+    el.dispatchEvent(new window.Event('click', { bubbles: true }));
   }
 
   test('reinforcement updates status and log', () => {
@@ -54,12 +54,12 @@ describe('main DOM interactions', () => {
     const status = document.getElementById('status');
     const log = document.getElementById('actionLog');
 
-    pointerDown(t1);
+    clickTerritory(t1);
     expect(log.textContent).toContain('reinforces t1');
     expect(status.textContent).toContain(REINFORCE);
 
-    pointerDown(t1);
-    pointerDown(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
     expect(status.textContent).toContain(ATTACK);
   });
 
@@ -68,14 +68,14 @@ describe('main DOM interactions', () => {
     const t4 = document.getElementById('t4');
     const log = document.getElementById('actionLog');
 
-    pointerDown(t1);
-    pointerDown(t1);
-    pointerDown(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
 
-    pointerDown(t1);
+    clickTerritory(t1);
     expect(t1.classList.contains('selected')).toBe(true);
 
-    pointerDown(t4);
+    clickTerritory(t4);
     expect(log.textContent).toContain('attacks t4 from t1');
     expect(t1.classList.contains('attack')).toBe(true);
     expect(t4.classList.contains('attack')).toBe(true);
@@ -89,16 +89,16 @@ describe('main DOM interactions', () => {
     const { game } = main;
     const { updateUI } = ui;
 
-    pointerDown(t1);
-    pointerDown(t1);
-    pointerDown(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
 
     game.endTurn();
     updateUI();
 
-    pointerDown(t1);
+    clickTerritory(t1);
     expect(t1.classList.contains('selected')).toBe(true);
-    pointerDown(t2);
+    clickTerritory(t2);
     await Promise.resolve();
     expect(log.textContent).toContain('moves 1 from t1 to t2');
     expect(status.textContent).toContain(REINFORCE);
@@ -111,9 +111,9 @@ describe('main DOM interactions', () => {
     const status = document.getElementById('status');
     const log = document.getElementById('actionLog');
 
-    pointerDown(t1);
-    pointerDown(t1);
-    pointerDown(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
 
     endTurnBtn.click();
     expect(status.textContent).toContain(FORTIFY);
@@ -126,9 +126,9 @@ describe('main DOM interactions', () => {
 
   test('state is saved and restored from localStorage', async () => {
     const t1 = document.getElementById('t1');
-    pointerDown(t1);
-    pointerDown(t1);
-    pointerDown(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
+    clickTerritory(t1);
     const armies = main.game.territoryById('t1').armies;
     const phase = main.game.getPhase();
     const saved = localStorage.getItem('netriskGame');
@@ -144,12 +144,12 @@ describe('main DOM interactions', () => {
       <div id="diceResults"></div>
       <div id="uiPanel"></div>
       <button id="endTurn"></button>
-      <div id="t1" class="territory" data-id="t1"></div>
-      <div id="t2" class="territory" data-id="t2"></div>
-      <div id="t3" class="territory" data-id="t3"></div>
-      <div id="t4" class="territory" data-id="t4"></div>
-      <div id="t5" class="territory" data-id="t5"></div>
-      <div id="t6" class="territory" data-id="t6"></div>`;
+      <button type="button" id="t1" class="territory" data-id="t1"></button>
+      <button type="button" id="t2" class="territory" data-id="t2"></button>
+      <button type="button" id="t3" class="territory" data-id="t3"></button>
+      <button type="button" id="t4" class="territory" data-id="t4"></button>
+      <button type="button" id="t5" class="territory" data-id="t5"></button>
+      <button type="button" id="t6" class="territory" data-id="t6"></button>`;
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );

--- a/menu.test.js
+++ b/menu.test.js
@@ -19,12 +19,12 @@ describe('main menu', () => {
         <div id="diceResults"></div>
         <div id="uiPanel"></div>
         <button id="endTurn"></button>
-        <div id="t1" class="territory" data-id="t1"></div>
-        <div id="t2" class="territory" data-id="t2"></div>
-        <div id="t3" class="territory" data-id="t3"></div>
-        <div id="t4" class="territory" data-id="t4"></div>
-        <div id="t5" class="territory" data-id="t5"></div>
-        <div id="t6" class="territory" data-id="t6"></div>
+        <button type="button" id="t1" class="territory" data-id="t1"></button>
+        <button type="button" id="t2" class="territory" data-id="t2"></button>
+        <button type="button" id="t3" class="territory" data-id="t3"></button>
+        <button type="button" id="t4" class="territory" data-id="t4"></button>
+        <button type="button" id="t5" class="territory" data-id="t5"></button>
+        <button type="button" id="t6" class="territory" data-id="t6"></button>
       </div>`;
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })

--- a/style.css
+++ b/style.css
@@ -132,6 +132,7 @@ button:hover {
   border: 2px solid #333;
   border-radius: 50%;
   background: #ddd;
+  padding: 0;
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -88,6 +88,13 @@ export default function initTerritorySelection({
     .then((svg) => {
       const boardEl = document.getElementById("board");
       boardEl.innerHTML = svg;
+      const map = boardEl.querySelector("#map");
+      map
+        ?.querySelectorAll(".map-territory")
+        .forEach((el) => {
+          el.setAttribute("tabindex", "0");
+          el.setAttribute("role", "button");
+        });
       const tokenEl = document.createElement("div");
       tokenEl.id = "token";
       tokenEl.className = "token";
@@ -95,10 +102,14 @@ export default function initTerritorySelection({
       const terrs = territories || game?.territories;
       if (terrs) {
         terrs.forEach((t) => {
-          const terrEl = document.createElement("div");
+          const terrEl = document.createElement("button");
+          terrEl.type = "button";
           terrEl.id = t.id;
           terrEl.className = "territory";
           terrEl.dataset.id = t.id;
+          if (t.name) {
+            terrEl.setAttribute("aria-label", t.name);
+          }
           boardEl.appendChild(terrEl);
         });
         attachTerritoryHandlers?.();
@@ -109,8 +120,8 @@ export default function initTerritorySelection({
         tokenEl.style.left = `${gameState.tokenPosition.x * scale.x}px`;
         tokenEl.style.top = `${gameState.tokenPosition.y * scale.y}px`;
       }
-        const map = boardEl.querySelector("#map");
-        map.addEventListener("pointerdown", (e) => {
+      if (map) {
+        map.addEventListener("click", (e) => {
           const target = e.target.closest(".map-territory");
           if (target) {
             selectTerritory(target);
@@ -118,6 +129,17 @@ export default function initTerritorySelection({
             selectTerritory(null);
           }
           e.stopPropagation();
+        });
+        map.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            const target = e.target.closest(".map-territory");
+            if (target) {
+              selectTerritory(target);
+              if (e.key === " ") {
+                e.preventDefault();
+              }
+            }
+          }
         });
         map.addEventListener("dblclick", (e) => {
           const target = e.target.closest(".map-territory");
@@ -132,6 +154,7 @@ export default function initTerritorySelection({
             selectTerritory(null);
           }
         });
+      }
       })
       .catch((err) => {
         logger?.error(err);


### PR DESCRIPTION
## Summary
- Make map regions focusable buttons and add ARIA labels
- Handle territory clicks via standard click events for keyboard users
- Style territory buttons to maintain layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d17fd48832c83fcd7ff971959db