### PR TITLE
Add full-screen home menu with navigation

### DIFF
--- a/accessibility.test.js
+++ b/accessibility.test.js
@@ -12,18 +12,7 @@ describe('Accessibility features', () => {
     const html = fs.readFileSync('index.html', 'utf-8');
     const dom = new JSDOM(html);
     const document = dom.window.document;
-    const ids = [
-      'themeToggle',
-      'startGame',
-      'playTutorial',
-      'muteBtn',
-      'musicToggle',
-      'moveToken',
-      'undo',
-      'endTurn',
-      'forceError',
-      'exportLog',
-    ];
+    const ids = ['themeToggle', 'playBtn', 'setupBtn', 'howToPlayBtn', 'aboutBtn'];
     ids.forEach((id) => {
       const el = document.getElementById(id);
       expect(el).not.toBeNull();

--- a/home.js
+++ b/home.js
@@ -1,0 +1,22 @@
+import { initThemeToggle } from "./theme.js";
+import { navigateTo } from "./navigation.js";
+
+export function initHome() {
+  initThemeToggle();
+  const mapping = [
+    ["playBtn", "game.html"],
+    ["setupBtn", "setup.html"],
+    ["howToPlayBtn", "how-to-play.html"],
+    ["aboutBtn", "about.html"],
+  ];
+  mapping.forEach(([id, url]) => {
+    const btn = document.getElementById(id);
+    if (btn) {
+      btn.addEventListener("click", () => navigateTo(url));
+    }
+  });
+}
+
+initHome();
+
+export default { initHome };

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>How to Play - NetRisk</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="index.html" id="homeLink">Home</a>
+    </nav>
+    <h1>How to Play</h1>
+    <ol>
+      <li>Click a territory</li>
+      <li>Choose an action</li>
+      <li>Press "End Turn"</li>
+    </ol>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,146 +6,38 @@
     <title>NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <link rel="stylesheet" href="./style.css" />
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
-  <body>
-    <button
-      id="themeToggle"
-      class="btn"
-      aria-label="Toggle high contrast mode"
-      accesskey="h"
-    >
-      High Contrast
-    </button>
-    <h1>NetRisk</h1>
-    <nav>
-      <a href="about.html" id="aboutLink">About/Help</a>
-    </nav>
-    <div id="mainMenu">
-      <button id="startGame" class="btn" aria-label="Start Game" accesskey="s">
-        Start Game
+  <body class="home-page">
+    <header class="home-header">
+      <button
+        id="themeToggle"
+        class="btn"
+        aria-label="Toggle high contrast mode"
+        accesskey="c"
+      >
+        High Contrast
+      </button>
+    </header>
+    <main id="mainMenu">
+      <h1>NetRisk</h1>
+      <button id="playBtn" class="btn" aria-label="Play game" accesskey="p">
+        Play
+      </button>
+      <button id="setupBtn" class="btn" aria-label="Player setup" accesskey="s">
+        Setup
       </button>
       <button
-        id="playTutorial"
+        id="howToPlayBtn"
         class="btn"
-        aria-label="Play Tutorial"
-        accesskey="t"
+        aria-label="How to play"
+        accesskey="h"
       >
-        Play Tutorial
+        How to Play
       </button>
-      <a
-        href="setup.html"
-        class="btn"
-        aria-label="Set up players"
-        accesskey="p"
-      >
-        Set up players
-      </a>
-    </div>
-    <div id="gameContainer" class="hidden">
-      <div id="uiPanel">
-        <div>Current turn: <span id="turnNumber">1</span></div>
-        <div>Current player: <span id="currentPlayer"></span></div>
-        <div id="howToPlayBox">
-          <div>
-            <strong>How to play (alpha)</strong>
-            <button
-              id="toggleHowToPlay"
-              class="btn"
-              aria-expanded="false"
-              aria-controls="howToPlaySteps"
-            >
-              Show details
-            </button>
-          </div>
-          <ol id="howToPlaySteps" hidden>
-            <li>Click a territory</li>
-            <li>Choose an action</li>
-            <li>Press "End Turn"</li>
-          </ol>
-          <button id="replayTutorial" class="btn">Play Tutorial</button>
-        </div>
-        <div><strong>Action log:</strong></div>
-        <div id="actionLog" class="log"></div>
-        <div id="status"></div>
-        <div>Phase time: <span id="phaseTimer"></span></div>
-        <div id="diceResults"></div>
-        <div id="selectedTerritory"></div>
-        <div id="audioSettings">
-          <label for="masterVolume">Master:</label>
-          <input
-            type="range"
-            id="masterVolume"
-            min="0"
-            max="1"
-            step="0.01"
-            value="0.5"
-          />
-          <label for="effectsVolume">Effects:</label>
-          <input
-            type="range"
-            id="effectsVolume"
-            min="0"
-            max="1"
-            step="0.01"
-            value="1"
-          />
-          <button
-            id="muteBtn"
-            class="btn"
-            aria-label="Toggle mute"
-            accesskey="m"
-          >
-            Mute
-          </button>
-          <button
-            id="musicToggle"
-            class="btn"
-            aria-label="Toggle music"
-            accesskey="i"
-          >
-            Music Off
-          </button>
-        </div>
-        <button
-          id="moveToken"
-          class="btn"
-          aria-label="Move Token"
-          accesskey="v"
-        >
-          Move Token
-        </button>
-        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
-          Undo
-        </button>
-        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
-          End Turn
-        </button>
-        <button
-          id="forceError"
-          class="btn"
-          aria-label="Force Error"
-          accesskey="f"
-        >
-          Force Error
-        </button>
-        <button
-          id="exportLog"
-          class="btn"
-          aria-label="Export Log"
-          accesskey="x"
-        >
-          Export Log
-        </button>
-      </div>
-      <div id="board" class="board"></div>
-    </div>
-        <script>
-      const lang = navigator.language && navigator.language.startsWith("it") ? "it" : "en";
-      const link = document.getElementById("aboutLink");
-      if (link) link.textContent = lang === "it" ? "Info/Aiuto" : "About/Help";
-    </script>
-    <script src="./logger.js"></script>
-    <script type="module" src="./main.js"></script>
+      <button id="aboutBtn" class="btn" aria-label="About and settings" accesskey="a">
+        About/Settings
+      </button>
+    </main>
+    <script type="module" src="./home.js"></script>
   </body>
 </html>

--- a/menu.test.js
+++ b/menu.test.js
@@ -1,42 +1,26 @@
-const mapData = require('./src/data/map.json');
-jest.mock('./territory-selection.js', () => jest.fn());
-jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
 jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
 
-describe('main menu', () => {
+describe('home navigation', () => {
   beforeEach(() => {
     jest.resetModules();
-    if (typeof localStorage !== 'undefined') {
-      localStorage.clear();
-    }
     document.body.innerHTML = `
-      <div id="mainMenu"><button id="startGame" class="btn"></button></div>
-      <div id="gameContainer">
-        <div id="status"></div>
-        <div id="currentPlayer"></div>
-        <div id="turnNumber"></div>
-        <div id="actionLog"></div>
-        <div id="diceResults"></div>
-        <div id="uiPanel"></div>
-        <button id="endTurn" class="btn"></button>
-        <button type="button" id="t1" class="territory" data-id="t1"></button>
-        <button type="button" id="t2" class="territory" data-id="t2"></button>
-        <button type="button" id="t3" class="territory" data-id="t3"></button>
-        <button type="button" id="t4" class="territory" data-id="t4"></button>
-        <button type="button" id="t5" class="territory" data-id="t5"></button>
-        <button type="button" id="t6" class="territory" data-id="t6"></button>
-      </div>`;
-    global.fetch = jest.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
-    );
-    global.logger = { info: jest.fn(), error: jest.fn() };
+      <button id="playBtn" class="btn"></button>
+      <button id="setupBtn" class="btn"></button>
+      <button id="howToPlayBtn" class="btn"></button>
+      <button id="aboutBtn" class="btn"></button>
+    `;
   });
 
-  test('initializes game after start button clicked', async () => {
-    const main = require('./main.js');
-    expect(main.game).toBeUndefined();
-    document.getElementById('startGame').click();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(main.game).toBeDefined();
+  test('buttons navigate to pages', () => {
+    const { navigateTo } = require('./navigation.js');
+    require('./home.js');
+    document.getElementById('playBtn').click();
+    document.getElementById('setupBtn').click();
+    document.getElementById('howToPlayBtn').click();
+    document.getElementById('aboutBtn').click();
+    expect(navigateTo).toHaveBeenNthCalledWith(1, 'game.html');
+    expect(navigateTo).toHaveBeenNthCalledWith(2, 'setup.html');
+    expect(navigateTo).toHaveBeenNthCalledWith(3, 'how-to-play.html');
+    expect(navigateTo).toHaveBeenNthCalledWith(4, 'about.html');
   });
 });

--- a/setup.html
+++ b/setup.html
@@ -8,7 +8,6 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
   </head>
   <body>
-    <button id="themeToggle" class="btn">High Contrast</button>
     <h1>Player Setup</h1>
     <form id="setupForm">
       <label>

--- a/setup.js
+++ b/setup.js
@@ -1,5 +1,4 @@
 import { colorPalette } from "./colors.js";
-import { initThemeToggle } from "./theme.js";
 import { navigateTo } from "./navigation.js";
 
 const form = document.getElementById("setupForm");
@@ -183,5 +182,4 @@ form.addEventListener("submit", (e) => {
 });
 
 loadFromStorage();
-initThemeToggle();
 export const mapLoadPromise = loadMapData();

--- a/style.css
+++ b/style.css
@@ -8,6 +8,20 @@ body {
   color: #3b2b16;
   text-align: center;
 }
+body.home-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.home-header {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
 
 h1 {
   font-family: 'Cinzel', serif;
@@ -22,6 +36,7 @@ h1 {
   color: #fff;
   border: 2px solid #8b4513;
   padding: 8px 16px;
+    min-height: 44px;
   cursor: pointer;
   box-shadow: 0 2px #8b4513;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- Replace home page with full-screen menu and large buttons for Play, Setup, How to Play, and About/Settings.
- Add dedicated How to Play page and navigation script.
- Limit high-contrast toggle to home page and ensure buttons meet accessibility size.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae122aa044832c80a510e59a9097bb