### PR TITLE
feat: add map previews in setup

### DIFF
--- a/map-manifest.json
+++ b/map-manifest.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "maps": [
+    {
+      "id": "map",
+      "name": "Classic",
+      "difficulty": "Medium",
+      "territories": 42,
+      "bonuses": {"North America": 5, "Europe": 5, "Asia": 7, "Africa": 3, "South America": 2, "Australia": 2},
+      "thumbnail": "map.svg",
+      "description": "Classic world domination map."
+    },
+    {
+      "id": "map2",
+      "name": "Desert",
+      "difficulty": "Hard",
+      "territories": 30,
+      "bonuses": {"North": 4, "South": 3},
+      "thumbnail": "map2.svg",
+      "description": "Battles across the arid desert."
+    },
+    {
+      "id": "map3",
+      "name": "Grid",
+      "difficulty": "Easy",
+      "territories": 20,
+      "bonuses": {"A": 2, "B": 2},
+      "thumbnail": "map3.svg",
+      "description": "Simple grid-based battlefield."
+    },
+    {
+      "id": "map-roman",
+      "name": "Roman Empire",
+      "difficulty": "Medium",
+      "territories": 35,
+      "bonuses": {"Italia": 5, "Gallia": 4},
+      "thumbnail": "map-roman.svg",
+      "description": "Conquer the ancient Roman world."
+    }
+  ]
+}

--- a/setup.html
+++ b/setup.html
@@ -19,15 +19,9 @@
         Number of AI players:
         <input type="number" id="aiCount" min="0" max="5" required value="2" />
       </label>
-      <label>
-        Map:
-        <select id="mapSelect">
-          <option value="map">Classic</option>
-          <option value="map2">Desert</option>
-          <option value="map3">Grid</option>
-          <option value="map-roman">Roman Empire</option>
-        </select>
-      </label>
+      <p>Map:</p>
+      <input type="hidden" id="mapSelect" />
+      <div id="mapGrid"></div>
       <div id="players"></div>
       <button type="submit" class="btn">Start</button>
     </form>

--- a/setup.js
+++ b/setup.js
@@ -7,6 +7,79 @@ const humanCountInput = document.getElementById("humanCount");
 const aiCountInput = document.getElementById("aiCount");
 const playersContainer = document.getElementById("players");
 const mapSelect = document.getElementById("mapSelect");
+const mapGrid = document.getElementById("mapGrid");
+
+const thumbnailCache = new Map();
+let selectedMap = null;
+
+function getCachedImage(src) {
+  if (thumbnailCache.has(src)) {
+    return thumbnailCache.get(src).cloneNode(true);
+  }
+  const img = document.createElement("img");
+  img.src = src;
+  thumbnailCache.set(src, img);
+  return img.cloneNode(true);
+}
+
+export async function loadMapData() {
+  if (!mapGrid) return;
+  const res = await fetch("./map-manifest.json");
+  const data = await res.json();
+  mapGrid.innerHTML = "";
+  mapGrid.style.display = "grid";
+  mapGrid.style.gridTemplateColumns = "repeat(auto-fit, minmax(150px, 1fr))";
+  data.maps.forEach((m) => {
+    const item = document.createElement("div");
+    item.className = "map-item";
+    item.dataset.id = m.id;
+    const img = getCachedImage(m.thumbnail);
+    img.alt = m.name;
+    img.addEventListener("error", () => {
+      item.classList.add("missing");
+      item.innerHTML = '<div class="placeholder">No preview</div>';
+    });
+    item.appendChild(img);
+    const name = document.createElement("h3");
+    name.textContent = m.name;
+    item.appendChild(name);
+    const diff = document.createElement("p");
+    diff.textContent = `Difficulty: ${m.difficulty}`;
+    item.appendChild(diff);
+    const terr = document.createElement("p");
+    terr.textContent = `Territories: ${m.territories}`;
+    item.appendChild(terr);
+    const bonus = document.createElement("p");
+    bonus.textContent =
+      "Bonuses: " +
+      Object.entries(m.bonuses || {})
+        .map(([k, v]) => `${k} ${v}`)
+        .join(", ");
+    item.appendChild(bonus);
+    const detail = document.createElement("div");
+    detail.className = "map-detail hidden";
+    detail.innerHTML = `<p>${m.description || ""}</p>`;
+    const layout = getCachedImage(m.thumbnail);
+    layout.alt = `${m.name} layout`;
+    layout.className = "layout";
+    detail.appendChild(layout);
+    item.appendChild(detail);
+    item.addEventListener("mouseenter", () => detail.classList.remove("hidden"));
+    item.addEventListener("mouseleave", () => detail.classList.add("hidden"));
+    item.addEventListener("click", () => {
+      selectedMap = m.id;
+      if (mapSelect) mapSelect.value = m.id;
+      document
+        .querySelectorAll(".map-item.selected")
+        .forEach((el) => el.classList.remove("selected"));
+      item.classList.add("selected");
+    });
+    if (selectedMap === m.id) {
+      item.classList.add("selected");
+    }
+    mapGrid.appendChild(item);
+  });
+}
 
 function renderPlayerInputs(humanCount) {
   playersContainer.innerHTML = "";
@@ -49,6 +122,7 @@ function loadFromStorage() {
   }
   if (savedMap && mapSelect) {
     mapSelect.value = savedMap;
+    selectedMap = savedMap;
   }
   renderPlayerInputs(humanCount);
   if (saved) {
@@ -101,3 +175,4 @@ form.addEventListener("submit", (e) => {
 
 loadFromStorage();
 initThemeToggle();
+export const mapLoadPromise = loadMapData();

--- a/setup.test.js
+++ b/setup.test.js
@@ -7,35 +7,62 @@ function setupDOM() {
         <input id="humanCount" />
         <input id="aiCount" />
         <div id="players"></div>
-        <select id="mapSelect">
-          <option value="map">Classic</option>
-          <option value="map2">Desert</option>
-          <option value="map3">Grid</option>
-          <option value="map-roman">Roman Empire</option>
-        </select>
+        <input type="hidden" id="mapSelect" />
+        <div id="mapGrid"></div>
       </form>`;
-  }
+}
 
 describe('setup map selection', () => {
   beforeEach(() => {
     setupDOM();
     localStorage.clear();
-    // mock colorPalette usage
     window.alert = jest.fn();
+    jest.resetModules();
   });
 
-  test('saves selected map to localStorage and navigates to game', () => {
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('saves selected map to localStorage and navigates to game', async () => {
+    const manifest = {
+      version: 1,
+      maps: [
+        { id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'map.svg', description: '' },
+        { id: 'map3', name: 'Grid', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'map3.svg', description: '' },
+      ],
+    };
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
     const { navigateTo } = require('./navigation.js');
-    require('./setup.js');
+    const { mapLoadPromise } = require('./setup.js');
+    await mapLoadPromise;
     document.getElementById('humanCount').value = '1';
     document.getElementById('aiCount').value = '0';
-    // setup.js rendered player input
     document.getElementById('name0').value = 'P1';
     document.getElementById('color0').value = colorPalette[0];
-      const mapSel = document.getElementById('mapSelect');
-      mapSel.value = 'map3';
-      document.getElementById('setupForm').dispatchEvent(new Event('submit'));
-      expect(localStorage.getItem('netriskMap')).toBe('map3');
-      expect(navigateTo).toHaveBeenCalledWith('index.html');
-    });
+    document.querySelector('.map-item[data-id="map3"]').click();
+    document.getElementById('setupForm').dispatchEvent(new Event('submit'));
+    expect(localStorage.getItem('netriskMap')).toBe('map3');
+    expect(navigateTo).toHaveBeenCalledWith('index.html');
   });
+
+  test('renders responsive grid', async () => {
+    const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'map.svg', description: '' }] };
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
+    const { mapLoadPromise } = require('./setup.js');
+    await mapLoadPromise;
+    const grid = document.getElementById('mapGrid');
+    expect(grid.style.display).toBe('grid');
+    expect(grid.style.gridTemplateColumns).toContain('auto-fit');
+  });
+
+  test('shows placeholder when thumbnail missing', async () => {
+    const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'missing.svg', description: '' }] };
+    global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
+    const { mapLoadPromise } = require('./setup.js');
+    await mapLoadPromise;
+    const img = document.querySelector('.map-item img');
+    img.dispatchEvent(new Event('error'));
+    expect(document.querySelector('.map-item .placeholder')).not.toBeNull();
+  });
+});

--- a/style.css
+++ b/style.css
@@ -67,6 +67,59 @@ h1 {
   margin: 0 auto;
 }
 
+#mapGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.map-item {
+  border: 2px solid #8b4513;
+  padding: 5px;
+  position: relative;
+  cursor: pointer;
+  background: rgba(245, 231, 198, 0.9);
+}
+
+.map-item.selected {
+  outline: 2px solid #ff0;
+}
+
+.map-item img {
+  max-width: 100%;
+  height: auto;
+}
+
+.map-item .map-detail {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(245, 231, 198, 0.95);
+  padding: 5px;
+  border: 1px solid #8b4513;
+}
+
+.map-item .map-detail.hidden {
+  display: none;
+}
+
+.map-item.missing .placeholder {
+  width: 100%;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ccc;
+  color: #333;
+}
+
+.map-item .layout {
+  width: 100px;
+  height: auto;
+}
+
 #setupForm label {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- load maps from versioned manifest and render preview grid with details and hover cards
- cache thumbnails and show placeholders when assets are missing
- test responsive grid and map selection flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfd0775f8832c883e9a860c8f4d0c