### PR TITLE
test: cover special items for all levels

### DIFF
--- a/tests/special-items.uat.test.js
+++ b/tests/special-items.uat.test.js
@@ -1,0 +1,28 @@
+const { getLevelItems } = require('../src/data/special-items.js');
+
+function toItemArray(items) {
+  return Object.entries(items)
+    .filter(([, value]) => value)
+    .map(([name]) => name);
+}
+
+describe('special items availability', () => {
+  test('map3 includes all special items', () => {
+    const items = getLevelItems('map3');
+    expect(toItemArray(items)).toEqual([
+      'starDust',
+      'crystalKey',
+      'rainbowPortal',
+    ]);
+  });
+
+  test('other and unknown levels provide no special items', () => {
+    ['map', 'map2', 'map-roman', 'unknown'].forEach(id => {
+      const items = getLevelItems(id);
+      expect(toItemArray(items)).toEqual([]);
+      expect(items.starDust).toBe(0);
+      expect(items.crystalKey).toBe(false);
+      expect(items.rainbowPortal).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add UAT test ensuring special item arrays match expectations
- verify levels without special items return defaults

## Testing
- `npx eslint tests/special-items.uat.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0482f2560832c93fde14a692d3860