### PR TITLE
fix: include html pages in build output

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -40,11 +40,16 @@ for (const asset of plainAssets) {
 // Copy additional data files (e.g., map.json)
 fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });
 
-let indexHtml = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+// Copy all HTML files, replacing references to hashed assets
+const htmlFiles = fs
+  .readdirSync(root)
+  .filter((file) => file.endsWith('.html'));
 
-for (const [orig, hashedName] of Object.entries(hashed)) {
-  indexHtml = indexHtml.replace(new RegExp(orig, 'g'), hashedName);
+for (const file of htmlFiles) {
+  let html = fs.readFileSync(path.join(root, file), 'utf8');
+  for (const [orig, hashedName] of Object.entries(hashed)) {
+    html = html.replace(new RegExp(orig, 'g'), hashedName);
+  }
+  fs.writeFileSync(path.join(dist, file), html);
 }
-
-fs.writeFileSync(path.join(dist, 'index.html'), indexHtml);
 


### PR DESCRIPTION
## Summary
- copy all HTML files to the build directory and rewrite asset references

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af4a35a728832c9d12f181c03d36e0