### PR TITLE
Add tests for navigation, colors and phases modules

### DIFF
--- a/colors.test.js
+++ b/colors.test.js
@@ -1,0 +1,22 @@
+import { colorPalette, getContrastingColor } from "./colors.js";
+
+describe("getContrastingColor", () => {
+  test("returns black for light colors", () => {
+    expect(getContrastingColor("#ffffff")).toBe("#000000");
+  });
+
+  test("returns white for dark colors", () => {
+    expect(getContrastingColor("#000000")).toBe("#ffffff");
+  });
+
+  test("supports short hex notation", () => {
+    expect(getContrastingColor("#fff")).toBe("#000000");
+    expect(getContrastingColor("#000")).toBe("#ffffff");
+  });
+});
+
+describe("colorPalette", () => {
+  test("contains 12 colors", () => {
+    expect(colorPalette).toHaveLength(12);
+  });
+});

--- a/navigation.js
+++ b/navigation.js
@@ -1,9 +1,9 @@
-export function navigateTo(url) {
-  if (typeof window !== "undefined") {
-    if (typeof window.location.assign === "function") {
-      window.location.assign(url);
+export function navigateTo(url, win = typeof window !== "undefined" ? window : undefined) {
+  if (win) {
+    if (typeof win.location.assign === "function") {
+      win.location.assign(url);
     } else {
-      window.location.href = url;
+      win.location.href = url;
     }
   }
 }

--- a/navigation.test.js
+++ b/navigation.test.js
@@ -1,0 +1,15 @@
+import { navigateTo } from "./navigation.js";
+
+describe("navigateTo", () => {
+  test("uses location.assign when available", () => {
+    const win = { location: { assign: jest.fn() } };
+    navigateTo("/somewhere", win);
+    expect(win.location.assign).toHaveBeenCalledWith("/somewhere");
+  });
+
+  test("falls back to setting location.href", () => {
+    const win = { location: { href: "" } };
+    navigateTo("/other", win);
+    expect(win.location.href).toBe("/other");
+  });
+});

--- a/phases.test.js
+++ b/phases.test.js
@@ -1,0 +1,14 @@
+import PHASES, { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "./phases.js";
+
+describe("PHASES constants", () => {
+  test("have expected values", () => {
+    expect(REINFORCE).toBe("reinforce");
+    expect(ATTACK).toBe("attack");
+    expect(FORTIFY).toBe("fortify");
+    expect(GAME_OVER).toBe("gameover");
+  });
+
+  test("object is frozen", () => {
+    expect(Object.isFrozen(PHASES)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for color utility functions
- Test phase constants and freeze status
- Refactor navigation to support dependency injection and test via new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adfea70d18832c88664e84707e7833