### PR TITLE
Reorganize game sidebar layout

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -199,7 +199,12 @@ body.game-page #uiPanel .btn {
   }
 }
 
+#turnInfo,
 #gameActions,
+#selectedTerritory,
+#cardPanel,
+#logSection,
+#howToPlayBox,
 #otherControls {
   margin-top: 10px;
   border: 1px solid #ccc;
@@ -208,6 +213,8 @@ body.game-page #uiPanel .btn {
 }
 
 #gameActions .btn,
+#cardPanel .btn,
+#howToPlayBox .btn,
 #otherControls .btn {
   display: block;
   width: 100%;

--- a/game.html
+++ b/game.html
@@ -18,11 +18,41 @@
     </p>
     <header id="gameHeader">
       <button id="exitGame" class="btn">Exit Game</button>
-      <div id="turnStatus">Turn <span id="turnNumber">1</span> - <span id="currentPlayer"></span></div>
     </header>
     <div id="gameContainer">
       <div id="board" class="board"></div>
       <div id="uiPanel">
+        <div id="turnInfo">
+          <div><strong>Turn:</strong> <span id="turnNumber">1</span></div>
+          <div><strong>Player:</strong> <span id="currentPlayer"></span></div>
+          <div><strong>Phase:</strong> <span id="status"></span></div>
+          <div><strong>Reinforcements:</strong> <span id="reinforcements">0</span></div>
+          <div><strong>Dice:</strong> <span id="diceResults"></span></div>
+          <div><strong>Phase time:</strong> <span id="phaseTimer"></span></div>
+        </div>
+        <div id="gameActions">
+          <strong>Game Actions:</strong>
+          <button
+            id="moveToken"
+            class="btn"
+            aria-label="Move Token"
+            accesskey="v"
+          >
+            Move Token
+          </button>
+          <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
+            Undo
+          </button>
+          <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
+            End Turn
+          </button>
+        </div>
+        <div id="selectedTerritory"></div>
+        <div id="cardPanel"></div>
+        <div id="logSection">
+          <strong>Action log:</strong>
+          <div id="actionLog" class="log"></div>
+        </div>
         <div id="howToPlayBox">
           <div>
             <strong>How to play (alpha)</strong>
@@ -42,29 +72,6 @@
           </ol>
           <button id="replayTutorial" class="btn">Play Tutorial</button>
         </div>
-        <div id="gameActions">
-          <strong>Game Actions:</strong>
-          <button
-            id="moveToken"
-            class="btn"
-            aria-label="Move Token"
-            accesskey="v"
-          >
-            Move Token
-          </button>
-          <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
-            Undo
-          </button>
-          <button id="endTurn" class="btn" aria-label="End Turn" accesskey="e">
-            End Turn
-          </button>
-        </div>
-        <div id="status"></div>
-        <div>Phase time: <span id="phaseTimer"></span></div>
-        <div id="diceResults"></div>
-        <div id="selectedTerritory"></div>
-        <div><strong>Action log:</strong></div>
-        <div id="actionLog" class="log"></div>
         <div id="otherControls">
           <strong>Other Controls:</strong>
           <div id="audioSettings">

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -377,27 +377,26 @@ async function initGame() {
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   });
-  const ui = document.getElementById("uiPanel");
-  const cardPanel = document.createElement("div");
-  cardPanel.id = "cardPanel";
-  cardPanel.innerHTML =
-    '<div><strong>Cards:</strong> <span id="cards"></span></div>' +
-    '<button id="playCardsBtn" class="btn">Play cards</button>' +
-    '<div id="bonusInfo"></div>';
-  ui.appendChild(cardPanel);
-  document.getElementById("playCardsBtn").addEventListener("click", () => {
-    const cards = getSelectedCards();
-    if (cards.length === 3) {
-      if (game.playCards(cards)) {
-        addLogEntry(`${game.players[game.currentPlayer].name} plays cards`, {
-          player: game.players[game.currentPlayer].name,
-          type: "cards",
-        });
-        resetSelectedCards();
-        updateUI();
-      }
+    const cardPanel = document.getElementById("cardPanel");
+    if (cardPanel) {
+      cardPanel.innerHTML =
+        '<div><strong>Cards:</strong> <span id="cards"></span></div>' +
+        '<button id="playCardsBtn" class="btn">Play cards</button>' +
+        '<div id="bonusInfo"></div>';
+      document.getElementById("playCardsBtn").addEventListener("click", () => {
+        const cards = getSelectedCards();
+        if (cards.length === 3) {
+          if (game.playCards(cards)) {
+            addLogEntry(`${game.players[game.currentPlayer].name} plays cards`, {
+              player: game.players[game.currentPlayer].name,
+              type: "cards",
+            });
+            resetSelectedCards();
+            updateUI();
+          }
+        }
+      });
     }
-  });
 
   const masterVolume = document.getElementById("masterVolume");
   const effectsVolume = document.getElementById("effectsVolume");

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,4 @@
 import { getContrastingColor } from "./colors.js";
-import { REINFORCE } from "./phases.js";
 import { getStats } from "./stats.js";
 
 const BOARD_WIDTH = 600;
@@ -79,6 +78,8 @@ function updateInfoPanel() {
   if (cp) cp.textContent = formatPlayerName(game.players[gameState.currentPlayer]);
   const tn = getElement("turnNumber");
   if (tn) tn.textContent = gameState.turnNumber;
+  const reinf = getElement("reinforcements");
+  if (reinf) reinf.textContent = game.reinforcements;
 }
 
 function highlightTerritories(ids) {
@@ -423,12 +424,8 @@ function updateToken(scale) {
 }
 
 function updateStatus() {
-  let status = `${game.players[game.currentPlayer].name} - ${game.getPhase()}`;
-  if (game.getPhase() === REINFORCE) {
-    status += ` (${game.reinforcements} reinforcements)`;
-  }
   const statusEl = getElement("status");
-  if (statusEl) statusEl.textContent = status;
+  if (statusEl) statusEl.textContent = game.getPhase();
 }
 
 function updateUndoButton() {
@@ -447,6 +444,7 @@ function updateUI() {
   updateTerritories(scale, playerColorClasses);
   updateToken(scale);
   updateStatus();
+  updateInfoPanel();
   updateUndoButton();
   updateBonusInfo();
   updateCardsUI();

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -29,6 +29,8 @@ describe('main DOM interactions', () => {
       <div id="turnNumber"></div>
       <div id="actionLog"></div>
       <div id="diceResults"></div>
+      <div id="reinforcements"></div>
+      <div id="cardPanel"></div>
       <div id="uiPanel"></div>
       <button id="endTurn" class="btn"></button>
       <button type="button" id="t1" class="territory" data-id="t1"></button>
@@ -145,8 +147,8 @@ describe('main DOM interactions', () => {
 
     endTurnBtn.click();
     expect(log.textContent).toContain('ends turn');
-    expect(status.textContent).toContain('Player 2');
-    expect(status.textContent).toContain(REINFORCE);
+    expect(document.getElementById('currentPlayer').textContent).toContain('Player 2');
+    expect(status.textContent).toBe(REINFORCE);
   });
 
   test('state is saved and restored from localStorage', async () => {


### PR DESCRIPTION
## Summary
- Reorder game sidebar to show turn details, actions, cards, log, and other controls in a clear sequence
- Initialize card panel from existing placeholder and refresh reinforcement info in the UI
- Adjust tests for new sidebar structure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc550d94832c935f50aaf1ae8114