### PR TITLE
chore: remove legacy env.js references

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,8 +28,8 @@ jobs:
             echo '❌ Found <script src="env.js"> in HTML'
             exit 1
           fi
-          if grep -RIn -E "window.__ENV" src; then
-            echo '❌ Found window.__ENV in src'
+          if grep -RIn --exclude-dir=.git -E "window.__ENV" .; then
+            echo '❌ Found window.__ENV in repository'
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-env.js


### PR DESCRIPTION
## Summary
- drop leftover env.js ignore
- guard against window.__ENV anywhere in repo

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb26e89e8832cab2bb59e7963678f