### PR TITLE
Add navigation UAT tests for redirect and exit flow

### DIFF
--- a/tests/navigation.uat.test.js
+++ b/tests/navigation.uat.test.js
@@ -1,0 +1,43 @@
+import { navigateTo, goHome, exitGame } from "../src/navigation.js";
+
+describe("navigation UAT", () => {
+  test("navigateTo redirects and updates history", () => {
+    const win = {
+      location: { assign: jest.fn(), pathname: "/base/path/current.html" },
+      history: { pushState: jest.fn() },
+    };
+    navigateTo("next.html", win);
+    expect(win.history.pushState).toHaveBeenCalled();
+    expect(win.location.assign).toHaveBeenCalledWith("/base/path/next.html");
+  });
+
+  test("goHome navigates to index.html", () => {
+    const win = {
+      location: { assign: jest.fn(), pathname: "/app/game.html" },
+      history: { pushState: jest.fn() },
+    };
+    goHome(win);
+    expect(win.location.assign).toHaveBeenCalledWith("/app/index.html");
+  });
+
+  test("exitGame confirms before navigating home", () => {
+    const win = {
+      confirm: jest.fn(() => true),
+      location: { assign: jest.fn(), pathname: "/game/play.html" },
+      history: { pushState: jest.fn() },
+    };
+    exitGame(win, "Are you sure?");
+    expect(win.confirm).toHaveBeenCalledWith("Are you sure?");
+    expect(win.location.assign).toHaveBeenCalledWith("/game/index.html");
+  });
+
+  test("exitGame aborts navigation when cancelled", () => {
+    const win = {
+      confirm: jest.fn(() => false),
+      location: { assign: jest.fn(), pathname: "/game/play.html" },
+      history: { pushState: jest.fn() },
+    };
+    exitGame(win);
+    expect(win.location.assign).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add user acceptance tests for navigation helpers
- ensure exitGame confirmation and goHome redirects work as expected

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b048348344832caf7cdf120b9998fc