### PR TITLE
test: add UAT for contrasting color

### DIFF
--- a/tests/colors.uat.test.js
+++ b/tests/colors.uat.test.js
@@ -1,0 +1,11 @@
+import { getContrastingColor } from "../src/colors.js";
+
+describe("getContrastingColor UAT", () => {
+  test("returns black for light colors", () => {
+    expect(getContrastingColor("#eeeeee")).toBe("#000000");
+  });
+
+  test("returns white for dark colors", () => {
+    expect(getContrastingColor("#111111")).toBe("#ffffff");
+  });
+});


### PR DESCRIPTION
## Summary
- document getContrastingColor brightness-based logic
- add user-acceptance tests for light and dark colors

## Testing
- `npm test tests/colors.uat.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0483111b0832c9ef6df7956b52273