### PR TITLE
feat: centralize navigation and remove legacy menu

### DIFF
--- a/game.html
+++ b/game.html
@@ -110,16 +110,6 @@
         </button>
       </div>
     </div>
-    <script>
-      const exitBtn = document.getElementById('exitGame');
-      if (exitBtn) {
-        exitBtn.addEventListener('click', () => {
-          if (window.confirm('Exit the game and return to home?')) {
-            window.location.href = 'index.html';
-          }
-        });
-      }
-    </script>
     <script src="./logger.js"></script>
     <script type="module" src="./main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ import {
   isMusicEnabled,
 } from "./audio.js";
 import askArmiesToMove from "./move-prompt.js";
-import { navigateTo } from "./navigation.js";
+import { navigateTo, goHome, exitGame } from "./navigation.js";
 import {
   REINFORCE,
   ATTACK,
@@ -425,7 +425,7 @@ async function initGame() {
     !hasSavedGame() &&
     !(typeof process !== "undefined" && process.env.JEST_WORKER_ID)
   ) {
-    window.location.href = "setup.html";
+    navigateTo("setup.html");
     return;
   }
   await loadGame();
@@ -580,23 +580,25 @@ async function initGame() {
   }
 }
 
-function init() {
-  const menu = document.getElementById("mainMenu");
-  const startBtn = document.getElementById("startGame");
-  const container = document.getElementById("gameContainer");
-  if (!menu || !startBtn || !container) {
-    initGame();
-    return;
+function attachNavigationHandlers() {
+  const back = document.getElementById("backHome");
+  if (back) {
+    back.addEventListener("click", (e) => {
+      e.preventDefault();
+      goHome();
+    });
   }
-  container.classList.add("hidden");
-  startBtn.addEventListener("click", async () => {
-    menu.classList.add("hidden");
-    container.classList.remove("hidden");
-    await initGame();
-  });
+  const exit = document.getElementById("exitGame");
+  if (exit) {
+    exit.addEventListener("click", (e) => {
+      e.preventDefault();
+      exitGame();
+    });
+  }
 }
 
-init();
+attachNavigationHandlers();
+initGame();
 initThemeToggle();
 initTutorialButtons();
 

--- a/main.test.js
+++ b/main.test.js
@@ -3,7 +3,11 @@ const { REINFORCE, ATTACK, FORTIFY, GAME_OVER } = require('./phases.js');
 
 jest.mock('./territory-selection.js', () => jest.fn());
 jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
-jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
+jest.mock('./navigation.js', () => ({
+  navigateTo: jest.fn(),
+  goHome: jest.fn(),
+  exitGame: jest.fn(),
+}));
 
 describe('main DOM interactions', () => {
   let main;

--- a/menu.test.js
+++ b/menu.test.js
@@ -1,4 +1,8 @@
-jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
+jest.mock('./navigation.js', () => ({
+  navigateTo: jest.fn(),
+  goHome: jest.fn(),
+  exitGame: jest.fn(),
+}));
 
 describe('home navigation', () => {
   beforeEach(() => {

--- a/navigation.js
+++ b/navigation.js
@@ -1,11 +1,32 @@
 export function navigateTo(url, win = typeof window !== "undefined" ? window : undefined) {
-  if (win) {
-    if (typeof win.location.assign === "function") {
-      win.location.assign(url);
-    } else {
-      win.location.href = url;
+  if (!win) return;
+  if (win.history && typeof win.history.pushState === "function") {
+    try {
+      win.history.pushState({}, "", url);
+    } catch {
+      // ignore history errors
     }
+  }
+  if (typeof win.location.assign === "function") {
+    win.location.assign(url);
+  } else {
+    win.location.href = url;
   }
 }
 
-export default { navigateTo };
+export function goHome(win = typeof window !== "undefined" ? window : undefined) {
+  navigateTo("index.html", win);
+}
+
+export function exitGame(
+  win = typeof window !== "undefined" ? window : undefined,
+  message = "Exit the game and return to home?",
+) {
+  if (!win) return;
+  const confirmed = typeof win.confirm === "function" ? win.confirm(message) : true;
+  if (confirmed) {
+    goHome(win);
+  }
+}
+
+export default { navigateTo, goHome, exitGame };

--- a/navigation.test.js
+++ b/navigation.test.js
@@ -1,4 +1,4 @@
-import { navigateTo } from "./navigation.js";
+import { navigateTo, goHome, exitGame } from "./navigation.js";
 
 describe("navigateTo", () => {
   test("uses location.assign when available", () => {
@@ -11,5 +11,30 @@ describe("navigateTo", () => {
     const win = { location: { href: "" } };
     navigateTo("/other", win);
     expect(win.location.href).toBe("/other");
+  });
+
+  test("goHome navigates to index.html", () => {
+    const win = { location: { assign: jest.fn() } };
+    goHome(win);
+    expect(win.location.assign).toHaveBeenCalledWith("index.html");
+  });
+
+  test("exitGame confirms and navigates home", () => {
+    const win = {
+      confirm: jest.fn(() => true),
+      location: { assign: jest.fn() },
+    };
+    exitGame(win);
+    expect(win.confirm).toHaveBeenCalled();
+    expect(win.location.assign).toHaveBeenCalledWith("index.html");
+  });
+
+  test("exitGame aborts when cancelled", () => {
+    const win = {
+      confirm: jest.fn(() => false),
+      location: { assign: jest.fn() },
+    };
+    exitGame(win);
+    expect(win.location.assign).not.toHaveBeenCalled();
   });
 });

--- a/setup.js
+++ b/setup.js
@@ -1,5 +1,5 @@
 import { colorPalette } from "./colors.js";
-import { navigateTo } from "./navigation.js";
+import { navigateTo, goHome } from "./navigation.js";
 
 const form = document.getElementById("setupForm");
 const humanCountInput = document.getElementById("humanCount");
@@ -9,6 +9,7 @@ const aiStyleInput = document.getElementById("aiStyle");
 const playersContainer = document.getElementById("players");
 const mapSelect = document.getElementById("mapSelect");
 const mapGrid = document.getElementById("mapGrid");
+const backHomeBtn = document.getElementById("backHome");
 
 const thumbnailCache = new Map();
 let selectedMap = null;
@@ -21,6 +22,13 @@ function getCachedImage(src) {
   img.src = src;
   thumbnailCache.set(src, img);
   return img.cloneNode(true);
+}
+
+if (backHomeBtn) {
+  backHomeBtn.addEventListener("click", (e) => {
+    e.preventDefault();
+    goHome();
+  });
 }
 
 export async function loadMapData() {

--- a/setup.test.js
+++ b/setup.test.js
@@ -1,6 +1,10 @@
 import { colorPalette } from './colors.js';
 import { readFileSync } from 'fs';
-jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
+jest.mock('./navigation.js', () => ({
+  navigateTo: jest.fn(),
+  goHome: jest.fn(),
+  exitGame: jest.fn(),
+}));
 
 function setupDOM() {
   document.body.innerHTML = `

--- a/tutorial.js
+++ b/tutorial.js
@@ -140,12 +140,6 @@ export function initTutorialButtons() {
       btn.classList.add('hidden');
     }
     btn.addEventListener('click', () => {
-      const menu = document.getElementById('mainMenu');
-      const container = document.getElementById('gameContainer');
-      if (menu && container) {
-        menu.classList.add('hidden');
-        container.classList.remove('hidden');
-      }
       startTutorial();
     });
   }


### PR DESCRIPTION
## Summary
- add unified navigation helpers `navigateTo`, `goHome`, `exitGame`
- use helpers across game and setup pages and drop inline scripts
- drop old menu-based init logic and clean up tutorial buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1c32ee98832ca391e5a36edd07df