### PR TITLE
Add Playwright UAT tests

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -1,0 +1,18 @@
+name: UAT
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  uat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run test:uat

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Esegui la suite di test e i controlli di lint per verificare le modifiche:
 ```bash
 npm test
 npm run lint
+npm run test:uat
 ```
 
 Per valutare l'equilibrio dell'IA, esegui una serie di partite automatizzate:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.24.0",
         "@babel/preset-typescript": "^7.24.0",
+        "@playwright/test": "^1.55.0",
         "ajv": "^8.17.1",
         "babel-jest": "^29.7.0",
         "babel-plugin-transform-vite-meta-env": "^1.0.3",
@@ -3147,6 +3148,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -7238,6 +7255,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -4,18 +4,20 @@
   "description": "Simple browser-based Risk-inspired game",
   "scripts": {
     "lint": "eslint .",
-      "start": "vite build && http-server dist",
+    "start": "vite build && http-server dist",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "server": "node src/multiplayer-server.js",
     "simulate": "node src/simulate.js",
     "test": "jest",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:uat": "playwright test"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-typescript": "^7.24.0",
+    "@playwright/test": "^1.55.0",
     "ajv": "^8.17.1",
     "babel-jest": "^29.7.0",
     "babel-plugin-transform-vite-meta-env": "^1.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/uat',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('UAT checklist', () => {
+  test('basic gameplay flow', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('netriskPlayers', JSON.stringify([
+        { name: 'Red', color: '#f00' },
+        { name: 'Blue', color: '#00f' },
+      ]));
+      localStorage.setItem('netriskMap', 'map');
+    });
+
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await page.goto('/game.html');
+    await page.waitForSelector('#north-america');
+
+    const terrs = ['#north-america', '#south-america', '#africa'];
+    for (const sel of terrs) {
+      await page.evaluate((s) => {
+        const el = document.querySelector(s);
+        el?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }, sel);
+      const name = await page.getAttribute(sel, 'data-name');
+      await expect(page.locator(sel)).toHaveClass(/selected/);
+      await expect(page.locator('#selectedTerritory')).toHaveText(name!);
+    }
+
+    await page.waitForSelector('#token');
+    const before = await page.locator('#token').evaluate((el) => ({
+      left: (el as HTMLElement).style.left,
+      top: (el as HTMLElement).style.top,
+    }));
+    await page.evaluate(async () => {
+      const mod = await import('/src/main.js');
+      const phases = await import('/src/phases.js');
+      mod.game.setPhase(phases.FORTIFY);
+    });
+    await page.evaluate(() => document.getElementById('moveToken')?.click());
+    await expect(page.locator('#actionLog')).toContainText('moves token');
+    await expect(page.locator('#token')).not.toHaveCSS('left', before.left || '');
+    await expect(page.locator('#token')).not.toHaveCSS('top', before.top || '');
+
+    const turnBefore = await page.locator('#turnNumber').textContent();
+    await page.click('#endTurn');
+    await expect(page.locator('#turnNumber')).not.toHaveText(turnBefore!);
+    await expect(page.locator('#actionLog')).toContainText('ends turn');
+
+    expect(errors).toEqual([]);
+  });
+
+  test('level 3 extras', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('netriskPlayers', JSON.stringify([
+        { name: 'Red', color: '#f00' },
+        { name: 'Blue', color: '#00f' },
+      ]));
+      localStorage.setItem('netriskMap', 'map3');
+    });
+
+    await page.goto('/game.html');
+    await page.waitForSelector('#board');
+
+    await expect(page.locator('body')).toHaveClass(/high-contrast/);
+    await expect(page.locator('body')).toHaveClass(/jump-assist/);
+
+    const hud = await page.evaluate(async () => {
+      const mod = await import('/src/data/level-hud.js');
+      return mod.getHudElements('map3');
+    });
+    expect(hud.starDust).toBeTruthy();
+    expect(hud.crystalKey).toBeTruthy();
+    expect(hud.powerUps).toBeTruthy();
+
+    const music = await page.evaluate(async () => {
+      const mod = await import('/src/audio.js');
+      return mod.getLevelMusic('map3');
+    });
+    expect(music).toContain('fairy-music');
+  });
+});


### PR DESCRIPTION
## Summary
- set up Playwright with dev server and local base URL
- automate user acceptance flow in `tests/uat/uat.spec.ts`
- document and wire up `npm run test:uat` with CI workflow

## Testing
- `npm run test:uat`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b0417f3c20832c9b1af55455420722