### PR TITLE
Remove move token feature

### DIFF
--- a/game.html
+++ b/game.html
@@ -32,14 +32,6 @@
         </div>
         <div id="gameActions">
           <strong>Game Actions:</strong>
-          <button
-            id="moveToken"
-            class="btn"
-            aria-label="Move Token"
-            accesskey="v"
-          >
-            Move Token
-          </button>
           <button id="undo" class="btn" aria-label="Undo" accesskey="u" disabled>
             Undo
           </button>

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -5,7 +5,6 @@ import * as logger from "./logger.js";
 export default function initTerritorySelection({
   game,
   territories,
-  addLogEntry,
   gameState,
   attachTerritoryHandlers,
   updateUI,
@@ -63,56 +62,6 @@ export default function initTerritorySelection({
     });
   }
 
-  function moveToken(el) {
-    if (!el) return;
-    const phase = game?.getPhase();
-    if (phase && ![ATTACK, FORTIFY].includes(phase)) {
-      addLogEntry?.(`Move not allowed during ${phase} phase`, { type: "error" });
-      return;
-    }
-    const box = el.getBBox();
-    const x = box.x + box.width / 2;
-    const y = box.y + box.height / 2;
-    const token = document.getElementById("token");
-    const scale = getBoardScale();
-    if (token) {
-      token.style.left = `${x * scale.x}px`;
-      token.style.top = `${y * scale.y}px`;
-    }
-    if (gameState) {
-      gameState.setTokenPosition({ x, y });
-    }
-    if (addLogEntry && game) {
-      const name = el.dataset.name || el.id;
-      addLogEntry(
-        `${game.players[game.currentPlayer].name} moves token to ${name}`,
-        {
-          player: game.players[game.currentPlayer].name,
-          type: "token",
-          territories: [el.id],
-        },
-      );
-      logger.info(
-        `${game.players[game.currentPlayer].name} moves token to ${name}`,
-      );
-    }
-  }
-
-  const moveBtn = document.getElementById("moveToken");
-  if (moveBtn) {
-    moveBtn.addEventListener("click", () => {
-      logger.info("Move token clicked");
-      try {
-        if (selectedTerritory) {
-          moveToken(selectedTerritory.el);
-        } else {
-          addLogEntry?.("No territory selected", { type: "error" });
-        }
-      } catch (err) {
-        logger.error(err);
-      }
-    });
-  }
 
   const mapName =
     (typeof localStorage !== "undefined" &&
@@ -195,14 +144,6 @@ export default function initTerritorySelection({
               }
             }
           }
-        });
-        map.addEventListener("dblclick", (e) => {
-          const target = e.target.closest(".map-territory");
-          if (target) {
-            selectTerritory(target);
-            moveToken(target);
-          }
-          e.stopPropagation();
         });
         document.addEventListener("pointerdown", (e) => {
           if (!map.contains(e.target)) {

--- a/tests/territory-selection.uat.test.js
+++ b/tests/territory-selection.uat.test.js
@@ -8,8 +8,7 @@ describe('territory selection user flow', () => {
     // basic DOM structure
     document.body.innerHTML =
       '<div id="board"></div>' +
-      '<div id="selectedTerritory"></div>' +
-      '<button id="moveToken">Move</button>';
+      '<div id="selectedTerritory"></div>';
 
     // stub getBBox with unique coordinates per territory
     SVGElement.prototype.getBBox = function () {
@@ -27,7 +26,7 @@ describe('territory selection user flow', () => {
     delete global.fetch;
   });
 
-  test('click highlights moves, double click moves token and cleanup works', async () => {
+  test('click highlights moves and cleanup works', async () => {
     const svg =
       '<svg id="map">' +
       '<path id="A" class="map-territory" data-name="Alpha" />' +
@@ -63,21 +62,9 @@ describe('territory selection user flow', () => {
     expect(bPath.classList.contains('possible-move')).toBe(true);
     expect(document.getElementById('selectedTerritory').textContent).toBe('Alpha');
 
-    // double click B to move token
-    bPath.dispatchEvent(new Event('dblclick', { bubbles: true }));
-
-    const token = document.getElementById('token');
-    expect(token.style.left).toBe('45px');
-    expect(token.style.top).toBe('55px');
-
-    // selection switched to B and highlights cleared
-    expect(aPath.classList.contains('selected')).toBe(false);
-    expect(bPath.classList.contains('selected')).toBe(true);
-    expect(document.querySelectorAll('.possible-move').length).toBe(0);
-
     // clicking outside map clears selection
     document.dispatchEvent(new Event('pointerdown'));
-    expect(bPath.classList.contains('selected')).toBe(false);
+    expect(aPath.classList.contains('selected')).toBe(false);
     expect(document.getElementById('selectedTerritory').textContent).toBe('');
   });
 });

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -27,21 +27,6 @@ test.describe('UAT checklist', () => {
       await expect(page.locator('#selectedTerritory')).toHaveText(name!);
     }
 
-    await page.waitForSelector('#token');
-    const before = await page.locator('#token').evaluate((el) => ({
-      left: (el as HTMLElement).style.left,
-      top: (el as HTMLElement).style.top,
-    }));
-    await page.evaluate(async () => {
-      const mod = await import('/src/main.js');
-      const phases = await import('/src/phases.js');
-      mod.game.setPhase(phases.FORTIFY);
-    });
-    await page.evaluate(() => document.getElementById('moveToken')?.click());
-    await expect(page.locator('#actionLog')).toContainText('moves token');
-    await expect(page.locator('#token')).not.toHaveCSS('left', before.left || '');
-    await expect(page.locator('#token')).not.toHaveCSS('top', before.top || '');
-
     const turnBefore = await page.locator('#turnNumber').textContent();
     await page.click('#endTurn');
     await expect(page.locator('#turnNumber')).not.toHaveText(turnBefore!);


### PR DESCRIPTION
## Summary
- remove Move Token button and associated token moving logic
- clean up tests after removing move token functionality

## Testing
- `npm test`
- `npm run test:uat` *(fails: Host system is missing dependencies to run browsers)*


------
https://chatgpt.com/codex/tasks/task_e_68b11f76a50c832c8829ce5fbd03ffca