### PR TITLE
docs: document Supabase secrets and guard client init

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ npm run build
 
 Il deploy su GitHub Pages è gestito automaticamente tramite GitHub Actions.
 
+### Configurare i secret per Supabase
+
+Per permettere al client di connettersi a Supabase durante il deploy, è
+necessario definire alcuni secret in GitHub:
+
+- `SUPABASE_URL` – l'URL del progetto Supabase.
+- `SUPABASE_ANON_KEY` – la chiave anon del progetto.
+
+Questi secret vengono usati durante la build (`VITE_SUPABASE_URL` e
+`VITE_SUPABASE_ANON_KEY`) e devono essere presenti nell'ambiente
+`github-pages`. Se si desidera distribuire anche le Edge Function, è
+necessario configurare inoltre `SUPABASE_PROJECT_REF` e `SUPABASE_ACCESS_TOKEN`
+per il workflow `supabase-deploy.yml`.
+
 ## Multiplayer
 
 NetRisk ships with a very small WebSocket relay and a plugin that keeps the

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -1,6 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+// Initialize the client only when both URL and key are provided.
+// This avoids hitting Supabase with empty credentials during development
+// or when GitHub Actions secrets are not configured correctly.
+export const supabase =
+  SUPABASE_URL && SUPABASE_KEY ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
+
+if (!supabase) {
+  // eslint-disable-next-line no-console
+  console.warn('Supabase client not initialized: missing URL or anon key');
+}
 
 export default supabase;


### PR DESCRIPTION
## Summary
- clarify required Supabase secrets for GitHub Actions
- avoid initializing Supabase client when URL or anon key are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afaf9a5f04832ca0c5340f8e876de7