### PR TITLE
feat: add full-screen home menu

### DIFF
--- a/accessibility.test.js
+++ b/accessibility.test.js
@@ -9,23 +9,23 @@ const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 
 describe('Accessibility features', () => {
   test('buttons expose aria-labels and access keys', () => {
-    const html = fs.readFileSync('index.html', 'utf-8');
-    const dom = new JSDOM(html);
-    const document = dom.window.document;
-    const ids = [
-      'themeToggle',
-      'startGame',
-      'playTutorial',
-      'muteBtn',
-      'musicToggle',
-      'moveToken',
-      'undo',
-      'endTurn',
-      'forceError',
-      'exportLog',
-    ];
+    const homeHtml = fs.readFileSync('index.html', 'utf-8');
+    const homeDom = new JSDOM(homeHtml);
+    const homeDoc = homeDom.window.document;
+    const homeIds = ['themeToggle','playBtn','setupBtn','howToPlayBtn','aboutBtn'];
+    homeIds.forEach((id) => {
+      const el = homeDoc.getElementById(id);
+      expect(el).not.toBeNull();
+      expect(el.getAttribute('aria-label')).toBeTruthy();
+      expect(el.getAttribute('accesskey')).toBeTruthy();
+    });
+
+    const gameHtml = fs.readFileSync('game.html', 'utf-8');
+    const gameDom = new JSDOM(gameHtml);
+    const doc = gameDom.window.document;
+    const ids = ['muteBtn','musicToggle','moveToken','undo','endTurn','forceError','exportLog'];
     ids.forEach((id) => {
-      const el = document.getElementById(id);
+      const el = doc.getElementById(id);
       expect(el).not.toBeNull();
       expect(el.getAttribute('aria-label')).toBeTruthy();
       expect(el.getAttribute('accesskey')).toBeTruthy();

--- a/build.js
+++ b/build.js
@@ -40,11 +40,14 @@ for (const asset of plainAssets) {
 // Copy additional data files (e.g., map.json)
 fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });
 
-let indexHtml = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 
-for (const [orig, hashedName] of Object.entries(hashed)) {
-  indexHtml = indexHtml.replace(new RegExp(orig, 'g'), hashedName);
+
+const htmlFiles = ['index.html', 'game.html', 'setup.html', 'about.html', 'how-to-play.html'];
+
+for (const file of htmlFiles) {
+  let html = fs.readFileSync(path.join(root, file), 'utf8');
+  for (const [orig, hashedName] of Object.entries(hashed)) {
+    html = html.replace(new RegExp(orig, 'g'), hashedName);
+  }
+  fs.writeFileSync(path.join(dist, file), html);
 }
-
-fs.writeFileSync(path.join(dist, 'index.html'), indexHtml);
-

--- a/game.html
+++ b/game.html
@@ -9,6 +9,9 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>
+    <nav>
+      <a href="index.html" id="homeLink">Home</a>
+    </nav>
     <h1>NetRisk</h1>
     <div id="gameContainer">
       <div id="uiPanel">
@@ -109,6 +112,7 @@
       <div id="board" class="board"></div>
     </div>
     <script src="./logger.js"></script>
+    <script type="module" src="./theme.js"></script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/game.html
+++ b/game.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NetRisk</title>
+    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+    <link rel="stylesheet" href="./style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body>
+    <h1>NetRisk</h1>
+    <div id="gameContainer">
+      <div id="uiPanel">
+        <div>Current turn: <span id="turnNumber">1</span></div>
+        <div>Current player: <span id="currentPlayer"></span></div>
+        <div id="howToPlayBox">
+          <div>
+            <strong>How to play (alpha)</strong>
+            <button
+              id="toggleHowToPlay"
+              class="btn"
+              aria-expanded="false"
+              aria-controls="howToPlaySteps"
+            >
+              Show details
+            </button>
+          </div>
+          <ol id="howToPlaySteps" hidden>
+            <li>Click a territory</li>
+            <li>Choose an action</li>
+            <li>Press "End Turn"</li>
+          </ol>
+          <button id="replayTutorial" class="btn">Play Tutorial</button>
+        </div>
+        <div><strong>Action log:</strong></div>
+        <div id="actionLog" class="log"></div>
+        <div id="status"></div>
+        <div>Phase time: <span id="phaseTimer"></span></div>
+        <div id="diceResults"></div>
+        <div id="selectedTerritory"></div>
+        <div id="audioSettings">
+          <label for="masterVolume">Master:</label>
+          <input
+            type="range"
+            id="masterVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="0.5"
+          />
+          <label for="effectsVolume">Effects:</label>
+          <input
+            type="range"
+            id="effectsVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="1"
+          />
+          <button
+            id="muteBtn"
+            class="btn"
+            aria-label="Toggle mute"
+            accesskey="m"
+          >
+            Mute
+          </button>
+          <button
+            id="musicToggle"
+            class="btn"
+            aria-label="Toggle music"
+            accesskey="i"
+          >
+            Music Off
+          </button>
+        </div>
+        <button
+          id="moveToken"
+          class="btn"
+          aria-label="Move Token"
+          accesskey="v"
+        >
+          Move Token
+        </button>
+        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
+          Undo
+        </button>
+        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
+          End Turn
+        </button>
+        <button
+          id="forceError"
+          class="btn"
+          aria-label="Force Error"
+          accesskey="f"
+        >
+          Force Error
+        </button>
+        <button
+          id="exportLog"
+          class="btn"
+          aria-label="Export Log"
+          accesskey="x"
+        >
+          Export Log
+        </button>
+      </div>
+      <div id="board" class="board"></div>
+    </div>
+    <script src="./logger.js"></script>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>How to Play - NetRisk</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="index.html" id="homeLink">Home</a>
+    </nav>
+    <h1>How to Play</h1>
+    <p>Learn the basics of NetRisk or launch the tutorial from the game menu.</p>
+    <script type="module" src="./theme.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,148 +4,60 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NetRisk</title>
-    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <link rel="stylesheet" href="./style.css" />
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>
-    <button
-      id="themeToggle"
-      class="btn"
-      aria-label="Toggle high contrast mode"
-      accesskey="h"
-    >
-      High Contrast
-    </button>
-    <h1>NetRisk</h1>
-    <nav>
-      <a href="about.html" id="aboutLink">About/Help</a>
-    </nav>
-    <div id="mainMenu">
-      <button id="startGame" class="btn" aria-label="Start Game" accesskey="s">
-        Start Game
-      </button>
+    <header>
       <button
-        id="playTutorial"
+        id="themeToggle"
         class="btn"
-        aria-label="Play Tutorial"
+        aria-label="Toggle high contrast mode"
         accesskey="t"
       >
-        Play Tutorial
+        High Contrast
       </button>
-      <a
-        href="setup.html"
-        class="btn"
-        aria-label="Set up players"
-        accesskey="p"
-      >
-        Set up players
-      </a>
-    </div>
-    <div id="gameContainer" class="hidden">
-      <div id="uiPanel">
-        <div>Current turn: <span id="turnNumber">1</span></div>
-        <div>Current player: <span id="currentPlayer"></span></div>
-        <div id="howToPlayBox">
-          <div>
-            <strong>How to play (alpha)</strong>
-            <button
-              id="toggleHowToPlay"
-              class="btn"
-              aria-expanded="false"
-              aria-controls="howToPlaySteps"
-            >
-              Show details
-            </button>
-          </div>
-          <ol id="howToPlaySteps" hidden>
-            <li>Click a territory</li>
-            <li>Choose an action</li>
-            <li>Press "End Turn"</li>
-          </ol>
-          <button id="replayTutorial" class="btn">Play Tutorial</button>
-        </div>
-        <div><strong>Action log:</strong></div>
-        <div id="actionLog" class="log"></div>
-        <div id="status"></div>
-        <div>Phase time: <span id="phaseTimer"></span></div>
-        <div id="diceResults"></div>
-        <div id="selectedTerritory"></div>
-        <div id="audioSettings">
-          <label for="masterVolume">Master:</label>
-          <input
-            type="range"
-            id="masterVolume"
-            min="0"
-            max="1"
-            step="0.01"
-            value="0.5"
-          />
-          <label for="effectsVolume">Effects:</label>
-          <input
-            type="range"
-            id="effectsVolume"
-            min="0"
-            max="1"
-            step="0.01"
-            value="1"
-          />
-          <button
-            id="muteBtn"
-            class="btn"
-            aria-label="Toggle mute"
-            accesskey="m"
-          >
-            Mute
-          </button>
-          <button
-            id="musicToggle"
-            class="btn"
-            aria-label="Toggle music"
-            accesskey="i"
-          >
-            Music Off
-          </button>
-        </div>
-        <button
-          id="moveToken"
+    </header>
+    <main id="homeMenu">
+      <h1>NetRisk</h1>
+      <nav>
+        <a
+          id="playBtn"
+          href="game.html"
           class="btn"
-          aria-label="Move Token"
-          accesskey="v"
+          aria-label="Play"
+          accesskey="p"
         >
-          Move Token
-        </button>
-        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
-          Undo
-        </button>
-        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
-          End Turn
-        </button>
-        <button
-          id="forceError"
+          Play
+        </a>
+        <a
+          id="setupBtn"
+          href="setup.html"
           class="btn"
-          aria-label="Force Error"
-          accesskey="f"
+          aria-label="Setup players"
+          accesskey="s"
         >
-          Force Error
-        </button>
-        <button
-          id="exportLog"
+          Setup
+        </a>
+        <a
+          id="howToPlayBtn"
+          href="how-to-play.html"
           class="btn"
-          aria-label="Export Log"
-          accesskey="x"
+          aria-label="How to Play"
+          accesskey="h"
         >
-          Export Log
-        </button>
-      </div>
-      <div id="board" class="board"></div>
-    </div>
-        <script>
-      const lang = navigator.language && navigator.language.startsWith("it") ? "it" : "en";
-      const link = document.getElementById("aboutLink");
-      if (link) link.textContent = lang === "it" ? "Info/Aiuto" : "About/Help";
-    </script>
-    <script src="./logger.js"></script>
-    <script type="module" src="./main.js"></script>
+          How to Play
+        </a>
+        <a
+          id="aboutBtn"
+          href="about.html"
+          class="btn"
+          aria-label="About and settings"
+          accesskey="a"
+        >
+          About / Settings
+        </a>
+      </nav>
+    </main>
+    <script type="module" src="./theme.js"></script>
   </body>
 </html>

--- a/menu.test.js
+++ b/menu.test.js
@@ -10,7 +10,6 @@ describe('main menu', () => {
       localStorage.clear();
     }
     document.body.innerHTML = `
-      <div id="mainMenu"><button id="startGame" class="btn"></button></div>
       <div id="gameContainer">
         <div id="status"></div>
         <div id="currentPlayer"></div>
@@ -32,10 +31,9 @@ describe('main menu', () => {
     global.logger = { info: jest.fn(), error: jest.fn() };
   });
 
-  test('initializes game after start button clicked', async () => {
+  test('initializes game automatically', async () => {
     const main = require('./main.js');
     expect(main.game).toBeUndefined();
-    document.getElementById('startGame').click();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(main.game).toBeDefined();
   });

--- a/setup.html
+++ b/setup.html
@@ -8,7 +8,6 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
   </head>
   <body>
-    <button id="themeToggle" class="btn">High Contrast</button>
     <h1>Player Setup</h1>
     <form id="setupForm">
       <label>

--- a/setup.js
+++ b/setup.js
@@ -179,7 +179,7 @@ form.addEventListener("submit", (e) => {
   } catch (err) {
     // ignore storage errors
   }
-  navigateTo("index.html");
+  navigateTo("game.html");
 });
 
 loadFromStorage();

--- a/setup.test.js
+++ b/setup.test.js
@@ -53,7 +53,7 @@ describe('setup map selection', () => {
     document.querySelector('.map-item[data-id="map3"]').click();
     document.getElementById('setupForm').dispatchEvent(new Event('submit'));
     expect(localStorage.getItem('netriskMap')).toBe('map3');
-    expect(navigateTo).toHaveBeenCalledWith('index.html');
+    expect(navigateTo).toHaveBeenCalledWith('game.html');
   });
 
   test('renders responsive grid', async () => {

--- a/style.css
+++ b/style.css
@@ -22,6 +22,7 @@ h1 {
   color: #fff;
   border: 2px solid #8b4513;
   padding: 8px 16px;
+  min-height: 44px;
   cursor: pointer;
   box-shadow: 0 2px #8b4513;
   text-decoration: none;
@@ -36,12 +37,17 @@ h1 {
   transform: translateY(2px);
 }
 
+.btn:focus {
+  outline: 3px solid #000;
+  outline-offset: 2px;
+}
+
 /* Utility classes */
 .hidden {
   display: none;
 }
 
-#mainMenu {
+#mainMenu, #homeMenu {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -54,7 +60,7 @@ h1 {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
-#mainMenu .btn {
+#mainMenu .btn, #homeMenu .btn {
   display: block;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- Split gameplay into new `game.html` and introduce a clean home screen with large navigation buttons
- Restrict the high-contrast toggle to the home page and size all buttons for mobile accessibility
- Update build and setup flows to point to `game.html` and adjust tests accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0eb5b214832cbeb69394b3aed118