### PR TITLE
feat: add level 3 special items

### DIFF
--- a/src/data/special-items.js
+++ b/src/data/special-items.js
@@ -1,10 +1,12 @@
+const DEFAULT_ITEMS = { starDust: 0, crystalKey: false, rainbowPortal: false };
+
 export const levelItems = {
-  map: { starDust: 0, crystalKey: false, rainbowPortal: false },
-  map2: { starDust: 0, crystalKey: false, rainbowPortal: false },
+  map: { ...DEFAULT_ITEMS },
+  map2: { ...DEFAULT_ITEMS },
   map3: { starDust: 30, crystalKey: true, rainbowPortal: true },
-  "map-roman": { starDust: 0, crystalKey: false, rainbowPortal: false },
+  "map-roman": { ...DEFAULT_ITEMS },
 };
 
 export function getLevelItems(levelId) {
-  return levelItems[levelId] || { starDust: 0, crystalKey: false, rainbowPortal: false };
+  return levelItems[levelId] || { ...DEFAULT_ITEMS };
 }

--- a/tests/level-items.test.js
+++ b/tests/level-items.test.js
@@ -16,4 +16,11 @@ describe('level item availability', () => {
       expect(items.rainbowPortal).toBe(false);
     });
   });
+
+  test('unknown levels default to no special items', () => {
+    const items = getLevelItems('unknown');
+    expect(items.starDust).toBe(0);
+    expect(items.crystalKey).toBe(false);
+    expect(items.rainbowPortal).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- centralize default special items data
- expose 30 star dust, crystal key, and rainbow portal only in level 3
- test that other levels (and unknown levels) receive no special items

## Testing
- `npm test` *(fails: Cannot find module 'babel-plugin-transform-vite-meta-env')*

------
https://chatgpt.com/codex/tasks/task_e_68af9b53a120832cb91bbaf87ff1976c