### PR TITLE
feat: add phase timer and visual feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
         <div><strong>Action log:</strong></div>
         <div id="actionLog" class="log"></div>
         <div id="status"></div>
+        <div>Phase time: <span id="phaseTimer"></span></div>
         <div id="diceResults"></div>
         <div id="selectedTerritory"></div>
         <div id="audioSettings">

--- a/main.js
+++ b/main.js
@@ -23,6 +23,8 @@ import {
   updateInfoPanel,
   addLogEntry,
   animateMove,
+  animateAttack,
+  animateReinforce,
   showVictoryModal,
   updateUI,
   destroyUI,
@@ -30,6 +32,7 @@ import {
   getSelectedCards,
   exportLog,
 } from "./ui.js";
+import initPhaseTimer from "./phase-timer.js";
 import { loadGame as loadGameData } from "./src/init/game-loader.js";
 import {
   updateGameState,
@@ -58,6 +61,7 @@ if (typeof navigator !== "undefined" && navigator.serviceWorker) {
 
 let game;
 let territoryPositions = {};
+let phaseTimer;
 
 const gameState = {
   turnNumber: 1,
@@ -90,6 +94,7 @@ function initialiseUI(game) {
   gameState.territories = game.territories;
   gameState.phase = game.getPhase();
   initUI({ game, gameState, territoryPositions });
+  phaseTimer = initPhaseTimer({ game });
   attachAIActionLogging();
 }
 
@@ -236,35 +241,37 @@ function attachTerritoryHandlers() {
             }, 500);
             document.getElementById("diceResults").textContent =
               `Attacker: ${result.attackRolls.join(", ")} | Defender: ${result.defendRolls.join(", ")}`;
-            if (result.conquered) {
-              playConquerSound();
-              toEl.classList.add("conquer");
-              setTimeout(() => toEl.classList.remove("conquer"), 1000);
-              const move = await askArmiesToMove(result.movableArmies, 0);
-              if (move > 0) {
-                game.moveArmies(result.from, result.to, move);
-                addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`, {
-                  player: playerName,
-                  type: "move",
-                  territories: [result.from, result.to],
-                });
-                animateMove(result.from, result.to);
-              }
+          if (result.conquered) {
+            playConquerSound();
+            toEl.classList.add("conquer");
+            setTimeout(() => toEl.classList.remove("conquer"), 1000);
+            const move = await askArmiesToMove(result.movableArmies, 0);
+            if (move > 0) {
+              game.moveArmies(result.from, result.to, move);
+              addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`, {
+                player: playerName,
+                type: "move",
+                territories: [result.from, result.to],
+              });
+              animateMove(result.from, result.to);
             }
-            addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`, {
-              player: playerName,
-              type: "attack",
-              territories: [result.from, result.to],
-            });
-          } else if (result.type === REINFORCE) {
-            if (typeof logger !== "undefined") {
-              logger.info(`${playerName} reinforces ${result.territory}`);
-            }
-            addLogEntry(`${playerName} reinforces ${result.territory}`, {
-              player: playerName,
-              type: "reinforce",
-              territories: [result.territory],
-            });
+          }
+          animateAttack(result.from, result.to);
+          addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`, {
+            player: playerName,
+            type: "attack",
+            territories: [result.from, result.to],
+          });
+        } else if (result.type === REINFORCE) {
+          if (typeof logger !== "undefined") {
+            logger.info(`${playerName} reinforces ${result.territory}`);
+          }
+          animateReinforce(result.territory);
+          addLogEntry(`${playerName} reinforces ${result.territory}`, {
+            player: playerName,
+            type: "reinforce",
+            territories: [result.territory],
+          });
           } else if (result.type === FORTIFY) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);

--- a/phase-timer.js
+++ b/phase-timer.js
@@ -1,0 +1,46 @@
+import EventBus from './src/core/event-bus.js';
+
+export default function initPhaseTimer({ game, elementId = 'phaseTimer', duration = 60000, serverOffset = 0, onTimeout }) {
+  const display = document.getElementById(elementId);
+  let endTime = 0;
+  let timerId;
+  const getNow = () => Date.now() + serverOffset;
+
+  function update() {
+    const remaining = endTime - getNow();
+    if (remaining <= 0) {
+      if (display) display.textContent = '0';
+      clearInterval(timerId);
+      if (onTimeout) {
+        onTimeout();
+      } else if (game && typeof game.endTurn === 'function') {
+        game.endTurn();
+      }
+      return;
+    }
+    if (display) display.textContent = Math.ceil(remaining / 1000).toString();
+  }
+
+  function start() {
+    endTime = getNow() + duration;
+    clearInterval(timerId);
+    update();
+    timerId = setInterval(update, 1000);
+  }
+
+  if (game && typeof game.on === 'function') {
+    game.on('phaseChange', start);
+    game.on('turnStart', start);
+  } else if (game && game.events instanceof EventBus) {
+    game.events.on('phaseChange', start);
+    game.events.on('turnStart', start);
+  }
+
+  start();
+
+  return {
+    stop() {
+      clearInterval(timerId);
+    },
+  };
+}

--- a/phase-timer.test.js
+++ b/phase-timer.test.js
@@ -1,0 +1,33 @@
+import initPhaseTimer from './phase-timer.js';
+import EventBus from './src/core/event-bus.js';
+
+jest.useFakeTimers();
+
+function createGame() {
+  const events = new EventBus();
+  return {
+    events,
+    on: events.on.bind(events),
+    endTurn: jest.fn(),
+  };
+}
+
+test('calls endTurn when timer expires', () => {
+  document.body.innerHTML = '<div id="phaseTimer"></div>';
+  const game = createGame();
+  initPhaseTimer({ game, duration: 1000 });
+  jest.advanceTimersByTime(1000);
+  expect(game.endTurn).toHaveBeenCalled();
+});
+
+test('resets on phase change', () => {
+  document.body.innerHTML = '<div id="phaseTimer"></div>';
+  const game = createGame();
+  initPhaseTimer({ game, duration: 1000 });
+  jest.advanceTimersByTime(500);
+  game.events.emit('phaseChange');
+  jest.advanceTimersByTime(700);
+  expect(game.endTurn).not.toHaveBeenCalled();
+  jest.advanceTimersByTime(300);
+  expect(game.endTurn).toHaveBeenCalled();
+});

--- a/style.css
+++ b/style.css
@@ -253,12 +253,20 @@ h1 {
   outline: 4px solid #ff0;
 }
 
+.territory.possible-move {
+  outline: 4px dashed #0f0;
+}
+
 .territory.attack {
   animation: attackPulse 0.5s ease-in-out;
 }
 
 .territory.conquer {
   animation: conquerFlash 1s ease-in-out;
+}
+
+.territory.reinforce {
+  animation: reinforcePulse 0.5s ease-in-out;
 }
 
 @keyframes attackPulse {
@@ -270,6 +278,12 @@ h1 {
 @keyframes conquerFlash {
   0% { box-shadow: 0 0 0 0 rgba(255,255,0,1); }
   100% { box-shadow: 0 0 20px 10px rgba(255,255,0,0); }
+}
+
+@keyframes reinforcePulse {
+  0% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.2); }
+  100% { transform: translate(-50%, -50%) scale(1); }
 }
 
 #status {

--- a/territory-selection.js
+++ b/territory-selection.js
@@ -11,12 +11,14 @@ export default function initTerritorySelection({
   updateUI,
 }) {
   let selectedTerritory = null;
+  let possibleMoveEls = [];
   const infoPanel = document.getElementById("selectedTerritory");
 
   function selectTerritory(el) {
     if (selectedTerritory && selectedTerritory.el) {
       selectedTerritory.el.classList.remove("selected");
     }
+    clearPossibleMoves();
     if (el) {
       const name = el.dataset.name || el.id;
       el.classList.add("selected");
@@ -27,10 +29,40 @@ export default function initTerritorySelection({
           `Selected territory: ${selectedTerritory.id} (${selectedTerritory.name})`,
         );
       }
+      highlightPossibleMoves(el.id);
     } else {
       selectedTerritory = null;
       infoPanel.textContent = "";
     }
+  }
+
+  function clearPossibleMoves() {
+    possibleMoveEls.forEach((el) => el.classList.remove("possible-move"));
+    possibleMoveEls = [];
+  }
+
+  function highlightPossibleMoves(id) {
+    if (!game) return;
+    const terr = game.territoryById ? game.territoryById(id) : null;
+    if (!terr) return;
+    const phase = game.getPhase ? game.getPhase() : null;
+    let targets = [];
+    if (phase === ATTACK) {
+      targets = terr.neighbors.filter(
+        (n) => game.territoryById(n)?.owner !== game.currentPlayer,
+      );
+    } else if (phase === FORTIFY) {
+      targets = terr.neighbors.filter(
+        (n) => game.territoryById(n)?.owner === game.currentPlayer,
+      );
+    }
+    targets.forEach((tid) => {
+      const btn = document.getElementById(tid);
+      if (btn) {
+        btn.classList.add("possible-move");
+        possibleMoveEls.push(btn);
+      }
+    });
   }
 
   function moveToken(el) {

--- a/territory-selection.moves.test.js
+++ b/territory-selection.moves.test.js
@@ -1,0 +1,26 @@
+import initTerritorySelection from './territory-selection.js';
+import { ATTACK } from './phases.js';
+
+const flushPromises = () => new Promise((res) => setTimeout(res, 0));
+
+test('selecting territory highlights possible moves', async () => {
+  document.body.innerHTML = '<div id="board"></div><div id="selectedTerritory"></div>';
+  const svg = '<svg id="map"><path id="A" class="map-territory"/><path id="B" class="map-territory"/><path id="C" class="map-territory"/></svg>';
+  global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(svg) }));
+  const territories = [
+    { id: 'A', neighbors: ['B'], owner: 0 },
+    { id: 'B', neighbors: ['A', 'C'], owner: 1 },
+    { id: 'C', neighbors: ['B'], owner: 0 },
+  ];
+  const game = {
+    currentPlayer: 0,
+    getPhase: () => ATTACK,
+    territoryById: (id) => territories.find((t) => t.id === id),
+  };
+  initTerritorySelection({ game, territories });
+  await flushPromises();
+  const aPath = document.getElementById('A');
+  aPath.dispatchEvent(new Event('click', { bubbles: true }));
+  const buttonB = document.getElementById('B');
+  expect(buttonB.classList.contains('possible-move')).toBe(true);
+});

--- a/ui.js
+++ b/ui.js
@@ -185,6 +185,28 @@ function animateMove(from, to) {
   );
 }
 
+function animateAttack(from, to) {
+  [from, to]
+    .map((id) => getElement(id))
+    .filter(Boolean)
+    .forEach((el) => {
+      el.classList.add("attack");
+      el.addEventListener("animationend", () => el.classList.remove("attack"), {
+        once: true,
+      });
+    });
+  animateMove(from, to);
+}
+
+function animateReinforce(id) {
+  const el = getElement(id);
+  if (!el) return;
+  el.classList.add("reinforce");
+  el.addEventListener("animationend", () => el.classList.remove("reinforce"), {
+    once: true,
+  });
+}
+
 function showVictoryModal(winnerIdx) {
   const modal = getElement("victoryModal");
   if (!modal) return;
@@ -355,6 +377,8 @@ function destroyUI() {
     updateInfoPanel,
     addLogEntry,
     animateMove,
+    animateAttack,
+    animateReinforce,
     showVictoryModal,
     updateBonusInfo,
     updateCardsUI,


### PR DESCRIPTION
## Summary
- add phase timer synced to game events and auto end turn
- highlight possible moves and show reinforce/attack animations
- include tests for phase timer and territory highlighting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae051b4ae0832cb2c532bfb1845fa1