### PR TITLE
test: add UAT coverage for level obstacles

### DIFF
--- a/tests/level-obstacles.uat.test.js
+++ b/tests/level-obstacles.uat.test.js
@@ -1,0 +1,19 @@
+const { getLevelObstacles, levelObstacles } = require('../src/data/level-obstacles.js');
+
+describe('getLevelObstacles UAT', () => {
+  const knownLevels = Object.keys(levelObstacles);
+
+  test.each(knownLevels)('returns configured obstacles for %s', level => {
+    expect(getLevelObstacles(level)).toEqual(levelObstacles[level]);
+  });
+
+  test('returns empty obstacle list for unknown level', () => {
+    const obstacles = getLevelObstacles('unknown-level');
+    expect(obstacles).toEqual({
+      purpleBrambles: undefined,
+      moonMilk: undefined,
+      seedWalls: undefined,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add UAT test to ensure known levels return configured obstacles
- verify unknown levels yield empty obstacle map

## Testing
- `npm test tests/level-obstacles.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0482a6534832cbb171833caf38e45