### PR TITLE
Refactor main entry to use modular initialization

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,1 +1,20 @@
-import './src/main.ts';
+import cleanupServiceWorkers from "./src/service-worker-cleanup.js";
+import {
+  initGame,
+  attachNavigationHandlers,
+  game,
+  territoryPositions,
+  runAI,
+  attachTerritoryHandlers,
+  startNewGame,
+} from "./src/ui-init.js";
+import { initThemeToggle } from "./src/theme.js";
+import { initTutorialButtons } from "./src/tutorial.js";
+
+cleanupServiceWorkers();
+attachNavigationHandlers();
+initGame();
+initThemeToggle();
+initTutorialButtons();
+
+export { game, territoryPositions, runAI, attachTerritoryHandlers, startNewGame };

--- a/src/build.js
+++ b/src/build.js
@@ -14,7 +14,7 @@ function hashContent(content) {
   return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8);
 }
 
-const assets = ['css/base.css', 'css/layout.css', 'css/components.css', 'css/theme.css', 'css/game.css', 'src/logger.js', 'src/main.ts'];
+const assets = ['css/base.css', 'css/layout.css', 'css/components.css', 'css/theme.css', 'css/game.css', 'src/logger.js', 'main.js'];
 const plainAssets = ['map.svg', 'map2.svg', 'map3.svg', 'map-roman.svg', 'src/game.js', 'src/territory-selection.js', 'src/audio.js', 'src/ui.js'];
 const hashed = {};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,2 @@
-import cleanupServiceWorkers from "./service-worker-cleanup.js";
-import {
-  initGame,
-  attachNavigationHandlers,
-  game,
-  territoryPositions,
-  runAI,
-  attachTerritoryHandlers,
-  startNewGame,
-} from "./ui-init.js";
-import { initThemeToggle } from "./theme.js";
-import { initTutorialButtons } from "./tutorial.js";
-
-cleanupServiceWorkers();
-attachNavigationHandlers();
-initGame();
-initThemeToggle();
-initTutorialButtons();
-
-export { game, territoryPositions, runAI, attachTerritoryHandlers, startNewGame };
+import "../main.js";
+export { game, territoryPositions, runAI, attachTerritoryHandlers, startNewGame } from "../main.js";


### PR DESCRIPTION
## Summary
- Simplify `main.js` by importing service worker cleanup, UI init, theme and tutorial modules directly
- Keep compatibility by re-exporting from `src/main.ts`
- Adjust build script to hash `main.js` instead of `src/main.ts`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b024c0a920832c97c8002141d88853