### PR TITLE
Fix army alignment with responsive map scaling

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -16,9 +16,10 @@ function getElement(id) {
 function getBoardScale() {
   const board = getElement("board");
   if (!board) return { x: 1, y: 1 };
-  const rect = board.getBoundingClientRect();
-  const x = rect.width ? rect.width / BOARD_WIDTH : 1;
-  const y = rect.height ? rect.height / BOARD_HEIGHT : 1;
+  const width = board.clientWidth || board.getBoundingClientRect().width;
+  const height = board.clientHeight || board.getBoundingClientRect().height;
+  const x = width ? width / BOARD_WIDTH : 1;
+  const y = height ? height / BOARD_HEIGHT : 1;
   return { x, y };
 }
 

--- a/ui.test.js
+++ b/ui.test.js
@@ -7,6 +7,7 @@ import {
   showVictoryModal,
   updateBonusInfo,
   updateCardsUI,
+  getBoardScale,
 } from './ui.js';
 
 describe('ui utilities', () => {
@@ -88,5 +89,14 @@ describe('ui utilities', () => {
     expect(logEl.children.length).toBe(10);
     expect(logEl.firstChild.textContent).toBe('msg3');
     expect(logEl.lastChild.textContent).toBe('msg12');
+  });
+
+  test('getBoardScale uses client size to align armies with map', () => {
+    const board = document.getElementById('board');
+    Object.defineProperty(board, 'clientWidth', { value: 600, configurable: true });
+    Object.defineProperty(board, 'clientHeight', { value: 400, configurable: true });
+    board.getBoundingClientRect = () => ({ width: 620, height: 420 });
+    const scale = getBoardScale();
+    expect(scale).toEqual({ x: 1, y: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- scale board using client dimensions to keep army positions accurate when the map resizes
- test board scaling to ensure army placement ignores borders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada5ee69e4832caa8cf270beab235c