### PR TITLE
feat: add post-game stats modal with export

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <link rel="stylesheet" href="./style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>
     <button id="themeToggle" class="btn">High Contrast</button>

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ import {
 } from "./phases.js";
 import { initThemeToggle } from "./theme.js";
 import { initTutorialButtons } from "./tutorial.js";
+import { attachStatsListeners, exportStats } from "./stats.js";
 import {
   initUI,
   updateInfoPanel,
@@ -98,6 +99,7 @@ async function loadGame() {
   if (!result || !result.game) return;
   game = result.game;
   territoryPositions = result.territoryPositions;
+  attachStatsListeners(game);
   initialiseUI(game);
   if (typeof module !== "undefined") {
     module.exports.game = game;
@@ -399,11 +401,41 @@ async function initGame() {
   modal.id = "victoryModal";
   modal.className = "modal";
   modal.innerHTML =
-    '<div class="modal-content"><h2 id="victoryTitle"></h2><div id="victoryStats"></div><button id="newGameBtn" class="btn">New Game</button></div>';
+    '<div class="modal-content"><h2 id="victoryTitle"></h2>' +
+    '<div id="victoryStats"></div>' +
+    '<canvas id="territoryChart" aria-label="Territories per turn" role="img"></canvas>' +
+    '<canvas id="armiesChart" aria-label="Armies placed per turn" role="img"></canvas>' +
+    '<canvas id="attackChart" aria-label="Attacks won and lost" role="img"></canvas>' +
+    '<div class="modal-buttons">' +
+    '<button id="shareResults" class="btn">Share Results</button>' +
+    '<button id="exportStats" class="btn">Export JSON</button>' +
+    '<button id="newGameBtn" class="btn">New Game</button>' +
+    '</div></div>';
   document.body.appendChild(modal);
-  document
-    .getElementById("newGameBtn")
-    .addEventListener("click", startNewGame);
+  document.getElementById("newGameBtn").addEventListener("click", startNewGame);
+  document.getElementById("shareResults").addEventListener("click", () => {
+    const canvas = document.getElementById("territoryChart");
+    if (!canvas) return;
+    const url = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "netrisk-results.png";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  });
+  document.getElementById("exportStats").addEventListener("click", () => {
+    const data = exportStats();
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "netrisk-stats.json";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
   const ui = document.getElementById("uiPanel");
   const cardPanel = document.createElement("div");
   cardPanel.id = "cardPanel";

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,52 @@
+import { REINFORCE } from "./phases.js";
+
+const stats = {
+  startTime: 0,
+  territories: [],
+  armies: [],
+  attacksWon: [],
+  attacksLost: [],
+};
+
+function recordTurn(game) {
+  game.players.forEach((_, idx) => {
+    const count = game.territories.filter((t) => t.owner === idx).length;
+    stats.territories[idx].push(count);
+    stats.armies[idx].push(0);
+    stats.attacksWon[idx].push(0);
+    stats.attacksLost[idx].push(0);
+  });
+}
+
+function attachStatsListeners(game) {
+  stats.startTime = Date.now();
+  stats.territories = game.players.map(() => []);
+  stats.armies = game.players.map(() => []);
+  stats.attacksWon = game.players.map(() => []);
+  stats.attacksLost = game.players.map(() => []);
+  recordTurn(game);
+  game.on('turnStart', () => {
+    recordTurn(game);
+  });
+  game.on(REINFORCE, ({ player }) => {
+    const i = stats.armies[player].length - 1;
+    if (i >= 0) stats.armies[player][i] += 1;
+  });
+  game.on('attackResolved', ({ result }) => {
+    const player = game.currentPlayer;
+    const i = stats.attacksWon[player].length - 1;
+    if (result.conquered) stats.attacksWon[player][i] += 1;
+    else stats.attacksLost[player][i] += 1;
+  });
+}
+
+function getStats() {
+  return stats;
+}
+
+function exportStats() {
+  const { startTime, territories, armies, attacksWon, attacksLost } = stats;
+  return JSON.stringify({ startTime, territories, armies, attacksWon, attacksLost });
+}
+
+export { attachStatsListeners, getStats, exportStats };

--- a/stats.test.js
+++ b/stats.test.js
@@ -1,0 +1,31 @@
+import { attachStatsListeners, getStats } from './stats.js';
+import { REINFORCE } from './phases.js';
+
+describe('stats tracking', () => {
+  test('records armies and attacks per turn', () => {
+    const game = {
+      players: [{}, {}],
+      territories: [
+        { id: 'a', owner: 0 },
+        { id: 'b', owner: 1 },
+      ],
+      currentPlayer: 0,
+      handlers: {},
+      on(event, cb) {
+        this.handlers[event] = this.handlers[event] || [];
+        this.handlers[event].push(cb);
+      },
+      emit(event, payload) {
+        (this.handlers[event] || []).forEach((cb) => cb(payload));
+      },
+    };
+    attachStatsListeners(game);
+    game.emit(REINFORCE, { player: 0 });
+    game.emit('attackResolved', { result: { conquered: true } });
+    game.emit('turnStart');
+    const s = getStats();
+    expect(s.armies[0][0]).toBe(1);
+    expect(s.attacksWon[0][0]).toBe(1);
+    expect(s.territories[0].length).toBe(2);
+  });
+});

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,6 @@
 import { getContrastingColor } from "./colors.js";
 import { REINFORCE } from "./phases.js";
+import { getStats } from "./stats.js";
 
 const BOARD_WIDTH = 600;
 const BOARD_HEIGHT = 400;
@@ -189,24 +190,88 @@ function showVictoryModal(winnerIdx) {
   const modal = getElement("victoryModal");
   if (!modal) return;
   const title = getElement("victoryTitle");
-  const stats = getElement("victoryStats");
+  const statsEl = getElement("victoryStats");
   if (title) title.textContent = `${game.players[winnerIdx].name} has won!`;
-  if (stats) {
-    // clear previous stats
-    while (stats.firstChild) stats.removeChild(stats.firstChild);
-
+  if (statsEl) {
+    while (statsEl.firstChild) statsEl.removeChild(statsEl.firstChild);
     const turns = document.createElement("p");
     turns.textContent = `Turns: ${gameState.turnNumber}`;
-    stats.appendChild(turns);
-
-    const ul = document.createElement("ul");
-    game.players.forEach((p, idx) => {
-      const count = game.territories.filter((t) => t.owner === idx).length;
+    statsEl.appendChild(turns);
+    const duration = getStats().startTime
+      ? Math.round((Date.now() - getStats().startTime) / 1000)
+      : 0;
+    const durationEl = document.createElement("p");
+    durationEl.textContent = `Duration: ${duration}s`;
+    statsEl.appendChild(durationEl);
+    const ranking = game.players
+      .map((p, idx) => ({
+        name: p.name,
+        territories: game.territories.filter((t) => t.owner === idx).length,
+      }))
+      .sort((a, b) => b.territories - a.territories);
+    const ol = document.createElement("ol");
+    ranking.forEach((r) => {
       const li = document.createElement("li");
-      li.textContent = `${p.name}: ${count} territories`;
-      ul.appendChild(li);
+      li.textContent = `${r.name}: ${r.territories} territories`;
+      ol.appendChild(li);
     });
-    stats.appendChild(ul);
+    statsEl.appendChild(ol);
+    const s = getStats();
+    if (s.territories.length && typeof window !== 'undefined' && window.Chart) {
+      const labels = s.territories[0].map((_, i) => `Turn ${i + 1}`);
+      const terrCtx = document
+        .getElementById("territoryChart")
+        ?.getContext("2d");
+      if (terrCtx) {
+        new window.Chart(terrCtx, {
+          type: "line",
+          data: {
+            labels,
+            datasets: game.players.map((p, idx) => ({
+              label: p.name,
+              data: s.territories[idx],
+              fill: false,
+            })),
+          },
+          options: { responsive: true },
+        });
+      }
+      const armCtx = document
+        .getElementById("armiesChart")
+        ?.getContext("2d");
+      if (armCtx) {
+        new window.Chart(armCtx, {
+          type: "line",
+          data: {
+            labels,
+            datasets: game.players.map((p, idx) => ({
+              label: p.name,
+              data: s.armies[idx],
+              fill: false,
+            })),
+          },
+          options: { responsive: true },
+        });
+      }
+      const attCtx = document
+        .getElementById("attackChart")
+        ?.getContext("2d");
+      if (attCtx) {
+        const wins = s.attacksWon.map((a) => a.reduce((sum, n) => sum + n, 0));
+        const losses = s.attacksLost.map((a) => a.reduce((sum, n) => sum + n, 0));
+        new window.Chart(attCtx, {
+          type: "bar",
+          data: {
+            labels: game.players.map((p) => p.name),
+            datasets: [
+              { label: "Wins", data: wins, backgroundColor: "#4caf50" },
+              { label: "Losses", data: losses, backgroundColor: "#f44336" },
+            ],
+          },
+          options: { responsive: true },
+        });
+      }
+    }
   }
   modal.classList.add("show");
 }


### PR DESCRIPTION
## Summary
- capture per-turn territories, armies, and battle outcomes
- display responsive charts and ranking on game victory
- allow exporting stats as PNG image or JSON

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0385af1c832cbfb8ff839ce4a585