### PR TITLE
Fix map selection not displaying in setup

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -63,8 +63,19 @@ export function initLobby() {
   (async () => {
     const select = document.getElementById('map');
     if (!select) return;
+    let res;
     try {
-      const res = await fetch('./assets/maps/map-manifest.json');
+      res = await fetch('./assets/maps/map-manifest.json');
+      if (res && res.ok === false) throw new Error('not ok');
+    } catch {
+      try {
+        res = await fetch('./public/assets/maps/map-manifest.json');
+        if (res && res.ok === false) throw new Error('not ok');
+      } catch {
+        return;
+      }
+    }
+    try {
       const data = await res.json();
       data.maps.forEach(m => {
         const opt = document.createElement('option');

--- a/src/setup.js
+++ b/src/setup.js
@@ -26,7 +26,15 @@ function getCachedImage(src) {
 
 export async function loadMapData() {
   if (!mapGrid) return;
-  const res = await fetch("./assets/maps/map-manifest.json");
+  let res;
+  let prefix = "";
+  try {
+    res = await fetch("./assets/maps/map-manifest.json");
+    if (res && res.ok === false) throw new Error("not ok");
+  } catch {
+    res = await fetch("./public/assets/maps/map-manifest.json");
+    prefix = "public/";
+  }
   const data = await res.json();
   mapGrid.innerHTML = "";
   mapGrid.style.display = "grid";
@@ -35,7 +43,7 @@ export async function loadMapData() {
     const item = document.createElement("div");
     item.className = "map-item";
     item.dataset.id = m.id;
-    const img = getCachedImage(m.thumbnail);
+    const img = getCachedImage(prefix + m.thumbnail);
     img.alt = m.name;
     img.addEventListener("error", () => {
       item.classList.add("missing");
@@ -61,7 +69,7 @@ export async function loadMapData() {
     const detail = document.createElement("div");
     detail.className = "map-detail hidden";
     detail.innerHTML = `<p>${m.description || ""}</p>`;
-    const layout = getCachedImage(m.thumbnail);
+    const layout = getCachedImage(prefix + m.thumbnail);
     layout.alt = `${m.name} layout`;
     layout.className = "layout";
     detail.appendChild(layout);


### PR DESCRIPTION
## Summary
- ensure setup page loads map manifest from `public/assets` when root assets are missing
- load lobby map list with same manifest fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d727aa98832ca962d874e1cc7b20