### PR TITLE
Ensure runtime env.js uses secrets

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,18 +49,17 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
           mkdir -p dist
-          cat > dist/env.js <<'EOF'
-          window.__ENV = {
-            SUPABASE_URL: '${SUPABASE_URL}',
-            SUPABASE_ANON_KEY: '${SUPABASE_ANON_KEY}',
-            WS_URL: (function() {
-              try {
-                const u = new URL('${SUPABASE_URL}');
-                return `wss://${u.host}/functions/v1/netrisk`;
-              } catch(e) { return ''; }
-            })()
-          };
-          EOF
+          node - <<'NODE'
+          const fs = require('fs');
+          const url = process.env.SUPABASE_URL;
+          const anon = process.env.SUPABASE_ANON_KEY;
+          let ws = '';
+          try {
+            const u = new URL(url);
+            ws = 'wss://' + u.host + '/functions/v1/netrisk';
+          } catch(e) {}
+          fs.writeFileSync('dist/env.js', `window.__ENV = {\n  SUPABASE_URL: '${url}',\n  SUPABASE_ANON_KEY: '${anon}',\n  WS_URL: '${ws}'\n};`);
+          NODE
 
       - name: Upload artifact (Pages)
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- write `dist/env.js` via a Node script that injects `SUPABASE_URL` and `SUPABASE_ANON_KEY`

## Testing
- `npm test`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anonkey npm run build`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anonkey node - <<'NODE'
const fs = require('fs');
const url = process.env.SUPABASE_URL;
const anon = process.env.SUPABASE_ANON_KEY;
let ws = '';
try {
  const u = new URL(url);
  ws = 'wss://' + u.host + '/functions/v1/netrisk';
} catch(e) {}
fs.writeFileSync('dist/env.js', `window.__ENV = {\n  SUPABASE_URL: '${url}',\n  SUPABASE_ANON_KEY: '${anon}',\n  WS_URL: '${ws}'\n};`);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68af531f685c832c90c94d7e2c5306b4