### PR TITLE
Add UI UAT tests and document core UI helpers

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -42,6 +42,10 @@ let territoryPositions = {};
 let selectedCards = [];
 let resizeHandler;
 
+/**
+ * Initialize UI state and attach a resize listener that refreshes
+ * rendering when the window size changes.
+ */
 function initUI({ game: g, gameState: gs, territoryPositions: tp }) {
   game = g;
   gameState = gs;
@@ -87,6 +91,10 @@ function highlightTerritories(ids) {
   });
 }
 
+/**
+ * Record a log entry in game state and update the on-screen log if
+ * the corresponding DOM element exists.
+ */
 function addLogEntry(entry, meta = {}) {
   const logEntry =
     typeof entry === "string" ? { message: entry, ...meta } : entry;
@@ -160,6 +168,11 @@ async function copyLog(format = "json", filter) {
   return data;
 }
 
+/**
+ * Create a transient token and animate its movement between two
+ * territories. Tokens fade out and remove themselves when the
+ * animation completes.
+ */
 function animateMove(from, to) {
   const board = getElement("board");
   if (!board) return;
@@ -423,6 +436,10 @@ function updateUndoButton() {
   if (btn) btn.disabled = !game.canUndo();
 }
 
+/**
+ * Refresh all dynamic board elements including territories, token
+ * position, status text, and player utilities.
+ */
 function updateUI() {
   const scale = getBoardScale();
   const playerColorClasses = game.players.map((p) => getColorClass(p.color));
@@ -435,6 +452,10 @@ function updateUI() {
   updateCardsUI();
 }
 
+/**
+ * Remove global listeners and clear cached DOM lookups, returning the
+ * module to an initial state.
+ */
 function destroyUI() {
   if (resizeHandler) {
     window.removeEventListener("resize", resizeHandler);

--- a/tests/ui.uat.test.js
+++ b/tests/ui.uat.test.js
@@ -1,0 +1,82 @@
+import * as ui from '../src/ui.js';
+
+const { initUI, addLogEntry, updateUI, animateMove, destroyUI } = ui;
+
+describe('ui integration', () => {
+  let game;
+  let gameState;
+
+  beforeEach(() => {
+    game = {
+      players: [{ name: 'P1', color: '#f00' }],
+      currentPlayer: 0,
+      territories: [{ id: 't1', owner: 0, armies: 5 }],
+      hands: [[]],
+      continents: [],
+      territoryById: (id) => game.territories.find((t) => t.id === id),
+      getPhase: () => 'attack',
+      reinforcements: 0,
+      canUndo: () => false,
+    };
+    gameState = { currentPlayer: 0, turnNumber: 1, log: [] };
+  });
+
+  afterEach(() => {
+    destroyUI();
+  });
+
+  test('initUI registers resize handler and renders territory', () => {
+    document.body.innerHTML = '<div id="board"></div><div id="t1"></div>';
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    initUI({ game, gameState, territoryPositions: { t1: { x: 0, y: 0 } } });
+    expect(addSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    updateUI();
+    expect(document.getElementById('t1').textContent).toBe('5');
+    addSpy.mockRestore();
+  });
+
+  test('addLogEntry records entry even without DOM', () => {
+    document.body.innerHTML = '';
+    initUI({ game, gameState, territoryPositions: {} });
+    const entry = addLogEntry('hello world');
+    expect(gameState.log).toHaveLength(1);
+    expect(entry.message).toBe('hello world');
+  });
+
+  test('updateUI handles missing elements gracefully', () => {
+    document.body.innerHTML = '<div id="t1"></div>';
+    initUI({ game, gameState, territoryPositions: { t1: { x: 0, y: 0 } } });
+    expect(() => updateUI()).not.toThrow();
+    expect(document.getElementById('t1').textContent).toBe('5');
+  });
+
+  test('animateMove supports multiple simultaneous tokens', () => {
+    document.body.innerHTML = '<div id="board"></div>';
+    const positions = { a: { x: 0, y: 0 }, b: { x: 10, y: 10 }, c: { x: 20, y: 20 } };
+    initUI({ game, gameState, territoryPositions: positions });
+    const raf = global.requestAnimationFrame;
+    global.requestAnimationFrame = (cb) => cb();
+    animateMove('a', 'b');
+    animateMove('b', 'c');
+    const tokens = document.querySelectorAll('.move-token');
+    expect(tokens.length).toBe(2);
+    tokens.forEach((t) => {
+      t.dispatchEvent(new Event('transitionend'));
+      t.dispatchEvent(new Event('animationend'));
+    });
+    expect(document.querySelectorAll('.move-token').length).toBe(0);
+    global.requestAnimationFrame = raf;
+  });
+
+  test('destroyUI removes resize listener', () => {
+    document.body.innerHTML = '<div id="board"></div>';
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    initUI({ game, gameState, territoryPositions: {} });
+    const handler = addSpy.mock.calls.find((c) => c[0] === 'resize')[1];
+    destroyUI();
+    expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- document core UI helpers like `initUI`, `addLogEntry`, `animateMove`, `updateUI`, and `destroyUI`
- add UAT-style Jest tests simulating DOM usage and edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b047fb9590832c990d008af8202969