### PR TITLE
Handle failed map fetch in territory selection

### DIFF
--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -119,7 +119,14 @@ export default function initTerritorySelection({
       localStorage.getItem("netriskMap")) ||
     "map";
   fetch(`assets/maps/${mapName}.svg`)
-    .then((r) => r.text())
+    .then((r) => {
+      if (!r.ok) {
+        const boardEl = document.getElementById("board");
+        boardEl.textContent = "Error loading map";
+        throw new Error(`Failed to load map: ${r.status}`);
+      }
+      return r.text();
+    })
     .then((svg) => {
       const boardEl = document.getElementById("board");
       boardEl.innerHTML = svg;

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -26,7 +26,7 @@ describe('Accessibility features', () => {
     const svg =
       '<svg id="map"><path id="A" class="map-territory"/><path id="B" class="map-territory"/></svg>';
     global.fetch = jest.fn(() =>
-      Promise.resolve({ text: () => Promise.resolve(svg) }),
+      Promise.resolve({ ok: true, text: () => Promise.resolve(svg) }),
     );
     const territories = [
       { id: 'A', name: 'Alpha' },

--- a/tests/map3.test.js
+++ b/tests/map3.test.js
@@ -43,7 +43,9 @@ describe('territory-selection with map3', () => {
     document.body.innerHTML = '<div id="board"></div><div id="selectedTerritory"></div>';
     localStorage.setItem('netriskMap', 'map3');
     const svg = fs.readFileSync('public/assets/maps/map3.svg', 'utf8');
-    global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(svg) }));
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve(svg) }),
+    );
     const init = require('../src/territory-selection.js').default;
     init({ territories: map.territories });
     await flushPromises();
@@ -56,7 +58,9 @@ describe('territory-selection with map3', () => {
     document.body.innerHTML = '<div id="board"></div><div id="selectedTerritory"></div>';
     localStorage.setItem('netriskMap', 'map3');
     const svg = fs.readFileSync('public/assets/maps/map3.svg', 'utf8');
-    global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(svg) }));
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve(svg) }),
+    );
     const init = require('../src/territory-selection.js').default;
     init({ territories: map.territories });
     await flushPromises();

--- a/tests/territory-selection.moves.test.js
+++ b/tests/territory-selection.moves.test.js
@@ -6,7 +6,9 @@ const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 test('selecting territory highlights possible moves', async () => {
   document.body.innerHTML = '<div id="board"></div><div id="selectedTerritory"></div>';
   const svg = '<svg id="map"><path id="A" class="map-territory"/><path id="B" class="map-territory"/><path id="C" class="map-territory"/></svg>';
-  global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(svg) }));
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, text: () => Promise.resolve(svg) }),
+  );
   const territories = [
     { id: 'A', neighbors: ['B'], owner: 0 },
     { id: 'B', neighbors: ['A', 'C'], owner: 1 },

--- a/tests/territory-selection.uat.test.js
+++ b/tests/territory-selection.uat.test.js
@@ -36,7 +36,7 @@ describe('territory selection user flow', () => {
       '</svg>';
 
     global.fetch = jest.fn(() =>
-      Promise.resolve({ text: () => Promise.resolve(svg) })
+      Promise.resolve({ ok: true, text: () => Promise.resolve(svg) })
     );
 
     const territories = [


### PR DESCRIPTION
## Summary
- show an error if the SVG map fetch fails
- avoid inserting invalid markup when the response isn't ok
- update tests to mock successful fetch responses

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0bde7aba8832cbe68a3e6220457a0