### PR TITLE
refactor: centralize selection logic

### DIFF
--- a/game.js
+++ b/game.js
@@ -134,78 +134,101 @@ class Game {
     return this.territories.find(t => t.id === id);
   }
 
-  handleReinforcePhase(territory) {
-    if (territory.owner === this.currentPlayer && this.reinforcements > 0) {
-      territory.armies += 1;
-      this.reinforcements -= 1;
-      this.emit(REINFORCE, { territory: territory.id, player: this.currentPlayer });
-      if (this.reinforcements === 0) {
-        this.phase = ATTACK;
-        this.emit('phaseChange', { phase: this.phase, player: this.currentPlayer });
+  processSelection(action, territory) {
+    const id = territory.id;
+    if (action.direct) {
+      if (!action.canSelect || action.canSelect(territory)) {
+        return action.onSelect ? action.onSelect.call(this, territory) : null;
       }
-      return { type: REINFORCE, territory: territory.id };
+      return null;
+    }
+    if (!this.selectedFrom) {
+      if (!action.canSelect || action.canSelect(territory)) {
+        this.selectedFrom = territory;
+        return { type: 'select', territory: id };
+      }
+    } else {
+      const from = this.selectedFrom;
+      const to = territory;
+      if (from.id === to.id) {
+        this.selectedFrom = null;
+        return { type: 'deselect', territory: id };
+      }
+      if (!action.canMove || action.canMove(from, to)) {
+        this.selectedFrom = null;
+        return action.onMove ? action.onMove.call(this, from, to) : null;
+      }
     }
     return null;
+  }
+
+  handleReinforcePhase(territory) {
+    return this.processSelection(
+      {
+        direct: true,
+        canSelect: (t) =>
+          t.owner === this.currentPlayer && this.reinforcements > 0,
+        onSelect: (t) => {
+          t.armies += 1;
+          this.reinforcements -= 1;
+          this.emit(REINFORCE, {
+            territory: t.id,
+            player: this.currentPlayer,
+          });
+          if (this.reinforcements === 0) {
+            this.phase = ATTACK;
+            this.emit('phaseChange', {
+              phase: this.phase,
+              player: this.currentPlayer,
+            });
+          }
+          return { type: REINFORCE, territory: t.id };
+        },
+      },
+      territory,
+    );
   }
 
   handleAttackPhase(territory) {
-    const id = territory.id;
-    if (!this.selectedFrom) {
-      if (territory.owner === this.currentPlayer && territory.armies > 1) {
-        this.selectedFrom = territory;
-        return { type: 'select', territory: id };
-      }
-    } else {
-      const from = this.selectedFrom;
-      const to = territory;
-      if (from.id === to.id) {
-        this.selectedFrom = null;
-        return { type: 'deselect', territory: id };
-      }
-      if (
-        from.owner === this.currentPlayer &&
-        to.owner !== this.currentPlayer &&
-        from.neighbors.includes(to.id)
-      ) {
-        const result = this.attack(from, to);
-        this.emit(ATTACK, { from: from.id, to: to.id, result });
-        this.selectedFrom = null;
-        return Object.assign({ type: ATTACK, from: from.id, to: to.id }, result);
-      }
-    }
-    return null;
+    return this.processSelection(
+      {
+        canSelect: (t) =>
+          t.owner === this.currentPlayer && t.armies > 1,
+        canMove: (from, to) =>
+          from.owner === this.currentPlayer &&
+          to.owner !== this.currentPlayer &&
+          from.neighbors.includes(to.id),
+        onMove: (from, to) => {
+          const result = this.attack(from, to);
+          this.emit(ATTACK, { from: from.id, to: to.id, result });
+          return Object.assign({ type: ATTACK, from: from.id, to: to.id }, result);
+        },
+      },
+      territory,
+    );
   }
 
   handleFortifyPhase(territory) {
-    const id = territory.id;
-    if (!this.selectedFrom) {
-      if (territory.owner === this.currentPlayer && territory.armies > 1) {
-        this.selectedFrom = territory;
-        return { type: 'select', territory: id };
-      }
-    } else {
-      const from = this.selectedFrom;
-      const to = territory;
-      if (from.id === to.id) {
-        this.selectedFrom = null;
-        return { type: 'deselect', territory: id };
-      }
-      if (
-        from.owner === this.currentPlayer &&
-        to.owner === this.currentPlayer &&
-        from.neighbors.includes(to.id)
-      ) {
-        const movable = from.armies - 1;
-        this.selectedFrom = null;
-        return {
-          type: FORTIFY,
-          from: from.id,
-          to: to.id,
-          movableArmies: movable,
-        };
-      }
-    }
-    return null;
+    return this.processSelection(
+      {
+        canSelect: (t) =>
+          t.owner === this.currentPlayer && t.armies > 1,
+        canMove: (from, to) =>
+          from.owner === this.currentPlayer &&
+          to.owner === this.currentPlayer &&
+          from.neighbors.includes(to.id),
+        onMove: (from, to) => {
+          const movable = from.armies - 1;
+          return {
+            type: FORTIFY,
+            from: from.id,
+            to: to.id,
+            movableArmies: movable,
+          };
+        },
+      },
+      territory,
+    );
   }
 
   handleTerritoryClick(id) {

--- a/game.test.js
+++ b/game.test.js
@@ -39,6 +39,35 @@ test('reinforce phase allows adding army and moves to attack', () => {
   expect(game.getPhase()).toBe(ATTACK);
 });
 
+test('processSelection handles select and deselect in attack phase', () => {
+  game.setPhase(ATTACK);
+  const t1 = game.territoryById('t1');
+  t1.armies = 3;
+  const selectRes = game.handleTerritoryClick('t1');
+  expect(selectRes).toEqual({ type: 'select', territory: 't1' });
+  const deselectRes = game.handleTerritoryClick('t1');
+  expect(deselectRes).toEqual({ type: 'deselect', territory: 't1' });
+});
+
+test('processSelection validates fortify moves', () => {
+  game.setPhase(FORTIFY);
+  const t1 = game.territoryById('t1');
+  const t2 = game.territoryById('t2');
+  t1.owner = 0;
+  t2.owner = 0;
+  t1.armies = 3;
+  t2.armies = 2;
+  const selectRes = game.handleTerritoryClick('t1');
+  expect(selectRes).toEqual({ type: 'select', territory: 't1' });
+  const moveRes = game.handleTerritoryClick('t2');
+  expect(moveRes).toEqual({
+    type: FORTIFY,
+    from: 't1',
+    to: 't2',
+    movableArmies: 2,
+  });
+});
+
 test('attack phase resolves battle between territories', () => {
   game.handleTerritoryClick('t1');
   game.handleTerritoryClick('t1');


### PR DESCRIPTION
## Summary
- add reusable `processSelection` helper to manage selection and movement validation
- refactor reinforce, attack and fortify handlers to use shared logic
- extend tests to cover selection, deselection and fortify move validation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc593c490832ca373e71e52c4dc91