### PR TITLE
test: add hashContent uat tests

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -2,53 +2,57 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-const root = path.join(__dirname, '..');
-const dist = path.join(root, 'dist');
-
-if (fs.existsSync(dist)) {
-  fs.rmSync(dist, { recursive: true, force: true });
-}
-fs.mkdirSync(dist);
-
 function hashContent(content) {
   return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8);
 }
 
-const assets = ['css/base.css', 'css/layout.css', 'css/components.css', 'css/theme.css', 'css/game.css', 'src/logger.js', 'main.js'];
-const plainAssets = ['map.svg', 'map2.svg', 'map3.svg', 'map-roman.svg', 'src/game.js', 'src/territory-selection.js', 'src/audio.js', 'src/ui.js'];
-const hashed = {};
+module.exports = { hashContent };
 
-for (const asset of assets) {
-  let filePath = path.join(root, asset);
-  let content = fs.readFileSync(filePath, 'utf8');
+if (require.main === module) {
+  const root = path.join(__dirname, '..');
+  const dist = path.join(root, 'dist');
 
-  const hash = hashContent(content);
-  const ext = path.extname(asset);
-  const base = path.basename(asset, ext);
-  const newName = `${base}.${hash}${ext}`;
-  fs.writeFileSync(path.join(dist, newName), content);
-  hashed[asset] = newName;
-}
-
-for (const asset of plainAssets) {
-  const srcPath = path.join(root, asset);
-  const destPath = path.join(dist, asset);
-  fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.copyFileSync(srcPath, destPath);
-}
-// Copy additional data files (e.g., map.json)
-fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });
-
-// Copy all HTML files, replacing references to hashed assets
-const htmlFiles = fs
-  .readdirSync(root)
-  .filter((file) => file.endsWith('.html'));
-
-for (const file of htmlFiles) {
-  let html = fs.readFileSync(path.join(root, file), 'utf8');
-  for (const [orig, hashedName] of Object.entries(hashed)) {
-    html = html.replace(new RegExp(orig, 'g'), hashedName);
+  if (fs.existsSync(dist)) {
+    fs.rmSync(dist, { recursive: true, force: true });
   }
-  fs.writeFileSync(path.join(dist, file), html);
+  fs.mkdirSync(dist);
+
+  const assets = ['css/base.css', 'css/layout.css', 'css/components.css', 'css/theme.css', 'css/game.css', 'src/logger.js', 'main.js'];
+  const plainAssets = ['map.svg', 'map2.svg', 'map3.svg', 'map-roman.svg', 'src/game.js', 'src/territory-selection.js', 'src/audio.js', 'src/ui.js'];
+  const hashed = {};
+
+  for (const asset of assets) {
+    let filePath = path.join(root, asset);
+    let content = fs.readFileSync(filePath, 'utf8');
+
+    const hash = hashContent(content);
+    const ext = path.extname(asset);
+    const base = path.basename(asset, ext);
+    const newName = `${base}.${hash}${ext}`;
+    fs.writeFileSync(path.join(dist, newName), content);
+    hashed[asset] = newName;
+  }
+
+  for (const asset of plainAssets) {
+    const srcPath = path.join(root, asset);
+    const destPath = path.join(dist, asset);
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(srcPath, destPath);
+  }
+  // Copy additional data files (e.g., map.json)
+  fs.cpSync(path.join(root, 'src'), path.join(dist, 'src'), { recursive: true });
+
+  // Copy all HTML files, replacing references to hashed assets
+  const htmlFiles = fs
+    .readdirSync(root)
+    .filter((file) => file.endsWith('.html'));
+
+  for (const file of htmlFiles) {
+    let html = fs.readFileSync(path.join(root, file), 'utf8');
+    for (const [orig, hashedName] of Object.entries(hashed)) {
+      html = html.replace(new RegExp(orig, 'g'), hashedName);
+    }
+    fs.writeFileSync(path.join(dist, file), html);
+  }
 }
 

--- a/tests/build.uat.test.js
+++ b/tests/build.uat.test.js
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+const { hashContent } = require('../src/build');
+
+describe('hashContent', () => {
+  test('produces consistent hash for same content', () => {
+    const content = 'hello world';
+    const expected = 'b94d27b9';
+    expect(hashContent(content)).toBe(expected);
+    expect(hashContent(content)).toBe(expected);
+  });
+
+  test('produces different hashes for different content', () => {
+    const a = hashContent('foo');
+    const b = hashContent('bar');
+    expect(a).not.toBe(b);
+  });
+
+  test('handles empty content', () => {
+    expect(hashContent('')).toBe('e3b0c442');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor build script to export `hashContent` and guard execution
- add UAT tests for `hashContent` consistency, uniqueness, and empty input

## Testing
- `npm test -- tests/build.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0480c9750832cbcecf8c2d7bd1e7d