### PR TITLE
feat: add level 3 exclusive obstacles

### DIFF
--- a/src/data/level-obstacles.js
+++ b/src/data/level-obstacles.js
@@ -1,0 +1,20 @@
+export const levelObstacles = {
+  map: {},
+  map2: {},
+  map3: {
+    purpleBrambles: { damage: 'instant' },
+    moonMilk: { respawn: 'checkpoint' },
+    seedWalls: { destructibleWith: 'shield' },
+  },
+  'map-roman': {},
+};
+
+export function getLevelObstacles(levelId) {
+  return (
+    levelObstacles[levelId] || {
+      purpleBrambles: undefined,
+      moonMilk: undefined,
+      seedWalls: undefined,
+    }
+  );
+}

--- a/tests/level-obstacles.test.js
+++ b/tests/level-obstacles.test.js
@@ -1,0 +1,19 @@
+const { getLevelObstacles } = require('../src/data/level-obstacles.js');
+
+describe('level obstacle availability', () => {
+  test('level 3 has purple brambles, moon milk, and seed walls', () => {
+    const obstacles = getLevelObstacles('map3');
+    expect(obstacles.purpleBrambles).toEqual({ damage: 'instant' });
+    expect(obstacles.moonMilk).toEqual({ respawn: 'checkpoint' });
+    expect(obstacles.seedWalls).toEqual({ destructibleWith: 'shield' });
+  });
+
+  test('other levels lack special obstacles', () => {
+    ['map', 'map2', 'map-roman'].forEach(id => {
+      const obstacles = getLevelObstacles(id);
+      expect(obstacles.purpleBrambles).toBeUndefined();
+      expect(obstacles.moonMilk).toBeUndefined();
+      expect(obstacles.seedWalls).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- define purple brambles, moon milk, and seed walls as map3-only obstacles
- test that other maps lack these unique obstacles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af90ed4b04832cbd5671f59d19f60e