### PR TITLE
test: cover home and move prompt

### DIFF
--- a/home.test.js
+++ b/home.test.js
@@ -1,0 +1,30 @@
+jest.mock('./theme.js', () => ({ initThemeToggle: jest.fn() }));
+jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
+
+describe('home page initialization', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <button id="playBtn"></button>
+      <button id="multiplayerBtn"></button>
+      <button id="setupBtn"></button>
+      <button id="howToPlayBtn"></button>
+      <button id="aboutBtn"></button>
+    `;
+  });
+
+  test('initHome sets up theme and navigation handlers', () => {
+    const { initThemeToggle } = require('./theme.js');
+    const { navigateTo } = require('./navigation.js');
+    require('./home.js');
+
+    document.getElementById('playBtn').click();
+    document.getElementById('aboutBtn').click();
+
+    expect(initThemeToggle).toHaveBeenCalledTimes(1);
+    expect(navigateTo).toHaveBeenCalledWith('game.html');
+    expect(navigateTo).toHaveBeenCalledWith('about.html');
+    expect(navigateTo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/move-prompt.test.js
+++ b/move-prompt.test.js
@@ -1,0 +1,24 @@
+import askArmiesToMove from './move-prompt.js';
+
+describe('askArmiesToMove', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('resolves 0 immediately when max <= 0', async () => {
+    const result = await askArmiesToMove(0);
+    expect(result).toBe(0);
+    expect(document.getElementById('moveArmiesModal')).toBeNull();
+  });
+
+  test('prompts for armies and clamps value', async () => {
+    const promise = askArmiesToMove(5, 1);
+    const input = document.getElementById('moveArmiesInput');
+    const button = document.getElementById('moveArmiesOk');
+    input.value = '10';
+    button.click();
+    const result = await promise;
+    expect(result).toBe(5);
+    expect(document.getElementById('moveArmiesModal')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for home page initialization handlers
- add tests for army move prompt utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeec3fed40832ca351b50ac03f868b