### PR TITLE
test(logger): ensure logging and global handlers

### DIFF
--- a/tests/logger.uat.test.js
+++ b/tests/logger.uat.test.js
@@ -1,0 +1,53 @@
+describe('logger', () => {
+  let info, warn, error, overlay;
+
+  beforeAll(() => {
+    ({ info, warn, error } = require('../src/logger.js'));
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    overlay = document.getElementById('error-overlay');
+  });
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    if (overlay) {
+      overlay.textContent = '';
+      overlay.classList.add('hidden');
+    }
+  });
+
+  test('info logs with prefix', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    info('hello');
+    expect(logSpy).toHaveBeenCalledWith('[INFO]', 'hello');
+  });
+
+  test('warn logs with prefix', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    warn('oops');
+    expect(warnSpy).toHaveBeenCalledWith('[WARN]', 'oops');
+  });
+
+  test('error logs with prefix', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    error('bad');
+    expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'bad');
+  });
+
+  test('window.onerror logs and shows overlay', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(overlay.classList.contains('hidden')).toBe(true);
+    window.onerror('boom');
+    expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'boom');
+    expect(overlay.textContent).toBe('boom');
+    expect(overlay.classList.contains('hidden')).toBe(false);
+  });
+
+  test('window.onunhandledrejection logs and shows overlay', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(overlay.classList.contains('hidden')).toBe(true);
+    window.onunhandledrejection({ reason: new Error('async boom') });
+    expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'async boom');
+    expect(overlay.textContent).toBe('async boom');
+    expect(overlay.classList.contains('hidden')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for logger API functions and window error handlers

## Testing
- `npm test tests/logger.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b04836ab70832cb15f774b83c7142a