### PR TITLE
Add world8 map and eight-player lobby tests

### DIFF
--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -57,6 +57,19 @@ describe('lobby screen', () => {
     expect(text).toContain('open');
   });
 
+  test('renderLobbies handles eight-player lobby', () => {
+    const { renderLobbies } = require('../src/lobby.js');
+    const players = Array.from({ length: 8 }, (_, i) => ({ id: `p${i}` }));
+    const data = [
+      { code: 'xyz', host: 'p0', players, map: 'world8', started: false, maxPlayers: 8 },
+    ];
+    renderLobbies(data);
+    const text = document.getElementById('lobbyList').textContent;
+    expect(text).toContain('xyz');
+    expect(text).toContain('8/8');
+    expect(text).toContain('world8');
+  });
+
   test('create game flow validates and sends message', async () => {
     const wsInstance = { send: jest.fn(), readyState: 1 };
     global.WebSocket = jest.fn(() => wsInstance);

--- a/tests/map-schema.test.js
+++ b/tests/map-schema.test.js
@@ -19,4 +19,17 @@ describe('map schema validation', () => {
     delete bad.territories[0].y;
     expect(() => validateMap(bad)).toThrow('Invalid map data');
   });
+
+  test('world8 territories have unique ids and reciprocal neighbors', () => {
+    const map = require('../src/data/world8.json');
+    const ids = new Set(map.territories.map((t) => t.id));
+    expect(ids.size).toBe(map.territories.length);
+    const byId = Object.fromEntries(map.territories.map((t) => [t.id, t]));
+    for (const terr of map.territories) {
+      for (const n of terr.neighbors) {
+        expect(byId[n]).toBeTruthy();
+        expect(byId[n].neighbors).toContain(terr.id);
+      }
+    }
+  });
 });

--- a/tests/map3.test.js
+++ b/tests/map3.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const map = require('../src/data/map3.json');
+const world8 = require('../src/data/world8.json');
 
 const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 
@@ -33,6 +34,20 @@ describe('map3 data', () => {
     for (const id of Object.keys(counts)) {
       for (const t of types) {
         expect(counts[id][t]).toBe(1);
+      }
+    }
+  });
+});
+
+describe('world8 data', () => {
+  test('territories have unique ids and reciprocal neighbors', () => {
+    const ids = new Set(world8.territories.map((t) => t.id));
+    expect(ids.size).toBe(world8.territories.length);
+    const byId = Object.fromEntries(world8.territories.map((t) => [t.id, t]));
+    for (const t of world8.territories) {
+      for (const n of t.neighbors) {
+        expect(byId[n]).toBeTruthy();
+        expect(byId[n].neighbors).toContain(t.id);
       }
     }
   });

--- a/tests/server-handlers.test.js
+++ b/tests/server-handlers.test.js
@@ -164,4 +164,39 @@ describe("server handlers", () => {
     await handleHeartbeat(ctx, {}, { type: "heartbeat", code: "c", id: "p1" });
     expect(player.lastSeen).toBeDefined();
   });
+
+  test("allows eight players to join and start", async () => {
+    const lobbies = new Map();
+    const lobby = {
+      code: "c",
+      players: [],
+      host: "p0",
+      started: false,
+      map: "world8",
+      maxPlayers: 8,
+    };
+    lobbies.set("c", lobby);
+    const ctx = {
+      lobbies,
+      createCode: () => "x",
+      maxPlayers: 8,
+      offlinePlayerTimeout: 0,
+      isValidMap: () => true,
+    };
+    for (let i = 0; i < 8; i++) {
+      const ws = { send: jest.fn(), readyState: 1 };
+      await handleJoinLobby(
+        ctx,
+        ws,
+        { type: "joinLobby", code: "c", player: { id: `p${i}` } },
+        {},
+      );
+    }
+    expect(lobby.players).toHaveLength(8);
+    for (const p of lobby.players) {
+      await handleReady(ctx, {}, { type: "ready", code: "c", id: p.id, ready: true });
+    }
+    await handleStart(ctx, {}, { type: "start", code: "c", id: "p0", state: { currentPlayer: "p0" } });
+    expect(lobby.started).toBe(true);
+  });
 });

--- a/tests/ui.uat.test.js
+++ b/tests/ui.uat.test.js
@@ -1,5 +1,6 @@
 import * as ui from '../src/ui.js';
 import { GameState } from "../src/state/game.js";
+const world8 = require('../src/data/world8.json');
 
 const { initUI, addLogEntry, updateUI, animateMove, destroyUI } = ui;
 
@@ -79,5 +80,33 @@ describe('ui integration', () => {
     expect(removeSpy).toHaveBeenCalledWith('resize', handler);
     addSpy.mockRestore();
     removeSpy.mockRestore();
+  });
+
+  test('world8 map renders eight starting territories', () => {
+    destroyUI();
+    const territoryDivs = world8.territories
+      .map((t) => `<div id="${t.id}"></div>`)
+      .join('');
+    document.body.innerHTML = `<div id="board"></div>${territoryDivs}`;
+    const gameWorld = {
+      players: world8.territories.map((_, i) => ({ name: `P${i + 1}`, color: '#000' })),
+      currentPlayer: 0,
+      territories: world8.territories.map((t, i) => ({ id: t.id, owner: i, armies: 1 })),
+      hands: Array(world8.territories.length).fill([]),
+      continents: [],
+      territoryById: (id) => gameWorld.territories.find((tt) => tt.id === id),
+      getPhase: () => 'attack',
+      reinforcements: 0,
+      canUndo: () => false,
+    };
+    const positions = Object.fromEntries(
+      world8.territories.map((t) => [t.id, { x: t.x, y: t.y }]),
+    );
+    const gs = new GameState();
+    initUI({ game: gameWorld, gameState: gs, territoryPositions: positions });
+    updateUI();
+    for (const t of world8.territories) {
+      expect(document.getElementById(t.id).textContent).toBe('1');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- validate world8 map territories and neighbor consistency
- cover eight-player lobby and server start scenarios
- ensure UI renders world8 with eight starting territories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cec432c8832cab8cf11acddc55da