### PR TITLE
Add standalone How to Play page

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>How to Play - NetRisk</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="index.html" id="navLink">Back to Home</a>
+      <ul id="toc">
+        <li><a href="#objective" id="tocObjective">Objective</a></li>
+        <li><a href="#phases" id="tocPhases">Phases</a></li>
+        <li><a href="#tips" id="tocTips">Quick Tips</a></li>
+        <li><a href="#shortcuts" id="tocShortcuts">Keyboard Shortcuts</a></li>
+        <li><a href="#faq" id="tocFAQ">FAQ</a></li>
+      </ul>
+    </nav>
+    <h1 id="title">How to Play</h1>
+    <main>
+      <section id="objective">
+        <h2 id="objectiveTitle">Objective</h2>
+        <p id="objectiveText"></p>
+      </section>
+      <section id="phases">
+        <h2 id="phasesTitle">Phases</h2>
+        <ol id="phasesList"></ol>
+      </section>
+      <section id="tips">
+        <h2 id="tipsTitle">Quick Tips</h2>
+        <ul id="tipsList"></ul>
+      </section>
+      <section id="shortcuts">
+        <h2 id="shortcutsTitle">Keyboard Shortcuts</h2>
+        <ul id="shortcutsList"></ul>
+      </section>
+      <section id="faq">
+        <h2 id="faqTitle">FAQ</h2>
+        <ul id="faqList"></ul>
+      </section>
+    </main>
+    <script>
+      const lang = navigator.language && navigator.language.startsWith('it') ? 'it' : 'en';
+      const i18n = {
+        en: {
+          navHome: 'Back to Home',
+          navTutorial: 'Start Tutorial',
+          tocObjective: 'Objective',
+          tocPhases: 'Phases',
+          tocTips: 'Quick Tips',
+          tocShortcuts: 'Keyboard Shortcuts',
+          tocFAQ: 'FAQ',
+          title: 'How to Play',
+          objectiveTitle: 'Objective',
+          objectiveText: 'Conquer all territories or eliminate all opponents.',
+          phasesTitle: 'Phases',
+          phasesList: [
+            'Reinforce: deploy armies to your territories.',
+            'Attack: attempt to conquer adjacent territories.',
+            'Fortify: move armies to strengthen your borders.'
+          ],
+          tipsTitle: 'Quick Tips',
+          tipsList: [
+            'Claim continents for bonus troops.',
+            'Leave borders defended.',
+            'Weaken opponents before final strikes.'
+          ],
+          shortcutsTitle: 'Keyboard Shortcuts',
+          shortcutsList: [
+            'N: next phase',
+            'U: undo last action',
+            'M: mute audio'
+          ],
+          faqTitle: 'FAQ',
+          faqList: [
+            { q: 'Is there online multiplayer?', a: "Not yet, but it's planned." },
+            { q: 'Can I save the game?', a: 'Games are saved automatically in your browser.' }
+          ]
+        },
+        it: {
+          navHome: 'Torna alla Home',
+          navTutorial: 'Avvia Tutorial',
+          tocObjective: 'Obiettivo',
+          tocPhases: 'Fasi',
+          tocTips: 'Consigli Rapidi',
+          tocShortcuts: 'Scorciatoie Tastiera',
+          tocFAQ: 'FAQ',
+          title: 'Come si gioca',
+          objectiveTitle: 'Obiettivo',
+          objectiveText: 'Conquista tutti i territori o elimina gli avversari.',
+          phasesTitle: 'Fasi',
+          phasesList: [
+            'Rinforza: schiera gli eserciti nei tuoi territori.',
+            'Attacca: prova a conquistare territori adiacenti.',
+            'Fortifica: sposta gli eserciti per rinforzare i confini.'
+          ],
+          tipsTitle: 'Consigli Rapidi',
+          tipsList: [
+            'Controlla i continenti per bonus truppe.',
+            'Lascia sempre i confini difesi.',
+            'Indebolisci gli avversari prima del colpo finale.'
+          ],
+          shortcutsTitle: 'Scorciatoie da Tastiera',
+          shortcutsList: [
+            'N: fase successiva',
+            'U: annulla ultima azione',
+            'M: disattiva audio'
+          ],
+          faqTitle: 'FAQ',
+          faqList: [
+            { q: 'Esiste il multiplayer online?', a: 'Non ancora, ma è previsto.' },
+            { q: 'Posso salvare la partita?', a: 'Le partite vengono salvate automaticamente nel tuo browser.' }
+          ]
+        }
+      };
+      function t(key) {
+        return i18n[lang][key];
+      }
+      function renderList(id, items) {
+        const list = document.getElementById(id);
+        list.innerHTML = '';
+        items.forEach(text => {
+          const li = document.createElement('li');
+          li.textContent = text;
+          list.appendChild(li);
+        });
+      }
+      function renderFaq(id, items) {
+        const list = document.getElementById(id);
+        list.innerHTML = '';
+        items.forEach(({ q, a }) => {
+          const li = document.createElement('li');
+          const question = document.createElement('strong');
+          question.textContent = q;
+          li.appendChild(question);
+          const answer = document.createElement('p');
+          answer.textContent = a;
+          li.appendChild(answer);
+          list.appendChild(li);
+        });
+      }
+      function render() {
+        const navLink = document.getElementById('navLink');
+        if (localStorage.getItem('tutorialCompleted') !== 'true') {
+          navLink.textContent = t('navTutorial');
+        } else {
+          navLink.textContent = t('navHome');
+        }
+        navLink.href = 'index.html';
+        document.getElementById('tocObjective').textContent = t('tocObjective');
+        document.getElementById('tocPhases').textContent = t('tocPhases');
+        document.getElementById('tocTips').textContent = t('tocTips');
+        document.getElementById('tocShortcuts').textContent = t('tocShortcuts');
+        document.getElementById('tocFAQ').textContent = t('tocFAQ');
+        document.getElementById('title').textContent = t('title');
+        document.getElementById('objectiveTitle').textContent = t('objectiveTitle');
+        document.getElementById('objectiveText').textContent = t('objectiveText');
+        document.getElementById('phasesTitle').textContent = t('phasesTitle');
+        renderList('phasesList', t('phasesList'));
+        document.getElementById('tipsTitle').textContent = t('tipsTitle');
+        renderList('tipsList', t('tipsList'));
+        document.getElementById('shortcutsTitle').textContent = t('shortcutsTitle');
+        renderList('shortcutsList', t('shortcutsList'));
+        document.getElementById('faqTitle').textContent = t('faqTitle');
+        renderFaq('faqList', t('faqList'));
+      }
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add `howto.html` page outlining objective, phases, tips, keyboard shortcuts and FAQ
- Include simple EN/IT translations and internal anchors for navigation
- Provide dynamic link to Start Tutorial or Back to Home without loading game scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0f3b9ee8832c85d4c6fbecb7dcf3