### PR TITLE
test: add EventBus UAT coverage

### DIFF
--- a/tests/event-bus.uat.test.js
+++ b/tests/event-bus.uat.test.js
@@ -1,0 +1,45 @@
+import EventBus from '../src/core/event-bus.js';
+
+describe('EventBus UAT', () => {
+  test('registers handler and emits events', () => {
+    const bus = new EventBus();
+    const handler = jest.fn();
+    bus.on('ping', handler);
+
+    bus.emit('ping', 'data');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith('data');
+  });
+
+  test('removes handler so it no longer receives events', () => {
+    const bus = new EventBus();
+    const handler = jest.fn();
+    const off = bus.on('ping', handler);
+
+    off();
+    bus.emit('ping');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('isolates errors thrown by handlers', () => {
+    const bus = new EventBus();
+    const errorHandler = jest.fn(() => {
+      throw new Error('bad');
+    });
+    const goodHandler = jest.fn();
+    bus.on('ping', errorHandler);
+    bus.on('ping', goodHandler);
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => bus.emit('ping')).not.toThrow();
+    expect(errorHandler).toHaveBeenCalled();
+    expect(goodHandler).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add UAT tests covering EventBus handler registration, removal, and error isolation

## Testing
- `npm test tests/event-bus.uat.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0483d5ec4832cbd9d0480da58f374