### PR TITLE
Use config vars for Supabase client

### DIFF
--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -1,20 +1,7 @@
-// Importing the Supabase client fails when the dependency isn't installed.
-// During unit tests we don't require the real client, so fall back to a no-op
-// implementation if the module cannot be resolved.
-let createClient;
-try {
-  // eslint-disable-next-line global-require
-  ({ createClient } = require('@supabase/supabase-js'));
-} catch {
-  createClient = null;
-}
+import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
 
-const supabaseUrl = 'https://kdrfohrmfppyzzywhmsn.supabase.co';
-const supabaseKey = process.env.SUPABASE_KEY;
-const supabase =
-  createClient && typeof supabaseKey === 'string' && supabaseKey.length
-    ? createClient(supabaseUrl, supabaseKey)
-    : null;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 export { supabase };
 export default supabase;

--- a/src/netriskRealtime.ts
+++ b/src/netriskRealtime.ts
@@ -1,8 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, SUPABASE_KEY } from './config.js';
 
-const supabaseUrl = 'https://kdrfohrmfppyzzywhmsn.supabase.co';
-const anonKey = process.env.SUPABASE_KEY || '';
-const client = createClient(supabaseUrl, anonKey);
+const client = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 export function subscribeToMatch(
   matchId: string,


### PR DESCRIPTION
## Summary
- Initialize Supabase client using config-sourced URL and key
- Streamline realtime module to use configurable Supabase connection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af0ea44274832cb1cf07b0b742ff94