### PR TITLE
fix: ensure e2e tests start server and install browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "http-server .",
     "test": "jest",
     "e2e": "playwright test",
-    "e2e:ci": "npx playwright install --with-deps && playwright test --reporter=github",
+    "e2e:ci": "playwright test --reporter=github",
+    "e2e:install": "playwright install --with-deps",
     "build": "node build.js",
     "server": "node multiplayer-server.js",
     "simulate": "node simulate.js"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
     headless: true,
     trace: 'on-first-retry',
   },
+  webServer: {
+    command: 'npx http-server . -p 4173',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
   projects: [
     {
       name: 'chromium',


### PR DESCRIPTION
## Summary
- start static http server for Playwright tests
- separate Playwright browser install into dedicated script to avoid network failure during e2e

## Testing
- `npm test`
- `npm run e2e` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68aee38aec18832c8992cf4c4a2967de