### PR TITLE
Handle move prompt cancellation and bounds

### DIFF
--- a/src/move-prompt.js
+++ b/src/move-prompt.js
@@ -4,26 +4,21 @@ function askArmiesToMove(max, min = 0) {
       resolve(0);
       return;
     }
-    const modal = document.createElement('div');
-    modal.id = 'moveArmiesModal';
-    modal.className = 'modal';
-    modal.innerHTML = `
-      <div class="modal-content">
-        <label>How many armies to move? (${min}-${max})</label>
-        <input type="number" id="moveArmiesInput" min="${min}" max="${max}" value="${max}" />
-        <button id="moveArmiesOk" class="btn">OK</button>
-      </div>`;
-    document.body.appendChild(modal);
-    modal.classList.add('show');
-    const input = modal.querySelector('#moveArmiesInput');
-    const btn = modal.querySelector('#moveArmiesOk');
-    btn.addEventListener('click', () => {
-      let count = parseInt(input.value, 10);
-      if (isNaN(count)) count = min;
-      count = Math.max(min, Math.min(max, count));
-      modal.remove();
-      resolve(count);
-    });
+
+    const input = window.prompt(
+      `How many armies to move? (${min}-${max})`,
+      String(max),
+    );
+
+    if (input === null) {
+      resolve(0);
+      return;
+    }
+
+    let count = parseInt(input, 10);
+    if (isNaN(count)) count = max;
+    count = Math.max(min, Math.min(max, count));
+    resolve(count);
   });
 }
 

--- a/tests/move-prompt.test.js
+++ b/tests/move-prompt.test.js
@@ -2,23 +2,20 @@ import askArmiesToMove from '../src/move-prompt.js';
 
 describe('askArmiesToMove', () => {
   afterEach(() => {
-    document.body.innerHTML = '';
+    jest.restoreAllMocks();
   });
 
   test('resolves 0 immediately when max <= 0', async () => {
+    const spy = jest.spyOn(window, 'prompt');
     const result = await askArmiesToMove(0);
     expect(result).toBe(0);
-    expect(document.getElementById('moveArmiesModal')).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
   });
 
   test('prompts for armies and clamps value', async () => {
-    const promise = askArmiesToMove(5, 1);
-    const input = document.getElementById('moveArmiesInput');
-    const button = document.getElementById('moveArmiesOk');
-    input.value = '10';
-    button.click();
-    const result = await promise;
+    const spy = jest.spyOn(window, 'prompt').mockReturnValue('10');
+    const result = await askArmiesToMove(5, 1);
+    expect(spy).toHaveBeenCalledWith('How many armies to move? (1-5)', '5');
     expect(result).toBe(5);
-    expect(document.getElementById('moveArmiesModal')).toBeNull();
   });
 });

--- a/tests/move-prompt.uat.test.js
+++ b/tests/move-prompt.uat.test.js
@@ -1,0 +1,31 @@
+import askArmiesToMove from '../src/move-prompt.js';
+
+describe('askArmiesToMove user input bounds', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('clamps below minimum', async () => {
+    jest.spyOn(window, 'prompt').mockReturnValue('-5');
+    const result = await askArmiesToMove(5, 1);
+    expect(result).toBe(1);
+  });
+
+  test('clamps above maximum', async () => {
+    jest.spyOn(window, 'prompt').mockReturnValue('10');
+    const result = await askArmiesToMove(5, 1);
+    expect(result).toBe(5);
+  });
+
+  test('defaults to max when input invalid', async () => {
+    jest.spyOn(window, 'prompt').mockReturnValue('');
+    const result = await askArmiesToMove(5, 1);
+    expect(result).toBe(5);
+  });
+
+  test('returns 0 on cancel', async () => {
+    jest.spyOn(window, 'prompt').mockReturnValue(null);
+    const result = await askArmiesToMove(5, 1);
+    expect(result).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- replace DOM-based move prompt with window.prompt that clamps values
- return 0 when user cancels prompt
- add tests covering bounds, default, and cancellation behavior

## Testing
- `npm test tests/move-prompt.test.js tests/move-prompt.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0482c22c0832c86032174e1726f5e