### PR TITLE
feat: add lobby chat

### DIFF
--- a/lobby.html
+++ b/lobby.html
@@ -36,6 +36,13 @@
           </menu>
         </form>
       </dialog>
+      <section class="chat">
+        <ul id="chatMessages" class="chat-messages"></ul>
+        <form id="chatForm" class="chat-form" autocomplete="off">
+          <input id="chatInput" maxlength="200" aria-label="Chat message" />
+          <button type="submit">Send</button>
+        </form>
+      </section>
     </main>
     <script type="module" src="./src/lobby.js"></script>
   </body>

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -8,6 +8,11 @@ const bus = new EventBus();
 let ws = null;
 
 const currentLobbies = [];
+const playerNames = new Map();
+let currentCode = null;
+let currentPlayerId = null;
+let chatHistoryLoaded = false;
+const MAX_CHAT_LENGTH = 200;
 
 export function renderLobbies(lobbies) {
   const list = document.getElementById('lobbyList');
@@ -40,6 +45,9 @@ export function initLobby() {
   const createBtn = document.getElementById('createBtn');
   const dialog = document.getElementById('createDialog');
   const form = document.getElementById('createForm');
+  const chatForm = document.getElementById('chatForm');
+  const chatInput = document.getElementById('chatInput');
+  const chatMessages = document.getElementById('chatMessages');
   // populate map select from manifest
   (async () => {
     const select = document.getElementById('map');
@@ -82,20 +90,7 @@ export function initLobby() {
             })
           );
         };
-        ws.onmessage = e => {
-          let msg;
-          try {
-            msg = JSON.parse(e.data);
-          } catch {
-            return;
-          }
-          if (msg.type === 'lobby') {
-            currentLobbies.push(msg);
-            renderLobbies(currentLobbies);
-            if (dialog.close) dialog.close();
-            else dialog.removeAttribute('open');
-          }
-        };
+        ws.onmessage = e => handleMessage(e, dialog);
       } else {
         ws.send(
           JSON.stringify({
@@ -108,6 +103,20 @@ export function initLobby() {
       }
     });
   }
+
+  if (chatForm && chatInput) {
+    chatForm.addEventListener('submit', ev => {
+      ev.preventDefault();
+      let text = chatInput.value.trim();
+      if (!text) return;
+      if (text.length > MAX_CHAT_LENGTH) text = text.slice(0, MAX_CHAT_LENGTH);
+      if (!ws || ws.readyState !== WebSocket.OPEN || !currentCode || !currentPlayerId) return;
+      ws.send(
+        JSON.stringify({ type: 'chat', code: currentCode, id: currentPlayerId, text })
+      );
+      chatInput.value = '';
+    });
+  }
   fetchLobbies();
   if (supabase) {
     supabase
@@ -117,6 +126,67 @@ export function initLobby() {
       })
       .subscribe();
     bus.on('lobbiesChanged', fetchLobbies);
+  }
+
+  function addChatMessage(id, text, time = new Date()) {
+    if (!chatMessages) return;
+    const li = document.createElement('li');
+    const name = playerNames.get(id) || id;
+    const ts = time instanceof Date ? time.toLocaleTimeString() : new Date(time).toLocaleTimeString();
+    li.textContent = `[${ts}] ${name}: ${text}`;
+    chatMessages.appendChild(li);
+  }
+
+  async function loadChatHistory() {
+    if (chatHistoryLoaded || !supabase || !currentCode) return;
+    chatHistoryLoaded = true;
+    try {
+      const { data } = await supabase
+        .from('lobby_chat')
+        .select()
+        .eq('code', currentCode)
+        .order('created_at', { ascending: true });
+      (data || []).forEach(row => addChatMessage(row.id, row.text, new Date(row.created_at)));
+    } catch {
+      // ignore fetch errors
+    }
+  }
+
+  function handleMessage(e, dlg) {
+    let msg;
+    try {
+      msg = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    switch (msg.type) {
+      case 'joined': {
+        currentCode = msg.code;
+        currentPlayerId = msg.id;
+        loadChatHistory();
+        break;
+      }
+      case 'lobby': {
+        currentCode = msg.code;
+        if (!currentPlayerId) currentPlayerId = msg.host;
+        playerNames.clear();
+        (msg.players || []).forEach(p => {
+          playerNames.set(p.id, p.name || p.id);
+        });
+        loadChatHistory();
+        currentLobbies.push(msg);
+        renderLobbies(currentLobbies);
+        if (dlg && dlg.close) dlg.close();
+        else if (dlg) dlg.removeAttribute('open');
+        break;
+      }
+      case 'chat': {
+        addChatMessage(msg.id, msg.text, new Date());
+        break;
+      }
+      default:
+        break;
+    }
   }
 }
 

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -19,6 +19,8 @@ describe('lobby screen', () => {
           <select id="map"></select>
         </form>
       </dialog>
+      <ul id="chatMessages"></ul>
+      <form id="chatForm"><input id="chatInput" /></form>
     `;
   });
 
@@ -84,6 +86,31 @@ describe('lobby screen', () => {
     document.getElementById('maxPlayers').value = '10';
     document.getElementById('createForm').dispatchEvent(new Event('submit'));
     expect(WebSocket).not.toHaveBeenCalled();
+    delete global.WebSocket;
+  });
+
+  test('chat sends and renders messages', async () => {
+    const wsInstance = { send: jest.fn(), readyState: 1 };
+    global.WebSocket = jest.fn(() => wsInstance);
+    global.WebSocket.OPEN = 1;
+    require('../src/lobby.js');
+    document.getElementById('createBtn').click();
+    document.getElementById('roomName').value = 'Room';
+    document.getElementById('maxPlayers').value = '2';
+    await new Promise(r => setTimeout(r, 0));
+    document.getElementById('map').value = '';
+    document.getElementById('createForm').dispatchEvent(new Event('submit'));
+    wsInstance.onopen();
+    wsInstance.onmessage({ data: JSON.stringify({ type: 'lobby', code: 'abc', host: 'p1', players: [{ id: 'p1', name: 'Host' }], map: null, maxPlayers: 2 }) });
+    document.getElementById('chatInput').value = 'hello';
+    document.getElementById('chatForm').dispatchEvent(new Event('submit'));
+    expect(wsInstance.send).toHaveBeenLastCalledWith(
+      JSON.stringify({ type: 'chat', code: 'abc', id: 'p1', text: 'hello' })
+    );
+    wsInstance.onmessage({ data: JSON.stringify({ type: 'chat', id: 'p1', text: 'hello' }) });
+    const text = document.getElementById('chatMessages').textContent;
+    expect(text).toContain('Host');
+    expect(text).toContain('hello');
     delete global.WebSocket;
   });
 });


### PR DESCRIPTION
## Summary
- add chat section to lobby page
- handle chat messages with timestamps, name lookup, and supabase history
- test lobby chat workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aefb0d10e4832cadfa03da1159afe9