### PR TITLE
Handle new game navigation for multiplayer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,13 @@ async function startNewGame() {
     phaseTimer.stop();
   }
   destroyUI();
-  navigateTo("setup.html");
+  const params =
+    typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
+  if (params && params.get("multiplayer")) {
+    navigateTo("lobby.html");
+  } else {
+    navigateTo("setup.html");
+  }
 }
 function initialiseUI(game) {
   initGameState(game);

--- a/tests/start-new-game.test.js
+++ b/tests/start-new-game.test.js
@@ -1,0 +1,104 @@
+jest.mock("../src/navigation.js", () => ({
+  navigateTo: jest.fn(),
+  exitGame: jest.fn(),
+}));
+
+jest.mock("../src/state/storage.js", () => ({
+  clearSavedData: jest.fn(),
+  hasSavedPlayers: jest.fn(() => true),
+  hasSavedGame: jest.fn(() => true),
+  updateGameState: jest.fn(),
+}));
+
+jest.mock("../src/ui.js", () => ({
+  initUI: jest.fn(),
+  updateInfoPanel: jest.fn(),
+  addLogEntry: jest.fn(),
+  animateMove: jest.fn(),
+  animateAttack: jest.fn(),
+  animateReinforce: jest.fn(),
+  showVictoryModal: jest.fn(),
+  updateUI: jest.fn(),
+  destroyUI: jest.fn(),
+  resetSelectedCards: jest.fn(),
+  getSelectedCards: jest.fn(() => []),
+  exportLog: jest.fn(),
+}));
+
+jest.mock("../src/init/game-loader.js", () => ({
+  loadGame: jest.fn(() =>
+    Promise.resolve({
+      game: {
+        on: jest.fn(),
+        use: jest.fn(),
+        players: [{ ai: false, name: "p1" }],
+        currentPlayer: 0,
+        getPhase: jest.fn(() => 0),
+        performAITurn: jest.fn(),
+        checkVictory: jest.fn(() => null),
+      },
+      territoryPositions: {},
+    }),
+  ),
+}));
+
+jest.mock("../src/phase-timer.js", () => jest.fn(() => ({ stop: jest.fn() })));
+
+jest.mock("../src/stats.js", () => ({
+  attachStatsListeners: jest.fn(),
+  exportStats: jest.fn(),
+}));
+
+jest.mock("../src/tutorial.js", () => ({ initTutorialButtons: jest.fn() }));
+
+jest.mock("../src/theme.js", () => ({ initThemeToggle: jest.fn() }));
+
+jest.mock("../src/move-prompt.js", () => jest.fn());
+
+jest.mock("../src/territory-selection.js", () => jest.fn());
+
+jest.mock("../src/audio.js", () => ({
+  playEffect: jest.fn(),
+  preloadEffects: jest.fn(),
+  setMasterVolume: jest.fn(),
+  getMasterVolume: jest.fn(() => 1),
+  setEffectsVolume: jest.fn(),
+  getEffectsVolume: jest.fn(() => 1),
+  setMuted: jest.fn(),
+  isMuted: jest.fn(() => false),
+  setMusicEnabled: jest.fn(),
+  isMusicEnabled: jest.fn(() => false),
+}));
+
+jest.mock("../src/state/game.js", () => ({
+  gameState: {},
+  initGameState: jest.fn(),
+}));
+
+global.logger = { info: jest.fn(), error: jest.fn() };
+document.body.innerHTML = '<div id="uiPanel"></div><button id="exitGame"></button><button id="endTurn"></button>';
+
+const { startNewGame } = require("../src/main.js");
+const { navigateTo } = require("../src/navigation.js");
+
+describe("startNewGame navigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const url = new URL(window.location.href);
+    url.search = "";
+    window.history.replaceState({}, "", url);
+  });
+
+  test("navigates to setup in single-player", () => {
+    startNewGame();
+    expect(navigateTo).toHaveBeenCalledWith("setup.html");
+  });
+
+  test("navigates to lobby in multiplayer", () => {
+    const url = new URL(window.location.href);
+    url.search = "?multiplayer=1";
+    window.history.replaceState({}, "", url);
+    startNewGame();
+    expect(navigateTo).toHaveBeenCalledWith("lobby.html");
+  });
+});


### PR DESCRIPTION
## Summary
- Redirect New Game to lobby when in multiplayer mode
- Add tests for New Game navigation in single-player and multiplayer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aefdd43ea0832ca0d39cbe301e587d