### PR TITLE
Fix YAML syntax in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Guard: no env.js refs
         run: |
-          ! grep -RIn "<script src=[\"']env.js" . || (echo "❌ Found <script src=\"env.js\"> in HTML"; exit 1)
-          ! grep -RIn "window.__ENV" src || (echo "❌ Found window.__ENV in src"; exit 1)
+          if grep -RIn "<script src=['"]env.js" .; then echo "❌ Found <script src=\"env.js\"> in HTML"; exit 1; fi
+          if grep -RIn "window.__ENV" src; then echo "❌ Found window.__ENV in src"; exit 1; fi
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- fix invalid YAML in Pages workflow by replacing `!` with shell conditionals to guard against env.js references

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9af7fb54832cb3790ac01378b7a9