### PR TITLE
chore: enable CI test workflows

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   tests:
-    if: false
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/playwright:v1.46.0-jammy
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   tests:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- enable PR tests by removing `if: false` guards in the test workflows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c82382e0832cbf55578f199a6daf