### PR TITLE
Add game user flow UATs

### DIFF
--- a/tests/game.uat.test.js
+++ b/tests/game.uat.test.js
@@ -1,0 +1,106 @@
+import { REINFORCE, ATTACK, FORTIFY } from "../src/phases.js";
+
+jest.mock("../src/core/event-bus.js", () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  }));
+});
+
+import Game from "../src/game.js";
+
+describe("game user flows", () => {
+  const baseMap = () => [
+    { id: "a", neighbors: ["b", "c"], x: 0, y: 0, owner: 0, armies: 3 },
+    { id: "b", neighbors: ["a", "c"], x: 0, y: 0, owner: 1, armies: 2 },
+    { id: "c", neighbors: ["a", "b"], x: 0, y: 0, owner: 0, armies: 1 },
+  ];
+
+  let game;
+  const plugin = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    game = new Game(
+      [{ name: "P1" }, { name: "P2" }],
+      baseMap(),
+      [],
+      [],
+      false,
+      false,
+    );
+    game.use(plugin);
+  });
+
+  test("plugin is applied", () => {
+    expect(plugin).toHaveBeenCalledWith(game);
+  });
+
+  test("reinforcement adds armies and switches phase", () => {
+    game.reinforcements = 1;
+    const res = game.handleTerritoryClick("a");
+    expect(res).toEqual({ type: REINFORCE, territory: "a" });
+    expect(game.territoryById("a").armies).toBe(4);
+    expect(game.reinforcements).toBe(0);
+    expect(game.getPhase()).toBe(ATTACK);
+  });
+
+  test("attack conquers territory", () => {
+    game.setPhase(ATTACK);
+    const from = game.territoryById("a");
+    from.armies = 5;
+    const to = game.territoryById("b");
+    to.owner = 1;
+    to.armies = 1;
+    jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.8)
+      .mockReturnValueOnce(0.7)
+      .mockReturnValueOnce(0.1);
+    game.handleTerritoryClick("a");
+    const result = game.handleTerritoryClick("b");
+    Math.random.mockRestore();
+    expect(result.conquered).toBe(true);
+    expect(to.owner).toBe(0);
+  });
+
+  test("fortify moves armies between owned territories", () => {
+    game.setPhase(FORTIFY);
+    const from = game.territoryById("a");
+    from.armies = 4;
+    const to = game.territoryById("c");
+    to.owner = 0;
+    const select = game.handleTerritoryClick("a");
+    expect(select).toEqual({ type: "select", territory: "a" });
+    const fortify = game.handleTerritoryClick("c");
+    expect(fortify).toEqual({ type: FORTIFY, from: "a", to: "c", movableArmies: 3 });
+    const moved = game.moveArmies("a", "c", 2);
+    expect(moved).toBe(true);
+    expect(game.territoryById("a").armies).toBe(2);
+    expect(game.territoryById("c").armies).toBe(3);
+  });
+
+  test("undo and redo revert state", () => {
+    game.setPhase(FORTIFY);
+    game.moveArmies("a", "c", 2);
+    expect(game.canUndo()).toBe(true);
+    game.undo();
+    expect(game.territoryById("a").armies).toBe(3);
+    expect(game.territoryById("c").armies).toBe(1);
+    game.redo();
+    expect(game.territoryById("a").armies).toBe(1);
+    expect(game.territoryById("c").armies).toBe(3);
+  });
+
+  test("serialize and deserialize preserve state", () => {
+    game.setPhase(ATTACK);
+    const state = game.serialize();
+    const clone = Game.deserialize(state);
+    expect(clone.getPhase()).toBe(ATTACK);
+    expect(clone.territoryById("a").armies).toBe(game.territoryById("a").armies);
+    expect(clone.players).toEqual(game.players);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add high level tests for game reinforcement, attack, fortify, undo/redo, and save/load flows
- mock event bus and plugin to focus on state transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b047f8e038832c8bdd852bf5ed563c