### PR TITLE
Add configurable undo feature with UI support

### DIFF
--- a/game.js
+++ b/game.js
@@ -41,6 +41,7 @@ class Game {
     deck = [],
     shuffleDeck = true,
     randomizeTerritories = true,
+    maxUndoSteps = 10,
   ) {
     this.players =
       players || [
@@ -99,11 +100,15 @@ class Game {
       [ATTACK]: this.handleAttackPhase.bind(this),
       [FORTIFY]: this.handleFortifyPhase.bind(this),
     };
+
+    this.maxUndo = maxUndoSteps;
+    this.undoStack = [];
+    this.redoStack = [];
   }
 
-  static async create(players, territories, continents, deck) {
+  static async create(players, territories, continents, deck, maxUndoSteps) {
     if (territories && continents && deck) {
-      return new Game(players, territories, continents, deck);
+      return new Game(players, territories, continents, deck, true, true, maxUndoSteps);
     }
     try {
       const map = await loadMapData();
@@ -111,7 +116,10 @@ class Game {
         players,
         territories || map.territories,
         continents || map.continents,
-        deck || map.deck
+        deck || map.deck,
+        true,
+        true,
+        maxUndoSteps
       );
     } catch (err) {
       console.error("Unable to load map data, starting with empty map.", err);
@@ -127,7 +135,10 @@ class Game {
         players,
         territories || [],
         continents || [],
-        deck || []
+        deck || [],
+        true,
+        true,
+        maxUndoSteps
       );
     }
   }
@@ -166,6 +177,7 @@ class Game {
     }
     if (!this.selectedFrom) {
       if (!action.canSelect || action.canSelect(territory)) {
+        this.pushUndoState();
         this.selectedFrom = territory;
         return { type: 'select', territory: id };
       }
@@ -173,6 +185,7 @@ class Game {
       const from = this.selectedFrom;
       const to = territory;
       if (from.id === to.id) {
+        this.pushUndoState();
         this.selectedFrom = null;
         return { type: 'deselect', territory: id };
       }
@@ -191,6 +204,7 @@ class Game {
         canSelect: (t) =>
           t.owner === this.currentPlayer && this.reinforcements > 0,
         onSelect: (t) => {
+          this.pushUndoState();
           t.armies += 1;
           this.reinforcements -= 1;
           this.emit(REINFORCE, {
@@ -300,9 +314,57 @@ class Game {
     if (from.owner !== this.currentPlayer || to.owner !== this.currentPlayer) return false;
     if (!from.neighbors.includes(to.id)) return false;
     if (count < 1 || from.armies <= count) return false;
+    this.pushUndoState();
     from.armies -= count;
     to.armies += count;
     this.emit('move', { from: fromId, to: toId, count });
+    return true;
+  }
+
+  pushUndoState() {
+    this.undoStack.push(this.serialize());
+    if (this.undoStack.length > this.maxUndo) this.undoStack.shift();
+    this.redoStack = [];
+  }
+
+  canUndo() {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo() {
+    return this.redoStack.length > 0;
+  }
+
+  restoreState(stateStr) {
+    const data = JSON.parse(stateStr);
+    this.players = data.players;
+    this.territories = data.territories;
+    this.continents = data.continents;
+    this.deck = data.deck;
+    this.hands = data.hands;
+    this.discard = data.discard || [];
+    this.currentPlayer = data.currentPlayer;
+    this.phase = data.phase;
+    this.reinforcements = data.reinforcements;
+    this.selectedFrom =
+      data.selectedFrom != null ? this.territoryById(data.selectedFrom) : null;
+    this.conqueredThisTurn = data.conqueredThisTurn || false;
+    this.winner = data.winner;
+  }
+
+  undo() {
+    if (!this.canUndo()) return false;
+    const prev = this.undoStack.pop();
+    this.redoStack.push(this.serialize());
+    this.restoreState(prev);
+    return true;
+  }
+
+  redo() {
+    if (!this.canRedo()) return false;
+    const next = this.redoStack.pop();
+    this.undoStack.push(this.serialize());
+    this.restoreState(next);
     return true;
   }
 
@@ -328,6 +390,8 @@ class Game {
     } else if (this.phase === FORTIFY) {
       const prev = this.currentPlayer;
       this.selectedFrom = null;
+      this.undoStack = [];
+      this.redoStack = [];
       // Move to the next player, skipping any who have been eliminated
       do {
         this.currentPlayer = (this.currentPlayer + 1) % this.players.length;

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
           <button id="muteBtn" class="btn">Mute</button>
         </div>
         <button id="moveToken" class="btn">Move Token</button>
+        <button id="undo" class="btn" disabled>Undo</button>
         <button id="endTurn" class="btn">End Turn</button>
         <button id="forceError" class="btn">Force Error</button>
         <button id="exportLog" class="btn">Export Log</button>

--- a/main.js
+++ b/main.js
@@ -317,6 +317,32 @@ function attachTerritoryHandlers() {
   });
 }
 
+const undoBtn = document.getElementById("undo");
+if (undoBtn) {
+  undoBtn.addEventListener("click", () => {
+    try {
+      if (game.undo()) {
+        const playerName = game.players[game.currentPlayer].name;
+        addLogEntry(`${playerName} undoes last action`, {
+          player: playerName,
+          type: "undo",
+        });
+        updateUI();
+        updateGameState(
+          gameState,
+          game,
+          game.selectedFrom ? game.selectedFrom.id : null,
+        );
+        updateInfoPanel();
+      }
+    } catch (err) {
+      if (typeof logger !== "undefined") {
+        logger.error(err);
+      }
+    }
+  });
+}
+
 document.getElementById("endTurn").addEventListener("click", () => {
   if (typeof logger !== "undefined") {
     logger.info("End turn clicked");

--- a/ui.js
+++ b/ui.js
@@ -396,6 +396,11 @@ function updateStatus() {
   if (statusEl) statusEl.textContent = status;
 }
 
+function updateUndoButton() {
+  const btn = getElement("undo");
+  if (btn) btn.disabled = !game.canUndo();
+}
+
 function updateUI() {
   const scale = getBoardScale();
   const playerColorClasses = game.players.map((p) => getColorClass(p.color));
@@ -403,6 +408,7 @@ function updateUI() {
   updateTerritories(scale, playerColorClasses);
   updateToken(scale);
   updateStatus();
+  updateUndoButton();
   updateBonusInfo();
   updateCardsUI();
 }

--- a/undo.test.js
+++ b/undo.test.js
@@ -1,0 +1,82 @@
+import Game from "./game.js";
+import { ATTACK, FORTIFY } from "./phases.js";
+
+describe("undo functionality", () => {
+  const createGame = (maxUndo = 10) => {
+    const territories = [
+      { id: "a", neighbors: ["b"], owner: 0, armies: 5 },
+      { id: "b", neighbors: ["a"], owner: 0, armies: 1 },
+    ];
+    return new Game(
+      [{ name: "P1" }, { name: "P2" }],
+      territories,
+      [],
+      [],
+      false,
+      false,
+      maxUndo,
+    );
+  };
+
+  test("undo and redo reinforcement", () => {
+    const game = createGame();
+    game.reinforcements = 1;
+    game.handleTerritoryClick("a");
+    expect(game.territories[0].armies).toBe(6);
+    expect(game.reinforcements).toBe(0);
+    expect(game.canUndo()).toBe(true);
+    game.undo();
+    expect(game.territories[0].armies).toBe(5);
+    expect(game.reinforcements).toBe(1);
+    game.redo();
+    expect(game.territories[0].armies).toBe(6);
+    expect(game.reinforcements).toBe(0);
+  });
+
+  test("undo move armies", () => {
+    const game = createGame();
+    game.setPhase(FORTIFY);
+    game.handleTerritoryClick("a");
+    game.handleTerritoryClick("b");
+    game.moveArmies("a", "b", 3);
+    expect(game.territories[0].armies).toBe(2);
+    expect(game.territories[1].armies).toBe(4);
+    game.undo();
+    expect(game.territories[0].armies).toBe(5);
+    expect(game.territories[1].armies).toBe(1);
+  });
+
+  test("undo attack selection", () => {
+    const territories = [
+      { id: "a", neighbors: ["b"], owner: 0, armies: 3 },
+      { id: "b", neighbors: ["a"], owner: 1, armies: 2 },
+    ];
+    const game = new Game([{ name: "P1" }, { name: "P2" }], territories, [], [], false, false);
+    game.setPhase(ATTACK);
+    game.handleTerritoryClick("a");
+    expect(game.getSelectedFrom().id).toBe("a");
+    game.undo();
+    expect(game.getSelectedFrom()).toBeNull();
+  });
+
+  test("undo stack limit", () => {
+    const game = createGame(2);
+    game.reinforcements = 3;
+    game.handleTerritoryClick("a"); // 6
+    game.handleTerritoryClick("a"); // 7
+    game.handleTerritoryClick("a"); // 8 (first state dropped)
+    game.undo(); // 7
+    game.undo(); // 6, cannot undo to 5
+    expect(game.territories[0].armies).toBe(6);
+  });
+
+  test("endTurn clears undo stack", () => {
+    const game = createGame();
+    game.reinforcements = 1;
+    game.handleTerritoryClick("a");
+    expect(game.canUndo()).toBe(true);
+    game.setPhase(FORTIFY);
+    game.endTurn();
+    expect(game.canUndo()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add undo/redo stacks with configurable depth and state restoration
- Expose undo button in UI with logging and state-based enable/disable
- Cover undo behavior with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae06fc6ab8832cb1442b5851bbe391