### PR TITLE
feat: add dead-zone camera for level 3

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -1,0 +1,41 @@
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function updateCamera(player, camera, level, viewport, opts) {
+  const { deadZoneWidthPct, deadZoneHeightPct, cameraLerp } = opts;
+  const dzWidth = viewport.width * deadZoneWidthPct;
+  const dzHeight = viewport.height * deadZoneHeightPct;
+  const offsetX = (viewport.width - dzWidth) / 2;
+  const offsetY = (viewport.height - dzHeight) / 2;
+
+  let targetX = camera.x;
+  let targetY = camera.y;
+
+  const dzLeft = camera.x + offsetX;
+  const dzRight = dzLeft + dzWidth;
+  const dzTop = camera.y + offsetY;
+  const dzBottom = dzTop + dzHeight;
+
+  if (player.x < dzLeft) targetX = player.x - offsetX;
+  else if (player.x > dzRight) targetX = player.x - offsetX - dzWidth;
+
+  if (player.y < dzTop) targetY = player.y - offsetY;
+  else if (player.y > dzBottom) targetY = player.y - offsetY - dzHeight;
+
+  const maxX = Math.max(0, level.width - viewport.width);
+  const maxY = Math.max(0, level.height - viewport.height);
+  targetX = Math.min(Math.max(0, targetX), maxX);
+  targetY = Math.min(Math.max(0, targetY), maxY);
+
+  return {
+    x: lerp(camera.x, targetX, cameraLerp),
+    y: lerp(camera.y, targetY, cameraLerp),
+  };
+}
+
+export function getParallaxOffset(camera, factor) {
+  return { x: -camera.x * factor, y: -camera.y * factor };
+}
+
+export default { updateCamera, getParallaxOffset };

--- a/src/data/level-camera.js
+++ b/src/data/level-camera.js
@@ -1,0 +1,13 @@
+export const levelCamera = {
+  map3: { deadZoneWidthPct: 0.5, deadZoneHeightPct: 0.5, cameraLerp: 0.1 },
+};
+
+export function getLevelCamera(levelId) {
+  return (
+    levelCamera[levelId] || {
+      deadZoneWidthPct: 1,
+      deadZoneHeightPct: 1,
+      cameraLerp: 1,
+    }
+  );
+}

--- a/tests/camera.test.js
+++ b/tests/camera.test.js
@@ -1,0 +1,36 @@
+const { updateCamera, getParallaxOffset } = require('../src/camera.js');
+
+function approx(value) {
+  return Number(value.toFixed(5));
+}
+
+describe('dead-zone camera', () => {
+  const viewport = { width: 100, height: 100 };
+  const level = { width: 300, height: 200 };
+  const params = { deadZoneWidthPct: 0.5, deadZoneHeightPct: 0.5, cameraLerp: 0.5 };
+
+  test('camera stays while player in dead-zone', () => {
+    const camera = { x: 0, y: 0 };
+    const p1 = { x: 50, y: 50 };
+    const next = updateCamera(p1, camera, level, viewport, params);
+    expect(next).toEqual({ x: 0, y: 0 });
+  });
+
+  test('camera moves smoothly and clamps', () => {
+    let camera = { x: 0, y: 0 };
+    // move to right
+    camera = updateCamera({ x: 100, y: 50 }, camera, level, viewport, params);
+    expect(approx(camera.x)).toBe(12.5);
+    // extreme right triggers clamp
+    camera = updateCamera({ x: 290, y: 50 }, camera, level, viewport, params);
+    expect(camera.x).toBeLessThanOrEqual(200);
+    expect(camera.x).toBeGreaterThan(12.5);
+  });
+
+  test('parallax uses camera position', () => {
+    const off1 = getParallaxOffset({ x: 0, y: 0 }, 0.5);
+    const off2 = getParallaxOffset({ x: 50, y: 0 }, 0.5);
+    expect(off1.x).toBeCloseTo(0);
+    expect(off2.x).toBe(-25);
+  });
+});

--- a/tests/level-camera.test.js
+++ b/tests/level-camera.test.js
@@ -1,0 +1,21 @@
+const { getLevelCamera } = require('../src/data/level-camera.js');
+
+describe('level camera params', () => {
+  test('level 3 defines dead-zone and lerp', () => {
+    const cam = getLevelCamera('map3');
+    expect(cam.deadZoneWidthPct).toBe(0.5);
+    expect(cam.deadZoneHeightPct).toBe(0.5);
+    expect(cam.cameraLerp).toBe(0.1);
+  });
+
+  test('other levels use default camera', () => {
+    ['map', 'map2', 'map-roman'].forEach((id) => {
+      const cam = getLevelCamera(id);
+      expect(cam).toEqual({
+        deadZoneWidthPct: 1,
+        deadZoneHeightPct: 1,
+        cameraLerp: 1,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add level-specific camera parameters for map3
- implement dead-zone camera logic with smoothing and parallax helper
- test camera behaviour and configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07f57d48c832cbb54b8187372e974