### PR TITLE
Improve game data load error handling

### DIFF
--- a/game.html
+++ b/game.html
@@ -19,6 +19,10 @@
     <header id="gameHeader">
       <button id="exitGame" class="btn">Exit Game</button>
     </header>
+    <div id="loadError" class="hidden">
+      <p id="loadErrorMsg"></p>
+      <button id="retryLoad" class="btn">Retry</button>
+    </div>
     <div id="gameContainer">
       <div id="board" class="board"></div>
       <div id="uiPanel">

--- a/src/init/game-loader.js
+++ b/src/init/game-loader.js
@@ -19,10 +19,7 @@ async function loadMap(mapName) {
     return map;
   } catch (err) {
     logger.error("Failed to load map data", err);
-    if (typeof alert !== "undefined") {
-      alert("Unable to load game data. Please try again later.");
-    }
-    return null;
+    throw err;
   }
 }
 
@@ -58,11 +55,14 @@ async function loadGame() {
   }
 
   const mapName = getMapName();
-  const map = await loadMap(mapName);
-  if (!map) return { game: null, territoryPositions: {} };
-  const game = restoreGameState(GameClass, map);
-  game.use(aiTurnManager);
-  return { game, territoryPositions };
+  try {
+    const map = await loadMap(mapName);
+    const game = restoreGameState(GameClass, map);
+    game.use(aiTurnManager);
+    return { game, territoryPositions };
+  } catch (err) {
+    return { game: null, territoryPositions: {}, error: err };
+  }
 }
 
 export { loadMap, restoreGameState, loadGame, territoryPositions };

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -54,6 +54,25 @@ let game;
 let territoryPositions = {};
 let phaseTimer;
 
+const loadErrorEl = document.getElementById("loadError");
+const loadErrorMsg = document.getElementById("loadErrorMsg");
+const retryBtn = document.getElementById("retryLoad");
+
+function showLoadError() {
+  if (loadErrorEl && loadErrorMsg) {
+    loadErrorMsg.textContent =
+      "Unable to load game data. Check your connection and try again.";
+    loadErrorEl.classList.remove("hidden");
+  }
+}
+
+if (retryBtn) {
+  retryBtn.addEventListener("click", () => {
+    if (loadErrorEl) loadErrorEl.classList.add("hidden");
+    loadGame();
+  });
+}
+
 function checkForVictory() {
   const winner = game.checkVictory();
   if (winner !== null) {
@@ -86,15 +105,23 @@ function initialiseUI(gameInstance) {
 }
 
 async function loadGame() {
-  const result = await loadGameData();
-  if (!result || !result.game) return;
-  game = result.game;
-  territoryPositions = result.territoryPositions;
-  attachStatsListeners(game);
-  initialiseUI(game);
-  if (typeof module !== "undefined") {
-    module.exports.game = game;
-    module.exports.territoryPositions = territoryPositions;
+  try {
+    const result = await loadGameData();
+    if (!result || !result.game) {
+      showLoadError();
+      return;
+    }
+    if (loadErrorEl) loadErrorEl.classList.add("hidden");
+    game = result.game;
+    territoryPositions = result.territoryPositions;
+    attachStatsListeners(game);
+    initialiseUI(game);
+    if (typeof module !== "undefined") {
+      module.exports.game = game;
+      module.exports.territoryPositions = territoryPositions;
+    }
+  } catch {
+    showLoadError();
   }
 }
 

--- a/tests/game-loader.uat.test.js
+++ b/tests/game-loader.uat.test.js
@@ -68,16 +68,17 @@ describe("game loader", () => {
     expect(territoryPositions).toEqual({ a: { x: 5, y: 6 } });
   });
 
-  test("returns null when map file is missing", async () => {
+  test("returns error when map file is missing", async () => {
     global.fetch.mockResolvedValue({ ok: false, status: 404 });
     global.localStorage.setItem("netriskMap", "missing");
     const errSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
 
-    const { game, territoryPositions } = await loadGame();
+    const { game, territoryPositions, error } = await loadGame();
     expect(global.fetch).toHaveBeenCalled();
     expect(errSpy).toHaveBeenCalled();
     expect(game).toBeNull();
     expect(territoryPositions).toEqual({});
+    expect(error).toBeInstanceOf(Error);
   });
 
   test("ignores corrupted saved game and loads map", async () => {

--- a/tests/ui-init.no-game.test.js
+++ b/tests/ui-init.no-game.test.js
@@ -49,7 +49,9 @@ jest.mock("../src/ui.js", () => ({
 jest.mock("../src/phase-timer.js", () => jest.fn(() => ({ stop: jest.fn() })));
 jest.mock("../src/config.js", () => ({ WS_URL: "ws://test" }));
 jest.mock("../src/init/game-loader.js", () => ({
-  loadGame: jest.fn(() => Promise.resolve({ game: null, territoryPositions: {} })),
+  loadGame: jest.fn(() =>
+    Promise.resolve({ game: null, territoryPositions: {}, error: new Error("fail") }),
+  ),
 }));
 jest.mock("../src/state/storage.js", () => ({
   updateGameState: jest.fn(),
@@ -68,11 +70,14 @@ jest.mock("../src/state/game.js", () => ({
 jest.mock("../src/ai-logging.js", () => jest.fn());
 
 describe("initGame handles load failure", () => {
-  test("returns without initializing when game fails to load", async () => {
-    document.body.innerHTML = '<button id="endTurn"></button>';
+  test("shows error message when game fails to load", async () => {
+    document.body.innerHTML =
+      '<div id="loadError" class="hidden"><p id="loadErrorMsg"></p><button id="retryLoad"></button></div><button id="endTurn"></button>';
     const audio = require("../src/audio.js");
     const uiInit = require("../src/ui-init.js");
     await expect(uiInit.initGame()).resolves.toBeUndefined();
+    const errorEl = document.getElementById("loadError");
+    expect(errorEl.classList.contains("hidden")).toBe(false);
     expect(audio.preloadEffects).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- propagate map load errors and expose them to the UI
- show a retryable error message when game data fails to load
- cover load failure with new tests

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b13b205494832ca2e5cead5a1a6f46