### PR TITLE
Enable lobby chat inserts with RLS policy

### DIFF
--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -44,10 +44,10 @@ export const persistLobby = async (lobby) => {
       ...(lastSeen ? { lastSeen } : {}),
     })),
     started: lobby.started,
-    currentPlayer: lobby.currentPlayer,
+    current_player: lobby.currentPlayer,
     state: lobby.state,
     map: lobby.map,
-    maxPlayers: lobby.maxPlayers,
+    max_players: lobby.maxPlayers,
   };
   try {
     await supabase.from("lobbies").upsert(row, { onConflict: "code" });
@@ -76,9 +76,9 @@ export const loadLobby = async (lobbies, code, offlinePlayerTimeout) => {
         players: (data.players || []).map((p) => ({ ...p, ws: null })),
         state: data.state || null,
         started: data.started || false,
-        currentPlayer: data.currentPlayer || null,
+        currentPlayer: data.current_player || null,
         map: data.map || null,
-        maxPlayers: data.maxPlayers || 6,
+        maxPlayers: data.max_players || 6,
       };
       const cutoff = Date.now() - offlinePlayerTimeout;
       lobby.players = lobby.players.filter(

--- a/supabase/migrations/202405170001_lobbies.sql
+++ b/supabase/migrations/202405170001_lobbies.sql
@@ -4,10 +4,10 @@ create table if not exists lobbies (
   host text,
   players jsonb,
   started boolean default false,
-  currentPlayer text,
+  current_player text,
   state jsonb,
   map text,
-  maxPlayers integer default 6
+  max_players integer default 6
 );
 
 alter table lobbies enable row level security;
@@ -15,3 +15,21 @@ create policy "allow_select_lobbies" on lobbies
   for select using (true);
 
 alter publication supabase_realtime add table lobbies;
+
+-- Rename existing camelCase columns to snake_case if needed
+alter table lobbies rename column currentplayer to current_player;
+alter table lobbies rename column maxplayers to max_players;
+
+-- Chat messages for lobbies
+create table if not exists lobby_chat (
+  code text references lobbies(code) on delete cascade,
+  id text,
+  text text,
+  created_at timestamptz default now()
+);
+
+alter table lobby_chat enable row level security;
+create policy "allow_select_lobby_chat" on lobby_chat
+  for select using (true);
+create policy "allow_insert_lobby_chat" on lobby_chat
+  for insert with check (true);


### PR DESCRIPTION
## Summary
- allow inserting rows into `lobby_chat` by adding an insert policy
- persist and load lobbies using snake_case columns to match updated schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09fa87bd4832c87a40d82cfa8f90d