### PR TITLE
Organize game action panel

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -192,11 +192,26 @@ body.game-page #uiPanel {
 }
 
 @media (max-width: 1023px) {
-  body.game-page #uiPanel .btn {
+body.game-page #uiPanel .btn {
     width: 100%;
     padding: 14px;
     font-size: 18px;
   }
+}
+
+#gameActions,
+#otherControls {
+  margin-top: 10px;
+  border: 1px solid #ccc;
+  padding: 5px;
+  background: #f9f9f9;
+}
+
+#gameActions .btn,
+#otherControls .btn {
+  display: block;
+  width: 100%;
+  margin-top: 5px;
 }
 
 /* Game theme */

--- a/game.html
+++ b/game.html
@@ -38,78 +38,84 @@
           </ol>
           <button id="replayTutorial" class="btn">Play Tutorial</button>
         </div>
-        <div><strong>Action log:</strong></div>
-        <div id="actionLog" class="log"></div>
+        <div id="gameActions">
+          <strong>Game Actions:</strong>
+          <button
+            id="moveToken"
+            class="btn"
+            aria-label="Move Token"
+            accesskey="v"
+          >
+            Move Token
+          </button>
+          <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
+            Undo
+          </button>
+          <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
+            End Turn
+          </button>
+        </div>
         <div id="status"></div>
         <div>Phase time: <span id="phaseTimer"></span></div>
         <div id="diceResults"></div>
         <div id="selectedTerritory"></div>
-        <div id="audioSettings">
-          <label for="masterVolume">Master:</label>
-          <input
-            type="range"
-            id="masterVolume"
-            min="0"
-            max="1"
-            step="0.01"
-            value="0.5"
-          />
-          <label for="effectsVolume">Effects:</label>
-          <input
-            type="range"
-            id="effectsVolume"
-            min="0"
-            max="1"
-            step="0.01"
-            value="1"
-          />
+        <div><strong>Action log:</strong></div>
+        <div id="actionLog" class="log"></div>
+        <div id="otherControls">
+          <strong>Other Controls:</strong>
+          <div id="audioSettings">
+            <label for="masterVolume">Master:</label>
+            <input
+              type="range"
+              id="masterVolume"
+              min="0"
+              max="1"
+              step="0.01"
+              value="0.5"
+            />
+            <label for="effectsVolume">Effects:</label>
+            <input
+              type="range"
+              id="effectsVolume"
+              min="0"
+              max="1"
+              step="0.01"
+              value="1"
+            />
+            <button
+              id="muteBtn"
+              class="btn"
+              aria-label="Toggle mute"
+              accesskey="m"
+            >
+              Mute
+            </button>
+            <button
+              id="musicToggle"
+              class="btn"
+              aria-label="Toggle music"
+              accesskey="i"
+            >
+              Music Off
+            </button>
+          </div>
           <button
-            id="muteBtn"
+            id="forceError"
             class="btn"
-            aria-label="Toggle mute"
-            accesskey="m"
+            aria-label="Force Error"
+            accesskey="f"
           >
-            Mute
+            Force Error
           </button>
           <button
-            id="musicToggle"
+            id="exportLog"
             class="btn"
-            aria-label="Toggle music"
-            accesskey="i"
+            aria-label="Export Log"
+            accesskey="x"
           >
-            Music Off
+            Export Log
           </button>
         </div>
-        <button
-          id="moveToken"
-          class="btn"
-          aria-label="Move Token"
-          accesskey="v"
-        >
-          Move Token
-        </button>
-        <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
-          Undo
-        </button>
-        <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
-          End Turn
-        </button>
-        <button
-          id="forceError"
-          class="btn"
-          aria-label="Force Error"
-          accesskey="f"
-        >
-          Force Error
-        </button>
-        <button
-          id="exportLog"
-          class="btn"
-          aria-label="Export Log"
-          accesskey="x"
-        >
-          Export Log
-        </button>
       </div>
     </div>
     <script src="./logger.js"></script>


### PR DESCRIPTION
## Summary
- Group key gameplay buttons into a dedicated Game Actions section
- Move audio and utility controls into a separate Other Controls block
- Style new control sections for clarity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae971a706c832c830a3e10e3ae41ec