### PR TITLE
feat: handle lobby join and leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ WebSocket connection. The most important message types are:
   `lobby` message containing the lobby `code`, `host`, current `players` and the
   selected `map` if any.
 - `joinLobby` – `{ type, code, player }` joins an existing lobby.
+- `leaveLobby` – `{ type, code, id }` removes a player from a lobby.
 - `selectMap` – `{ type, code, id, map }` can be sent by the host to choose the
   board; all clients receive an updated `lobby` message with the `map` field.
 - `ready` – `{ type, code, id, ready }` toggles a player's ready state.
@@ -119,6 +120,10 @@ WebSocket connection. The most important message types are:
 
 Every `lobby` broadcast includes the lobby `code`, host id, list of players with
 their readiness and the selected `map`.
+
+If a lobby fills up (max 6 players) a `joinLobby` request will return an
+`error` message with `error: "lobbyFull"`. Joining a lobby that has started or
+was closed results in `error: "lobbyNotOpen"`.
 
 All lobby information is persisted in Supabase and relayed by the server so
 that peers never communicate directly with one another.

--- a/multiplayer-server-join-leave.test.js
+++ b/multiplayer-server-join-leave.test.js
@@ -1,0 +1,128 @@
+/** @jest-environment node */
+import WebSocket from "ws";
+jest.mock("./src/init/supabase-client.js", () => null);
+const { createLobbyServer } = require("./multiplayer-server.js");
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+function onceOpen(ws) {
+  return new Promise(resolve => ws.once("open", resolve));
+}
+function onceClose(ws) {
+  return new Promise(resolve => ws.once("close", resolve));
+}
+function messageQueue(ws) {
+  const q = [];
+  ws.on("message", data => q.push(JSON.parse(data.toString())));
+  return q;
+}
+
+test(
+  "enforces max players and closes empty lobby",
+  async () => {
+  const port = 12347;
+  const server = createLobbyServer({ port, closeEmptyLobbiesAfter: 50 });
+  const url = `ws://localhost:${port}`;
+
+  const host = new WebSocket(url);
+  await onceOpen(host);
+  const qHost = messageQueue(host);
+  host.send(
+    JSON.stringify({
+      type: "createLobby",
+      player: { id: "p1", name: "P1", color: "#f00" },
+    })
+  );
+  await wait(50);
+  const lobbyMsg = qHost.shift();
+  const code = lobbyMsg.code;
+
+  const clients = [];
+  for (let i = 2; i <= 5; i++) {
+    const ws = new WebSocket(url);
+    await onceOpen(ws);
+    const q = messageQueue(ws);
+    ws.send(
+      JSON.stringify({
+        type: "joinLobby",
+        code,
+        player: { id: `p${i}`, name: `P${i}`, color: "#000" },
+      })
+    );
+    await wait(20);
+    q.shift(); // joined
+    clients.push({ ws, q, id: `p${i}` });
+  }
+  qHost.splice(0); // clear join broadcasts
+
+  const wsA = new WebSocket(url);
+  const wsB = new WebSocket(url);
+  await onceOpen(wsA);
+  await onceOpen(wsB);
+  const qA = messageQueue(wsA);
+  const qB = messageQueue(wsB);
+  wsA.send(
+    JSON.stringify({
+      type: "joinLobby",
+      code,
+      player: { id: "p6", name: "P6", color: "#aaa" },
+    })
+  );
+  wsB.send(
+    JSON.stringify({
+      type: "joinLobby",
+      code,
+      player: { id: "p7", name: "P7", color: "#bbb" },
+    })
+  );
+  await wait(100);
+  const respA = qA.shift();
+  const respB = qB.shift();
+  expect([respA.type, respB.type].sort()).toEqual(["error", "joined"]);
+  expect((respA.error || respB.error)).toBe("lobbyFull");
+
+  let joinedWs, joinedId;
+  if (respA.type === "joined") {
+    joinedWs = wsA;
+    joinedId = "p6";
+  } else {
+    joinedWs = wsB;
+    joinedId = "p7";
+  }
+  qHost.splice(0); // clear join broadcast
+  joinedWs.send(JSON.stringify({ type: "leaveLobby", code, id: joinedId }));
+  await wait(80);
+  const update = qHost.shift();
+  expect(update.players.length).toBe(5);
+
+  qHost.splice(0);
+  host.send(JSON.stringify({ type: "leaveLobby", code, id: "p1" }));
+  for (const c of clients) {
+    c.ws.send(JSON.stringify({ type: "leaveLobby", code, id: c.id }));
+  }
+  await wait(100);
+
+  const wsNew = new WebSocket(url);
+  await onceOpen(wsNew);
+  const qNew = messageQueue(wsNew);
+  wsNew.send(
+    JSON.stringify({
+      type: "joinLobby",
+      code,
+      player: { id: "px", name: "PX", color: "#ccc" },
+    })
+  );
+  await wait(100);
+  const err = qNew.shift();
+  expect(err.error).toBe("lobbyNotOpen");
+
+  wsNew.close();
+  joinedWs.close();
+  for (const c of clients) c.ws.close();
+  host.close();
+  await onceClose(host);
+  server.close();
+  },
+  10000
+);

--- a/multiplayer-server.js
+++ b/multiplayer-server.js
@@ -11,9 +11,15 @@ import supabase from "./src/init/supabase-client.js";
  *
  * @param {object} [opts]
  * @param {number} [opts.port] Port to listen on
- * @returns {WebSocketServer} the running WebSocketServer instance
- */
-export function createLobbyServer({ port = process.env.PORT || 8081 } = {}) {
+ * @param {number} [opts.maxPlayers] Maximum players per lobby
+ * @param {number} [opts.closeEmptyLobbiesAfter] Delay in ms before closing empty lobbies
+* @returns {WebSocketServer} the running WebSocketServer instance
+*/
+export function createLobbyServer({
+  port = process.env.PORT || 8081,
+  maxPlayers = 6,
+  closeEmptyLobbiesAfter = 5000,
+} = {}) {
   const wss = new WebSocketServer({ port });
 
   /**
@@ -139,7 +145,11 @@ export function createLobbyServer({ port = process.env.PORT || 8081 } = {}) {
         case "joinLobby": {
           const lobby = await loadLobby(msg.code);
           if (!lobby || lobby.started) {
-            ws.send(JSON.stringify({ type: "error", error: "lobbyNotFound" }));
+            ws.send(JSON.stringify({ type: "error", error: "lobbyNotOpen" }));
+            return;
+          }
+          if (lobby.players.length >= maxPlayers) {
+            ws.send(JSON.stringify({ type: "error", error: "lobbyFull" }));
             return;
           }
           const player = {
@@ -163,6 +173,41 @@ export function createLobbyServer({ port = process.env.PORT || 8081 } = {}) {
             players: publicPlayers(lobby),
             map: lobby.map,
           });
+          break;
+        }
+        case "leaveLobby": {
+          const lobby = await loadLobby(msg.code);
+          if (!lobby) return;
+          const idx = lobby.players.findIndex(p => p.id === msg.id);
+          if (idx === -1) return;
+          const [player] = lobby.players.splice(idx, 1);
+          if (currentPlayer === player) {
+            currentPlayer = null;
+            currentLobby = null;
+          }
+          if (lobby.host === player.id) {
+            lobby.host = lobby.players[0]?.id || null;
+          }
+          await persistLobby(lobby);
+          broadcast(lobby, {
+            type: "lobby",
+            code: lobby.code,
+            host: lobby.host,
+            players: publicPlayers(lobby),
+            map: lobby.map,
+          });
+          ws.send(JSON.stringify({ type: "left", code: lobby.code }));
+          if (lobby.players.length === 0) {
+            setTimeout(async () => {
+              const still = lobbies.get(lobby.code);
+              if (still && still.players.length === 0) {
+                lobbies.delete(lobby.code);
+                if (supabase) {
+                  await supabase.from("lobbies").delete().eq("code", lobby.code);
+                }
+              }
+            }, closeEmptyLobbiesAfter);
+          }
           break;
         }
         case "ready": {


### PR DESCRIPTION
## Summary
- enforce max lobby size and reject joins when full or closed
- add leaveLobby handling with delayed cleanup of empty lobbies
- document new errors and write concurrency tests

## Testing
- `npm run lint`
- `npm test -- multiplayer-server-join-leave.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeec13e858832caa2ce771b07f7d70