### PR TITLE
Add basic Playwright smoke test

### DIFF
--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage responds and has a title', async ({ page, baseURL }) => {
+  const url = baseURL || 'http://localhost:4173';
+  await page.goto(url);
+  await expect(page).toHaveTitle(/netrisk|Risk|Game|Play/i);
+});


### PR DESCRIPTION
## Summary
- add Playwright smoke test that checks homepage title

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68aea41b2c98832ca9612b90ae966436