### PR TITLE
refactor: encapsulate game state

### DIFF
--- a/src/ai-logging.js
+++ b/src/ai-logging.js
@@ -94,7 +94,7 @@ export default function attachAIActionLogging(game) {
         type: "endTurn",
       });
       logInfo(`${prevName} ends turn. Next: ${nextName}`);
-      gameState.turnNumber += 1;
+      gameState.incrementTurnNumber();
     }
     lastPlayer = player;
     updateGameState(gameState, game);

--- a/src/state/game.js
+++ b/src/state/game.js
@@ -1,32 +1,92 @@
 import { REINFORCE } from "../phases.js";
 
-// Centralized game state object used by the application.
-// Keeping this in a dedicated module decouples the game's
-// logic from any particular UI implementation.
-const gameState = {
-  turnNumber: 1,
-  currentPlayer: 0,
-  players: [],
-  territories: [],
-  selectedTerritory: null,
-  tokenPosition: null,
-  phase: REINFORCE,
-  log: [],
-};
+// Factory for encapsulated game state. Consumers interact via
+// getters/setters rather than mutating a shared object directly.
+class GameState {
+  constructor() {
+    this._state = {
+      turnNumber: 1,
+      currentPlayer: 0,
+      players: [],
+      territories: [],
+      selectedTerritory: null,
+      tokenPosition: null,
+      phase: REINFORCE,
+      log: [],
+    };
+  }
 
-// Initialize the game state from a Game instance
+  // --- getters exposing read-only views ---
+  get turnNumber() {
+    return this._state.turnNumber;
+  }
+  get currentPlayer() {
+    return this._state.currentPlayer;
+  }
+  get players() {
+    return [...this._state.players];
+  }
+  get territories() {
+    return [...this._state.territories];
+  }
+  get selectedTerritory() {
+    return this._state.selectedTerritory;
+  }
+  get tokenPosition() {
+    return this._state.tokenPosition;
+  }
+  get phase() {
+    return this._state.phase;
+  }
+  get log() {
+    return [...this._state.log];
+  }
+
+  // Return a frozen snapshot of the current state
+  getSnapshot() {
+    return Object.freeze({
+      ...this._state,
+      players: [...this._state.players],
+      territories: [...this._state.territories],
+      log: [...this._state.log],
+    });
+  }
+
+  // --- mutation helpers ---
+  initFromGame(game) {
+    if (!game) return;
+    this._state.currentPlayer = game.currentPlayer;
+    this._state.players = game.players;
+    this._state.territories = game.territories;
+    this._state.phase = game.getPhase();
+  }
+
+  setSelectedTerritory(selected) {
+    this._state.selectedTerritory = selected;
+  }
+
+  setTokenPosition(pos) {
+    this._state.tokenPosition = pos;
+  }
+
+  incrementTurnNumber() {
+    this._state.turnNumber += 1;
+  }
+
+  addLogEntry(entry) {
+    this._state.log.push(entry);
+  }
+}
+
+const gameState = new GameState();
+
 function initGameState(game) {
-  if (!game) return;
-  gameState.currentPlayer = game.currentPlayer;
-  gameState.players = game.players;
-  gameState.territories = game.territories;
-  gameState.phase = game.getPhase();
+  gameState.initFromGame(game);
 }
 
-// Helper to update only the selected territory reference
 function setSelectedTerritory(selected) {
-  gameState.selectedTerritory = selected;
+  gameState.setSelectedTerritory(selected);
 }
 
-export { gameState, initGameState, setSelectedTerritory };
+export { GameState, gameState, initGameState, setSelectedTerritory };
 export default gameState;

--- a/src/state/storage.js
+++ b/src/state/storage.js
@@ -142,11 +142,8 @@ function hasSavedGame() {
 
 function updateGameState(gameState, game, selected = null) {
   if (!gameState || !game) return;
-  gameState.currentPlayer = game.currentPlayer;
-  gameState.players = game.players;
-  gameState.territories = game.territories;
-  gameState.phase = game.getPhase();
-  gameState.selectedTerritory = selected;
+  gameState.initFromGame(game);
+  gameState.setSelectedTerritory(selected);
   saveGame(game);
 }
 

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -80,7 +80,7 @@ export default function initTerritorySelection({
       token.style.top = `${y * scale.y}px`;
     }
     if (gameState) {
-      gameState.tokenPosition = { x, y };
+      gameState.setTokenPosition({ x, y });
     }
     if (addLogEntry && game) {
       const name = el.dataset.name || el.id;

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -174,7 +174,7 @@ function attachTerritoryHandlers() {
             }
             game.endTurn();
             const nextName = game.players[game.currentPlayer].name;
-            gameState.turnNumber += 1;
+            gameState.incrementTurnNumber();
             addLogEntry(
               `${playerName} ends turn. Next: ${nextName}`,
               { player: playerName, type: "endTurn" },
@@ -239,7 +239,7 @@ document.getElementById("endTurn").addEventListener("click", () => {
       });
       logger.info(`${game.players[prevPlayer].name} enters fortify phase`);
     } else if (prevPhase === FORTIFY && game.getPhase() === REINFORCE) {
-      gameState.turnNumber += 1;
+      gameState.incrementTurnNumber();
       addLogEntry(
         `${game.players[prevPlayer].name} ends turn. Next: ${game.players[game.currentPlayer].name}`,
         { player: game.players[prevPlayer].name, type: "endTurn" },

--- a/src/ui.js
+++ b/src/ui.js
@@ -99,7 +99,7 @@ function addLogEntry(entry, meta = {}) {
   const logEntry =
     typeof entry === "string" ? { message: entry, ...meta } : entry;
   if (logEntry.turn == null) logEntry.turn = gameState?.turnNumber;
-  gameState.log.push(logEntry);
+  gameState.addLogEntry(logEntry);
   const logEl = getElement("actionLog");
   if (logEl) {
     // rebuild log using DOM nodes to avoid innerHTML

--- a/tests/state-game.uat.test.js
+++ b/tests/state-game.uat.test.js
@@ -10,10 +10,11 @@ test("initGameState synchronizes game properties", () => {
   const game = new Game(players, territories, [], [], false, false);
   initGameState(game);
 
-  expect(gameState.currentPlayer).toBe(game.currentPlayer);
-  expect(gameState.players).toBe(game.players);
-  expect(gameState.territories).toBe(game.territories);
-  expect(gameState.phase).toBe(game.getPhase());
+  const snapshot = gameState.getSnapshot();
+  expect(snapshot.currentPlayer).toBe(game.currentPlayer);
+  expect(snapshot.players).toEqual(game.players);
+  expect(snapshot.territories).toEqual(game.territories);
+  expect(snapshot.phase).toBe(game.getPhase());
 });
 
 test("setSelectedTerritory updates selection", () => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -14,6 +14,7 @@ import {
   exportLog,
   copyLog,
 } from '../src/ui.js';
+import { GameState } from "../src/state/game.js";
 
 describe('ui utilities', () => {
   let game;
@@ -50,7 +51,7 @@ describe('ui utilities', () => {
       ],
       territoryById: (id) => game.territories.find(t => t.id === id)
     };
-    gameState = { currentPlayer: 0, turnNumber: 1, log: [] };
+    gameState = new GameState();
     const territoryPositions = { from: { x: 0, y: 0 }, to: { x: 10, y: 10 } };
     initUI({ game, gameState, territoryPositions });
   });

--- a/tests/ui.uat.test.js
+++ b/tests/ui.uat.test.js
@@ -1,4 +1,5 @@
 import * as ui from '../src/ui.js';
+import { GameState } from "../src/state/game.js";
 
 const { initUI, addLogEntry, updateUI, animateMove, destroyUI } = ui;
 
@@ -18,7 +19,7 @@ describe('ui integration', () => {
       reinforcements: 0,
       canUndo: () => false,
     };
-    gameState = { currentPlayer: 0, turnNumber: 1, log: [] };
+    gameState = new GameState();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- encapsulate game state in a GameState class with read-only getters and snapshot API
- update modules to mutate state via methods (token position, turn number, log entries)
- adjust tests for the new GameState interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a280e64c832ca75961660afbd4a9