### PR TITLE
Add navigation controls to setup page

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -40,6 +40,7 @@
       <div id="players"></div>
       <button type="submit" class="btn">Start</button>
     </form>
+    <a id="backHome" href="index.html" class="btn">Back to Home</a>
     <script type="module" src="./setup.js"></script>
   </body>
 </html>

--- a/setup.js
+++ b/setup.js
@@ -178,7 +178,7 @@ form.addEventListener("submit", (e) => {
   } catch (err) {
     // ignore storage errors
   }
-  navigateTo("index.html");
+  navigateTo("game.html");
 });
 
 loadFromStorage();

--- a/setup.test.js
+++ b/setup.test.js
@@ -1,4 +1,5 @@
 import { colorPalette } from './colors.js';
+import { readFileSync } from 'fs';
 jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
 
 function setupDOM() {
@@ -53,7 +54,7 @@ describe('setup map selection', () => {
     document.querySelector('.map-item[data-id="map3"]').click();
     document.getElementById('setupForm').dispatchEvent(new Event('submit'));
     expect(localStorage.getItem('netriskMap')).toBe('map3');
-    expect(navigateTo).toHaveBeenCalledWith('index.html');
+    expect(navigateTo).toHaveBeenCalledWith('game.html');
   });
 
   test('renders responsive grid', async () => {
@@ -90,5 +91,11 @@ describe('setup map selection', () => {
     document.getElementById('setupForm').dispatchEvent(new Event('submit'));
     const saved = JSON.parse(localStorage.getItem('netriskPlayers'));
     expect(saved[1]).toEqual(expect.objectContaining({ ai: true, difficulty: 'hard', style: 'aggressive' }));
+  });
+
+  test('has back to home link', () => {
+    const html = readFileSync('./setup.html', 'utf8');
+    expect(html).toMatch(/id="backHome"/);
+    expect(html).toMatch(/Back to Home/);
   });
 });


### PR DESCRIPTION
## Summary
- Add Back to Home button on setup page
- Redirect game setup to game.html and save map selection
- Test setup page navigation and map selection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae14b32d14832c9cddfd084fe21be9