### PR TITLE
refactor storage keys and add tests

### DIFF
--- a/src/state/storage.js
+++ b/src/state/storage.js
@@ -1,10 +1,16 @@
 import * as logger from "../logger.js";
 
+// Storage keys
+const KEY_MAP = "netriskMap";
+const KEY_PLAYERS = "netriskPlayers";
+const KEY_GAME = "netriskGame";
+const KEY_SAVES = "netriskSaves";
+
 // Helper functions to manage persisted state via localStorage
 
 function getMapName() {
   if (typeof localStorage !== "undefined") {
-    return localStorage.getItem("netriskMap") || "map";
+    return localStorage.getItem(KEY_MAP) || "map";
   }
   return "map";
 }
@@ -12,7 +18,7 @@ function getMapName() {
 function getSavedPlayers() {
   if (typeof localStorage !== "undefined") {
     try {
-      return JSON.parse(localStorage.getItem("netriskPlayers")) || [];
+      return JSON.parse(localStorage.getItem(KEY_PLAYERS)) || [];
     } catch {
       return [];
     }
@@ -23,7 +29,7 @@ function getSavedPlayers() {
 function getSavedGame(GameClass) {
   if (typeof localStorage !== "undefined") {
     try {
-      const saved = localStorage.getItem("netriskGame");
+      const saved = localStorage.getItem(KEY_GAME);
       if (saved && GameClass) {
         return GameClass.deserialize(saved);
       }
@@ -37,7 +43,7 @@ function getSavedGame(GameClass) {
 function saveGame(game) {
   if (typeof localStorage !== "undefined" && game) {
     try {
-      localStorage.setItem("netriskGame", game.serialize());
+      localStorage.setItem(KEY_GAME, game.serialize());
     } catch (err) {
       logger.error("Failed to save game", err);
     }
@@ -49,7 +55,7 @@ function saveGame(game) {
 function getAllSavedGames() {
   if (typeof localStorage === "undefined") return {};
   try {
-    return JSON.parse(localStorage.getItem("netriskSaves")) || {};
+    return JSON.parse(localStorage.getItem(KEY_SAVES)) || {};
   } catch {
     return {};
   }
@@ -58,7 +64,7 @@ function getAllSavedGames() {
 function persistAllSavedGames(saves) {
   if (typeof localStorage === "undefined") return;
   try {
-    localStorage.setItem("netriskSaves", JSON.stringify(saves));
+    localStorage.setItem(KEY_SAVES, JSON.stringify(saves));
   } catch (err) {
     logger.error("Failed to persist saves", err);
   }
@@ -121,21 +127,21 @@ function deleteSavedGame(name) {
 
 function clearSavedData() {
   if (typeof localStorage !== "undefined") {
-    localStorage.removeItem("netriskGame");
-    localStorage.removeItem("netriskPlayers");
+    localStorage.removeItem(KEY_GAME);
+    localStorage.removeItem(KEY_PLAYERS);
   }
 }
 
 function hasSavedPlayers() {
   if (typeof localStorage !== "undefined") {
-    return !!localStorage.getItem("netriskPlayers");
+    return !!localStorage.getItem(KEY_PLAYERS);
   }
   return false;
 }
 
 function hasSavedGame() {
   if (typeof localStorage !== "undefined") {
-    return !!localStorage.getItem("netriskGame");
+    return !!localStorage.getItem(KEY_GAME);
   }
   return false;
 }
@@ -148,6 +154,10 @@ function updateGameState(gameState, game, selected = null) {
 }
 
 export {
+  KEY_MAP,
+  KEY_PLAYERS,
+  KEY_GAME,
+  KEY_SAVES,
   getMapName,
   getSavedGame,
   getSavedPlayers,

--- a/tests/storage-keys.test.js
+++ b/tests/storage-keys.test.js
@@ -1,0 +1,88 @@
+import {
+  KEY_MAP,
+  KEY_PLAYERS,
+  KEY_GAME,
+  KEY_SAVES,
+  getMapName,
+  getSavedPlayers,
+  getSavedGame,
+  saveGame,
+  saveNamedGame,
+  loadNamedGame,
+  clearSavedData,
+  hasSavedPlayers,
+  hasSavedGame,
+} from "../src/state/storage.js";
+
+describe("storage helpers use correct keys", () => {
+  beforeEach(() => {
+    const store = {};
+    Object.defineProperty(global, "localStorage", {
+      value: {
+        getItem: jest.fn(key => store[key] || null),
+        setItem: jest.fn((key, value) => {
+          store[key] = String(value);
+        }),
+        removeItem: jest.fn(key => {
+          delete store[key];
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete global.localStorage;
+  });
+
+  test("getMapName reads KEY_MAP", () => {
+    getMapName();
+    expect(global.localStorage.getItem).toHaveBeenCalledWith(KEY_MAP);
+  });
+
+  test("getSavedPlayers reads KEY_PLAYERS", () => {
+    global.localStorage.getItem.mockReturnValue("[]");
+    getSavedPlayers();
+    expect(global.localStorage.getItem).toHaveBeenCalledWith(KEY_PLAYERS);
+  });
+
+  test("getSavedGame reads KEY_GAME", () => {
+    getSavedGame();
+    expect(global.localStorage.getItem).toHaveBeenCalledWith(KEY_GAME);
+  });
+
+  test("saveGame writes KEY_GAME", () => {
+    const game = { serialize: () => "{}" };
+    saveGame(game);
+    expect(global.localStorage.setItem).toHaveBeenCalledWith(KEY_GAME, "{}");
+  });
+
+  test("saveNamedGame writes KEY_SAVES", () => {
+    const game = { serialize: () => "{}" };
+    saveNamedGame("slot", game);
+    expect(global.localStorage.setItem).toHaveBeenCalledWith(KEY_SAVES, expect.any(String));
+  });
+
+  test("loadNamedGame reads KEY_SAVES", () => {
+    const payload = JSON.stringify({ slot: { data: "{}", map: "map", savedAt: 0, turn: 0 } });
+    global.localStorage.getItem.mockReturnValue(payload);
+    loadNamedGame("slot", { deserialize: () => ({}) });
+    expect(global.localStorage.getItem).toHaveBeenCalledWith(KEY_SAVES);
+  });
+
+  test("clearSavedData removes KEY_GAME and KEY_PLAYERS", () => {
+    clearSavedData();
+    expect(global.localStorage.removeItem).toHaveBeenCalledWith(KEY_GAME);
+    expect(global.localStorage.removeItem).toHaveBeenCalledWith(KEY_PLAYERS);
+  });
+
+  test("hasSavedPlayers reads KEY_PLAYERS", () => {
+    hasSavedPlayers();
+    expect(global.localStorage.getItem).toHaveBeenCalledWith(KEY_PLAYERS);
+  });
+
+  test("hasSavedGame reads KEY_GAME", () => {
+    hasSavedGame();
+    expect(global.localStorage.getItem).toHaveBeenCalledWith(KEY_GAME);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize storage key strings into exported constants
- add tests verifying storage helpers use the correct keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a4cc6494832cbb1a3cd3f714df7f