### PR TITLE
feat: add about settings page

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,24 +3,15 @@
   <head>
     <meta charset="UTF-8" >
     <meta name="viewport" content="width=device-width, initial-scale=1.0" >
-    <title>About &amp; Help - NetRisk</title>
+    <title>About &amp; Settings - NetRisk</title>
     <link rel="stylesheet" href="./style.css" >
   </head>
   <body>
     <nav>
       <a href="index.html" id="homeLink">Home</a>
     </nav>
-    <h1 id="pageTitle">About &amp; Help</h1>
-    <input type="search" id="helpSearch" aria-label="Search" >
+    <h1 id="pageTitle">About &amp; Settings</h1>
     <div id="helpContent">
-      <section id="rules">
-        <h2>Rules</h2>
-        <div class="content"></div>
-      </section>
-      <section id="tips">
-        <h2>Tips</h2>
-        <div class="content"></div>
-      </section>
       <section id="credits">
         <h2>Credits</h2>
         <div class="content"></div>
@@ -33,9 +24,32 @@
         <h2>GitHub</h2>
         <div class="content"></div>
       </section>
-      <section id="privacy">
-        <h2>Privacy</h2>
-        <div class="content"></div>
+      <section id="settings">
+        <h2>Settings</h2>
+        <div class="content">
+          <label for="themeSelect">Theme:</label>
+          <select id="themeSelect" aria-label="Theme selection">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+          <button
+            id="themeToggle"
+            class="btn"
+            aria-label="Toggle high contrast mode"
+          >
+            High Contrast
+          </button>
+          <label for="masterVolume">Volume:</label>
+          <input
+            type="range"
+            id="masterVolume"
+            min="0"
+            max="1"
+            step="0.01"
+            value="0.5"
+          />
+          <button id="muteBtn" class="btn" aria-label="Toggle mute">Mute</button>
+        </div>
       </section>
     </div>
     <script type="module" src="./about.js"></script>

--- a/about.js
+++ b/about.js
@@ -1,19 +1,17 @@
+import {
+  setMasterVolume,
+  getMasterVolume,
+  setMuted,
+  isMuted,
+} from './audio.js';
+import { initThemeToggle, initThemeSelect } from './theme.js';
+
 const lang = navigator.language && navigator.language.startsWith('it') ? 'it' : 'en';
 
 const texts = {
   en: {
-    title: 'About & Help',
-    search: 'Search...',
+    title: 'About & Settings',
     sections: {
-      rules: {
-        title: 'Rules',
-        content:
-          'Each player deploys armies, attacks adjacent territories and ends the turn. Conquer all territories to win.',
-      },
-      tips: {
-        title: 'Tips',
-        content: 'Expand early, defend borders and watch your opponents.',
-      },
       credits: {
         title: 'Credits',
         content: 'Created by the NetRisk team.',
@@ -27,26 +25,12 @@ const texts = {
         content:
           '<a href="https://github.com" target="_blank" rel="noopener">Source code on GitHub</a>',
       },
-      privacy: {
-        title: 'Privacy',
-        content:
-          'Game saves are stored locally in your browser. No tracking cookies are used. Audio preferences remain local.',
-      },
+      settings: { title: 'Settings', content: '' },
     },
   },
   it: {
-    title: 'Info e Aiuto',
-    search: 'Cerca...',
+    title: 'Info e Impostazioni',
     sections: {
-      rules: {
-        title: 'Regole',
-        content:
-          'Ogni giocatore schiera gli eserciti, attacca territori adiacenti e termina il turno. Chi conquista tutte le terre vince.',
-      },
-      tips: {
-        title: 'Suggerimenti',
-        content: 'Espandi all\'inizio, difendi i confini e osserva gli avversari.',
-      },
       credits: {
         title: 'Credits',
         content: 'Creato dal team NetRisk.',
@@ -60,11 +44,7 @@ const texts = {
         content:
           '<a href="https://github.com" target="_blank" rel="noopener">Codice sorgente su GitHub</a>',
       },
-      privacy: {
-        title: 'Privacy',
-        content:
-          'I salvataggi sono memorizzati localmente nel browser. Nessun cookie di tracciamento viene utilizzato. Le preferenze audio restano locali.',
-      },
+      settings: { title: 'Impostazioni', content: '' },
     },
   },
 };
@@ -84,15 +64,32 @@ export function initAbout(doc = document) {
   const t = texts[lang];
   doc.getElementById('pageTitle').textContent = t.title;
   doc.title = `${t.title} - NetRisk`;
-  const searchInput = doc.getElementById('helpSearch');
-  searchInput.placeholder = t.search;
-  searchInput.addEventListener('input', (e) => filterSections(e.target.value, doc));
   Object.entries(t.sections).forEach(([id, data]) => {
     const section = doc.getElementById(id);
     if (!section) return;
     section.querySelector('h2').textContent = data.title;
-    section.querySelector('.content').innerHTML = data.content;
+    if (data.content) {
+      section.querySelector('.content').innerHTML = data.content;
+    }
   });
+  initThemeToggle(doc);
+  initThemeSelect(doc);
+  const vol = doc.getElementById('masterVolume');
+  if (vol) {
+    vol.value = getMasterVolume();
+    vol.addEventListener('input', (e) => {
+      setMasterVolume(parseFloat(e.target.value));
+    });
+  }
+  const muteBtn = doc.getElementById('muteBtn');
+  if (muteBtn) {
+    muteBtn.textContent = isMuted() ? 'Unmute' : 'Mute';
+    muteBtn.addEventListener('click', () => {
+      const muted = isMuted();
+      setMuted(!muted);
+      muteBtn.textContent = muted ? 'Mute' : 'Unmute';
+    });
+  }
 }
 
 if (typeof window !== 'undefined') {

--- a/settings.test.js
+++ b/settings.test.js
@@ -1,0 +1,30 @@
+const { describe, test, beforeEach, expect } = global;
+
+describe('settings persistence between pages', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+    document.body.innerHTML = '';
+  });
+
+  test('audio and theme survive reload', () => {
+    const audio1 = require('./audio.js');
+    const theme1 = require('./theme.js');
+    audio1.setMasterVolume(0.25);
+    audio1.setMuted(true);
+    document.body.innerHTML = '<button id="themeToggle" class="btn">High Contrast</button>';
+    theme1.initThemeToggle();
+    document.getElementById('themeToggle').click();
+
+    jest.resetModules();
+    document.body.innerHTML = '';
+    const audio2 = require('./audio.js');
+    const theme2 = require('./theme.js');
+    theme2.initThemeToggle();
+    expect(audio2.getMasterVolume()).toBe(0.25);
+    expect(audio2.isMuted()).toBe(true);
+    expect(document.body.classList.contains('high-contrast')).toBe(true);
+  });
+});

--- a/style.css
+++ b/style.css
@@ -187,6 +187,17 @@ h1 {
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
 }
 
+body.dark-theme {
+  background: #222;
+  color: #eee;
+}
+
+body.dark-theme .btn {
+  background: #444;
+  color: #fff;
+  border-color: #666;
+}
+
 #howToPlayBox {
   margin-top: 5px;
   font-size: 14px;

--- a/theme.js
+++ b/theme.js
@@ -1,8 +1,22 @@
-export function initThemeToggle() {
-  const body = document.body;
+function applyColorTheme(doc = document) {
+  const body = doc.body;
   if (!body) return;
-  const btn = document.getElementById('themeToggle');
-  const stored = (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) || 'default';
+  const stored =
+    (typeof localStorage !== 'undefined' && localStorage.getItem('colorTheme')) ||
+    'light';
+  if (stored === 'dark') {
+    body.classList.add('dark-theme');
+  }
+}
+
+export function initThemeToggle(doc = document) {
+  const body = doc.body;
+  if (!body) return;
+  applyColorTheme(doc);
+  const btn = doc.getElementById('themeToggle');
+  const stored =
+    (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) ||
+    'default';
   if (stored === 'high-contrast') {
     body.classList.add('high-contrast');
     if (btn) btn.textContent = 'Standard Theme';
@@ -15,6 +29,29 @@ export function initThemeToggle() {
     if (typeof localStorage !== 'undefined') {
       try {
         localStorage.setItem('theme', high ? 'high-contrast' : 'default');
+      } catch (err) {
+        // ignore storage errors
+      }
+    }
+  });
+}
+
+export function initThemeSelect(doc = document) {
+  const body = doc.body;
+  if (!body) return;
+  const sel = doc.getElementById('themeSelect');
+  if (!sel) return;
+  const stored =
+    (typeof localStorage !== 'undefined' && localStorage.getItem('colorTheme')) ||
+    'light';
+  sel.value = stored;
+  if (stored === 'dark') body.classList.add('dark-theme');
+  sel.addEventListener('change', (e) => {
+    const val = e.target.value;
+    body.classList.toggle('dark-theme', val === 'dark');
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem('colorTheme', val);
       } catch (err) {
         // ignore storage errors
       }

--- a/theme.test.js
+++ b/theme.test.js
@@ -1,4 +1,4 @@
-import { initThemeToggle } from './theme.js';
+import { initThemeToggle, initThemeSelect } from './theme.js';
 
 describe('theme toggle', () => {
   beforeEach(() => {
@@ -25,5 +25,26 @@ describe('theme toggle', () => {
     localStorage.setItem('theme', 'high-contrast');
     initThemeToggle();
     expect(document.body.classList.contains('high-contrast')).toBe(true);
+  });
+});
+
+describe('theme select', () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<select id="themeSelect"><option value="light">Light</option><option value="dark">Dark</option></select>';
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  test('applies stored theme and saves changes', () => {
+    localStorage.setItem('colorTheme', 'dark');
+    initThemeSelect();
+    expect(document.body.classList.contains('dark-theme')).toBe(true);
+    const sel = document.getElementById('themeSelect');
+    sel.value = 'light';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.body.classList.contains('dark-theme')).toBe(false);
+    expect(localStorage.getItem('colorTheme')).toBe('light');
   });
 });


### PR DESCRIPTION
## Summary
- add About & Settings page with credits, changelog, GitHub link and user preferences
- support dark theme selection, high contrast toggle, volume and mute controls with persistence
- cover theme selection and settings persistence with new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae163d6bb4832cb38bd13bebf8bd89