### PR TITLE
Organize tests and add test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "http-server .",
     "build": "node build.js",
     "server": "node multiplayer-server.js",
-    "simulate": "node simulate.js"
+    "simulate": "node simulate.js",
+    "test": "jest"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.0",

--- a/tests/about.test.js
+++ b/tests/about.test.js
@@ -1,4 +1,4 @@
-const { filterSections } = require('./about.js');
+const { filterSections } = require('../about.js');
 
 describe('about page search', () => {
   test('filters sections based on query', () => {

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -3,7 +3,7 @@ const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 const { JSDOM } = require('jsdom');
-const initTerritorySelection = require('./territory-selection.js').default;
+const initTerritorySelection = require('../territory-selection.js').default;
 
 const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -1,4 +1,4 @@
-import { attackSuccessProbability, territoryPriority } from './ai.js';
+import { attackSuccessProbability, territoryPriority } from '../ai.js';
 
 class MockGame {
   constructor(map) { this.map = map; }

--- a/tests/audio.test.js
+++ b/tests/audio.test.js
@@ -8,7 +8,7 @@ import {
   isMuted,
   setMusicEnabled,
   isMusicEnabled,
-} from "./audio.js";
+} from "../audio.js";
 
 describe("audio helpers", () => {
   test("playEffect is safe when Audio is undefined", () => {

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -11,15 +11,15 @@ describe('build script', () => {
   });
 
   afterAll(() => {
-    fs.rmSync(path.join(__dirname, 'dist'), { recursive: true, force: true });
+    fs.rmSync(path.join(__dirname, '..', 'dist'), { recursive: true, force: true });
   });
 
   test('copies map data file', () => {
-    const mapPath = path.join(__dirname, 'dist', 'src', 'data', 'map.json');
+    const mapPath = path.join(__dirname, '..', 'dist', 'src', 'data', 'map.json');
     expect(fs.existsSync(mapPath)).toBe(true);
-    const romanPath = path.join(__dirname, 'dist', 'src', 'data', 'map-roman.json');
+    const romanPath = path.join(__dirname, '..', 'dist', 'src', 'data', 'map-roman.json');
     expect(fs.existsSync(romanPath)).toBe(true);
-    const map3Path = path.join(__dirname, 'dist', 'src', 'data', 'map3.json');
+    const map3Path = path.join(__dirname, '..', 'dist', 'src', 'data', 'map3.json');
     expect(fs.existsSync(map3Path)).toBe(true);
   });
 });

--- a/tests/colors.test.js
+++ b/tests/colors.test.js
@@ -1,4 +1,4 @@
-import { colorPalette, getContrastingColor } from "./colors.js";
+import { colorPalette, getContrastingColor } from "../colors.js";
 
 describe("getContrastingColor", () => {
   test("returns black for light colors", () => {

--- a/tests/editor-tutorial.test.js
+++ b/tests/editor-tutorial.test.js
@@ -1,4 +1,4 @@
-const { startEditorTutorial } = require('./editor-tutorial.js');
+const { startEditorTutorial } = require('../editor-tutorial.js');
 
 describe('editor tutorial', () => {
   beforeEach(() => {

--- a/tests/event-bus.test.js
+++ b/tests/event-bus.test.js
@@ -1,5 +1,5 @@
-import Game from "./game.js";
-import { REINFORCE } from "./phases.js";
+import Game from "../game.js";
+import { REINFORCE } from "../phases.js";
 
 describe('Event bus', () => {
   const mapMock = {

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,6 +1,6 @@
-import Game from "./game.js";
-import { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "./phases.js";
-import aiTurnManager from "./src/ai/turn-manager.js";
+import Game from "../game.js";
+import { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "../phases.js";
+import aiTurnManager from "../src/ai/turn-manager.js";
 
 let game;
 

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -1,5 +1,5 @@
-jest.mock('./theme.js', () => ({ initThemeToggle: jest.fn() }));
-jest.mock('./navigation.js', () => ({ navigateTo: jest.fn() }));
+jest.mock('../theme.js', () => ({ initThemeToggle: jest.fn() }));
+jest.mock('../navigation.js', () => ({ navigateTo: jest.fn() }));
 
 describe('home page initialization', () => {
   beforeEach(() => {
@@ -15,9 +15,9 @@ describe('home page initialization', () => {
   });
 
   test('initHome sets up theme and navigation handlers', () => {
-    const { initThemeToggle } = require('./theme.js');
-    const { navigateTo } = require('./navigation.js');
-    require('./home.js');
+    const { initThemeToggle } = require('../theme.js');
+    const { navigateTo } = require('../navigation.js');
+    require('../home.js');
 
     document.getElementById('playBtn').click();
     document.getElementById('aboutBtn').click();

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -1,6 +1,6 @@
-jest.mock('./navigation.js', () => ({ goHome: jest.fn() }));
-jest.mock('./theme.js', () => ({ initThemeToggle: jest.fn() }));
-jest.mock('./src/init/supabase-client.js', () => null);
+jest.mock('../navigation.js', () => ({ goHome: jest.fn() }));
+jest.mock('../theme.js', () => ({ initThemeToggle: jest.fn() }));
+jest.mock('../src/init/supabase-client.js', () => null);
 
 describe('lobby screen', () => {
   beforeEach(() => {
@@ -27,14 +27,14 @@ describe('lobby screen', () => {
   });
 
   test('back button goes home', () => {
-    const { goHome } = require('./navigation.js');
-    require('./lobby.js');
+    const { goHome } = require('../navigation.js');
+    require('../lobby.js');
     document.getElementById('backBtn').click();
     expect(goHome).toHaveBeenCalled();
   });
 
   test('renderLobbies displays info', () => {
-    const { renderLobbies } = require('./lobby.js');
+    const { renderLobbies } = require('../lobby.js');
     const data = [
       { code: 'abc', host: 'host', players: [{}, {}], map: 'map', started: false, maxPlayers: 5 },
     ];
@@ -51,7 +51,7 @@ describe('lobby screen', () => {
     const wsInstance = { send: jest.fn(), readyState: 1 };
     global.WebSocket = jest.fn(() => wsInstance);
     global.WebSocket.OPEN = 1;
-    require('./lobby.js');
+    require('../lobby.js');
     document.getElementById('createBtn').click();
     expect(document.getElementById('createDialog').hasAttribute('open')).toBe(true);
     document.getElementById('roomName').value = 'Room';
@@ -78,7 +78,7 @@ describe('lobby screen', () => {
     const wsInstance = { send: jest.fn(), readyState: 1 };
     global.WebSocket = jest.fn(() => wsInstance);
     global.WebSocket.OPEN = 1;
-    require('./lobby.js');
+    require('../lobby.js');
     document.getElementById('createBtn').click();
     document.getElementById('roomName').value = '';
     document.getElementById('maxPlayers').value = '10';

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,9 +1,9 @@
-const mapData = require('./src/data/map.json');
-const { REINFORCE, ATTACK, FORTIFY, GAME_OVER } = require('./phases.js');
+const mapData = require('../src/data/map.json');
+const { REINFORCE, ATTACK, FORTIFY, GAME_OVER } = require('../phases.js');
 
-jest.mock('./territory-selection.js', () => jest.fn());
-jest.mock('./move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
-jest.mock('./navigation.js', () => ({
+jest.mock('../territory-selection.js', () => jest.fn());
+jest.mock('../move-prompt.js', () => jest.fn(() => Promise.resolve(1)));
+jest.mock('../navigation.js', () => ({
   navigateTo: jest.fn(),
   goHome: jest.fn(),
   exitGame: jest.fn(),
@@ -35,8 +35,8 @@ describe('main DOM interactions', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
-    main = require('./main.js');
-    ui = require('./ui.js');
+    main = require('../main.js');
+    ui = require('../ui.js');
       await Promise.resolve();
       main.attachTerritoryHandlers();
       jest.useFakeTimers();
@@ -174,8 +174,8 @@ describe('main DOM interactions', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
     global.logger = { info: jest.fn(), error: jest.fn() };
-    const main2 = require('./main.js');
-    require('./ui.js');
+    const main2 = require('../main.js');
+    require('../ui.js');
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -230,7 +230,7 @@ describe('main DOM interactions', () => {
     expect(destroySpy).toHaveBeenCalled();
     expect(localStorage.getItem('netriskPlayers')).toBeNull();
     expect(localStorage.getItem('netriskGame')).toBeNull();
-    const navigation = require('./navigation.js');
+    const navigation = require('../navigation.js');
     expect(navigation.navigateTo).toHaveBeenCalledWith('setup.html');
     destroySpy.mockRestore();
   });

--- a/tests/map-schema.test.js
+++ b/tests/map-schema.test.js
@@ -1,11 +1,11 @@
-const validateMap = require('./validate-map.js');
+const validateMap = require('../validate-map.js');
 
 const maps = ['map.json', 'map2.json', 'map3.json', 'map-roman.json'];
 
 describe('map schema validation', () => {
   test.each(maps)('%s matches schema', (file) => {
     // eslint-disable-next-line global-require
-    const data = require(`./src/data/${file}`);
+    const data = require(`../src/data/${file}`);
     expect(() => validateMap(data)).not.toThrow();
   });
 

--- a/tests/map3.test.js
+++ b/tests/map3.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const map = require('./src/data/map3.json');
+const map = require('../src/data/map3.json');
 
 const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 
@@ -44,7 +44,7 @@ describe('territory-selection with map3', () => {
     localStorage.setItem('netriskMap', 'map3');
     const svg = fs.readFileSync('map3.svg', 'utf8');
     global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(svg) }));
-    const init = require('./territory-selection.js').default;
+    const init = require('../territory-selection.js').default;
     init({ territories: map.territories });
     await flushPromises();
     expect(fetch).toHaveBeenCalledWith('map3.svg');
@@ -57,7 +57,7 @@ describe('territory-selection with map3', () => {
     localStorage.setItem('netriskMap', 'map3');
     const svg = fs.readFileSync('map3.svg', 'utf8');
     global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(svg) }));
-    const init = require('./territory-selection.js').default;
+    const init = require('../territory-selection.js').default;
     init({ territories: map.territories });
     await flushPromises();
     const board = document.getElementById('board');

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -1,4 +1,4 @@
-jest.mock('./navigation.js', () => ({
+jest.mock('../navigation.js', () => ({
   navigateTo: jest.fn(),
   goHome: jest.fn(),
   exitGame: jest.fn(),
@@ -17,8 +17,8 @@ describe('home navigation', () => {
   });
 
   test('buttons navigate to pages', () => {
-    const { navigateTo } = require('./navigation.js');
-    require('./home.js');
+    const { navigateTo } = require('../navigation.js');
+    require('../home.js');
     document.getElementById('playBtn').click();
     document.getElementById('multiplayerBtn').click();
     document.getElementById('setupBtn').click();

--- a/tests/move-prompt.test.js
+++ b/tests/move-prompt.test.js
@@ -1,4 +1,4 @@
-import askArmiesToMove from './move-prompt.js';
+import askArmiesToMove from '../move-prompt.js';
 
 describe('askArmiesToMove', () => {
   afterEach(() => {

--- a/tests/multiplayer-server-join-leave.test.js
+++ b/tests/multiplayer-server-join-leave.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 import WebSocket from "ws";
-jest.mock("./src/init/supabase-client.js", () => null);
-const { createLobbyServer } = require("./multiplayer-server.js");
+jest.mock("../src/init/supabase-client.js", () => null);
+const { createLobbyServer } = require("../multiplayer-server.js");
 
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -124,5 +124,5 @@ test(
   await onceClose(host);
   server.close();
   },
-  10000
+  20000
 );

--- a/tests/multiplayer-server.test.js
+++ b/tests/multiplayer-server.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 import WebSocket from "ws";
-jest.mock("./src/init/supabase-client.js", () => null);
-const { createLobbyServer } = require("./multiplayer-server.js");
+jest.mock("../src/init/supabase-client.js", () => null);
+const { createLobbyServer } = require("../multiplayer-server.js");
 
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -1,4 +1,4 @@
-import { navigateTo, goHome, exitGame } from "./navigation.js";
+import { navigateTo, goHome, exitGame } from "../navigation.js";
 
 describe("navigateTo", () => {
   test("uses location.assign when available", () => {

--- a/tests/phase-timer.test.js
+++ b/tests/phase-timer.test.js
@@ -1,5 +1,5 @@
-import initPhaseTimer from './phase-timer.js';
-import EventBus from './src/core/event-bus.js';
+import initPhaseTimer from '../phase-timer.js';
+import EventBus from '../src/core/event-bus.js';
 
 jest.useFakeTimers();
 

--- a/tests/phases.test.js
+++ b/tests/phases.test.js
@@ -1,4 +1,4 @@
-import PHASES, { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "./phases.js";
+import PHASES, { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "../phases.js";
 
 describe("PHASES constants", () => {
   test("have expected values", () => {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -10,8 +10,8 @@ describe('settings persistence between pages', () => {
   });
 
   test('audio and theme survive reload', () => {
-    const audio1 = require('./audio.js');
-    const theme1 = require('./theme.js');
+    const audio1 = require('../audio.js');
+    const theme1 = require('../theme.js');
     audio1.setMasterVolume(0.25);
     audio1.setMuted(true);
     document.body.innerHTML = '<button id="themeToggle" class="btn">High Contrast</button>';
@@ -20,8 +20,8 @@ describe('settings persistence between pages', () => {
 
     jest.resetModules();
     document.body.innerHTML = '';
-    const audio2 = require('./audio.js');
-    const theme2 = require('./theme.js');
+    const audio2 = require('../audio.js');
+    const theme2 = require('../theme.js');
     theme2.initThemeToggle();
     expect(audio2.getMasterVolume()).toBe(0.25);
     expect(audio2.isMuted()).toBe(true);

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -1,6 +1,7 @@
-import { colorPalette } from './colors.js';
+import { colorPalette } from '../colors.js';
 import { readFileSync } from 'fs';
-jest.mock('./navigation.js', () => ({
+import path from 'path';
+jest.mock('../navigation.js', () => ({
   navigateTo: jest.fn(),
   goHome: jest.fn(),
   exitGame: jest.fn(),
@@ -48,8 +49,8 @@ describe('setup map selection', () => {
       ],
     };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
-    const { navigateTo } = require('./navigation.js');
-    const { mapLoadPromise } = require('./setup.js');
+    const { navigateTo } = require('../navigation.js');
+    const { mapLoadPromise } = require('../setup.js');
     await mapLoadPromise;
     document.getElementById('humanCount').value = '1';
     document.getElementById('aiCount').value = '0';
@@ -64,7 +65,7 @@ describe('setup map selection', () => {
   test('renders responsive grid', async () => {
     const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'map.svg', description: '' }] };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
-    const { mapLoadPromise } = require('./setup.js');
+    const { mapLoadPromise } = require('../setup.js');
     await mapLoadPromise;
     const grid = document.getElementById('mapGrid');
     expect(grid.style.display).toBe('grid');
@@ -74,7 +75,7 @@ describe('setup map selection', () => {
   test('shows placeholder when thumbnail missing', async () => {
     const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'missing.svg', description: '' }] };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
-    const { mapLoadPromise } = require('./setup.js');
+    const { mapLoadPromise } = require('../setup.js');
     await mapLoadPromise;
     const img = document.querySelector('.map-item img');
     img.dispatchEvent(new Event('error'));
@@ -84,7 +85,7 @@ describe('setup map selection', () => {
   test('saves AI difficulty and style', async () => {
     const manifest = { version: 1, maps: [{ id: 'map', name: 'Classic', difficulty: 'Easy', territories: 1, bonuses: {}, thumbnail: 'map.svg', description: '' }] };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
-    const { mapLoadPromise } = require('./setup.js');
+    const { mapLoadPromise } = require('../setup.js');
     await mapLoadPromise;
     document.getElementById('humanCount').value = '1';
     document.getElementById('aiCount').value = '1';
@@ -98,7 +99,7 @@ describe('setup map selection', () => {
   });
 
   test('has header navigation', () => {
-    const html = readFileSync('./setup.html', 'utf8');
+    const html = readFileSync(path.join(__dirname, '..', 'setup.html'), 'utf8');
     expect(html).toMatch(/<header class="main-header">/);
     expect(html).toMatch(/href="index.html"/);
   });

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,4 +1,4 @@
-import { initGameState } from "./src/state/game.js";
+import { initGameState } from "../src/state/game.js";
 
 // This test ensures that the central game state can be reused
 // across different UI layers (e.g. different layout skins) by
@@ -16,8 +16,8 @@ test("game state is shared across layouts", async () => {
 
   initGameState(dummyGame);
 
-  const { gameState: layout1 } = await import("./src/state/game.js");
-  const { gameState: layout2 } = await import("./src/state/game.js");
+  const { gameState: layout1 } = await import("../src/state/game.js");
+  const { gameState: layout2 } = await import("../src/state/game.js");
 
   expect(layout1).toBe(layout2);
   expect(layout1.currentPlayer).toBe(2);

--- a/tests/stats.test.js
+++ b/tests/stats.test.js
@@ -1,5 +1,5 @@
-import { attachStatsListeners, getStats } from './stats.js';
-import { REINFORCE } from './phases.js';
+import { attachStatsListeners, getStats } from '../stats.js';
+import { REINFORCE } from '../phases.js';
 
 describe('stats tracking', () => {
   test('records armies and attacks per turn', () => {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -4,7 +4,7 @@ import {
   listSavedGames,
   renameSavedGame,
   deleteSavedGame,
-} from "./src/state/storage.js";
+} from "../src/state/storage.js";
 
 class DummyGame {
   constructor(state) {

--- a/tests/territory-selection.moves.test.js
+++ b/tests/territory-selection.moves.test.js
@@ -1,5 +1,5 @@
-import initTerritorySelection from './territory-selection.js';
-import { ATTACK } from './phases.js';
+import initTerritorySelection from '../territory-selection.js';
+import { ATTACK } from '../phases.js';
 
 const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -1,4 +1,4 @@
-import { initThemeToggle, initThemeSelect } from './theme.js';
+import { initThemeToggle, initThemeSelect } from '../theme.js';
 
 describe('theme toggle', () => {
   beforeEach(() => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -13,7 +13,7 @@ import {
   getLog,
   exportLog,
   copyLog,
-} from './ui.js';
+} from '../ui.js';
 
 describe('ui utilities', () => {
   let game;

--- a/tests/undo.test.js
+++ b/tests/undo.test.js
@@ -1,5 +1,5 @@
-import Game from "./game.js";
-import { ATTACK, FORTIFY } from "./phases.js";
+import Game from "../game.js";
+import { ATTACK, FORTIFY } from "../phases.js";
 
 describe("undo functionality", () => {
   const createGame = (maxUndo = 10) => {

--- a/tests/websocket-multiplayer-plugin.test.js
+++ b/tests/websocket-multiplayer-plugin.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment node */
-import Game from "./game.js";
-import { FORTIFY } from "./phases.js";
-import createWebSocketMultiplayer from "./src/plugins/websocket-multiplayer-plugin.js";
+import Game from "../game.js";
+import { FORTIFY } from "../phases.js";
+import createWebSocketMultiplayer from "../src/plugins/websocket-multiplayer-plugin.js";
 import WebSocket, { WebSocketServer } from "ws";
 
 function wait(ms) {


### PR DESCRIPTION
## Summary
- move all test files into a dedicated `tests/` folder and fix relative imports
- adjust build and setup tests for new locations and extend multiplayer timeout
- add a `test` npm script for running Jest

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68aef129b9d0832cbbe9cfb0d5ff9f8c