### PR TITLE
Consolidate map data loading into shared module

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,27 +7,7 @@ import {
 } from "./phases.js";
 import { colorPalette } from "./colors.js";
 import EventBus from "./src/core/event-bus.js";
-
-async function loadMapData() {
-  const mapName =
-    (typeof localStorage !== "undefined" &&
-      localStorage.getItem("netriskMap")) ||
-    "map";
-  const jsonPath = `./src/data/${mapName}.json`;
-  try {
-    if (typeof fetch === "function") {
-      const res = await fetch(jsonPath);
-      if (res.ok) return await res.json();
-    }
-    const fs = await import("fs/promises");
-    const pathMod = await import("path");
-    const filePath = pathMod.resolve(`src/data/${mapName}.json`);
-    const data = await fs.readFile(filePath, "utf-8");
-    return JSON.parse(data);
-  } catch {
-    return { territories: [], continents: [], deck: [] };
-  }
-}
+import loadMapData from "./src/load-map-data.js";
 
 class Game {
   constructor(
@@ -95,7 +75,10 @@ class Game {
     if (territories && continents && deck) {
       return new Game(players, territories, continents, deck);
     }
-    const map = await loadMapData();
+    let map = { territories: [], continents: [], deck: [] };
+    try {
+      map = await loadMapData();
+    } catch {}
     return new Game(
       players,
       territories || map.territories,

--- a/main.js
+++ b/main.js
@@ -97,30 +97,6 @@ async function startNewGame() {
 }
 
 async function loadGame() {
-  let map;
-  const mapName =
-    (typeof localStorage !== "undefined" &&
-      localStorage.getItem("netriskMap")) ||
-    "map";
-  try {
-    const res = await fetch(`./src/data/${mapName}.json`);
-    if (!res.ok) {
-      throw new Error(`Failed to fetch map data: ${res.status}`);
-    }
-    map = await res.json();
-  } catch (err) {
-    if (typeof logger !== "undefined") {
-      logger.error("Failed to load map data", err);
-    }
-    if (typeof alert !== "undefined") {
-      alert("Unable to load game data. Please try again later.");
-    }
-    return;
-  }
-  territoryPositions = map.territories.reduce((acc, t) => {
-    acc[t.id] = { x: t.x, y: t.y };
-    return acc;
-  }, {});
   const GameClass =
     (typeof window !== "undefined" && window.Game) || Game;
   if (typeof GameClass !== "function") {
@@ -147,16 +123,15 @@ async function loadGame() {
         players = [];
       }
     }
-    game = new GameClass(
-      players.length ? players : null,
-      map.territories,
-      map.continents,
-      map.deck,
-    );
+    game = await GameClass.create(players.length ? players : null);
     if (typeof logger !== "undefined") {
       logger.info("Game initialised");
     }
   }
+  territoryPositions = game.territories.reduce((acc, t) => {
+    acc[t.id] = { x: t.x, y: t.y };
+    return acc;
+  }, {});
   gameState.currentPlayer = game.currentPlayer;
   gameState.players = game.players;
   gameState.territories = game.territories;

--- a/main.test.js
+++ b/main.test.js
@@ -158,6 +158,7 @@ describe('main DOM interactions', () => {
     require('./ui.js');
     await Promise.resolve();
     await Promise.resolve();
+    await Promise.resolve();
     expect(main2.game.territoryById('t1').armies).toBe(armies);
     expect(main2.game.getPhase()).toBe(phase);
   });

--- a/menu.test.js
+++ b/menu.test.js
@@ -36,8 +36,7 @@ describe('main menu', () => {
     const main = require('./main.js');
     expect(main.game).toBeUndefined();
     document.getElementById('startGame').click();
-    await Promise.resolve();
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(main.game).toBeDefined();
   });
 });

--- a/src/load-map-data.js
+++ b/src/load-map-data.js
@@ -1,0 +1,23 @@
+export default async function loadMapData(mapName) {
+  const resolvedName =
+    mapName ||
+    (typeof localStorage !== "undefined" &&
+      localStorage.getItem("netriskMap")) ||
+    "map";
+  const jsonPath = `./src/data/${resolvedName}.json`;
+  try {
+    if (typeof fetch === "function") {
+      try {
+        const res = await fetch(jsonPath);
+        if (res.ok) return await res.json();
+      } catch {}
+    }
+    const fs = await import("fs/promises");
+    const pathMod = await import("path");
+    const filePath = pathMod.resolve(`src/data/${resolvedName}.json`);
+    const data = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(data);
+  } catch (err) {
+    throw new Error(`Unable to load map data: ${err.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Extract map loading into `src/load-map-data.js`
- Reuse shared loader in `game.js` and `main.js` to remove duplicated logic
- Refactor main startup to rely on `Game.create` for map data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada8641674832caba9f269727ab82a