### PR TITLE
docs: explain skipping Playwright browser download

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ npm install
 npm start
 ```
 
+If your environment blocks browser downloads (for example, in restricted CI
+systems), prevent Playwright from fetching its browser binaries during
+installation by setting an environment variable:
+
+```bash
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+npm ci
+```
+
 Open `http://localhost:8080` in your browser.
 
 ## Testing


### PR DESCRIPTION
## Summary
- document how to disable Playwright browser download using `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9cb16b2c832ca34174b22f346fc8