### PR TITLE
fix: quote guard step name in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Guard: no env.js refs
+      - name: "Guard: no env.js refs"
         run: |
           if grep -RIn "<script src['\\"]env.js" .; then echo "❌ Found <script src=\\"env.js\\"> in HTML"; exit 1; fi
           if grep -RIn "window.__ENV" src; then echo "❌ Found window.__ENV in src"; exit 1; fi


### PR DESCRIPTION
## Summary
- quote colon-containing Guard step name to fix pages workflow syntax

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afa817bcfc832cbd5dc528292aa5bd