### PR TITLE
feat: add lobby-based multiplayer server

### DIFF
--- a/multiplayer-server.js
+++ b/multiplayer-server.js
@@ -1,17 +1,204 @@
 import { WebSocketServer } from "ws";
+import { randomBytes } from "crypto";
 
-const port = process.env.PORT || 8081;
-const wss = new WebSocketServer({ port });
+/**
+ * Creates a multiplayer lobby server. The server supports creating and joining
+ * lobbies, ready states, basic chat and synchronized turn based game state
+ * updates. All state is kept in memory and broadcast to connected clients
+ * through WebSocket messages.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.port] Port to listen on
+ * @returns {WebSocketServer} the running WebSocketServer instance
+ */
+export function createLobbyServer({ port = process.env.PORT || 8081 } = {}) {
+  const wss = new WebSocketServer({ port });
 
-wss.on("connection", ws => {
-  ws.on("message", message => {
-    wss.clients.forEach(client => {
-      if (client !== ws && client.readyState === 1) {
-        client.send(message);
+  /**
+   * Active lobbies keyed by lobby code
+   * @type {Map<string, {code:string, players:Array, host:string, state:any, started:boolean, currentPlayer?:string}>}
+   */
+  const lobbies = new Map();
+
+  // Generate short lobby code
+  const createCode = () => randomBytes(3).toString("hex");
+
+  // Remove websocket instances when broadcasting lobby data
+  const publicPlayers = lobby =>
+    lobby.players.map(({ ws, ...p }) => ({ ...p, connected: !!ws }));
+
+  const broadcast = (lobby, msg, except) => {
+    const data = JSON.stringify(msg);
+    lobby.players.forEach(p => {
+      if (p.ws && p.ws.readyState === 1 && p.ws !== except) {
+        p.ws.send(data);
+      }
+    });
+  };
+
+  wss.on("connection", ws => {
+    let currentLobby = null;
+    let currentPlayer = null;
+
+    ws.on("message", raw => {
+      let msg;
+      try {
+        msg = JSON.parse(raw);
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case "createLobby": {
+          const code = createCode();
+          const player = {
+            id: msg.player?.id || createCode(),
+            name: msg.player?.name,
+            color: msg.player?.color,
+            ready: false,
+            ws,
+          };
+          const lobby = {
+            code,
+            players: [player],
+            host: player.id,
+            state: null,
+            started: false,
+            currentPlayer: null,
+          };
+          lobbies.set(code, lobby);
+          currentLobby = lobby;
+          currentPlayer = player;
+          ws.send(
+            JSON.stringify({
+              type: "lobby",
+              code,
+              host: player.id,
+              players: publicPlayers(lobby),
+            })
+          );
+          break;
+        }
+        case "joinLobby": {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby || lobby.started) {
+            ws.send(JSON.stringify({ type: "error", error: "lobbyNotFound" }));
+            return;
+          }
+          const player = {
+            id: msg.player?.id || createCode(),
+            name: msg.player?.name,
+            color: msg.player?.color,
+            ready: false,
+            ws,
+          };
+          lobby.players.push(player);
+          currentLobby = lobby;
+          currentPlayer = player;
+          ws.send(
+            JSON.stringify({ type: "joined", code: lobby.code, id: player.id })
+          );
+          broadcast(lobby, {
+            type: "lobby",
+            code: lobby.code,
+            host: lobby.host,
+            players: publicPlayers(lobby),
+          });
+          break;
+        }
+        case "ready": {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby) return;
+          const player = lobby.players.find(p => p.id === msg.id);
+          if (!player) return;
+          player.ready = !!msg.ready;
+          broadcast(lobby, {
+            type: "lobby",
+            code: lobby.code,
+            host: lobby.host,
+            players: publicPlayers(lobby),
+          });
+          break;
+        }
+        case "start": {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby || lobby.host !== msg.id) return;
+          if (!lobby.players.every(p => p.ready)) return;
+          lobby.state = msg.state;
+          lobby.started = true;
+          lobby.currentPlayer = msg.state?.currentPlayer ?? null;
+          broadcast(lobby, { type: "start", state: lobby.state });
+          break;
+        }
+        case "state": {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby || !lobby.started) return;
+          if (lobby.state && msg.id !== lobby.state.currentPlayer) return;
+          lobby.state = msg.state;
+          lobby.currentPlayer = msg.state?.currentPlayer ?? null;
+          broadcast(lobby, { type: "state", state: lobby.state }, ws);
+          break;
+        }
+        case "chat": {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby) return;
+          broadcast(lobby, {
+            type: "chat",
+            id: msg.id,
+            text: msg.text,
+          });
+          break;
+        }
+        case "reconnect": {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby) return;
+          const player = lobby.players.find(p => p.id === msg.id);
+          if (!player) return;
+          player.ws = ws;
+          currentLobby = lobby;
+          currentPlayer = player;
+          ws.send(
+            JSON.stringify({
+              type: "reconnected",
+              code: lobby.code,
+              player: {
+                id: player.id,
+                name: player.name,
+                color: player.color,
+                ready: player.ready,
+              },
+              state: lobby.state,
+            })
+          );
+          break;
+        }
+        default:
+          break;
+      }
+    });
+
+    ws.on("close", () => {
+      if (currentLobby && currentPlayer) {
+        currentPlayer.ws = null;
+        currentPlayer.ready = false;
+        broadcast(currentLobby, {
+          type: "lobby",
+          code: currentLobby.code,
+          host: currentLobby.host,
+          players: publicPlayers(currentLobby),
+        });
       }
     });
   });
-});
 
-// eslint-disable-next-line no-console
-console.log(`Multiplayer server listening on port ${port}`);
+  return wss;
+}
+
+// If this module is executed directly, start the server immediately
+if (typeof require !== "undefined" && require.main === module) {
+  const port = process.env.PORT || 8081;
+  createLobbyServer({ port });
+  // eslint-disable-next-line no-console
+  console.log(`Multiplayer server listening on port ${port}`);
+}
+

--- a/multiplayer-server.test.js
+++ b/multiplayer-server.test.js
@@ -1,0 +1,130 @@
+/** @jest-environment node */
+import WebSocket from "ws";
+import { createLobbyServer } from "./multiplayer-server.js";
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function onceOpen(ws) {
+  return new Promise(resolve => ws.once("open", resolve));
+}
+
+function onceClose(ws) {
+  return new Promise(resolve => ws.once("close", resolve));
+}
+
+function messageQueue(ws) {
+  const q = [];
+  ws.on("message", data => q.push(JSON.parse(data.toString())));
+  return q;
+}
+
+test("lobby server manages lifecycle", async () => {
+  const port = 12346;
+  const server = createLobbyServer({ port });
+  const url = `ws://localhost:${port}`;
+
+  const ws1 = new WebSocket(url);
+  await onceOpen(ws1);
+  const q1 = messageQueue(ws1);
+  ws1.send(
+    JSON.stringify({
+      type: "createLobby",
+      player: { id: "p1", name: "P1", color: "#f00" },
+    })
+  );
+  await wait(50);
+  const lobbyMsg = q1.shift();
+  const code = lobbyMsg.code;
+
+  const ws2 = new WebSocket(url);
+  await onceOpen(ws2);
+  const q2 = messageQueue(ws2);
+  ws2.send(
+    JSON.stringify({
+      type: "joinLobby",
+      code,
+      player: { id: "p2", name: "P2", color: "#0f0" },
+    })
+  );
+  await wait(50);
+  q2.shift(); // joined
+  q1.shift(); // lobby update
+  q2.shift(); // lobby broadcast
+
+  const ws3 = new WebSocket(url);
+  await onceOpen(ws3);
+  const q3 = messageQueue(ws3);
+  ws3.send(
+    JSON.stringify({
+      type: "joinLobby",
+      code,
+      player: { id: "p3", name: "P3", color: "#00f" },
+    })
+  );
+  await wait(50);
+  q3.shift();
+  q1.shift();
+  q2.shift();
+  q3.shift();
+
+  ws1.send(JSON.stringify({ type: "ready", code, id: "p1", ready: true }));
+  ws2.send(JSON.stringify({ type: "ready", code, id: "p2", ready: true }));
+  ws3.send(JSON.stringify({ type: "ready", code, id: "p3", ready: true }));
+  await wait(50);
+  q1.splice(0); q2.splice(0); q3.splice(0);
+
+  ws1.send(
+    JSON.stringify({
+      type: "start",
+      code,
+      id: "p1",
+      state: { currentPlayer: "p1" },
+    })
+  );
+  await wait(50);
+  const start2 = q2.shift();
+  const start3 = q3.shift();
+  const start1 = q1.shift();
+  expect(start2.type).toBe("start");
+  expect(start3.state.currentPlayer).toBe("p1");
+  expect(start1.type).toBe("start");
+
+  ws1.send(
+    JSON.stringify({
+      type: "state",
+      code,
+      id: "p1",
+      state: { currentPlayer: "p2" },
+    })
+  );
+  await wait(50);
+  const stateMsg = q2.shift();
+  expect(stateMsg.state.currentPlayer).toBe("p2");
+
+  q1.shift(); // clear host state broadcast
+
+  ws2.send(JSON.stringify({ type: "chat", code, id: "p2", text: "hi" }));
+  await wait(50);
+  const chatMsg = q1.shift();
+  expect(chatMsg.type).toBe("chat");
+  expect(chatMsg.text).toBe("hi");
+
+  ws3.close();
+  await onceClose(ws3);
+  const ws3b = new WebSocket(url);
+  await onceOpen(ws3b);
+  const q3b = messageQueue(ws3b);
+  ws3b.send(JSON.stringify({ type: "reconnect", code, id: "p3" }));
+  await wait(50);
+  const rec = q3b.shift();
+  expect(rec.type).toBe("reconnected");
+  expect(rec.state.currentPlayer).toBe("p2");
+
+  ws1.close();
+  ws2.close();
+  ws3b.close();
+  server.close();
+});
+


### PR DESCRIPTION
## Summary
- add lobby-based multiplayer server supporting create/join, ready checks, state sync, chat, and reconnection
- add integration test covering lobby lifecycle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf5df6a1c832ca75c9bc91629e441