### PR TITLE
Add AI battle probability UAT tests

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -16,7 +16,7 @@ function enumerateRolls(dice) {
   return rolls;
 }
 
-function battleOutcomeProbs(attDice, defDice) {
+export function battleOutcomeProbs(attDice, defDice) {
   const key = `${attDice}v${defDice}`;
   if (battleCache[key]) return battleCache[key];
   const aRolls = enumerateRolls(attDice);

--- a/tests/ai.uat.test.js
+++ b/tests/ai.uat.test.js
@@ -1,0 +1,45 @@
+import { battleOutcomeProbs, territoryPriority } from '../src/ai.js';
+
+class MockGame {
+  constructor(map) {
+    this.map = map;
+  }
+  territoryById(id) {
+    return this.map[id];
+  }
+}
+
+describe('battleOutcomeProbs', () => {
+  test('probabilities sum to 1', () => {
+    const outcomes = battleOutcomeProbs(3, 2);
+    const total = outcomes.reduce((sum, o) => sum + o.prob, 0);
+    expect(total).toBeCloseTo(1, 10);
+  });
+
+  test('memoizes results for dice combinations', () => {
+    const first = battleOutcomeProbs(3, 2);
+    const second = battleOutcomeProbs(3, 2);
+    expect(second).toBe(first);
+  });
+});
+
+describe('territoryPriority', () => {
+  test('applies profile styles to scoring', () => {
+    const map = {
+      b: { owner: 1 },
+      c: { owner: 2 },
+      d: { owner: 0 }
+    };
+    const game = new MockGame(map);
+    const territory = { id: 'a', owner: 0, neighbors: ['b', 'c', 'd'], armies: 5 };
+
+    const base = territoryPriority(game, territory);
+    const aggressive = territoryPriority(game, territory, { style: 'aggressive' });
+    const defensive = territoryPriority(game, territory, { style: 'defensive' });
+
+    expect(base).toBe(15);
+    expect(aggressive).toBe(20);
+    expect(defensive).toBe(10);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Export `battleOutcomeProbs` for test access
- Add UAT tests covering battle outcome probabilities, memoization, and profile-based territory prioritization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b048379bf8832cac057ebdbbca8ec3