### PR TITLE
fix: import updateGameState from correct module

### DIFF
--- a/src/ai-logging.js
+++ b/src/ai-logging.js
@@ -1,6 +1,7 @@
 /* global logger */
 import { REINFORCE, ATTACK } from "./phases.js";
-import { addLogEntry, updateGameState, updateInfoPanel } from "./ui.js";
+import { addLogEntry, updateInfoPanel } from "./ui.js";
+import { updateGameState } from "./state/storage.js";
 import { gameState } from "./state/game.js";
 
 let lastPlayer;


### PR DESCRIPTION
## Summary
- fix ai logging to import updateGameState from state/storage instead of ui

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b01bed7378832c9eec8ab39c57847f