### PR TITLE
fix: quote workflow step name

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Guard: no legacy env and src scripts
+      - name: "Guard: no legacy env and src scripts"
         shell: bash
         run: |
           set -e


### PR DESCRIPTION
## Summary
- fix invalid workflow YAML by quoting step name containing colon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afbb21fb9c832cae987305091ec542