### PR TITLE
fix: remove map assets copy step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Stage static files
         run: |
           if [ -d dist ]; then true; elif [ -d build ]; then mv build dist; elif [ -d out ]; then mv out dist; else mkdir -p dist; fi
-          cp -r map*.svg map-manifest.json supabase dist/
+          cp -r supabase dist/
       - name: Upload artifact (Pages)
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- stop copying map svg files in Pages workflow and only copy supabase directory

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b0b0e8fa50832c8adbf8512d6a66ae