### PR TITLE
Add accessibility tests and keyboard shortcuts

### DIFF
--- a/accessibility.test.js
+++ b/accessibility.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
+const initTerritorySelection = require('./territory-selection.js').default;
+
+const flushPromises = () => new Promise((res) => setTimeout(res, 0));
+
+describe('Accessibility features', () => {
+  test('buttons expose aria-labels and access keys', () => {
+    const html = fs.readFileSync('index.html', 'utf-8');
+    const dom = new JSDOM(html);
+    const document = dom.window.document;
+    const ids = [
+      'themeToggle',
+      'startGame',
+      'playTutorial',
+      'muteBtn',
+      'musicToggle',
+      'moveToken',
+      'undo',
+      'endTurn',
+      'forceError',
+      'exportLog',
+    ];
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      expect(el).not.toBeNull();
+      expect(el.getAttribute('aria-label')).toBeTruthy();
+      expect(el.getAttribute('accesskey')).toBeTruthy();
+    });
+  });
+
+  test('territories are accessible via keyboard with ARIA labels', async () => {
+    document.body.innerHTML = '<div id="board"></div><div id="selectedTerritory"></div>';
+    const svg =
+      '<svg id="map"><path id="A" class="map-territory"/><path id="B" class="map-territory"/></svg>';
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve(svg) }),
+    );
+    const territories = [
+      { id: 'A', name: 'Alpha' },
+      { id: 'B', name: 'Beta' },
+    ];
+    initTerritorySelection({ territories });
+    await flushPromises();
+    const btnA = document.querySelector('button#A');
+    expect(btnA.getAttribute('aria-label')).toBe('Alpha');
+    const pathA = document.querySelector('#map #A');
+    expect(pathA.getAttribute('tabindex')).toBe('0');
+    expect(pathA.getAttribute('role')).toBe('button');
+    pathA.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+    expect(document.getElementById('selectedTerritory').textContent).toBe('A');
+  });
+
+  test('victory charts include ARIA labels', () => {
+    const js = fs.readFileSync('main.js', 'utf-8');
+    expect(js).toMatch(
+      'canvas id="territoryChart" aria-label="Territories per turn" role="img"',
+    );
+    expect(js).toMatch(
+      'canvas id="armiesChart" aria-label="Armies placed per turn" role="img"',
+    );
+    expect(js).toMatch(
+      'canvas id="attackChart" aria-label="Attacks won and lost" role="img"',
+    );
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -9,15 +9,38 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>
-    <button id="themeToggle" class="btn">High Contrast</button>
+    <button
+      id="themeToggle"
+      class="btn"
+      aria-label="Toggle high contrast mode"
+      accesskey="h"
+    >
+      High Contrast
+    </button>
     <h1>NetRisk</h1>
     <nav>
       <a href="about.html" id="aboutLink">About/Help</a>
     </nav>
     <div id="mainMenu">
-      <button id="startGame" class="btn">Start Game</button>
-      <button id="playTutorial" class="btn">Play Tutorial</button>
-      <a href="setup.html" class="btn">Set up players</a>
+      <button id="startGame" class="btn" aria-label="Start Game" accesskey="s">
+        Start Game
+      </button>
+      <button
+        id="playTutorial"
+        class="btn"
+        aria-label="Play Tutorial"
+        accesskey="t"
+      >
+        Play Tutorial
+      </button>
+      <a
+        href="setup.html"
+        class="btn"
+        aria-label="Set up players"
+        accesskey="p"
+      >
+        Set up players
+      </a>
     </div>
     <div id="gameContainer" class="hidden">
       <div id="uiPanel">
@@ -67,14 +90,53 @@
             step="0.01"
             value="1"
           />
-          <button id="muteBtn" class="btn">Mute</button>
-          <button id="musicToggle" class="btn">Music Off</button>
+          <button
+            id="muteBtn"
+            class="btn"
+            aria-label="Toggle mute"
+            accesskey="m"
+          >
+            Mute
+          </button>
+          <button
+            id="musicToggle"
+            class="btn"
+            aria-label="Toggle music"
+            accesskey="i"
+          >
+            Music Off
+          </button>
         </div>
-        <button id="moveToken" class="btn">Move Token</button>
-        <button id="undo" class="btn" disabled>Undo</button>
-        <button id="endTurn" class="btn">End Turn</button>
-        <button id="forceError" class="btn">Force Error</button>
-        <button id="exportLog" class="btn">Export Log</button>
+        <button
+          id="moveToken"
+          class="btn"
+          aria-label="Move Token"
+          accesskey="v"
+        >
+          Move Token
+        </button>
+        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
+          Undo
+        </button>
+        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
+          End Turn
+        </button>
+        <button
+          id="forceError"
+          class="btn"
+          aria-label="Force Error"
+          accesskey="f"
+        >
+          Force Error
+        </button>
+        <button
+          id="exportLog"
+          class="btn"
+          aria-label="Export Log"
+          accesskey="x"
+        >
+          Export Log
+        </button>
       </div>
       <div id="board" class="board"></div>
     </div>

--- a/validate-map.js
+++ b/validate-map.js
@@ -1,5 +1,6 @@
-const Ajv = require('ajv/dist/2020').default;
+const Ajv = require('ajv');
 const schema = require('./src/data/map-schema.json');
+delete schema.$schema;
 
 const ajv = new Ajv();
 const validate = ajv.compile(schema);


### PR DESCRIPTION
## Summary
- add ARIA labels and accesskey shortcuts to UI buttons
- ensure map validator works without 2020 meta-schema
- test ARIA labels, keyboard navigation and chart descriptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0ab8c390832caa08fc7db7933616