### PR TITLE
Cap board width and center layout for large screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,8 +74,9 @@ button:active {
 
 @media (min-width: 768px) {
   #gameContainer {
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: minmax(300px, 1fr) 2fr;
     align-items: flex-start;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- Cap board width by switching `grid-template-columns` to `minmax(300px, 1fr) 2fr`
- Center game grid at larger breakpoints with `justify-content: center`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add67b84fc832cb70f15e4ee975e97