### PR TITLE
Ensure env.js is generated for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Simple browser-based Risk-inspired game",
   "scripts": {
     "lint": "eslint .",
-    "start": "http-server .",
-    "dev": "http-server .",
+    "generate-env": "node src/generate-env.js",
+    "start": "npm run generate-env && http-server .",
+    "dev": "npm run generate-env && http-server .",
     "build": "node src/build.js",
     "server": "node src/multiplayer-server.js",
     "simulate": "node src/simulate.js",

--- a/src/build.js
+++ b/src/build.js
@@ -38,8 +38,8 @@ for (const asset of plainAssets) {
 }
 
 // Generate env.js dynamically from environment variables
-const envContent = `window.__ENV = window.__ENV || {\n  SUPABASE_URL: '${process.env.SUPABASE_URL || ''}',\n  SUPABASE_ANON_KEY: '${process.env.SUPABASE_ANON_KEY || ''}',\n  WS_URL: '${process.env.WS_URL || ''}'\n};\n`;
-fs.writeFileSync(path.join(dist, 'env.js'), envContent);
+const generateEnv = require('./generate-env');
+generateEnv(dist);
 
 // Copy additional data files (e.g., map.json)
 fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });

--- a/src/generate-env.js
+++ b/src/generate-env.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+function generateEnv(targetDir) {
+  const envContent = `window.__ENV = window.__ENV || {\n  SUPABASE_URL: '${process.env.SUPABASE_URL || ''}',\n  SUPABASE_ANON_KEY: '${process.env.SUPABASE_ANON_KEY || ''}',\n  WS_URL: '${process.env.WS_URL || ''}'\n};\n`;
+  fs.writeFileSync(path.join(targetDir, 'env.js'), envContent);
+}
+
+if (require.main === module) {
+  const dir = process.argv[2] ? path.resolve(process.argv[2]) : path.join(__dirname, '..');
+  generateEnv(dir);
+}
+
+module.exports = generateEnv;


### PR DESCRIPTION
## Summary
- generate env.js from environment variables with a reusable script
- invoke env generation during build and startup so production always has env.js

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af72437240832caf5e03943150ebab