### PR TITLE
Handle lobby error messages

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -250,6 +250,10 @@ export function initLobby() {
         addChatMessage(msg.id, msg.text, new Date());
         break;
       }
+      case 'error': {
+        notifyUser(msg.error || 'An error occurred.');
+        break;
+      }
       default:
         break;
     }

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -177,4 +177,16 @@ describe('lobby screen', () => {
     expect(global.alert).toHaveBeenCalled();
     delete global.WebSocket;
   });
+
+  test('notifies user when server sends error message', () => {
+    const wsInstance = { send: jest.fn(), readyState: 1 };
+    global.WebSocket = jest.fn(() => wsInstance);
+    global.WebSocket.OPEN = 1;
+    localStorage.setItem('lobbyCode', 'abc');
+    localStorage.setItem('playerId', 'p1');
+    require('../src/lobby.js');
+    wsInstance.onmessage({ data: JSON.stringify({ type: 'error', error: 'oops' }) });
+    expect(global.alert).toHaveBeenCalledWith('oops');
+    delete global.WebSocket;
+  });
 });


### PR DESCRIPTION
## Summary
- Notify users when server sends error message by adding case in lobby message handler
- Test error messages trigger user alerts

## Testing
- `npx eslint src/lobby.js tests/lobby.test.js`
- `npm test tests/lobby.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af714681c4832c99e43cf4ddb98b6d