### PR TITLE
Add world8 map with schema data

### DIFF
--- a/public/assets/maps/world8.svg
+++ b/public/assets/maps/world8.svg
@@ -1,0 +1,27 @@
+<svg id="world8" viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+  <rect width="600" height="400" fill="#87ceeb" />
+  <!-- North America -->
+  <path id="north-america" class="map-territory" data-name="North America"
+    d="M50 60 L150 40 L200 100 L160 140 L120 160 L80 120 Z" fill="#c8e6c9" />
+  <!-- South America -->
+  <path id="south-america" class="map-territory" data-name="South America"
+    d="M120 160 L160 180 L180 260 L140 350 L100 300 Z" fill="#c8e6c9" />
+  <!-- Europe -->
+  <path id="europe" class="map-territory" data-name="Europe"
+    d="M220 60 L340 60 L300 140 L250 100 Z" fill="#c8e6c9" />
+  <!-- Asia -->
+  <path id="asia" class="map-territory" data-name="Asia"
+    d="M340 60 L560 60 L580 140 L520 180 L400 160 L340 120 Z" fill="#c8e6c9" />
+  <!-- Middle East -->
+  <path id="middle-east" class="map-territory" data-name="Middle East"
+    d="M300 140 L400 160 L350 180 L300 170 Z" fill="#c8e6c9" />
+  <!-- Africa -->
+  <path id="africa" class="map-territory" data-name="Africa"
+    d="M300 140 L360 180 L380 260 L340 340 L300 280 L280 200 Z" fill="#c8e6c9" />
+  <!-- Australia -->
+  <path id="australia" class="map-territory" data-name="Australia"
+    d="M470 260 L540 260 L560 300 L520 340 L460 320 Z" fill="#c8e6c9" />
+  <!-- Antarctica -->
+  <path id="antarctica" class="map-territory" data-name="Antarctica"
+    d="M200 360 L400 360 L380 390 L220 390 Z" fill="#c8e6c9" />
+</svg>

--- a/src/data/world8.json
+++ b/src/data/world8.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "territories": [
+    { "id": "north-america", "neighbors": ["south-america", "europe"], "x": 110, "y": 90 },
+    { "id": "south-america", "neighbors": ["north-america", "africa", "antarctica"], "x": 140, "y": 260 },
+    { "id": "europe", "neighbors": ["north-america", "asia", "africa", "middle-east"], "x": 280, "y": 90 },
+    { "id": "asia", "neighbors": ["europe", "middle-east", "australia"], "x": 450, "y": 100 },
+    { "id": "middle-east", "neighbors": ["europe", "asia", "africa"], "x": 340, "y": 160 },
+    { "id": "africa", "neighbors": ["south-america", "europe", "middle-east", "antarctica"], "x": 320, "y": 260 },
+    { "id": "australia", "neighbors": ["asia", "antarctica"], "x": 500, "y": 300 },
+    { "id": "antarctica", "neighbors": ["south-america", "africa", "australia"], "x": 300, "y": 380 }
+  ],
+  "continents": [
+    { "name": "North America", "territories": ["north-america"], "bonus": 2 },
+    { "name": "South America", "territories": ["south-america"], "bonus": 2 },
+    { "name": "Europe", "territories": ["europe"], "bonus": 2 },
+    { "name": "Asia", "territories": ["asia"], "bonus": 2 },
+    { "name": "Middle East", "territories": ["middle-east"], "bonus": 2 },
+    { "name": "Africa", "territories": ["africa"], "bonus": 2 },
+    { "name": "Australia", "territories": ["australia"], "bonus": 2 },
+    { "name": "Antarctica", "territories": ["antarctica"], "bonus": 2 }
+  ],
+  "deck": [
+    { "territory": "north-america", "type": "infantry" },
+    { "territory": "north-america", "type": "cavalry" },
+    { "territory": "north-america", "type": "artillery" },
+    { "territory": "south-america", "type": "infantry" },
+    { "territory": "south-america", "type": "cavalry" },
+    { "territory": "south-america", "type": "artillery" },
+    { "territory": "europe", "type": "infantry" },
+    { "territory": "europe", "type": "cavalry" },
+    { "territory": "europe", "type": "artillery" },
+    { "territory": "asia", "type": "infantry" },
+    { "territory": "asia", "type": "cavalry" },
+    { "territory": "asia", "type": "artillery" },
+    { "territory": "middle-east", "type": "infantry" },
+    { "territory": "middle-east", "type": "cavalry" },
+    { "territory": "middle-east", "type": "artillery" },
+    { "territory": "africa", "type": "infantry" },
+    { "territory": "africa", "type": "cavalry" },
+    { "territory": "africa", "type": "artillery" },
+    { "territory": "australia", "type": "infantry" },
+    { "territory": "australia", "type": "cavalry" },
+    { "territory": "australia", "type": "artillery" },
+    { "territory": "antarctica", "type": "infantry" },
+    { "territory": "antarctica", "type": "cavalry" },
+    { "territory": "antarctica", "type": "artillery" }
+  ]
+}

--- a/tests/map-schema.test.js
+++ b/tests/map-schema.test.js
@@ -1,6 +1,6 @@
 const validateMap = require('../src/validate-map.js');
 
-const maps = ['map.json', 'map2.json', 'map3.json', 'map-roman.json'];
+const maps = ['map.json', 'map2.json', 'map3.json', 'map-roman.json', 'world8.json'];
 
 describe('map schema validation', () => {
   test.each(maps)('%s matches schema', (file) => {


### PR DESCRIPTION
## Summary
- add world8.svg map with 8 territory regions
- define world8.json map data and update schema tests

## Testing
- `npm test -- tests/map-schema.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0c797da9c832c81e7cb973872a4b0