### PR TITLE
refactor: export logger functions

### DIFF
--- a/src/ai-logging.js
+++ b/src/ai-logging.js
@@ -1,8 +1,8 @@
-/* global logger */
 import { REINFORCE, ATTACK } from "./phases.js";
 import { addLogEntry, updateInfoPanel } from "./ui.js";
 import { updateGameState } from "./state/storage.js";
 import { gameState } from "./state/game.js";
+import * as logger from "./logger.js";
 
 let lastPlayer;
 
@@ -17,9 +17,7 @@ export default function attachAIActionLogging(game) {
         type: "reinforce",
         territories: [territory],
       });
-      if (typeof logger !== "undefined") {
-        logger.info(`${name} reinforces ${territory}`);
-      }
+      logger.info(`${name} reinforces ${territory}`);
     }
   });
 
@@ -31,9 +29,7 @@ export default function attachAIActionLogging(game) {
         type: "attack",
         territories: [from, to],
       });
-      if (typeof logger !== "undefined") {
-        logger.info(`${name} attacks ${to} from ${from}`);
-      }
+      logger.info(`${name} attacks ${to} from ${from}`);
     }
   });
 
@@ -45,9 +41,7 @@ export default function attachAIActionLogging(game) {
         type: "move",
         territories: [from, to],
       });
-      if (typeof logger !== "undefined") {
-        logger.info(`${name} moves ${count} from ${from} to ${to}`);
-      }
+      logger.info(`${name} moves ${count} from ${from} to ${to}`);
     }
   });
 
@@ -58,9 +52,7 @@ export default function attachAIActionLogging(game) {
         player: name,
         type: "cards",
       });
-      if (typeof logger !== "undefined") {
-        logger.info(`${name} plays cards`);
-      }
+      logger.info(`${name} plays cards`);
     }
   });
 
@@ -71,9 +63,7 @@ export default function attachAIActionLogging(game) {
       player: name,
       type: "card",
     });
-    if (typeof logger !== "undefined") {
-      logger.info(`${name} receives card ${card.type}`);
-    }
+    logger.info(`${name} receives card ${card.type}`);
   });
 
   game.on("turnStart", ({ player }) => {
@@ -85,9 +75,7 @@ export default function attachAIActionLogging(game) {
         player: prevName,
         type: "endTurn",
       });
-      if (typeof logger !== "undefined") {
-        logger.info(`${prevName} ends turn. Next: ${nextName}`);
-      }
+      logger.info(`${prevName} ends turn. Next: ${nextName}`);
       gameState.turnNumber += 1;
     }
     lastPlayer = player;

--- a/src/game.js
+++ b/src/game.js
@@ -1,4 +1,3 @@
-/* global logger */
 import {
   REINFORCE,
   ATTACK,
@@ -8,6 +7,7 @@ import {
 import { colorPalette } from "./colors.js";
 import EventBus from "./core/event-bus.js";
 import loadJson from "./utils/load-json.js";
+import * as logger from "./logger.js";
 
 async function loadMapData() {
   const mapName =
@@ -19,11 +19,7 @@ async function loadMapData() {
     return await loadJson(jsonPath);
   } catch (err) {
     const msg = `Failed to load map data from ${jsonPath}`;
-    if (typeof logger !== "undefined") {
-      logger.error(msg, err);
-    } else {
-      console.error(msg, err);
-    }
+    logger.error(msg, err);
     throw new Error(`Map data file not found: ${jsonPath}`);
   }
 }

--- a/src/init/game-loader.js
+++ b/src/init/game-loader.js
@@ -1,7 +1,7 @@
-/* global logger */
 import Game from "../game.js";
 import aiTurnManager from "../ai/turn-manager.js";
 import { getMapName, getSavedGame, getSavedPlayers } from "../state/storage.js";
+import * as logger from "../logger.js";
 
 let territoryPositions = {};
 
@@ -18,9 +18,7 @@ async function loadMap(mapName) {
     }, {});
     return map;
   } catch (err) {
-    if (typeof logger !== "undefined") {
-      logger.error("Failed to load map data", err);
-    }
+    logger.error("Failed to load map data", err);
     if (typeof alert !== "undefined") {
       alert("Unable to load game data. Please try again later.");
     }
@@ -38,9 +36,7 @@ function restoreGameState(GameClass, map) {
       map.continents,
       map.deck,
     );
-    if (typeof logger !== "undefined") {
-      logger.info("Game initialised");
-    }
+    logger.info("Game initialised");
   }
   return loadedGame;
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,5 +1,6 @@
-(function () {
-  const overlay = document.createElement("div");
+let overlay;
+if (typeof document !== "undefined") {
+  overlay = document.createElement("div");
   overlay.id = "error-overlay";
   Object.assign(overlay.style, {
     position: "fixed",
@@ -17,20 +18,30 @@
   document.addEventListener("DOMContentLoaded", () => {
     document.body.appendChild(overlay);
   });
+}
 
-  function showError(message) {
+function showError(message) {
+  if (overlay) {
     overlay.textContent = message;
     overlay.classList.remove("hidden");
   }
+}
 
-  window.logger = {
-    info: (...args) => console.log("[INFO]", ...args),
-    warn: (...args) => console.warn("[WARN]", ...args),
-    error: (...args) => console.error("[ERROR]", ...args),
-  };
+export function info(...args) {
+  console.log("[INFO]", ...args);
+}
 
+export function warn(...args) {
+  console.warn("[WARN]", ...args);
+}
+
+export function error(...args) {
+  console.error("[ERROR]", ...args);
+}
+
+if (typeof window !== "undefined") {
   window.onerror = function (msg) {
-    window.logger.error(msg);
+    error(msg);
     showError(msg);
   };
 
@@ -39,7 +50,7 @@
       event.reason && event.reason.message
         ? event.reason.message
         : String(event.reason);
-    window.logger.error(msg);
+    error(msg);
     showError(msg);
   };
-})();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import "./logger.js";
 import cleanupServiceWorkers from "./service-worker-cleanup.js";
 import {
   initGame,

--- a/src/service-worker-cleanup.js
+++ b/src/service-worker-cleanup.js
@@ -1,4 +1,4 @@
-/* global logger */
+import * as logger from "./logger.js";
 // Remove any previously registered service workers to avoid stale caches
 // and log their status so that we know if any were present.
 export default function cleanupServiceWorkers() {
@@ -6,15 +6,11 @@ export default function cleanupServiceWorkers() {
     navigator.serviceWorker
       .getRegistrations()
       .then((regs) => {
-        if (typeof logger !== "undefined") {
-          logger.info(`Found ${regs.length} service worker(s)`);
-        }
+        logger.info(`Found ${regs.length} service worker(s)`);
         regs.forEach((reg) => reg.unregister());
       })
       .catch((err) => {
-        if (typeof logger !== "undefined") {
-          logger.error("Service worker check failed", err);
-        }
+        logger.error("Service worker check failed", err);
       });
   }
 }

--- a/src/state/storage.js
+++ b/src/state/storage.js
@@ -1,4 +1,4 @@
-/* global logger */
+import * as logger from "../logger.js";
 
 // Helper functions to manage persisted state via localStorage
 
@@ -28,9 +28,7 @@ function getSavedGame(GameClass) {
         return GameClass.deserialize(saved);
       }
     } catch (err) {
-      if (typeof logger !== "undefined") {
-        logger.error("Failed to load saved game", err);
-      }
+      logger.error("Failed to load saved game", err);
     }
   }
   return null;
@@ -41,9 +39,7 @@ function saveGame(game) {
     try {
       localStorage.setItem("netriskGame", game.serialize());
     } catch (err) {
-      if (typeof logger !== "undefined") {
-        logger.error("Failed to save game", err);
-      }
+      logger.error("Failed to save game", err);
     }
   }
 }
@@ -64,9 +60,7 @@ function persistAllSavedGames(saves) {
   try {
     localStorage.setItem("netriskSaves", JSON.stringify(saves));
   } catch (err) {
-    if (typeof logger !== "undefined") {
-      logger.error("Failed to persist saves", err);
-    }
+    logger.error("Failed to persist saves", err);
   }
 }
 
@@ -90,9 +84,7 @@ function loadNamedGame(name, GameClass) {
     try {
       return GameClass.deserialize(slot.data);
     } catch (err) {
-      if (typeof logger !== "undefined") {
-        logger.error("Failed to load named game", err);
-      }
+      logger.error("Failed to load named game", err);
     }
   }
   return null;

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -1,8 +1,8 @@
 import { ATTACK, FORTIFY } from "./phases.js";
 import { getBoardScale } from "./ui.js";
+import * as logger from "./logger.js";
 
 export default function initTerritorySelection({
-  logger,
   game,
   territories,
   addLogEntry,
@@ -24,11 +24,9 @@ export default function initTerritorySelection({
       el.classList.add("selected");
       selectedTerritory = { id: el.id, name, el };
       infoPanel.textContent = name;
-      if (logger) {
-        logger.info(
-          `Selected territory: ${selectedTerritory.id} (${selectedTerritory.name})`,
-        );
-      }
+      logger.info(
+        `Selected territory: ${selectedTerritory.id} (${selectedTerritory.name})`,
+      );
       highlightPossibleMoves(el.id);
     } else {
       selectedTerritory = null;
@@ -94,7 +92,7 @@ export default function initTerritorySelection({
           territories: [el.id],
         },
       );
-      logger?.info(
+      logger.info(
         `${game.players[game.currentPlayer].name} moves token to ${name}`,
       );
     }
@@ -103,7 +101,7 @@ export default function initTerritorySelection({
   const moveBtn = document.getElementById("moveToken");
   if (moveBtn) {
     moveBtn.addEventListener("click", () => {
-      logger?.info("Move token clicked");
+      logger.info("Move token clicked");
       try {
         if (selectedTerritory) {
           moveToken(selectedTerritory.el);
@@ -111,7 +109,7 @@ export default function initTerritorySelection({
           addLogEntry?.("No territory selected", { type: "error" });
         }
       } catch (err) {
-        logger?.error(err);
+        logger.error(err);
       }
     });
   }
@@ -195,7 +193,7 @@ export default function initTerritorySelection({
       }
       })
       .catch((err) => {
-        logger?.error(err);
+        logger.error(err);
       });
   }
 

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -1,5 +1,5 @@
-/* global logger */
 import initTerritorySelection from "./territory-selection.js";
+import * as logger from "./logger.js";
 import {
   playEffect,
   preloadEffects,
@@ -114,18 +114,14 @@ function runAI() {
 function attachTerritoryHandlers() {
   document.querySelectorAll(".territory").forEach((el) => {
     el.addEventListener("click", async () => {
-      if (typeof logger !== "undefined") {
-        logger.info(`Territory clicked: ${el.dataset.id}`);
-      }
+      logger.info(`Territory clicked: ${el.dataset.id}`);
       try {
         const prevPlayer = game.currentPlayer;
         const result = game.handleTerritoryClick(el.dataset.id);
         if (result) {
           const playerName = game.players[prevPlayer].name;
           if (result.type === ATTACK) {
-            if (typeof logger !== "undefined") {
-              logger.info(`${playerName} attacks ${result.to} from ${result.from}`);
-            }
+            logger.info(`${playerName} attacks ${result.to} from ${result.from}`);
             const fromEl = document.getElementById(result.from);
             const toEl = document.getElementById(result.to);
             fromEl.classList.add("attack", "animate__animated", "animate__shakeX");
@@ -157,9 +153,7 @@ function attachTerritoryHandlers() {
               territories: [result.from, result.to],
             });
           } else if (result.type === REINFORCE) {
-            if (typeof logger !== "undefined") {
-              logger.info(`${playerName} reinforces ${result.territory}`);
-            }
+            logger.info(`${playerName} reinforces ${result.territory}`);
             animateReinforce(result.territory);
             addLogEntry(`${playerName} reinforces ${result.territory}`, {
               player: playerName,
@@ -167,9 +161,7 @@ function attachTerritoryHandlers() {
               territories: [result.territory],
             });
           } else if (result.type === FORTIFY) {
-            if (typeof logger !== "undefined") {
-              logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
-            }
+            logger.info(`${playerName} moves from ${result.from} to ${result.to}`);
             const move = await askArmiesToMove(result.movableArmies, 1);
             if (move > 0) {
               game.moveArmies(result.from, result.to, move);
@@ -187,16 +179,12 @@ function attachTerritoryHandlers() {
               `${playerName} ends turn. Next: ${nextName}`,
               { player: playerName, type: "endTurn" },
             );
-            if (typeof logger !== "undefined") {
-              logger.info(`${playerName} ends turn. Next: ${nextName}`);
-            }
+            logger.info(`${playerName} ends turn. Next: ${nextName}`);
           }
         }
         updateUI();
         if (result && result.type === "select") {
-          if (typeof logger !== "undefined") {
-            logger.info(`${game.players[game.currentPlayer].name} selects ${result.territory}`);
-          }
+          logger.info(`${game.players[game.currentPlayer].name} selects ${result.territory}`);
           document.getElementById(result.territory).classList.add("selected");
         }
         updateGameState(
@@ -208,9 +196,7 @@ function attachTerritoryHandlers() {
         runAI();
         checkForVictory();
       } catch (err) {
-        if (typeof logger !== "undefined") {
-          logger.error(err);
-        }
+        logger.error(err);
       }
     });
   });
@@ -235,17 +221,13 @@ if (undoBtn) {
         updateInfoPanel();
       }
     } catch (err) {
-      if (typeof logger !== "undefined") {
-        logger.error(err);
-      }
+      logger.error(err);
     }
   });
 }
 
 document.getElementById("endTurn").addEventListener("click", () => {
-  if (typeof logger !== "undefined") {
-    logger.info("End turn clicked");
-  }
+  logger.info("End turn clicked");
   try {
     const prevPlayer = game.currentPlayer;
     const prevPhase = game.getPhase();
@@ -255,20 +237,16 @@ document.getElementById("endTurn").addEventListener("click", () => {
         player: game.players[prevPlayer].name,
         type: "phase",
       });
-      if (typeof logger !== "undefined") {
-        logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
-      }
+      logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
     } else if (prevPhase === FORTIFY && game.getPhase() === REINFORCE) {
       gameState.turnNumber += 1;
       addLogEntry(
         `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
         { player: game.players[prevPlayer].name, type: "endTurn" },
       );
-      if (typeof logger !== "undefined") {
-        logger.info(
-          `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
-        );
-      }
+      logger.info(
+        `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
+      );
     }
     updateUI();
     updateGameState(gameState, game);
@@ -276,9 +254,7 @@ document.getElementById("endTurn").addEventListener("click", () => {
     runAI();
     checkForVictory();
   } catch (err) {
-    if (typeof logger !== "undefined") {
-      logger.error(err);
-    }
+    logger.error(err);
   }
 });
 
@@ -449,7 +425,6 @@ async function initGame() {
     });
   }
   initTerritorySelection({
-    logger,
     game,
     territories: game.territories,
     addLogEntry,

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -9,6 +9,12 @@ jest.mock('../src/navigation.js', () => ({
   exitGame: jest.fn(),
 }));
 
+jest.mock('../src/logger.js', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
 describe('main DOM interactions', () => {
   let main;
   let ui;
@@ -34,7 +40,6 @@ describe('main DOM interactions', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
-    global.logger = { info: jest.fn(), error: jest.fn() };
     main = require('../src/main.js');
     ui = require('../src/ui.js');
       await Promise.resolve();
@@ -173,7 +178,6 @@ describe('main DOM interactions', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(mapData) })
     );
-    global.logger = { info: jest.fn(), error: jest.fn() };
     const main2 = require('../src/main.js');
     require('../src/ui.js');
     await Promise.resolve();

--- a/tests/start-new-game.test.js
+++ b/tests/start-new-game.test.js
@@ -77,7 +77,12 @@ jest.mock("../src/state/game.js", () => ({
   initGameState: jest.fn(),
 }));
 
-global.logger = { info: jest.fn(), error: jest.fn() };
+jest.mock("../src/logger.js", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
 document.body.innerHTML = '<div id="uiPanel"></div><button id="exitGame"></button><button id="endTurn"></button>';
 
 const { startNewGame } = require("../src/main.js");


### PR DESCRIPTION
## Summary
- export logger's info/warn/error and guard DOM access
- import logger module where needed instead of relying on window
- mock logger in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b01a4b035c832c8c025e69f761babf