### PR TITLE
Set create dialog submit type for cross-browser compatibility

### DIFF
--- a/lobby.html
+++ b/lobby.html
@@ -32,7 +32,7 @@
           <label>Map <select id="map"></select></label>
           <menu>
             <button type="button" value="cancel" id="cancelCreate">Cancel</button>
-            <button id="submitCreate" value="default">Create</button>
+            <button type="submit" id="submitCreate" value="default">Create</button>
           </menu>
         </form>
       </dialog>


### PR DESCRIPTION
## Summary
- ensure lobby dialog submit button uses `type="submit"` so forms submit across browsers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7044ef08832c9ae1dda75387eaea