### PR TITLE
Add dedicated setup navigation and game page

### DIFF
--- a/game.html
+++ b/game.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NetRisk</title>
+    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+    <link rel="stylesheet" href="./style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body>
+    <button
+      id="themeToggle"
+      class="btn"
+      aria-label="Toggle high contrast mode"
+      accesskey="h"
+    >
+      High Contrast
+    </button>
+    <h1>NetRisk</h1>
+    <nav>
+      <a href="about.html" id="aboutLink">About/Help</a>
+    </nav>
+    <div id="gameContainer">
+      <div id="uiPanel">
+        <div>Current turn: <span id="turnNumber">1</span></div>
+        <div>Current player: <span id="currentPlayer"></span></div>
+        <div id="howToPlayBox">
+          <div>
+            <strong>How to play (alpha)</strong>
+            <button
+              id="toggleHowToPlay"
+              class="btn"
+              aria-expanded="false"
+              aria-controls="howToPlaySteps"
+            >
+              Show details
+            </button>
+          </div>
+          <ol id="howToPlaySteps" hidden>
+            <li>Click a territory</li>
+            <li>Choose an action</li>
+            <li>Press "End Turn"</li>
+          </ol>
+          <button id="replayTutorial" class="btn">Play Tutorial</button>
+        </div>
+        <div><strong>Action log:</strong></div>
+        <div id="actionLog" class="log"></div>
+        <div id="status"></div>
+        <div>Phase time: <span id="phaseTimer"></span></div>
+        <div id="diceResults"></div>
+        <div id="selectedTerritory"></div>
+        <div id="audioSettings">
+          <label for="masterVolume">Master:</label>
+          <input
+            type="range"
+            id="masterVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="0.5"
+          />
+          <label for="effectsVolume">Effects:</label>
+          <input
+            type="range"
+            id="effectsVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="1"
+          />
+          <button
+            id="muteBtn"
+            class="btn"
+            aria-label="Toggle mute"
+            accesskey="m"
+          >
+            Mute
+          </button>
+          <button
+            id="musicToggle"
+            class="btn"
+            aria-label="Toggle music"
+            accesskey="i"
+          >
+            Music Off
+          </button>
+        </div>
+        <button
+          id="moveToken"
+          class="btn"
+          aria-label="Move Token"
+          accesskey="v"
+        >
+          Move Token
+        </button>
+        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
+          Undo
+        </button>
+        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
+          End Turn
+        </button>
+        <button
+          id="forceError"
+          class="btn"
+          aria-label="Force Error"
+          accesskey="f"
+        >
+          Force Error
+        </button>
+        <button
+          id="exportLog"
+          class="btn"
+          aria-label="Export Log"
+          accesskey="x"
+        >
+          Export Log
+        </button>
+      </div>
+      <div id="board" class="board"></div>
+    </div>
+        <script>
+      const lang = navigator.language && navigator.language.startsWith("it") ? "it" : "en";
+      const link = document.getElementById("aboutLink");
+      if (link) link.textContent = lang === "it" ? "Info/Aiuto" : "About/Help";
+    </script>
+    <script src="./logger.js"></script>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/setup.html
+++ b/setup.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <button id="themeToggle" class="btn">High Contrast</button>
+    <button id="homeBtn" class="btn">Back to Home</button>
     <h1>Player Setup</h1>
     <form id="setupForm">
       <label>

--- a/setup.js
+++ b/setup.js
@@ -10,6 +10,7 @@ const aiStyleInput = document.getElementById("aiStyle");
 const playersContainer = document.getElementById("players");
 const mapSelect = document.getElementById("mapSelect");
 const mapGrid = document.getElementById("mapGrid");
+const homeBtn = document.getElementById("homeBtn");
 
 const thumbnailCache = new Map();
 let selectedMap = null;
@@ -148,8 +149,16 @@ humanCountInput.addEventListener("change", () => {
   renderPlayerInputs(count);
 });
 
+if (homeBtn) {
+  homeBtn.addEventListener("click", () => navigateTo("index.html"));
+}
+
 form.addEventListener("submit", (e) => {
   e.preventDefault();
+  if (!form.checkValidity()) {
+    if (typeof form.reportValidity === "function") form.reportValidity();
+    return;
+  }
   const humanCount = parseInt(humanCountInput.value, 10) || 0;
   const aiCount = parseInt(aiCountInput.value, 10) || 0;
   const difficulty = aiDifficultyInput ? aiDifficultyInput.value : "normal";
@@ -179,7 +188,7 @@ form.addEventListener("submit", (e) => {
   } catch (err) {
     // ignore storage errors
   }
-  navigateTo("index.html");
+  navigateTo("game.html");
 });
 
 loadFromStorage();

--- a/setup.test.js
+++ b/setup.test.js
@@ -3,6 +3,7 @@ jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
 
 function setupDOM() {
   document.body.innerHTML = `
+      <button id="homeBtn"></button>
       <form id="setupForm">
         <input id="humanCount" />
         <input id="aiCount" />
@@ -52,9 +53,9 @@ describe('setup map selection', () => {
     document.getElementById('color0').value = colorPalette[0];
     document.querySelector('.map-item[data-id="map3"]').click();
     document.getElementById('setupForm').dispatchEvent(new Event('submit'));
-    expect(localStorage.getItem('netriskMap')).toBe('map3');
-    expect(navigateTo).toHaveBeenCalledWith('index.html');
-  });
+      expect(localStorage.getItem('netriskMap')).toBe('map3');
+      expect(navigateTo).toHaveBeenCalledWith('game.html');
+    });
 
   test('renders responsive grid', async () => {
     const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'map.svg', description: '' }] };
@@ -66,7 +67,7 @@ describe('setup map selection', () => {
     expect(grid.style.gridTemplateColumns).toContain('auto-fit');
   });
 
-  test('shows placeholder when thumbnail missing', async () => {
+    test('shows placeholder when thumbnail missing', async () => {
     const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'missing.svg', description: '' }] };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
     const { mapLoadPromise } = require('./setup.js');
@@ -90,5 +91,15 @@ describe('setup map selection', () => {
     document.getElementById('setupForm').dispatchEvent(new Event('submit'));
     const saved = JSON.parse(localStorage.getItem('netriskPlayers'));
     expect(saved[1]).toEqual(expect.objectContaining({ ai: true, difficulty: 'hard', style: 'aggressive' }));
+    });
+
+    test('home button navigates to index', async () => {
+      const manifest = { version: 1, maps: [] };
+      global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
+      const { mapLoadPromise } = require('./setup.js');
+      await mapLoadPromise;
+      const { navigateTo } = require('./navigation.js');
+      document.getElementById('homeBtn').click();
+      expect(navigateTo).toHaveBeenCalledWith('index.html');
+    });
   });
-});


### PR DESCRIPTION
## Summary
- add visible **Back to Home** control on setup screen
- save player/map settings and start game via `game.html`
- introduce standalone `game.html` without main menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0f2d5ea0832cae48ff350f4b30d9