### PR TITLE
chore: guard against legacy env.js

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,9 +23,27 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Guard: no env.js refs
+        shell: bash
         run: |
-          if grep -RIn "<script src=['"]env.js" .; then echo "❌ Found <script src=\"env.js\"> in HTML"; exit 1; fi
-          if grep -RIn "window.__ENV" src; then echo "❌ Found window.__ENV in src"; exit 1; fi
+          set -euo pipefail
+          cat > guard.sh <<'BASH'
+          set -euo pipefail
+
+          # 1) block if any HTML still includes env.js (search only known entry pages)
+          if grep -RInE '<script\s+src=["'\'']env\.js' index.html setup.html how-to-play.html about.html game.html 2>/dev/null; then
+            echo '❌ Found <script src="env.js"> in HTML'
+            exit 1
+          fi
+
+          # 2) block if source still references window.__ENV
+          if grep -RIn 'window.__ENV' src 2>/dev/null; then
+            echo '❌ Found window.__ENV in src'
+            exit 1
+          fi
+
+          echo '✅ Guard passed: no env.js refs'
+          BASH
+          bash guard.sh
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- ensure Pages workflow blocks env.js or window.__ENV references and reports success when none found

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9ff697b8832c9d230aeda0787012