### PR TITLE
Refactor visibility toggling to use hidden class

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       <button id="startGame">Start Game</button>
       <a href="setup.html">Set up players</a>
     </div>
-    <div id="gameContainer" style="display: none">
+    <div id="gameContainer" class="hidden">
       <div id="uiPanel">
         <div>Current turn: <span id="turnNumber">1</span></div>
         <div>Current player: <span id="currentPlayer"></span></div>

--- a/logger.js
+++ b/logger.js
@@ -9,18 +9,18 @@
     background: "rgba(255,0,0,0.9)",
     color: "#fff",
     padding: "4px",
-    display: "none",
     zIndex: "1000",
     fontFamily: "monospace",
     whiteSpace: "pre-wrap",
   });
+  overlay.classList.add("hidden");
   document.addEventListener("DOMContentLoaded", () => {
     document.body.appendChild(overlay);
   });
 
   function showError(message) {
     overlay.textContent = message;
-    overlay.style.display = "block";
+    overlay.classList.remove("hidden");
   }
 
   window.logger = {

--- a/main.js
+++ b/main.js
@@ -513,10 +513,10 @@ function init() {
     initGame();
     return;
   }
-  container.style.display = "none";
+  container.classList.add("hidden");
   startBtn.addEventListener("click", async () => {
-    menu.style.display = "none";
-    container.style.display = "";
+    menu.classList.add("hidden");
+    container.classList.remove("hidden");
     await initGame();
   });
 }

--- a/style.css
+++ b/style.css
@@ -35,6 +35,11 @@ button:active {
   transform: translateY(2px);
 }
 
+/* Utility classes */
+.hidden {
+  display: none;
+}
+
 #mainMenu {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Remove inline `display: none` from `#gameContainer`
- Introduce `.hidden` utility class and apply it in scripts
- Show error overlay by toggling `.hidden`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add6761c0c832c9f00b496902ba419