### PR TITLE
feat: read config from Vite env

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }]
-  ]
+  ],
+  plugins: ['babel-plugin-transform-vite-meta-env']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/preset-env": "^7.24.0",
         "ajv": "^8.17.1",
         "babel-jest": "^29.7.0",
+        "babel-plugin-transform-vite-meta-env": "^1.0.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "http-server": "^14.1.1",
@@ -1747,6 +1748,16 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -3218,6 +3229,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@babel/preset-env": "^7.24.0",
     "ajv": "^8.17.1",
     "babel-jest": "^29.7.0",
+    "babel-plugin-transform-vite-meta-env": "^1.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "http-server": "^14.1.1",

--- a/src/config.js
+++ b/src/config.js
@@ -1,15 +1,12 @@
-export const SUPABASE_URL = '';
-export const SUPABASE_KEY = '';
-export const WS_URL = (function(){
-  if (SUPABASE_URL) {
-    try {
-      const u = new URL(SUPABASE_URL);
-      return `wss://${u.host}/functions/v1/netrisk`;
-    } catch {
-      // invalid SUPABASE_URL
-    }
-  }
-  console.error('[ENV] Missing SUPABASE_URL/ANON_KEY');
-  return '';
-})();
+export const SUPABASE_URL = (import.meta.env?.VITE_SUPABASE_URL || '').replace(/\/+$/, '');
+export const SUPABASE_KEY = import.meta.env?.VITE_SUPABASE_ANON_KEY || '';
 
+export const WS_URL = (() => {
+  if (!SUPABASE_URL) return '';
+  try {
+    const u = new URL(SUPABASE_URL);
+    return `wss://${u.host}/functions/v1/netrisk`;
+  } catch {
+    return '';
+  }
+})();

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -1,7 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
-export { supabase };
 export default supabase;


### PR DESCRIPTION
## Summary
- pull SUPABASE_URL and SUPABASE_KEY from `import.meta.env`
- compute WebSocket endpoint from `SUPABASE_URL`
- create Supabase client using new config

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68af91c94830832cba3a819f9ee2f8c4