### PR TITLE
Add About/Help page with client-side search

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" >
+    <title>About &amp; Help - NetRisk</title>
+    <link rel="stylesheet" href="./style.css" >
+  </head>
+  <body>
+    <nav>
+      <a href="index.html" id="homeLink">Home</a>
+    </nav>
+    <h1 id="pageTitle">About &amp; Help</h1>
+    <input type="search" id="helpSearch" aria-label="Search" >
+    <div id="helpContent">
+      <section id="rules">
+        <h2>Rules</h2>
+        <div class="content"></div>
+      </section>
+      <section id="tips">
+        <h2>Tips</h2>
+        <div class="content"></div>
+      </section>
+      <section id="credits">
+        <h2>Credits</h2>
+        <div class="content"></div>
+      </section>
+      <section id="changelog">
+        <h2>Changelog</h2>
+        <div class="content"></div>
+      </section>
+      <section id="github">
+        <h2>GitHub</h2>
+        <div class="content"></div>
+      </section>
+      <section id="privacy">
+        <h2>Privacy</h2>
+        <div class="content"></div>
+      </section>
+    </div>
+    <script type="module" src="./about.js"></script>
+  </body>
+</html>

--- a/about.js
+++ b/about.js
@@ -1,0 +1,102 @@
+const lang = navigator.language && navigator.language.startsWith('it') ? 'it' : 'en';
+
+const texts = {
+  en: {
+    title: 'About & Help',
+    search: 'Search...',
+    sections: {
+      rules: {
+        title: 'Rules',
+        content:
+          'Each player deploys armies, attacks adjacent territories and ends the turn. Conquer all territories to win.',
+      },
+      tips: {
+        title: 'Tips',
+        content: 'Expand early, defend borders and watch your opponents.',
+      },
+      credits: {
+        title: 'Credits',
+        content: 'Created by the NetRisk team.',
+      },
+      changelog: {
+        title: 'Changelog',
+        content: '<ul><li>v0.1: Initial alpha release.</li></ul>',
+      },
+      github: {
+        title: 'GitHub',
+        content:
+          '<a href="https://github.com" target="_blank" rel="noopener">Source code on GitHub</a>',
+      },
+      privacy: {
+        title: 'Privacy',
+        content:
+          'Game saves are stored locally in your browser. No tracking cookies are used. Audio preferences remain local.',
+      },
+    },
+  },
+  it: {
+    title: 'Info e Aiuto',
+    search: 'Cerca...',
+    sections: {
+      rules: {
+        title: 'Regole',
+        content:
+          'Ogni giocatore schiera gli eserciti, attacca territori adiacenti e termina il turno. Chi conquista tutte le terre vince.',
+      },
+      tips: {
+        title: 'Suggerimenti',
+        content: 'Espandi all\'inizio, difendi i confini e osserva gli avversari.',
+      },
+      credits: {
+        title: 'Credits',
+        content: 'Creato dal team NetRisk.',
+      },
+      changelog: {
+        title: 'Changelog',
+        content: '<ul><li>v0.1: Rilascio alpha iniziale.</li></ul>',
+      },
+      github: {
+        title: 'GitHub',
+        content:
+          '<a href="https://github.com" target="_blank" rel="noopener">Codice sorgente su GitHub</a>',
+      },
+      privacy: {
+        title: 'Privacy',
+        content:
+          'I salvataggi sono memorizzati localmente nel browser. Nessun cookie di tracciamento viene utilizzato. Le preferenze audio restano locali.',
+      },
+    },
+  },
+};
+
+export function filterSections(query, doc = document) {
+  const sections = doc.querySelectorAll('#helpContent section');
+  sections.forEach((sec) => {
+    if (sec.textContent.toLowerCase().includes(query.toLowerCase())) {
+      sec.style.display = '';
+    } else {
+      sec.style.display = 'none';
+    }
+  });
+}
+
+export function initAbout(doc = document) {
+  const t = texts[lang];
+  doc.getElementById('pageTitle').textContent = t.title;
+  doc.title = `${t.title} - NetRisk`;
+  const searchInput = doc.getElementById('helpSearch');
+  searchInput.placeholder = t.search;
+  searchInput.addEventListener('input', (e) => filterSections(e.target.value, doc));
+  Object.entries(t.sections).forEach(([id, data]) => {
+    const section = doc.getElementById(id);
+    if (!section) return;
+    section.querySelector('h2').textContent = data.title;
+    section.querySelector('.content').innerHTML = data.content;
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => initAbout());
+}
+
+export default { initAbout, filterSections };

--- a/about.test.js
+++ b/about.test.js
@@ -1,0 +1,15 @@
+const { filterSections } = require('./about.js');
+
+describe('about page search', () => {
+  test('filters sections based on query', () => {
+    document.body.innerHTML = `
+      <div id="helpContent">
+        <section id="s1"><h2>Rules</h2><p>battle</p></section>
+        <section id="s2"><h2>Tips</h2><p>strategy</p></section>
+      </div>`;
+    filterSections('battle', document);
+    const sections = document.querySelectorAll('#helpContent section');
+    expect(sections[0].style.display).toBe('');
+    expect(sections[1].style.display).toBe('none');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
   <body>
     <button id="themeToggle" class="btn">High Contrast</button>
     <h1>NetRisk</h1>
+    <nav>
+      <a href="about.html" id="aboutLink">About/Help</a>
+    </nav>
     <div id="mainMenu">
       <button id="startGame" class="btn">Start Game</button>
       <button id="playTutorial" class="btn">Play Tutorial</button>
@@ -64,6 +67,11 @@
       </div>
       <div id="board" class="board"></div>
     </div>
+        <script>
+      const lang = navigator.language && navigator.language.startsWith("it") ? "it" : "en";
+      const link = document.getElementById("aboutLink");
+      if (link) link.textContent = lang === "it" ? "Info/Aiuto" : "About/Help";
+    </script>
     <script src="./logger.js"></script>
     <script type="module" src="./main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add About/Help page with rules, tips, credits, changelog, GitHub link and privacy section
- client-side search and English/Italian translations
- link About/Help from main page

## Testing
- `npm run lint`
- `npm test`
- `npx -y linkinator about.html`
- `npx -y html-validate about.html && echo 'html-validate: OK'`


------
https://chatgpt.com/codex/tasks/task_e_68ae07f26bc8832cb065fd00d45a77b4