### PR TITLE
Normalize lobby schema and add chat table

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -44,7 +44,12 @@ async function fetchLobbies() {
     return;
   }
   const { data } = await supabase.from('lobbies').select();
-  currentLobbies.splice(0, currentLobbies.length, ...(data || []));
+  const normalized = (data || []).map(row => ({
+    ...row,
+    currentPlayer: row.current_player,
+    maxPlayers: row.max_players,
+  }));
+  currentLobbies.splice(0, currentLobbies.length, ...normalized);
   renderLobbies(currentLobbies);
 }
 

--- a/src/netriskRealtime.ts
+++ b/src/netriskRealtime.ts
@@ -22,7 +22,18 @@ export function subscribeToMatch<S extends GameState = GameState, A = unknown, R
     channel.on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: 'events', filter: `match_id=eq.${matchId}` },
-      (payload) => handlers.onEvent?.(payload.new as Event<A, R>)
+      (payload) => {
+        const row = payload.new as any;
+        const ev: Event<A, R> = {
+          id: row.id,
+          matchId: row.match_id,
+          playerId: row.player_id,
+          action: row.action,
+          result: row.result,
+          createdAt: row.created_at,
+        };
+        handlers.onEvent?.(ev);
+      }
     );
   }
 

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -44,10 +44,10 @@ export const persistLobby = async (lobby) => {
       ...(lastSeen ? { lastSeen } : {}),
     })),
     started: lobby.started,
-    currentPlayer: lobby.currentPlayer,
+    current_player: lobby.currentPlayer,
     state: lobby.state,
     map: lobby.map,
-    maxPlayers: lobby.maxPlayers,
+    max_players: lobby.maxPlayers,
   };
   try {
     await supabase.from("lobbies").upsert(row, { onConflict: "code" });
@@ -76,9 +76,9 @@ export const loadLobby = async (lobbies, code, offlinePlayerTimeout) => {
         players: (data.players || []).map((p) => ({ ...p, ws: null })),
         state: data.state || null,
         started: data.started || false,
-        currentPlayer: data.currentPlayer || null,
+        currentPlayer: data.current_player || null,
         map: data.map || null,
-        maxPlayers: data.maxPlayers || 6,
+        maxPlayers: data.max_players || 6,
       };
       const cutoff = Date.now() - offlinePlayerTimeout;
       lobby.players = lobby.players.filter(

--- a/supabase/migrations/202406120001_lobby_chat_and_snake_case.sql
+++ b/supabase/migrations/202406120001_lobby_chat_and_snake_case.sql
@@ -1,0 +1,16 @@
+-- Rename camelCase columns in lobbies and add lobby_chat table
+alter table lobbies rename column currentplayer to current_player;
+alter table lobbies rename column maxplayers to max_players;
+
+create table if not exists lobby_chat (
+  code text references lobbies(code) on delete cascade,
+  id text,
+  text text,
+  created_at timestamptz default now()
+);
+
+alter table lobby_chat enable row level security;
+create policy "allow_select_lobby_chat" on lobby_chat
+  for select using (true);
+
+alter publication supabase_realtime add table lobby_chat;


### PR DESCRIPTION
## Summary
- rename Supabase lobby columns to snake_case and introduce lobby_chat table
- map Supabase lobby and event fields to camelCase in server, client, and realtime helper

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b0827b5adc832cb12559332eb539e9