### PR TITLE
Load env.js before script on How to Play page

### DIFF
--- a/how-to-play.html
+++ b/how-to-play.html
@@ -52,6 +52,7 @@
         <ul id="faqList"></ul>
       </section>
     </main>
+    <script src="env.js"></script>
     <script>
       const lang = navigator.language && navigator.language.startsWith('it') ? 'it' : 'en';
       const i18n = {


### PR DESCRIPTION
## Summary
- Ensure the How to Play page loads `env.js` before its main script so environment variables are defined

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5848d570832cbc827b145be9b0b0