### PR TITLE
feat: add configurable audio system

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -1,55 +1,152 @@
-let audioCtx;
-let volume = 0.2;
-let muted = false;
+const SETTINGS_KEY = "audioSettings";
 
-function playTone(freq, duration = 0.2) {
-  if (typeof window === "undefined") return;
-  const AudioContext = window.AudioContext || window.webkitAudioContext;
-  if (!AudioContext) return;
-  if (!audioCtx) audioCtx = new AudioContext();
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.type = "sine";
-  osc.frequency.value = freq;
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
-  osc.start();
-  const gainValue = muted ? 0 : volume;
-  gain.gain.setValueAtTime(gainValue, audioCtx.currentTime);
-  gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + duration);
-  osc.stop(audioCtx.currentTime + duration);
+// Default settings
+let settings = {
+  master: 0.5,
+  effects: 1,
+  muted: false,
+  music: true,
+};
+
+// Load persisted settings
+if (typeof localStorage !== "undefined") {
+  try {
+    const stored = localStorage.getItem(SETTINGS_KEY);
+    if (stored) Object.assign(settings, JSON.parse(stored));
+  } catch {
+    // ignore storage errors
+  }
 }
 
-function playAttackSound() {
-  playTone(300);
+function saveSettings() {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // ignore storage errors
+  }
 }
 
-function playConquerSound() {
-  playTone(600, 0.3);
+const EFFECT_FILES = {
+  reinforce: "assets/reinforce.mp3",
+  attackWin: "assets/attack-win.mp3",
+  attackLoss: "assets/attack-loss.mp3",
+  conquer: "assets/conquer.mp3",
+  endTurn: "assets/end-turn.mp3",
+};
+
+const cache = new Map();
+let musicAudio;
+
+function clamp(v) {
+  return Math.min(Math.max(v, 0), 1);
 }
 
-function setVolume(v) {
-  volume = Math.min(Math.max(v, 0), 1);
+function loadAudio(src) {
+  if (cache.has(src)) return cache.get(src);
+  if (typeof Audio === "undefined") {
+    cache.set(src, null);
+    return null;
+  }
+  const a = new Audio();
+  a.src = src;
+  cache.set(src, a);
+  return a;
 }
 
-function getVolume() {
-  return volume;
+function playEffect(name) {
+  if (settings.muted) return;
+  if (settings.master === 0 || settings.effects === 0) return;
+  const src = EFFECT_FILES[name];
+  if (!src) return;
+  const audio = loadAudio(src);
+  if (!audio) return;
+  audio.volume = settings.master * settings.effects;
+  try {
+    audio.currentTime = 0;
+    const playPromise = audio.play();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise.catch(() => {});
+    }
+  } catch {
+    // ignore play errors
+  }
+}
+
+function ensureMusic() {
+  if (musicAudio || typeof Audio === "undefined") return musicAudio;
+  musicAudio = new Audio();
+  musicAudio.src = "assets/music.mp3";
+  musicAudio.loop = true;
+  return musicAudio;
+}
+
+function setMasterVolume(v) {
+  settings.master = clamp(v);
+  if (musicAudio) musicAudio.volume = settings.master;
+  saveSettings();
+}
+
+function getMasterVolume() {
+  return settings.master;
+}
+
+function setEffectsVolume(v) {
+  settings.effects = clamp(v);
+  saveSettings();
+}
+
+function getEffectsVolume() {
+  return settings.effects;
 }
 
 function setMuted(m) {
-  muted = m;
+  settings.muted = m;
+  if (musicAudio) musicAudio.muted = m;
+  saveSettings();
 }
 
 function isMuted() {
-  return muted;
+  return settings.muted;
+}
+
+function setMusicEnabled(on) {
+  settings.music = on;
+  const music = ensureMusic();
+  if (!music) return saveSettings();
+  if (on && !settings.muted) {
+    music.volume = settings.master;
+    try {
+      const p = music.play();
+      if (p && typeof p.catch === "function") p.catch(() => {});
+    } catch {
+      // ignore play errors
+    }
+  } else {
+    music.pause();
+  }
+  saveSettings();
+}
+
+function isMusicEnabled() {
+  return settings.music;
+}
+
+function preloadEffects() {
+  Object.values(EFFECT_FILES).forEach(loadAudio);
+  if (settings.music) ensureMusic();
 }
 
 export {
-  playTone,
-  playAttackSound,
-  playConquerSound,
-  setVolume,
-  getVolume,
+  playEffect,
+  preloadEffects,
+  setMasterVolume,
+  getMasterVolume,
+  setEffectsVolume,
+  getEffectsVolume,
   setMuted,
   isMuted,
+  setMusicEnabled,
+  isMusicEnabled,
 };
+

--- a/audio.test.js
+++ b/audio.test.js
@@ -1,61 +1,44 @@
-import * as audio from './audio.js';
+import {
+  playEffect,
+  setMasterVolume,
+  getMasterVolume,
+  setEffectsVolume,
+  getEffectsVolume,
+  setMuted,
+  isMuted,
+  setMusicEnabled,
+  isMusicEnabled,
+} from "./audio.js";
 
-describe('audio helpers', () => {
-  test('playTone returns without error when window is undefined', () => {
-    const originalWindow = global.window;
-    // Simulate environment without window
+describe("audio helpers", () => {
+  test("playEffect is safe when Audio is undefined", () => {
+    const original = global.Audio;
     // eslint-disable-next-line no-undefined
-    global.window = undefined;
-    expect(() => audio.playTone(440)).not.toThrow();
-    global.window = originalWindow;
+    global.Audio = undefined;
+    expect(() => playEffect("reinforce")).not.toThrow();
+    global.Audio = original;
   });
 
-  test('playAttackSound does not throw', () => {
-    expect(() => audio.playAttackSound()).not.toThrow();
+  test("volume setters clamp between 0 and 1", () => {
+    setMasterVolume(2);
+    expect(getMasterVolume()).toBe(1);
+    setMasterVolume(-1);
+    expect(getMasterVolume()).toBe(0);
+    setEffectsVolume(2);
+    expect(getEffectsVolume()).toBe(1);
+    setEffectsVolume(-1);
+    expect(getEffectsVolume()).toBe(0);
   });
 
-  test('playConquerSound does not throw', () => {
-    expect(() => audio.playConquerSound()).not.toThrow();
-  });
-
-  test('playTone creates audio nodes when AudioContext is available', () => {
-    const originalWindow = global.window;
-    const mockCtx = {
-      createOscillator: () => ({
-        type: '',
-        frequency: { value: 0 },
-        connect: jest.fn(),
-        start: jest.fn(),
-        stop: jest.fn(),
-      }),
-      createGain: () => ({
-        connect: jest.fn(),
-        gain: {
-          setValueAtTime: jest.fn(),
-          exponentialRampToValueAtTime: jest.fn(),
-        },
-      }),
-      destination: {},
-      currentTime: 0,
-    };
-    global.window = { AudioContext: function () { return mockCtx; } };
-    expect(() => audio.playTone(440, 0.1)).not.toThrow();
-    global.window = originalWindow;
-  });
-
-  test('setVolume clamps between 0 and 1', () => {
-    audio.setVolume(2);
-    expect(audio.getVolume()).toBe(1);
-    audio.setVolume(-1);
-    expect(audio.getVolume()).toBe(0);
-    audio.setVolume(0.5);
-    expect(audio.getVolume()).toBe(0.5);
-  });
-
-  test('setMuted controls mute state', () => {
-    audio.setMuted(true);
-    expect(audio.isMuted()).toBe(true);
-    audio.setMuted(false);
-    expect(audio.isMuted()).toBe(false);
+  test("mute and music toggles", () => {
+    setMuted(true);
+    expect(isMuted()).toBe(true);
+    setMuted(false);
+    expect(isMuted()).toBe(false);
+    setMusicEnabled(false);
+    expect(isMusicEnabled()).toBe(false);
+    setMusicEnabled(true);
+    expect(isMusicEnabled()).toBe(true);
   });
 });
+

--- a/game.js
+++ b/game.js
@@ -269,11 +269,15 @@ class Game {
     const defendRolls = Array.from({ length: defendDice }, () => Math.ceil(Math.random() * 6)).sort((a, b) => b - a);
 
     const comparisons = Math.min(attackRolls.length, defendRolls.length);
+    let attackerLosses = 0;
+    let defenderLosses = 0;
     for (let i = 0; i < comparisons; i++) {
       if (attackRolls[i] > defendRolls[i]) {
         to.armies -= 1;
+        defenderLosses += 1;
       } else {
         from.armies -= 1;
+        attackerLosses += 1;
       }
     }
 
@@ -288,7 +292,7 @@ class Game {
       this.conqueredThisTurn = true;
       this.checkVictory();
     }
-    const result = { attackRolls, defendRolls, conquered, movableArmies };
+    const result = { attackRolls, defendRolls, conquered, movableArmies, attackerLosses, defenderLosses };
     this.emit('attackResolved', { from: from.id, to: to.id, result });
     return result;
   }

--- a/index.html
+++ b/index.html
@@ -46,16 +46,26 @@
         <div id="diceResults"></div>
         <div id="selectedTerritory"></div>
         <div id="audioSettings">
-          <label for="volumeControl">Volume:</label>
+          <label for="masterVolume">Master:</label>
           <input
             type="range"
-            id="volumeControl"
+            id="masterVolume"
             min="0"
             max="1"
             step="0.01"
-            value="0.2"
+            value="0.5"
+          />
+          <label for="effectsVolume">Effects:</label>
+          <input
+            type="range"
+            id="effectsVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="1"
           />
           <button id="muteBtn" class="btn">Mute</button>
+          <button id="musicToggle" class="btn">Music Off</button>
         </div>
         <button id="moveToken" class="btn">Move Token</button>
         <button id="endTurn" class="btn">End Turn</button>

--- a/main.js
+++ b/main.js
@@ -1,12 +1,16 @@
 /* global logger */
 import initTerritorySelection from "./territory-selection.js";
 import {
-  playAttackSound,
-  playConquerSound,
-  setVolume,
+  playEffect,
+  preloadEffects,
+  setMasterVolume,
+  getMasterVolume,
+  setEffectsVolume,
+  getEffectsVolume,
   setMuted,
   isMuted,
-  getVolume,
+  setMusicEnabled,
+  isMusicEnabled,
 } from "./audio.js";
 import askArmiesToMove from "./move-prompt.js";
 import { navigateTo } from "./navigation.js";
@@ -235,7 +239,6 @@ function attachTerritoryHandlers() {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} attacks ${result.to} from ${result.from}`);
             }
-            playAttackSound();
             const fromEl = document.getElementById(result.from);
             const toEl = document.getElementById(result.to);
             fromEl.classList.add("attack", "animate__animated", "animate__shakeX");
@@ -246,37 +249,36 @@ function attachTerritoryHandlers() {
             }, 500);
             document.getElementById("diceResults").textContent =
               `Attacker: ${result.attackRolls.join(", ")} | Defender: ${result.defendRolls.join(", ")}`;
-          if (result.conquered) {
-            playConquerSound();
-            toEl.classList.add("conquer");
-            setTimeout(() => toEl.classList.remove("conquer"), 1000);
-            const move = await askArmiesToMove(result.movableArmies, 0);
-            if (move > 0) {
-              game.moveArmies(result.from, result.to, move);
-              addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`, {
-                player: playerName,
-                type: "move",
-                territories: [result.from, result.to],
-              });
-              animateMove(result.from, result.to);
+            if (result.conquered) {
+              toEl.classList.add("conquer");
+              setTimeout(() => toEl.classList.remove("conquer"), 1000);
+              const move = await askArmiesToMove(result.movableArmies, 0);
+              if (move > 0) {
+                game.moveArmies(result.from, result.to, move);
+                addLogEntry(`${playerName} moves ${move} from ${result.from} to ${result.to}`, {
+                  player: playerName,
+                  type: "move",
+                  territories: [result.from, result.to],
+                });
+                animateMove(result.from, result.to);
+              }
             }
-          }
-          animateAttack(result.from, result.to);
-          addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`, {
-            player: playerName,
-            type: "attack",
-            territories: [result.from, result.to],
-          });
-        } else if (result.type === REINFORCE) {
-          if (typeof logger !== "undefined") {
-            logger.info(`${playerName} reinforces ${result.territory}`);
-          }
-          animateReinforce(result.territory);
-          addLogEntry(`${playerName} reinforces ${result.territory}`, {
-            player: playerName,
-            type: "reinforce",
-            territories: [result.territory],
-          });
+            animateAttack(result.from, result.to);
+            addLogEntry(`${playerName} attacks ${result.to} from ${result.from}`, {
+              player: playerName,
+              type: "attack",
+              territories: [result.from, result.to],
+            });
+          } else if (result.type === REINFORCE) {
+            if (typeof logger !== "undefined") {
+              logger.info(`${playerName} reinforces ${result.territory}`);
+            }
+            animateReinforce(result.territory);
+            addLogEntry(`${playerName} reinforces ${result.territory}`, {
+              player: playerName,
+              type: "reinforce",
+              territories: [result.territory],
+            });
           } else if (result.type === FORTIFY) {
             if (typeof logger !== "undefined") {
               logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
@@ -401,6 +403,23 @@ async function initGame() {
     return;
   }
   await loadGame();
+  preloadEffects();
+
+  let firstTurn = true;
+  game.on(REINFORCE, () => playEffect("reinforce"));
+  game.on("attackResolved", ({ result }) => {
+    if (result.conquered) {
+      playEffect("conquer");
+    } else if (result.defenderLosses > result.attackerLosses) {
+      playEffect("attackWin");
+    } else {
+      playEffect("attackLoss");
+    }
+  });
+  game.on("turnStart", () => {
+    if (!firstTurn) playEffect("endTurn");
+    firstTurn = false;
+  });
   const resetBtn = document.createElement("button");
   resetBtn.id = "resetGame";
   resetBtn.textContent = "New Game";
@@ -468,12 +487,20 @@ async function initGame() {
     }
   });
 
-  const volumeControl = document.getElementById("volumeControl");
+  const masterVolume = document.getElementById("masterVolume");
+  const effectsVolume = document.getElementById("effectsVolume");
   const muteBtn = document.getElementById("muteBtn");
-  if (volumeControl) {
-    volumeControl.value = getVolume();
-    volumeControl.addEventListener("input", (e) => {
-      setVolume(parseFloat(e.target.value));
+  const musicToggle = document.getElementById("musicToggle");
+  if (masterVolume) {
+    masterVolume.value = getMasterVolume();
+    masterVolume.addEventListener("input", (e) => {
+      setMasterVolume(parseFloat(e.target.value));
+    });
+  }
+  if (effectsVolume) {
+    effectsVolume.value = getEffectsVolume();
+    effectsVolume.addEventListener("input", (e) => {
+      setEffectsVolume(parseFloat(e.target.value));
     });
   }
   if (muteBtn) {
@@ -482,6 +509,14 @@ async function initGame() {
       const muted = isMuted();
       setMuted(!muted);
       muteBtn.textContent = muted ? "Mute" : "Unmute";
+    });
+  }
+  if (musicToggle) {
+    musicToggle.textContent = isMusicEnabled() ? "Music Off" : "Music On";
+    musicToggle.addEventListener("click", () => {
+      const on = isMusicEnabled();
+      setMusicEnabled(!on);
+      musicToggle.textContent = on ? "Music On" : "Music Off";
     });
   }
   initTerritorySelection({


### PR DESCRIPTION
## Summary
- add master/effects volume, mute and music toggles with persistence
- play distinct sounds for reinforce, attack outcomes, conquest and end turns
- load/caches audio assets on demand and hook into game events

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68ae08025de0832ca5be2b9939a1b5a6