### PR TITLE
feat: derive websocket url fallback

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,17 @@
-const ENV = (typeof window !== 'undefined' && window.__ENV) ? window.__ENV : {};
+const ENV = (typeof window!=='undefined' && window.__ENV) ? window.__ENV : {};
 export const SUPABASE_URL = ENV.SUPABASE_URL || '';
 export const SUPABASE_KEY = ENV.SUPABASE_ANON_KEY || '';
 export const WS_URL = (function(){
   if (ENV.WS_URL) return ENV.WS_URL;
-  try {
-    const u = new URL(SUPABASE_URL);
-    const wss = `wss://${u.host}/functions/v1/netrisk`;
-    return (location.protocol === 'https:' ? wss : (location.hostname==='localhost' ? 'ws://localhost:8081' : wss));
-  } catch { return ''; }
+  if (SUPABASE_URL) {
+    try {
+      const u = new URL(SUPABASE_URL);
+      return `wss://${u.host}/functions/v1/netrisk`;
+    } catch {
+      // invalid SUPABASE_URL
+    }
+  }
+  console.error('[ENV] Missing SUPABASE_URL/ANON_KEY in env.js');
+  return '';
 })();
+


### PR DESCRIPTION
## Summary
- derive websocket URL from SUPABASE_URL when env.js is missing
- log explicit error when required SUPABASE variables absent

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af575b821c832c98febbd821150f81