### PR TITLE
feat: add advanced game log with export

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ import {
   destroyUI,
   resetSelectedCards,
   getSelectedCards,
-  getLog,
+  exportLog,
 } from "./ui.js";
 import { loadGame as loadGameData } from "./src/init/game-loader.js";
 import {
@@ -126,7 +126,11 @@ function attachAIActionLogging() {
   game.on(REINFORCE, ({ territory, player }) => {
     if (game.players[player].ai) {
       const name = game.players[player].name;
-      addLogEntry(`${name} reinforces ${territory}`);
+      addLogEntry(`${name} reinforces ${territory}`, {
+        player: name,
+        type: "reinforce",
+        territories: [territory],
+      });
       if (typeof logger !== "undefined") {
         logger.info(`${name} reinforces ${territory}`);
       }
@@ -136,7 +140,11 @@ function attachAIActionLogging() {
   game.on(ATTACK, ({ from, to }) => {
     if (game.players[game.currentPlayer].ai) {
       const name = game.players[game.currentPlayer].name;
-      addLogEntry(`${name} attacks ${to} from ${from}`);
+      addLogEntry(`${name} attacks ${to} from ${from}`, {
+        player: name,
+        type: "attack",
+        territories: [from, to],
+      });
       if (typeof logger !== "undefined") {
         logger.info(`${name} attacks ${to} from ${from}`);
       }
@@ -146,7 +154,11 @@ function attachAIActionLogging() {
   game.on("move", ({ from, to, count }) => {
     if (game.players[game.currentPlayer].ai) {
       const name = game.players[game.currentPlayer].name;
-      addLogEntry(`${name} moves ${count} from ${from} to ${to}`);
+      addLogEntry(`${name} moves ${count} from ${from} to ${to}`, {
+        player: name,
+        type: "move",
+        territories: [from, to],
+      });
       if (typeof logger !== "undefined") {
         logger.info(`${name} moves ${count} from ${from} to ${to}`);
       }
@@ -156,7 +168,10 @@ function attachAIActionLogging() {
   game.on("cardsPlayed", ({ player }) => {
     if (game.players[player].ai) {
       const name = game.players[player].name;
-      addLogEntry(`${name} plays cards`);
+      addLogEntry(`${name} plays cards`, {
+        player: name,
+        type: "cards",
+      });
       if (typeof logger !== "undefined") {
         logger.info(`${name} plays cards`);
       }
@@ -166,7 +181,10 @@ function attachAIActionLogging() {
   game.on("cardAwarded", ({ player, card }) => {
     const name = game.players[player].name;
     const icons = { infantry: "🪖", cavalry: "🐎", artillery: "💣" };
-    addLogEntry(`${name} receives a card ${icons[card.type] || card.type}`);
+    addLogEntry(`${name} receives a card ${icons[card.type] || card.type}`, {
+      player: name,
+      type: "card",
+    });
     if (typeof logger !== "undefined") {
       logger.info(`${name} receives card ${card.type}`);
     }
@@ -177,7 +195,10 @@ function attachAIActionLogging() {
     const prevName = game.players[prev].name;
     const nextName = game.players[player].name;
     if (game.players[prev].ai) {
-      addLogEntry(`${prevName} ends turn. Next: ${nextName}`);
+      addLogEntry(`${prevName} ends turn. Next: ${nextName}`, {
+        player: prevName,
+        type: "endTurn",
+      });
       if (typeof logger !== "undefined") {
         logger.info(`${prevName} ends turn. Next: ${nextName}`);
       }
@@ -222,16 +243,28 @@ function attachTerritoryHandlers() {
               const move = await askArmiesToMove(result.movableArmies, 0);
               if (move > 0) {
                 game.moveArmies(result.from, result.to, move);
-                addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`);
+                addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`, {
+                  player: playerName,
+                  type: "move",
+                  territories: [result.from, result.to],
+                });
                 animateMove(result.from, result.to);
               }
             }
-            addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`);
+            addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`, {
+              player: playerName,
+              type: "attack",
+              territories: [result.from, result.to],
+            });
           } else if (result.type === REINFORCE) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} reinforces ${result.territory}`);
             }
-            addLogEntry(`${playerName} reinforces ${result.territory}`);
+            addLogEntry(`${playerName} reinforces ${result.territory}`, {
+              player: playerName,
+              type: "reinforce",
+              territories: [result.territory],
+            });
           } else if (result.type === FORTIFY) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
@@ -239,15 +272,20 @@ function attachTerritoryHandlers() {
             const move = await askArmiesToMove(result.movableArmies, 1);
             if (move > 0) {
               game.moveArmies(result.from, result.to, move);
-              addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`);
+                addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`, {
+                  player: playerName,
+                  type: "move",
+                  territories: [result.from, result.to],
+                });
               animateMove(result.from, result.to);
             }
             game.endTurn();
             const nextName = game.players[game.currentPlayer].name;
             gameState.turnNumber += 1;
-            addLogEntry(
-              `${playerName} ends turn. Next: ${nextName}`,
-            );
+              addLogEntry(
+                `${playerName} ends turn. Next: ${nextName}`,
+                { player: playerName, type: "endTurn" },
+              );
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} ends turn. Next: ${nextName}`);
             }
@@ -286,15 +324,19 @@ document.getElementById("endTurn").addEventListener("click", () => {
     const prevPhase = game.getPhase();
     game.endTurn();
     if (prevPhase === ATTACK && game.getPhase() === FORTIFY) {
-      addLogEntry(`${game.players[prevPlayer].name} enters fortify phase`);
+        addLogEntry(`${game.players[prevPlayer].name} enters fortify phase`, {
+          player: game.players[prevPlayer].name,
+          type: "phase",
+        });
       if (typeof logger !== "undefined") {
         logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
       }
     } else if (prevPhase === FORTIFY && game.getPhase() === REINFORCE) {
       gameState.turnNumber += 1;
-      addLogEntry(
-        `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
-      );
+        addLogEntry(
+          `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
+          { player: game.players[prevPlayer].name, type: "endTurn" },
+        );
       if (typeof logger !== "undefined") {
         logger.info(
           `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
@@ -323,12 +365,12 @@ if (forceErrorBtn) {
 const exportLogBtn = document.getElementById("exportLog");
 if (exportLogBtn) {
   exportLogBtn.addEventListener("click", () => {
-    const logData = getLog();
-    const blob = new Blob([logData.join("\n")], { type: "text/plain" });
+    const logData = exportLog("json");
+    const blob = new Blob([logData], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "netrisk-log.txt";
+    a.download = "netrisk-log.json";
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
@@ -374,7 +416,10 @@ async function initGame() {
     const cards = getSelectedCards();
     if (cards.length === 3) {
       if (game.playCards(cards)) {
-        addLogEntry(`${game.players[game.currentPlayer].name} plays cards`);
+        addLogEntry(`${game.players[game.currentPlayer].name} plays cards`, {
+          player: game.players[game.currentPlayer].name,
+          type: "cards",
+        });
         resetSelectedCards();
         game.calculateReinforcements();
         updateUI();
@@ -414,7 +459,10 @@ async function initGame() {
 
   updateGameState(gameState, game);
   updateInfoPanel();
-  addLogEntry(`Turn ${gameState.turnNumber}: ${game.players[game.currentPlayer].name}`);
+    addLogEntry(`Turn ${gameState.turnNumber}: ${game.players[game.currentPlayer].name}`, {
+      player: game.players[game.currentPlayer].name,
+      type: "turn",
+    });
 
   const toggleHowToPlay = document.getElementById("toggleHowToPlay");
   if (toggleHowToPlay) {

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -37,7 +37,7 @@ export default function initTerritorySelection({
     if (!el) return;
     const phase = game?.getPhase();
     if (phase && ![ATTACK, FORTIFY].includes(phase)) {
-      addLogEntry?.(`Move not allowed during ${phase} phase`);
+      addLogEntry?.(`Move not allowed during ${phase} phase`, { type: "error" });
       return;
     }
     const box = el.getBBox();
@@ -56,6 +56,11 @@ export default function initTerritorySelection({
       const name = el.dataset.name || el.id;
       addLogEntry(
         `${game.players[game.currentPlayer].name} moves token to ${name}`,
+        {
+          player: game.players[game.currentPlayer].name,
+          type: "token",
+          territories: [el.id],
+        },
       );
       logger?.info(
         `${game.players[game.currentPlayer].name} moves token to ${name}`,
@@ -71,7 +76,7 @@ export default function initTerritorySelection({
         if (selectedTerritory) {
           moveToken(selectedTerritory.el);
         } else {
-          addLogEntry?.("No territory selected");
+          addLogEntry?.("No territory selected", { type: "error" });
         }
       } catch (err) {
         logger?.error(err);

--- a/ui.js
+++ b/ui.js
@@ -76,8 +76,21 @@ function updateInfoPanel() {
   if (tn) tn.textContent = gameState.turnNumber;
 }
 
-function addLogEntry(msg) {
-  gameState.log.push(msg);
+function highlightTerritories(ids) {
+  ids.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.classList.add("highlight");
+      setTimeout(() => el.classList.remove("highlight"), 1000);
+    }
+  });
+}
+
+function addLogEntry(entry, meta = {}) {
+  const logEntry =
+    typeof entry === "string" ? { message: entry, ...meta } : entry;
+  if (logEntry.turn == null) logEntry.turn = gameState?.turnNumber;
+  gameState.log.push(logEntry);
   const logEl = getElement("actionLog");
   if (logEl) {
     // rebuild log using DOM nodes to avoid innerHTML
@@ -86,16 +99,64 @@ function addLogEntry(msg) {
     const recent = gameState.log.slice(-10);
     recent.forEach((l) => {
       const div = document.createElement("div");
-      div.textContent = l;
+      div.textContent = l.message;
+      if (l.territories && l.territories.length) {
+        const link = document.createElement("a");
+        link.href = "#";
+        link.textContent = " go to move";
+        link.addEventListener("click", (e) => {
+          e.preventDefault();
+          highlightTerritories(l.territories);
+        });
+        div.appendChild(link);
+      }
       fragment.appendChild(div);
     });
     logEl.appendChild(fragment);
     logEl.scrollTop = logEl.scrollHeight;
   }
+  return logEntry;
 }
 
-function getLog() {
-  return gameState.log;
+function getLog(filter = {}) {
+  if (!filter.player && !filter.type && !filter.turn) {
+    return gameState.log;
+  }
+  return gameState.log.filter((e) => {
+    if (filter.player != null && e.player !== filter.player) return false;
+    if (filter.type && e.type !== filter.type) return false;
+    if (filter.turn != null && e.turn !== filter.turn) return false;
+    return true;
+  });
+}
+
+function exportLog(format = "json", filter) {
+  const entries = getLog(filter);
+  if (format === "json") {
+    return JSON.stringify(entries);
+  }
+  if (format === "csv") {
+    const header = ["turn", "player", "type", "message", "territories"].join(",");
+    const rows = entries.map((e) =>
+      [
+        e.turn,
+        e.player || "",
+        e.type || "",
+        `"${e.message.replace(/"/g, '""')}"`,
+        (e.territories || []).join("|")
+      ].join(","),
+    );
+    return [header, ...rows].join("\n");
+  }
+  throw new Error("Unsupported format");
+}
+
+async function copyLog(format = "json", filter) {
+  const data = exportLog(format, filter);
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    await navigator.clipboard.writeText(data);
+  }
+  return data;
 }
 
 function animateMove(from, to) {
@@ -289,18 +350,20 @@ function destroyUI() {
   elementCache.clear();
 }
 
-export {
-  initUI,
-  updateInfoPanel,
-  addLogEntry,
-  animateMove,
-  showVictoryModal,
-  updateBonusInfo,
-  updateCardsUI,
-  updateUI,
-  destroyUI,
-  getSelectedCards,
-  resetSelectedCards,
-  getBoardScale,
-  getLog,
-};
+  export {
+    initUI,
+    updateInfoPanel,
+    addLogEntry,
+    animateMove,
+    showVictoryModal,
+    updateBonusInfo,
+    updateCardsUI,
+    updateUI,
+    destroyUI,
+    getSelectedCards,
+    resetSelectedCards,
+    getBoardScale,
+    getLog,
+    exportLog,
+    copyLog,
+  };

--- a/ui.test.js
+++ b/ui.test.js
@@ -10,6 +10,9 @@ import {
   getBoardScale,
   destroyUI,
   updateInfoPanel,
+  getLog,
+  exportLog,
+  copyLog,
 } from './ui.js';
 
 describe('ui utilities', () => {
@@ -24,6 +27,8 @@ describe('ui utilities', () => {
       <div id="bonusInfo"></div>
       <div id="cards"></div>
       <div id="actionLog"></div>
+      <button id="t1" class="territory"></button>
+      <button id="t2" class="territory"></button>
     `;
     game = {
       players: [
@@ -93,6 +98,40 @@ describe('ui utilities', () => {
     expect(logEl.children.length).toBe(10);
     expect(logEl.firstChild.textContent).toBe('msg3');
     expect(logEl.lastChild.textContent).toBe('msg12');
+  });
+
+  test('getLog filters by player and type', () => {
+    addLogEntry('P1 attacks', { player: 'P1', type: 'attack' });
+    addLogEntry('P2 reinforces', { player: 'P2', type: 'reinforce' });
+    expect(getLog({ player: 'P1' })).toHaveLength(1);
+    expect(getLog({ type: 'reinforce' })).toHaveLength(1);
+  });
+
+  test('exportLog outputs JSON and CSV', () => {
+    addLogEntry('P1 attacks', { player: 'P1', type: 'attack', territories: ['t1', 't2'] });
+    const json = exportLog('json');
+    expect(json).toContain('"P1"');
+    const csv = exportLog('csv');
+    expect(csv.split('\n')[1]).toContain('P1');
+  });
+
+  test('copyLog writes to clipboard', async () => {
+    const writeText = jest.fn().mockResolvedValue();
+    Object.assign(navigator, { clipboard: { writeText } });
+    await copyLog('json');
+    expect(writeText).toHaveBeenCalled();
+  });
+
+  test('go to move link highlights territories', () => {
+    jest.useFakeTimers();
+    addLogEntry('P1 attacks t2 from t1', { player: 'P1', type: 'attack', territories: ['t1', 't2'] });
+    const logEl = document.getElementById('actionLog');
+    const link = logEl.querySelector('a');
+    link.dispatchEvent(new window.Event('click'));
+    expect(document.getElementById('t1').classList.contains('highlight')).toBe(true);
+    jest.runAllTimers();
+    expect(document.getElementById('t1').classList.contains('highlight')).toBe(false);
+    jest.useRealTimers();
   });
 
   test('getBoardScale uses client size to align armies with map', () => {


### PR DESCRIPTION
## Summary
- store structured log entries with player, type, turn, territories
- add filtering and export to JSON/CSV with clipboard support
- link log entries to highlight involved territories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae010926a0832ca2f8c11015e138fd