### PR TITLE
Add accessibility menu with font scaling and color-blind mode

### DIFF
--- a/accessibility.js
+++ b/accessibility.js
@@ -1,0 +1,81 @@
+import { initThemeToggle } from './theme.js';
+
+export function initAccessibility() {
+  const body = document.body;
+  if (!body) return;
+
+  initThemeToggle();
+
+  const root = document.documentElement;
+  const fontSelect = document.getElementById('fontScale');
+  if (fontSelect && root) {
+    const storedScale =
+      (typeof localStorage !== 'undefined' && localStorage.getItem('font-scale')) || '1';
+    root.style.setProperty('--font-scale', storedScale);
+    fontSelect.value = storedScale;
+    fontSelect.addEventListener('change', () => {
+      const scale = fontSelect.value;
+      root.style.setProperty('--font-scale', scale);
+      if (typeof localStorage !== 'undefined') {
+        try {
+          localStorage.setItem('font-scale', scale);
+        } catch (err) {
+          /* ignore storage errors */
+        }
+      }
+    });
+  }
+
+  const cbBtn = document.getElementById('colorBlindToggle');
+  if (cbBtn) {
+    const stored =
+      typeof localStorage !== 'undefined' && localStorage.getItem('colorblind');
+    if (stored === 'on') {
+      body.classList.add('colorblind');
+      cbBtn.textContent = 'Standard Colors';
+    }
+    cbBtn.addEventListener('click', () => {
+      body.classList.toggle('colorblind');
+      const on = body.classList.contains('colorblind');
+      cbBtn.textContent = on ? 'Standard Colors' : 'Color Blind Mode';
+      if (typeof localStorage !== 'undefined') {
+        try {
+          localStorage.setItem('colorblind', on ? 'on' : 'off');
+        } catch (err) {
+          /* ignore storage errors */
+        }
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.altKey && e.shiftKey && e.key.toLowerCase() === 'h') {
+      const btn = document.getElementById('themeToggle');
+      if (btn) btn.click();
+    }
+    if (e.altKey && e.shiftKey && e.key.toLowerCase() === 'c') {
+      if (cbBtn) cbBtn.click();
+    }
+    if (e.altKey && e.shiftKey && (e.key === '+' || e.key === '=')) {
+      adjustFont(0.25);
+    }
+    if (e.altKey && e.shiftKey && e.key === '-') {
+      adjustFont(-0.25);
+    }
+  });
+
+  function adjustFont(delta) {
+    const current =
+      parseFloat(root.style.getPropertyValue('--font-scale') || '1');
+    const next = Math.min(2, Math.max(0.5, current + delta));
+    root.style.setProperty('--font-scale', next.toString());
+    if (fontSelect) fontSelect.value = next.toString();
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem('font-scale', next.toString());
+      } catch (err) {
+        /* ignore storage errors */
+      }
+    }
+  }
+}

--- a/accessibility.test.js
+++ b/accessibility.test.js
@@ -3,8 +3,8 @@ import { initAccessibility } from './accessibility.js';
 describe('accessibility controls', () => {
   beforeEach(() => {
     document.body.innerHTML = `
+      <button id="themeToggle" class="btn">High Contrast</button>
       <div id="accessibilityMenu">
-        <button id="themeToggle" class="btn">High Contrast</button>
         <label for="fontScale">Font size:</label>
         <select id="fontScale">
           <option value="1">100%</option>

--- a/accessibility.test.js
+++ b/accessibility.test.js
@@ -1,0 +1,37 @@
+import { initAccessibility } from './accessibility.js';
+
+describe('accessibility controls', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="accessibilityMenu">
+        <button id="themeToggle" class="btn">High Contrast</button>
+        <label for="fontScale">Font size:</label>
+        <select id="fontScale">
+          <option value="1">100%</option>
+          <option value="1.5">150%</option>
+        </select>
+        <button id="colorBlindToggle" class="btn">Color Blind Mode</button>
+      </div>`;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  test('font scaling updates CSS variable and stores preference', () => {
+    initAccessibility();
+    const select = document.getElementById('fontScale');
+    select.value = '1.5';
+    select.dispatchEvent(new Event('change'));
+    expect(document.documentElement.style.getPropertyValue('--font-scale')).toBe('1.5');
+    expect(localStorage.getItem('font-scale')).toBe('1.5');
+  });
+
+  test('color blind toggle switches class and stores setting', () => {
+    initAccessibility();
+    const btn = document.getElementById('colorBlindToggle');
+    btn.click();
+    expect(document.body.classList.contains('colorblind')).toBe(true);
+    expect(btn.textContent).toBe('Standard Colors');
+    expect(localStorage.getItem('colorblind')).toBe('on');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -9,15 +9,19 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>
-    <div id="accessibilityMenu">
-      <button id="themeToggle" class="btn" aria-label="Toggle high contrast">High Contrast</button>
+    <button id="themeToggle" class="btn" aria-label="Toggle high contrast">
+      High Contrast
+    </button>
+    <div id="accessibilityMenu" aria-label="Accessibility options">
       <label for="fontScale">Font size:</label>
       <select id="fontScale" aria-label="Font size">
         <option value="1">100%</option>
         <option value="1.25">125%</option>
         <option value="1.5">150%</option>
       </select>
-      <button id="colorBlindToggle" class="btn" aria-label="Toggle color blind palette">Color Blind Mode</button>
+      <button id="colorBlindToggle" class="btn" aria-label="Toggle color blind palette">
+        Color Blind Mode
+      </button>
     </div>
     <h1>NetRisk</h1>
     <div id="mainMenu">

--- a/index.html
+++ b/index.html
@@ -9,12 +9,21 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>
-    <button id="themeToggle" class="btn">High Contrast</button>
+    <div id="accessibilityMenu">
+      <button id="themeToggle" class="btn" aria-label="Toggle high contrast">High Contrast</button>
+      <label for="fontScale">Font size:</label>
+      <select id="fontScale" aria-label="Font size">
+        <option value="1">100%</option>
+        <option value="1.25">125%</option>
+        <option value="1.5">150%</option>
+      </select>
+      <button id="colorBlindToggle" class="btn" aria-label="Toggle color blind palette">Color Blind Mode</button>
+    </div>
     <h1>NetRisk</h1>
     <div id="mainMenu">
-      <button id="startGame" class="btn">Start Game</button>
-      <button id="playTutorial" class="btn">Play Tutorial</button>
-      <a href="setup.html" class="btn">Set up players</a>
+      <button id="startGame" class="btn" aria-label="Start Game">Start Game</button>
+      <button id="playTutorial" class="btn" aria-label="Play Tutorial">Play Tutorial</button>
+      <a href="setup.html" class="btn" aria-label="Set up players">Set up players</a>
     </div>
     <div id="gameContainer" class="hidden">
       <div id="uiPanel">
@@ -28,6 +37,7 @@
               class="btn"
               aria-expanded="false"
               aria-controls="howToPlaySteps"
+              aria-label="Toggle how to play details"
             >
               Show details
             </button>
@@ -37,7 +47,7 @@
             <li>Choose an action</li>
             <li>Press "End Turn"</li>
           </ol>
-          <button id="replayTutorial" class="btn">Play Tutorial</button>
+          <button id="replayTutorial" class="btn" aria-label="Play Tutorial">Play Tutorial</button>
         </div>
         <div><strong>Action log:</strong></div>
         <div id="actionLog" class="log"></div>
@@ -55,14 +65,14 @@
             step="0.01"
             value="0.2"
           />
-          <button id="muteBtn" class="btn">Mute</button>
+          <button id="muteBtn" class="btn" aria-label="Mute audio">Mute</button>
         </div>
-        <button id="moveToken" class="btn">Move Token</button>
-        <button id="endTurn" class="btn">End Turn</button>
-        <button id="forceError" class="btn">Force Error</button>
-        <button id="exportLog" class="btn">Export Log</button>
+        <button id="moveToken" class="btn" aria-label="Move Token">Move Token</button>
+        <button id="endTurn" class="btn" aria-label="End Turn">End Turn</button>
+        <button id="forceError" class="btn" aria-label="Force Error">Force Error</button>
+        <button id="exportLog" class="btn" aria-label="Export Log">Export Log</button>
       </div>
-      <div id="board" class="board"></div>
+      <div id="board" class="board" role="region" aria-label="Game board"></div>
     </div>
     <script src="./logger.js"></script>
     <script type="module" src="./main.js"></script>

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ import {
   FORTIFY,
   GAME_OVER,
 } from "./phases.js";
-import { initThemeToggle } from "./theme.js";
+import { initAccessibility } from "./accessibility.js";
 import { initTutorialButtons } from "./tutorial.js";
 import { attachStatsListeners, exportStats } from "./stats.js";
 import {
@@ -536,7 +536,7 @@ function init() {
 }
 
 init();
-initThemeToggle();
+initAccessibility();
 initTutorialButtons();
 
 export {

--- a/style.css
+++ b/style.css
@@ -1,8 +1,13 @@
 @import url('https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css');
 @import url('https://fonts.googleapis.com/css2?family=Cinzel&display=swap');
 
+:root {
+  --font-scale: 1;
+}
+
 body {
   font-family: 'Cinzel', serif;
+  font-size: calc(16px * var(--font-scale));
   background: #e8dcc0
     url('https://www.transparenttextures.com/patterns/aged-paper.png');
   color: #3b2b16;
@@ -34,6 +39,12 @@ h1 {
 .btn:active {
   box-shadow: none;
   transform: translateY(2px);
+}
+
+.btn:focus,
+.territory:focus {
+  outline: 3px solid #ff0;
+  outline-offset: 2px;
 }
 
 /* Utility classes */
@@ -396,4 +407,21 @@ body.high-contrast .modal-content {
   background: #000;
   color: #fff;
   border: 2px solid #fff;
+}
+
+/* Color blind friendly palette */
+body.colorblind .btn {
+  background: #005a9c;
+  color: #fff;
+  border-color: #003a6d;
+}
+
+body.colorblind .territory {
+  background: #bcbcbc;
+  border-color: #000;
+  color: #000;
+}
+
+body.colorblind .board {
+  filter: grayscale(40%);
 }


### PR DESCRIPTION
## Summary
- Introduce accessibility menu offering high contrast toggle, font scaling, and color-blind palette.
- Persist accessibility preferences and add keyboard shortcuts for quick access.
- Improve focus outlines and ARIA labeling for better keyboard navigation.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae07d7dbe4832c8440dca6e64fbfdd