### PR TITLE
Add multiplayer menu option with Supabase backend

### DIFF
--- a/home.js
+++ b/home.js
@@ -5,6 +5,7 @@ export function initHome() {
   initThemeToggle();
   const mapping = [
     ["playBtn", "game.html"],
+    ["multiplayerBtn", "game.html?multiplayer=1"],
     ["setupBtn", "setup.html"],
     ["howToPlayBtn", "how-to-play.html"],
     ["aboutBtn", "about.html"],

--- a/index.html
+++ b/index.html
@@ -33,6 +33,14 @@
       <button id="playBtn" class="btn" aria-label="Play game" accesskey="p">
         Play
       </button>
+      <button
+        id="multiplayerBtn"
+        class="btn"
+        aria-label="Multiplayer game"
+        accesskey="m"
+      >
+        Multiplayer
+      </button>
       <button id="setupBtn" class="btn" aria-label="Player setup" accesskey="s">
         Setup
       </button>

--- a/main.js
+++ b/main.js
@@ -416,6 +416,21 @@ async function initGame() {
     return;
   }
   await loadGame();
+
+  const params =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : null;
+  if (params && params.get("multiplayer")) {
+    const url =
+      params.get("server") ||
+      `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.hostname}:8081`;
+    const { default: createWebSocketMultiplayer } = await import(
+      "./src/plugins/websocket-multiplayer-plugin.js"
+    );
+    game.use(createWebSocketMultiplayer(url));
+  }
+
   preloadEffects();
 
   let firstTurn = true;

--- a/menu.test.js
+++ b/menu.test.js
@@ -9,6 +9,7 @@ describe('home navigation', () => {
     jest.resetModules();
     document.body.innerHTML = `
       <button id="playBtn" class="btn"></button>
+      <button id="multiplayerBtn" class="btn"></button>
       <button id="setupBtn" class="btn"></button>
       <button id="howToPlayBtn" class="btn"></button>
       <button id="aboutBtn" class="btn"></button>
@@ -19,12 +20,14 @@ describe('home navigation', () => {
     const { navigateTo } = require('./navigation.js');
     require('./home.js');
     document.getElementById('playBtn').click();
+    document.getElementById('multiplayerBtn').click();
     document.getElementById('setupBtn').click();
     document.getElementById('howToPlayBtn').click();
     document.getElementById('aboutBtn').click();
     expect(navigateTo).toHaveBeenNthCalledWith(1, 'game.html');
-    expect(navigateTo).toHaveBeenNthCalledWith(2, 'setup.html');
-    expect(navigateTo).toHaveBeenNthCalledWith(3, 'how-to-play.html');
-    expect(navigateTo).toHaveBeenNthCalledWith(4, 'about.html');
+    expect(navigateTo).toHaveBeenNthCalledWith(2, 'game.html?multiplayer=1');
+    expect(navigateTo).toHaveBeenNthCalledWith(3, 'setup.html');
+    expect(navigateTo).toHaveBeenNthCalledWith(4, 'how-to-play.html');
+    expect(navigateTo).toHaveBeenNthCalledWith(5, 'about.html');
   });
 });

--- a/multiplayer-server.test.js
+++ b/multiplayer-server.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 import WebSocket from "ws";
-import { createLobbyServer } from "./multiplayer-server.js";
+jest.mock("./src/init/supabase-client.js", () => null);
+const { createLobbyServer } = require("./multiplayer-server.js");
 
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
- add Multiplayer button to home menu linking to game with multiplayer mode
- load WebSocket multiplayer plugin when `multiplayer` query param is present
- adjust tests and mock Supabase client for server tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aee2121a6c832cb94650f7a81648fb