### PR TITLE
Add setup page notice and redirect warning

### DIFF
--- a/game.html
+++ b/game.html
@@ -12,6 +12,10 @@
     <link rel="stylesheet" href="./css/game.css" />
   </head>
   <body class="game-page">
+    <p id="setupNotice">
+      Need to configure players or map? Visit the
+      <a href="setup.html">setup page</a>.
+    </p>
     <header id="gameHeader">
       <button id="exitGame" class="btn">Exit Game</button>
       <div id="turnStatus">Turn <span id="turnNumber">1</span> - <span id="currentPlayer"></span></div>

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -289,6 +289,9 @@ async function initGame() {
     !hasSavedGame() &&
     !IS_TEST
   ) {
+    if (typeof window.alert === "function") {
+      window.alert("No saved players or map found. Redirecting to setup.");
+    }
     navigateTo("setup.html");
     return;
   }


### PR DESCRIPTION
## Summary
- Link users from game screen to setup page for configuring players and map
- Show alert before redirecting to setup when no saved game or players are found

## Testing
- `npm test`
- `npm run lint`
- `node -e "const fs=require('fs'); const {JSDOM}=require('jsdom'); const html=fs.readFileSync('game.html','utf8'); const dom=new JSDOM(html); const notice=dom.window.document.querySelector('#setupNotice'); console.log(notice.textContent.trim());"`


------
https://chatgpt.com/codex/tasks/task_e_68b02c304438832c8fc3da5d67c77a7f