### PR TITLE
Add typed interfaces for NetRisk API and realtime

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  testMatch: ['**/*.test.js'],
+  testMatch: ['**/*.test.[jt]s'],
   transform: {
     '^.+\\.[tj]s$': 'babel-jest'
   }

--- a/src/netriskApi.ts
+++ b/src/netriskApi.ts
@@ -1,6 +1,34 @@
 import { SUPABASE_URL, SUPABASE_KEY } from './config.js';
 import type { Match, Player, GameState, Event } from './types/netrisk';
 
+// Request/response types for the NetRisk API
+export interface CreateMatchRequest {
+  action: 'create_match';
+  player: Player;
+}
+export type CreateMatchResponse = Match;
+
+export interface JoinMatchRequest {
+  action: 'join_match';
+  matchId: string;
+  player: Player;
+}
+export type JoinMatchResponse = Match;
+
+export interface StartMatchRequest {
+  action: 'start_match';
+  matchId: string;
+}
+export type StartMatchResponse = GameState;
+
+export interface ActionRequest<TAction extends Record<string, unknown>> {
+  action: 'action';
+  matchId: string;
+  playerId: string;
+  payload: TAction;
+}
+export type ActionResponse<TAction, TResult> = Event<TAction, TResult>;
+
 const functionUrl = `${SUPABASE_URL}/functions/v1/netrisk`;
 
 async function call<TResponse, TBody extends object>(body: TBody): Promise<TResponse> {
@@ -18,25 +46,24 @@ async function call<TResponse, TBody extends object>(body: TBody): Promise<TResp
 }
 
 export const createMatch = (player: Player) =>
-  call<Match, { action: string; player: Player }>({ action: 'create_match', player });
+  call<CreateMatchResponse, CreateMatchRequest>({ action: 'create_match', player });
 
 export const joinMatch = (matchId: string, player: Player) =>
-  call<Match, { action: string; matchId: string; player: Player }>({
-    action: 'join_match',
-    matchId,
-    player,
-  });
+  call<JoinMatchResponse, JoinMatchRequest>({ action: 'join_match', matchId, player });
 
 export const startMatch = (matchId: string) =>
-  call<GameState, { action: string; matchId: string }>({ action: 'start_match', matchId });
+  call<StartMatchResponse, StartMatchRequest>({ action: 'start_match', matchId });
 
 export const sendAction = <TAction extends Record<string, unknown>, TResult = unknown>(
   matchId: string,
   playerId: string,
   payload: TAction
 ) =>
-  call<Event<TAction, TResult>, { action: string; matchId: string; playerId: string; payload: TAction }>(
-    { action: 'action', matchId, playerId, payload }
-  );
+  call<ActionResponse<TAction, TResult>, ActionRequest<TAction>>({
+    action: 'action',
+    matchId,
+    playerId,
+    payload,
+  });
 
 export default { createMatch, joinMatch, startMatch, sendAction };

--- a/src/netriskRealtime.ts
+++ b/src/netriskRealtime.ts
@@ -2,27 +2,37 @@ import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_KEY } from './config.js';
 import type { GameState, Event } from './types/netrisk';
 
+// Types for realtime subscription requests and payloads
+export interface MatchSubscriptionHandlers<S extends GameState, A, R> {
+  onState?: (state: S) => void;
+  onEvent?: (ev: Event<A, R>) => void;
+}
+
+interface RealtimePayload<T> {
+  new: T;
+}
+
 const client = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 export function subscribeToMatch<S extends GameState = GameState, A = unknown, R = unknown>(
   matchId: string,
-  handlers: { onState?: (state: S) => void; onEvent?: (ev: Event<A, R>) => void }
+  handlers: MatchSubscriptionHandlers<S, A, R>
 ) {
   const channel = client.channel(`netrisk:${matchId}`);
 
   if (handlers.onState) {
-    channel.on(
+    (channel as any).on(
       'postgres_changes',
       { event: '*', schema: 'public', table: 'game_states', filter: `match_id=eq.${matchId}` },
-      (payload) => handlers.onState?.((payload.new as { state: S }).state)
+      (payload: RealtimePayload<{ state: S }>) => handlers.onState?.(payload.new.state)
     );
   }
 
   if (handlers.onEvent) {
-    channel.on(
+    (channel as any).on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: 'events', filter: `match_id=eq.${matchId}` },
-      (payload) => handlers.onEvent?.(payload.new as Event<A, R>)
+      (payload: RealtimePayload<Event<A, R>>) => handlers.onEvent?.(payload.new)
     );
   }
 

--- a/tests/netriskApi.uat.test.ts
+++ b/tests/netriskApi.uat.test.ts
@@ -1,4 +1,10 @@
-import { createMatch, joinMatch, startMatch, sendAction } from '../src/netriskApi.ts';
+import {
+  createMatch,
+  joinMatch,
+  startMatch,
+  sendAction,
+  type CreateMatchResponse,
+} from '../src/netriskApi.ts';
 
 jest.mock('../src/config.js', () => ({
   SUPABASE_URL: 'https://example.supabase.co',
@@ -24,7 +30,7 @@ describe('netriskApi', () => {
 
   test('createMatch sends correct payload', async () => {
     const player = { id: 'p1' };
-    const res = await createMatch(player);
+    const res: CreateMatchResponse = await createMatch(player);
     expect(fetchMock).toHaveBeenCalledWith(functionUrl, {
       method: 'POST',
       headers,

--- a/tests/netriskRealtime.test.ts
+++ b/tests/netriskRealtime.test.ts
@@ -1,0 +1,49 @@
+import { subscribeToMatch } from '../src/netriskRealtime.ts';
+import type { Event } from '../src/types/netrisk';
+
+// Mock Supabase client
+const stateHandlers: any = {};
+const eventHandlers: any = {};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    channel: jest.fn(() => ({
+      on: jest.fn((_, cfg: any, cb: any) => {
+        if (cfg.table === 'game_states') stateHandlers.cb = cb;
+        if (cfg.table === 'events') eventHandlers.cb = cb;
+        return this;
+      }),
+      subscribe: jest.fn(),
+    })),
+    removeChannel: jest.fn(),
+  })),
+}));
+
+describe('netriskRealtime', () => {
+  test('subscribeToMatch forwards realtime payloads', () => {
+    const onState = jest.fn();
+    const onEvent = jest.fn();
+    const unsubscribe = subscribeToMatch('m1', { onState, onEvent });
+    const client = (require('@supabase/supabase-js').createClient as jest.Mock).mock
+      .results[0].value;
+    const channel = client.channel.mock.results[0].value;
+
+    // simulate incoming messages
+    stateHandlers.cb({ new: { state: { turn: 1 } } });
+    expect(onState).toHaveBeenCalledWith({ turn: 1 });
+
+    const ev: Event<{ move: string }, { ok: boolean }> = {
+      id: 'e1',
+      matchId: 'm1',
+      playerId: 'p1',
+      action: { move: 'attack' },
+      result: { ok: true },
+      createdAt: 'now',
+    };
+    eventHandlers.cb({ new: ev });
+    expect(onEvent).toHaveBeenCalledWith(ev);
+
+    unsubscribe();
+    expect(client.removeChannel).toHaveBeenCalledWith(channel);
+  });
+});


### PR DESCRIPTION
## Summary
- define request/response interfaces for NetRisk API actions and use them throughout
- add typed handlers and payload wrappers for realtime subscriptions
- enable TypeScript tests and add coverage for realtime subscription

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b0a6eb5600832cbdf9ff05cefb23b1