### PR TITLE
ci: verify pages build secrets

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,6 +27,15 @@ jobs:
         with:
           node-version: 20
           cache: npm
+
+      - name: Verify secrets presence
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          [ -n "$SUPABASE_URL" ] || { echo "❌ Missing SUPABASE_URL"; exit 1; }
+          [ -n "$SUPABASE_ANON_KEY" ] || { echo "❌ Missing SUPABASE_ANON_KEY"; exit 1; }
+          echo "✅ Secrets present (pages build)"
 
       - name: Install deps
         run: npm ci


### PR DESCRIPTION
## Summary
- ensure Pages build runs in `github-pages` environment
- fail early when required Supabase secrets are missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af553db560832c824fad925149d318