### PR TITLE
Add audio UAT tests and export helpers with error handling

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -55,10 +55,23 @@ function loadAudio(src) {
     cache.set(src, null);
     return null;
   }
-  const a = new Audio();
-  a.src = src;
-  cache.set(src, a);
-  return a;
+  try {
+    const a = new Audio();
+    cache.set(src, a);
+    a.addEventListener(
+      "error",
+      () => {
+        console.warn(`Missing audio file: ${src}`);
+        cache.set(src, null);
+      },
+      { once: true }
+    );
+    a.src = src;
+    return a;
+  } catch {
+    cache.set(src, null);
+    return null;
+  }
 }
 
 function playEffect(name) {
@@ -156,8 +169,12 @@ function preloadEffects() {
 }
 
 export {
+  saveSettings,
+  loadAudio,
   playEffect,
-  preloadEffects,
+  ensureMusic,
+  setLevelMusic,
+  getLevelMusic,
   setMasterVolume,
   getMasterVolume,
   setEffectsVolume,
@@ -166,7 +183,6 @@ export {
   isMuted,
   setMusicEnabled,
   isMusicEnabled,
-  setLevelMusic,
-  getLevelMusic,
+  preloadEffects,
 };
 

--- a/tests/audio.uat.test.js
+++ b/tests/audio.uat.test.js
@@ -1,0 +1,108 @@
+describe('audio user acceptance', () => {
+  let audio;
+  let playMock;
+  let audioObj;
+  let store;
+
+  beforeEach(() => {
+    jest.resetModules();
+    store = {};
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: jest.fn((k) => store[k]),
+        setItem: jest.fn((k, v) => {
+          store[k] = v;
+        }),
+      },
+      configurable: true,
+    });
+    playMock = jest.fn().mockResolvedValue();
+    audioObj = {
+      play: playMock,
+      pause: jest.fn(),
+      addEventListener: jest.fn(),
+      currentTime: 0,
+      _volume: 1,
+      set volume(v) {
+        this._volume = v;
+      },
+      get volume() {
+        return this._volume;
+      },
+      muted: false,
+    };
+    global.Audio = jest.fn(() => audioObj);
+    // eslint-disable-next-line global-require
+    audio = require('../src/audio.js');
+  });
+
+  test('persists volume and mute settings', () => {
+    audio.setMasterVolume(0.7);
+    audio.setEffectsVolume(0.6);
+    audio.setMuted(true);
+    const saved = JSON.parse(
+      global.localStorage.setItem.mock.calls[
+        global.localStorage.setItem.mock.calls.length - 1
+      ][1]
+    );
+    expect(saved.master).toBe(0.7);
+    expect(saved.effects).toBe(0.6);
+    expect(saved.muted).toBe(true);
+    expect(audio.getMasterVolume()).toBe(0.7);
+    expect(audio.getEffectsVolume()).toBe(0.6);
+    expect(audio.isMuted()).toBe(true);
+  });
+
+  test('playEffect respects volume and mute', () => {
+    audio.setMuted(false);
+    audio.setMasterVolume(0.8);
+    audio.setEffectsVolume(0.5);
+    audio.playEffect('reinforce');
+    expect(playMock).toHaveBeenCalled();
+    expect(audioObj._volume).toBeCloseTo(0.4);
+
+    playMock.mockClear();
+    audio.setMuted(true);
+    audio.playEffect('reinforce');
+    expect(playMock).not.toHaveBeenCalled();
+  });
+
+  test('handles missing audio files gracefully', () => {
+    jest.resetModules();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const storage = {};
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: jest.fn((k) => storage[k]),
+        setItem: jest.fn((k, v) => {
+          storage[k] = v;
+        }),
+      },
+      configurable: true,
+    });
+    const errAudio = {
+      play: jest.fn(),
+      pause: jest.fn(),
+      currentTime: 0,
+      _volume: 1,
+      set volume(v) {
+        this._volume = v;
+      },
+      get volume() {
+        return this._volume;
+      },
+      muted: false,
+      addEventListener: (event, handler) => {
+        if (event === 'error') handler();
+      },
+    };
+    global.Audio = jest.fn(() => errAudio);
+    // eslint-disable-next-line global-require
+    const mod = require('../src/audio.js');
+    mod.loadAudio('missing.mp3');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing.mp3'));
+    expect(mod.loadAudio('missing.mp3')).toBeNull();
+    warn.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- export all audio helper functions and handle missing audio files
- add UAT coverage for volume, mute, and effect playback behaviour

## Testing
- `npm test tests/audio.test.js tests/level-audio.test.js tests/audio.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b04835d668832c8e7b0fcdbc57d137