### PR TITLE
Fix cancel button behavior in lobby dialog

### DIFF
--- a/lobby.html
+++ b/lobby.html
@@ -31,7 +31,7 @@
           <label>Max players <input id="maxPlayers" type="number" min="2" max="6" value="2" required /></label>
           <label>Map <select id="map"></select></label>
           <menu>
-            <button value="cancel" id="cancelCreate">Cancel</button>
+            <button type="button" value="cancel" id="cancelCreate">Cancel</button>
             <button id="submitCreate" value="default">Create</button>
           </menu>
         </form>

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -54,6 +54,7 @@ export function initLobby() {
   if (backBtn) backBtn.addEventListener('click', () => goHome());
   const createBtn = document.getElementById('createBtn');
   const dialog = document.getElementById('createDialog');
+  const cancelBtn = document.getElementById('cancelCreate');
   const form = document.getElementById('createForm');
   const chatForm = document.getElementById('chatForm');
   const chatInput = document.getElementById('chatInput');
@@ -83,6 +84,12 @@ export function initLobby() {
     createBtn.addEventListener('click', () => {
       if (dialog.showModal) dialog.showModal();
       else dialog.setAttribute('open', '');
+    });
+  }
+  if (cancelBtn && dialog) {
+    cancelBtn.addEventListener('click', () => {
+      if (dialog.close) dialog.close();
+      else dialog.removeAttribute('open');
     });
   }
   if (form) {

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -19,6 +19,10 @@ describe('lobby screen', () => {
           <input id="roomName" />
           <input id="maxPlayers" />
           <select id="map"></select>
+          <menu>
+            <button type="button" id="cancelCreate" value="cancel">Cancel</button>
+            <button id="submitCreate" value="default">Create</button>
+          </menu>
         </form>
       </dialog>
       <ul id="chatMessages"></ul>
@@ -77,6 +81,23 @@ describe('lobby screen', () => {
     const text = document.getElementById('lobbyList').textContent;
     expect(text).toContain('abc');
     expect(text).toContain('1/4');
+    delete global.WebSocket;
+  });
+
+  test('cancel closes dialog and does not send message', async () => {
+    const wsInstance = { send: jest.fn(), readyState: 1 };
+    global.WebSocket = jest.fn(() => wsInstance);
+    global.WebSocket.OPEN = 1;
+    require('../src/lobby.js');
+    document.getElementById('createBtn').click();
+    expect(document.getElementById('createDialog').hasAttribute('open')).toBe(true);
+    document.getElementById('roomName').value = 'Room';
+    document.getElementById('maxPlayers').value = '2';
+    await new Promise(r => setTimeout(r, 0));
+    document.getElementById('map').value = 'map';
+    document.getElementById('cancelCreate').click();
+    expect(document.getElementById('createDialog').hasAttribute('open')).toBe(false);
+    expect(WebSocket).not.toHaveBeenCalled();
     delete global.WebSocket;
   });
 


### PR DESCRIPTION
## Summary
- Prevent cancel button from submitting lobby form
- Close create-game dialog on cancel
- Add regression test for cancel button

## Testing
- `npm test tests/lobby.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af51417a80832c91aa507f39bbee2b