### PR TITLE
Add Level 3 collectible items and tests

### DIFF
--- a/src/data/special-items.js
+++ b/src/data/special-items.js
@@ -1,0 +1,10 @@
+export const levelItems = {
+  map: { starDust: 0, crystalKey: false, rainbowPortal: false },
+  map2: { starDust: 0, crystalKey: false, rainbowPortal: false },
+  map3: { starDust: 30, crystalKey: true, rainbowPortal: true },
+  "map-roman": { starDust: 0, crystalKey: false, rainbowPortal: false },
+};
+
+export function getLevelItems(levelId) {
+  return levelItems[levelId] || { starDust: 0, crystalKey: false, rainbowPortal: false };
+}

--- a/tests/level-items.test.js
+++ b/tests/level-items.test.js
@@ -1,0 +1,19 @@
+const { getLevelItems } = require('../src/data/special-items.js');
+
+describe('level item availability', () => {
+  test('level 3 has star dust, crystal key, and rainbow portal', () => {
+    const items = getLevelItems('map3');
+    expect(items.starDust).toBe(30);
+    expect(items.crystalKey).toBe(true);
+    expect(items.rainbowPortal).toBe(true);
+  });
+
+  test('other levels lack star dust, key, and portal', () => {
+    ['map', 'map2', 'map-roman'].forEach(id => {
+      const items = getLevelItems(id);
+      expect(items.starDust).toBe(0);
+      expect(items.crystalKey).toBe(false);
+      expect(items.rainbowPortal).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- define per-level special item table with star dust, crystal key, and rainbow portal only for Level 3
- ensure other levels lack these items
- add tests verifying item availability by level

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af901455ac832c8798a6e2de1fffe0