### PR TITLE
chore: separate local and CI Playwright scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "http-server .",
     "test": "jest",
     "e2e": "playwright test",
+    "e2e:ci": "npx playwright install --with-deps && playwright test --reporter=github",
     "build": "node build.js",
     "server": "node multiplayer-server.js",
     "simulate": "node simulate.js"


### PR DESCRIPTION
## Summary
- add dedicated CI Playwright script that installs browsers and uses the GitHub reporter

## Testing
- `npm test`
- `npm run e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99a060bc832cb54d5a28300e4d3e