### PR TITLE
build: generate env.js during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+env.js

--- a/env.js
+++ b/env.js
@@ -1,5 +1,0 @@
-window.__ENV = window.__ENV || {
-  SUPABASE_URL: '',
-  SUPABASE_ANON_KEY: '',
-  WS_URL: ''
-};

--- a/src/build.js
+++ b/src/build.js
@@ -15,7 +15,7 @@ function hashContent(content) {
 }
 
 const assets = ['css/base.css', 'css/layout.css', 'css/components.css', 'css/theme.css', 'css/game.css', 'src/logger.js', 'src/main.js'];
-const plainAssets = ['map.svg', 'map2.svg', 'map3.svg', 'map-roman.svg', 'src/game.js', 'src/territory-selection.js', 'src/audio.js', 'src/ui.js', 'env.js'];
+const plainAssets = ['map.svg', 'map2.svg', 'map3.svg', 'map-roman.svg', 'src/game.js', 'src/territory-selection.js', 'src/audio.js', 'src/ui.js'];
 const hashed = {};
 
 for (const asset of assets) {
@@ -36,6 +36,10 @@ for (const asset of plainAssets) {
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
   fs.copyFileSync(srcPath, destPath);
 }
+
+// Generate env.js dynamically from environment variables
+const envContent = `window.__ENV = window.__ENV || {\n  SUPABASE_URL: '${process.env.SUPABASE_URL || ''}',\n  SUPABASE_ANON_KEY: '${process.env.SUPABASE_ANON_KEY || ''}',\n  WS_URL: '${process.env.WS_URL || ''}'\n};\n`;
+fs.writeFileSync(path.join(dist, 'env.js'), envContent);
 
 // Copy additional data files (e.g., map.json)
 fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });


### PR DESCRIPTION
## Summary
- remove env.js from version control
- ignore env.js in git
- create env.js dynamically during build using environment variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6dd93338832c932d909f481e8b74