### PR TITLE
Show validation when creating multiplayer lobby

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -98,7 +98,12 @@ export function initLobby() {
       const name = document.getElementById('roomName').value.trim();
       const maxPlayers = parseInt(document.getElementById('maxPlayers').value, 10);
       const map = document.getElementById('map').value.trim();
-      if (!name || isNaN(maxPlayers) || maxPlayers < 2 || maxPlayers > 6) return;
+      if (!name || isNaN(maxPlayers) || maxPlayers < 2 || maxPlayers > 6) {
+        if (typeof form.reportValidity === 'function') {
+          form.reportValidity();
+        }
+        return;
+      }
       const url = WS_URL;
       if (!url) {
         notifyUser('WebSocket server is not available.');

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -107,10 +107,13 @@ describe('lobby screen', () => {
     global.WebSocket.OPEN = 1;
     require('../src/lobby.js');
     document.getElementById('createBtn').click();
+    const form = document.getElementById('createForm');
+    form.reportValidity = jest.fn();
     document.getElementById('roomName').value = '';
     document.getElementById('maxPlayers').value = '10';
-    document.getElementById('createForm').dispatchEvent(new Event('submit'));
+    form.dispatchEvent(new Event('submit'));
     expect(WebSocket).not.toHaveBeenCalled();
+    expect(form.reportValidity).toHaveBeenCalled();
     delete global.WebSocket;
   });
 


### PR DESCRIPTION
## Summary
- show HTML validation errors when lobby creation form has invalid input
- test that form validation is triggered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7a76b270832cbaccdeb2f116d20b