### PR TITLE
test: add game state synchronization tests

### DIFF
--- a/tests/state-game.uat.test.js
+++ b/tests/state-game.uat.test.js
@@ -1,0 +1,34 @@
+import Game from "../src/game.js";
+import { gameState, initGameState, setSelectedTerritory } from "../src/state/game.js";
+
+test("initGameState synchronizes game properties", () => {
+  const players = [{ name: "A" }, { name: "B" }];
+  const territories = [
+    { id: "t1", neighbors: [], x: 0, y: 0 },
+    { id: "t2", neighbors: [], x: 1, y: 1 },
+  ];
+  const game = new Game(players, territories, [], [], false, false);
+  initGameState(game);
+
+  expect(gameState.currentPlayer).toBe(game.currentPlayer);
+  expect(gameState.players).toBe(game.players);
+  expect(gameState.territories).toBe(game.territories);
+  expect(gameState.phase).toBe(game.getPhase());
+});
+
+test("setSelectedTerritory updates selection", () => {
+  const players = [{ name: "A" }, { name: "B" }];
+  const territories = [
+    { id: "t1", neighbors: [], x: 0, y: 0 },
+    { id: "t2", neighbors: [], x: 1, y: 1 },
+  ];
+  const game = new Game(players, territories, [], [], false, false);
+  initGameState(game);
+  const selected = game.territories[0];
+
+  setSelectedTerritory(selected);
+  expect(gameState.selectedTerritory).toBe(selected);
+
+  setSelectedTerritory(null);
+  expect(gameState.selectedTerritory).toBeNull();
+});


### PR DESCRIPTION
## Summary
- verify that `initGameState` mirrors a `Game` instance's core properties
- ensure `setSelectedTerritory` updates the state selection reference

## Testing
- `npm test tests/state-game.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b048396fcc832c8950c1cb0ca2c334