### PR TITLE
Add full-screen game page

### DIFF
--- a/game.html
+++ b/game.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NetRisk Game</title>
+    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body class="game-page">
+    <header id="gameHeader">
+      <a href="index.html" class="btn" id="backHome">Back to Home</a>
+      <button id="exitGame" class="btn">Exit Game</button>
+    </header>
+    <div id="gameContainer">
+      <div id="board" class="board"></div>
+      <div id="uiPanel">
+        <div>Current turn: <span id="turnNumber">1</span></div>
+        <div>Current player: <span id="currentPlayer"></span></div>
+        <div id="howToPlayBox">
+          <div>
+            <strong>How to play (alpha)</strong>
+            <button
+              id="toggleHowToPlay"
+              class="btn"
+              aria-expanded="false"
+              aria-controls="howToPlaySteps"
+            >
+              Show details
+            </button>
+          </div>
+          <ol id="howToPlaySteps" hidden>
+            <li>Click a territory</li>
+            <li>Choose an action</li>
+            <li>Press "End Turn"</li>
+          </ol>
+          <button id="replayTutorial" class="btn">Play Tutorial</button>
+        </div>
+        <div><strong>Action log:</strong></div>
+        <div id="actionLog" class="log"></div>
+        <div id="status"></div>
+        <div>Phase time: <span id="phaseTimer"></span></div>
+        <div id="diceResults"></div>
+        <div id="selectedTerritory"></div>
+        <div id="audioSettings">
+          <label for="masterVolume">Master:</label>
+          <input
+            type="range"
+            id="masterVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="0.5"
+          />
+          <label for="effectsVolume">Effects:</label>
+          <input
+            type="range"
+            id="effectsVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="1"
+          />
+          <button
+            id="muteBtn"
+            class="btn"
+            aria-label="Toggle mute"
+            accesskey="m"
+          >
+            Mute
+          </button>
+          <button
+            id="musicToggle"
+            class="btn"
+            aria-label="Toggle music"
+            accesskey="i"
+          >
+            Music Off
+          </button>
+        </div>
+        <button
+          id="moveToken"
+          class="btn"
+          aria-label="Move Token"
+          accesskey="v"
+        >
+          Move Token
+        </button>
+        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
+          Undo
+        </button>
+        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
+          End Turn
+        </button>
+        <button
+          id="forceError"
+          class="btn"
+          aria-label="Force Error"
+          accesskey="f"
+        >
+          Force Error
+        </button>
+        <button
+          id="exportLog"
+          class="btn"
+          aria-label="Export Log"
+          accesskey="x"
+        >
+          Export Log
+        </button>
+      </div>
+    </div>
+    <script>
+      const exitBtn = document.getElementById('exitGame');
+      if (exitBtn) {
+        exitBtn.addEventListener('click', () => {
+          if (window.confirm('Exit the game and return to home?')) {
+            window.location.href = 'index.html';
+          }
+        });
+      }
+    </script>
+    <script src="./logger.js"></script>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -397,3 +397,57 @@ body.high-contrast .modal-content {
   color: #fff;
   border: 2px solid #fff;
 }
+body.game-page {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+body.game-page #gameHeader {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+  background: rgba(245, 231, 198, 0.9);
+  border-bottom: 2px solid #8b4513;
+}
+
+body.game-page #gameContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+body.game-page #board {
+  flex: 1;
+  margin: 0;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+body.game-page #uiPanel {
+  overflow-y: auto;
+  max-height: 100%;
+}
+
+@media (min-width: 1024px) {
+  body.game-page #gameContainer {
+    flex-direction: row;
+  }
+  body.game-page #board {
+    flex: 2;
+  }
+  body.game-page #uiPanel {
+    flex: 1;
+    max-width: 400px;
+  }
+}
+
+@media (max-width: 1023px) {
+  body.game-page #uiPanel .btn {
+    width: 100%;
+    padding: 14px;
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
## Summary
- Add standalone `game.html` with board, side panel, and minimal header for Back to Home and Exit Game
- Extend styles for a responsive full-screen layout with top bar and touch-friendly buttons on small screens
- Include exit-game confirmation redirecting to home

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0f1e23ac832c9d4317e39946968f