### PR TITLE
Expand lobby player limit to 8

### DIFF
--- a/lobby.html
+++ b/lobby.html
@@ -28,7 +28,7 @@
       <dialog id="createDialog">
         <form id="createForm">
           <label>Room name <input id="roomName" required /></label>
-          <label>Max players <input id="maxPlayers" type="number" min="2" max="6" value="2" required /></label>
+          <label>Max players <input id="maxPlayers" type="number" min="2" max="8" value="2" required /></label>
           <label>Map <select id="map"></select></label>
           <menu>
             <button type="button" value="cancel" id="cancelCreate">Cancel</button>

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -31,7 +31,7 @@ export function renderLobbies(lobbies) {
   lobbies.forEach(lobby => {
     const li = document.createElement('li');
     const playerCount = Array.isArray(lobby.players) ? lobby.players.length : 0;
-    const max = lobby.maxPlayers || 6;
+    const max = lobby.maxPlayers || 8;
     const status = lobby.started ? 'started' : 'open';
     li.textContent = `${lobby.code} – host: ${lobby.host} – players: ${playerCount}/${max} – map: ${lobby.map || '-' } – status: ${status}`;
     list.appendChild(li);
@@ -152,7 +152,7 @@ export function initLobby() {
       const name = document.getElementById('roomName').value.trim();
       const maxPlayers = parseInt(document.getElementById('maxPlayers').value, 10);
       const map = document.getElementById('map').value.trim();
-      if (!name || isNaN(maxPlayers) || maxPlayers < 2 || maxPlayers > 6) {
+      if (!name || isNaN(maxPlayers) || maxPlayers < 2 || maxPlayers > 8) {
         if (typeof form.reportValidity === 'function') {
           form.reportValidity();
         }

--- a/src/server/handlers/createLobby.js
+++ b/src/server/handlers/createLobby.js
@@ -13,7 +13,7 @@ export async function handleCreateLobby(ctx, ws, msg, state) {
     ready: false,
     ws,
   };
-  const maxPlayers = Math.max(2, Math.min(6, msg.maxPlayers || 6));
+  const maxPlayers = Math.max(2, Math.min(8, msg.maxPlayers || 8));
   const lobby = {
     code,
     players: [player],

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -21,7 +21,7 @@ import { handleHeartbeat } from "./handlers/heartbeat.js";
 
 export function createLobbyServer({
   port = 8081,
-  maxPlayers = 6,
+  maxPlayers = 8,
   closeEmptyLobbiesAfter = 5000,
   offlinePlayerTimeout = 2 * 60_000,
 } = {}) {

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -78,7 +78,7 @@ export const loadLobby = async (lobbies, code, offlinePlayerTimeout) => {
         started: data.started || false,
         currentPlayer: data.current_player || null,
         map: data.map || null,
-        maxPlayers: data.max_players || 6,
+        maxPlayers: data.max_players || 8,
       };
       const cutoff = Date.now() - offlinePlayerTimeout;
       lobby.players = lobby.players.filter(

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -17,7 +17,7 @@ describe('lobby screen', () => {
       <dialog id="createDialog">
         <form id="createForm">
           <input id="roomName" />
-          <input id="maxPlayers" />
+          <input id="maxPlayers" max="8" />
           <select id="map"></select>
           <menu>
             <button type="button" id="cancelCreate" value="cancel">Cancel</button>
@@ -110,7 +110,7 @@ describe('lobby screen', () => {
     const form = document.getElementById('createForm');
     form.reportValidity = jest.fn();
     document.getElementById('roomName').value = '';
-    document.getElementById('maxPlayers').value = '10';
+    document.getElementById('maxPlayers').value = '9';
     form.dispatchEvent(new Event('submit'));
     expect(WebSocket).not.toHaveBeenCalled();
     expect(form.reportValidity).toHaveBeenCalled();

--- a/tests/server-handlers.test.js
+++ b/tests/server-handlers.test.js
@@ -29,19 +29,19 @@ describe("server handlers", () => {
 
   test("handleJoinLobby adds player", async () => {
     const lobbies = new Map();
-    const lobby = {
-      code: "code",
-      players: [],
-      host: "h",
-      started: false,
-      map: null,
-      maxPlayers: 6,
-    };
+      const lobby = {
+        code: "code",
+        players: [],
+        host: "h",
+        started: false,
+        map: null,
+        maxPlayers: 8,
+      };
     lobbies.set("code", lobby);
     const ctx = {
       lobbies,
       createCode: () => "p2",
-      maxPlayers: 6,
+        maxPlayers: 8,
       offlinePlayerTimeout: 0,
     };
       const ws = { send: jest.fn(), readyState: 1 };
@@ -77,7 +77,7 @@ describe("server handlers", () => {
 
   test("handleReady toggles ready", async () => {
     const lobbies = new Map();
-    const lobby = { code: "c", players: [{ id: "p1", ready: false }], host: "p1", map: null, maxPlayers:6 };
+    const lobby = { code: "c", players: [{ id: "p1", ready: false }], host: "p1", map: null, maxPlayers:8 };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };
     await handleReady(ctx, {}, { type: "ready", code: "c", id: "p1", ready: true });
@@ -86,7 +86,7 @@ describe("server handlers", () => {
 
   test("handleSelectMap updates map", async () => {
     const lobbies = new Map();
-    const lobby = { code: "c", players: [], host: "h", started: false, map: null, maxPlayers:6 };
+    const lobby = { code: "c", players: [], host: "h", started: false, map: null, maxPlayers:8 };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0, isValidMap: () => true };
     await handleSelectMap(ctx, {}, { type: "selectMap", code: "c", id: "h", map: "m1" });
@@ -144,7 +144,7 @@ describe("server handlers", () => {
       players: [{ id: "p1", ws: null, ready: false }],
       host: "p1",
       map: null,
-      maxPlayers:6,
+      maxPlayers:8,
     };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };


### PR DESCRIPTION
## Summary
- allow up to eight players when creating lobbies
- propagate new max player setting through server logic and schema
- adjust tests for expanded lobby capacity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ccf269f0832caad1ae5fbffeb2ca