### PR TITLE
refactor: centralize Game instance creation

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -99,20 +99,31 @@ class Game {
   }
 
   static async create(players, territories, continents, deck, maxUndoSteps) {
-    if (territories && continents && deck) {
-      return new Game(players, territories, continents, deck, true, true, maxUndoSteps);
-    }
-    try {
-      const map = await loadMapData();
+    const buildGame = (mapData = {}) => {
+      const {
+        territories: mapTerritories = [],
+        continents: mapContinents = [],
+        deck: mapDeck = [],
+      } = mapData;
+
       return new Game(
         players,
-        territories || map.territories,
-        continents || map.continents,
-        deck || map.deck,
+        territories || mapTerritories,
+        continents || mapContinents,
+        deck || mapDeck,
         true,
         true,
         maxUndoSteps
       );
+    };
+
+    if (territories && continents && deck) {
+      return buildGame();
+    }
+
+    try {
+      const map = await loadMapData();
+      return buildGame(map);
     } catch (err) {
       console.error("Unable to load map data, starting with empty map.", err);
       if (typeof alert === "function") {
@@ -123,15 +134,7 @@ class Game {
           console.error("Failed to display alert", alertErr);
         }
       }
-      return new Game(
-        players,
-        territories || [],
-        continents || [],
-        deck || [],
-        true,
-        true,
-        maxUndoSteps
-      );
+      return buildGame();
     }
   }
 


### PR DESCRIPTION
## Summary
- centralize Game instance creation in new buildGame helper
- invoke buildGame for both map load success and error paths

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b017f5f074832caaf33c7d8f9de0d8