### PR TITLE
feat: sync game state via websocket plugin

### DIFF
--- a/src/plugins/websocket-multiplayer-plugin.js
+++ b/src/plugins/websocket-multiplayer-plugin.js
@@ -1,21 +1,35 @@
 /* eslint-env browser */
 import Game from "../../game.js";
-import { REINFORCE, ATTACK, FORTIFY } from "../../phases.js";
 
 export default function createWebSocketMultiplayer(url) {
-  return game => {
+  return (game) => {
     const ws = new WebSocket(url);
 
-    const sync = () => {
+    const originalEmit = game.emit.bind(game);
+
+    const sync = (event, payload) => {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(
-          JSON.stringify({ type: "state", state: game.serialize() })
+          JSON.stringify({
+            type: "state",
+            state: game.serialize(),
+            event,
+            payload,
+          }),
         );
       }
     };
 
-    ws.addEventListener("open", sync);
-    ws.addEventListener("message", event => {
+    game.emit = (event, payload) => {
+      const result = originalEmit(event, payload);
+      if (event !== "stateUpdated") {
+        sync(event, payload);
+      }
+      return result;
+    };
+
+    ws.addEventListener("open", () => sync());
+    ws.addEventListener("message", (event) => {
       const msg = JSON.parse(event.data);
       if (msg.type === "state") {
         const preserved = game.events;
@@ -35,13 +49,11 @@ export default function createWebSocketMultiplayer(url) {
           winner: updated.winner,
         });
         game.events = preserved;
-        game.emit("stateUpdated", { player: game.currentPlayer });
+        if (msg.event && msg.event !== "stateUpdated") {
+          originalEmit(msg.event, msg.payload);
+        }
+        originalEmit("stateUpdated", { player: game.currentPlayer });
       }
     });
-
-    game.on("phaseChange", sync);
-    game.on(REINFORCE, sync);
-    game.on(ATTACK, sync);
-    game.on(FORTIFY, sync);
   };
 }

--- a/websocket-multiplayer-plugin.test.js
+++ b/websocket-multiplayer-plugin.test.js
@@ -34,6 +34,9 @@ test("syncs game state over websocket", async () => {
   const game1 = new Game(players, territories, [], [], false, false);
   const game2 = new Game(players, territories, [], [], false, false);
 
+  const events2 = [];
+  game2.on("turnStart", e => events2.push(e));
+
   createWebSocketMultiplayer("ws://localhost:12345")(game1);
   createWebSocketMultiplayer("ws://localhost:12345")(game2);
 
@@ -43,6 +46,7 @@ test("syncs game state over websocket", async () => {
   await wait(100);
 
   expect(game2.getCurrentPlayer()).toBe(1);
+  expect(events2).toEqual([{ player: 1 }]);
 
   wss.close();
   delete global.WebSocket;


### PR DESCRIPTION
## Summary
- sync game state and events through websocket plugin
- test turn and event propagation between clients

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef53bac5c832c8fa42aa9bed8e8d6