### PR TITLE
test: add UAT checks for level HUD elements

### DIFF
--- a/tests/level-hud.uat.test.js
+++ b/tests/level-hud.uat.test.js
@@ -1,0 +1,27 @@
+const { getHudElements } = require('../src/data/level-hud.js');
+
+describe('level HUD elements (UAT)', () => {
+  const required = ['starDust', 'crystalKey', 'powerUps'];
+
+  const expectStructure = (hud) => {
+    required.forEach((prop) => expect(hud).toHaveProperty(prop));
+  };
+
+  test.each([
+    ['map', { starDust: false, crystalKey: false, powerUps: false }],
+    ['map2', { starDust: false, crystalKey: false, powerUps: false }],
+    ['map3', { starDust: true, crystalKey: true, powerUps: true }],
+    ['map-roman', { starDust: false, crystalKey: false, powerUps: false }],
+  ])('returns expected HUD for %s', (id, expected) => {
+    const hud = getHudElements(id);
+    expectStructure(hud);
+    expect(hud).toEqual(expected);
+  });
+
+  test('unknown level returns base HUD structure', () => {
+    const hud = getHudElements('unknown-level');
+    expectStructure(hud);
+    expect(hud).toEqual({ starDust: false, crystalKey: false, powerUps: false });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add UAT-level tests asserting HUD elements for each map and unknown levels

## Testing
- `npm test tests/level-hud.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b04814dc94832c9263c86282a2f0c9