### PR TITLE
refactor html structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,16 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
-    <button id="themeToggle">High Contrast</button>
-    <h1>NetRisk</h1>
-    <div id="mainMenu">
-      <button id="startGame">Start Game</button>
-      <a href="setup.html">Set up players</a>
-    </div>
-    <div id="gameContainer" style="display: none">
+    <header>
+      <h1>NetRisk</h1>
+      <button id="themeToggle">High Contrast</button>
+    </header>
+    <main>
+      <div id="mainMenu">
+        <button id="startGame">Start Game</button>
+        <a href="setup.html">Set up players</a>
+      </div>
+      <div id="gameContainer" style="display: none">
       <div id="uiPanel">
         <div>Current turn: <span id="turnNumber">1</span></div>
         <div>Current player: <span id="currentPlayer"></span></div>
@@ -59,6 +62,7 @@
       </div>
       <div id="board" class="board"></div>
     </div>
+    </main>
     <script src="./logger.js"></script>
     <script type="module" src="./main.js"></script>
   </body>

--- a/setup.html
+++ b/setup.html
@@ -9,26 +9,34 @@
   </head>
   <body>
     <button id="themeToggle">High Contrast</button>
-    <h1>Player Setup</h1>
-    <form id="setupForm">
-      <label>
-        Number of human players:
-        <input type="number" id="humanCount" min="1" max="6" required value="1" />
-      </label>
-      <label>
-        Number of AI players:
-        <input type="number" id="aiCount" min="0" max="5" required value="2" />
-      </label>
-      <label>
-        Map:
-        <select id="mapSelect">
-          <option value="map">Classic</option>
-          <option value="map2">Desert</option>
-        </select>
-      </label>
-      <div id="players"></div>
-      <button type="submit">Start</button>
-    </form>
+    <main>
+      <h1>Player Setup</h1>
+      <form id="setupForm">
+        <fieldset>
+          <legend>Players</legend>
+          <label>
+            Number of human players:
+            <input type="number" id="humanCount" min="1" max="6" required value="1" />
+          </label>
+          <label>
+            Number of AI players:
+            <input type="number" id="aiCount" min="0" max="5" required value="2" />
+          </label>
+        </fieldset>
+        <fieldset>
+          <legend>Map</legend>
+          <label>
+            Map:
+            <select id="mapSelect">
+              <option value="map">Classic</option>
+              <option value="map2">Desert</option>
+            </select>
+          </label>
+        </fieldset>
+        <div id="players"></div>
+        <button type="submit">Start</button>
+      </form>
+    </main>
     <script type="module" src="./setup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- use semantic header element around title and theme toggle
- wrap menu and game sections in `<main>` on landing page
- place setup form inside `<main>` and group fields with `<fieldset>` for clarity

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add678d7c8832c987fffc5a9eb050a