### PR TITLE
feat: add lobby screen for multiplayer

### DIFF
--- a/home.js
+++ b/home.js
@@ -5,7 +5,7 @@ export function initHome() {
   initThemeToggle();
   const mapping = [
     ["playBtn", "game.html"],
-    ["multiplayerBtn", "game.html?multiplayer=1"],
+    ["multiplayerBtn", "lobby.html"],
     ["setupBtn", "setup.html"],
     ["howToPlayBtn", "how-to-play.html"],
     ["aboutBtn", "about.html"],

--- a/lobby.html
+++ b/lobby.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./css/base.css" />
+    <link rel="stylesheet" href="./css/layout.css" />
+    <link rel="stylesheet" href="./css/components.css" />
+    <link rel="stylesheet" href="./css/theme.css" />
+    <title>Lobby - NetRisk</title>
+    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+  </head>
+  <body class="lobby-page">
+    <header class="main-header">
+      <a href="index.html" class="logo">NetRisk</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="setup.html">Setup</a>
+        <a href="how-to-play.html">How To</a>
+        <a href="about.html">About</a>
+      </nav>
+    </header>
+    <main>
+      <h1>Lobby</h1>
+      <button id="backBtn" class="btn" aria-label="Back to home" accesskey="b">Back</button>
+      <ul id="lobbyList" class="lobby-list"></ul>
+    </main>
+    <script type="module" src="./lobby.js"></script>
+  </body>
+</html>

--- a/lobby.js
+++ b/lobby.js
@@ -1,0 +1,48 @@
+import { initThemeToggle } from './theme.js';
+import { goHome } from './navigation.js';
+import supabase from './src/init/supabase-client.js';
+import EventBus from './src/core/event-bus.js';
+
+const bus = new EventBus();
+
+export function renderLobbies(lobbies) {
+  const list = document.getElementById('lobbyList');
+  if (!list) return;
+  list.innerHTML = '';
+  lobbies.forEach(lobby => {
+    const li = document.createElement('li');
+    const playerCount = Array.isArray(lobby.players) ? lobby.players.length : 0;
+    const status = lobby.started ? 'started' : 'open';
+    li.textContent = `${lobby.code} – host: ${lobby.host} – players: ${playerCount}/6 – map: ${lobby.map || '-' } – status: ${status}`;
+    list.appendChild(li);
+  });
+}
+
+async function fetchLobbies() {
+  if (!supabase) {
+    renderLobbies([]);
+    return;
+  }
+  const { data } = await supabase.from('lobbies').select();
+  renderLobbies(data || []);
+}
+
+export function initLobby() {
+  initThemeToggle();
+  const backBtn = document.getElementById('backBtn');
+  if (backBtn) backBtn.addEventListener('click', () => goHome());
+  fetchLobbies();
+  if (supabase) {
+    supabase
+      .channel('public:lobbies')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'lobbies' }, () => {
+        bus.emit('lobbiesChanged');
+      })
+      .subscribe();
+    bus.on('lobbiesChanged', fetchLobbies);
+  }
+}
+
+initLobby();
+
+export default { initLobby, renderLobbies };

--- a/lobby.test.js
+++ b/lobby.test.js
@@ -1,0 +1,34 @@
+jest.mock('./navigation.js', () => ({ goHome: jest.fn() }));
+jest.mock('./theme.js', () => ({ initThemeToggle: jest.fn() }));
+jest.mock('./src/init/supabase-client.js', () => null);
+
+describe('lobby screen', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <button id="backBtn" class="btn"></button>
+      <ul id="lobbyList"></ul>
+    `;
+  });
+
+  test('back button goes home', () => {
+    const { goHome } = require('./navigation.js');
+    require('./lobby.js');
+    document.getElementById('backBtn').click();
+    expect(goHome).toHaveBeenCalled();
+  });
+
+  test('renderLobbies displays info', () => {
+    const { renderLobbies } = require('./lobby.js');
+    const data = [
+      { code: 'abc', host: 'host', players: [{}, {}], map: 'earth', started: false },
+    ];
+    renderLobbies(data);
+    const text = document.getElementById('lobbyList').textContent;
+    expect(text).toContain('abc');
+    expect(text).toContain('host');
+    expect(text).toContain('2/6');
+    expect(text).toContain('earth');
+    expect(text).toContain('open');
+  });
+});

--- a/menu.test.js
+++ b/menu.test.js
@@ -25,7 +25,7 @@ describe('home navigation', () => {
     document.getElementById('howToPlayBtn').click();
     document.getElementById('aboutBtn').click();
     expect(navigateTo).toHaveBeenNthCalledWith(1, 'game.html');
-    expect(navigateTo).toHaveBeenNthCalledWith(2, 'game.html?multiplayer=1');
+    expect(navigateTo).toHaveBeenNthCalledWith(2, 'lobby.html');
     expect(navigateTo).toHaveBeenNthCalledWith(3, 'setup.html');
     expect(navigateTo).toHaveBeenNthCalledWith(4, 'how-to-play.html');
     expect(navigateTo).toHaveBeenNthCalledWith(5, 'about.html');


### PR DESCRIPTION
## Summary
- route multiplayer menu button to new lobby screen
- implement lobby page with realtime lobby list and back navigation
- test lobby navigation and rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee7630408832cb32ae1e67a4d3a60