### PR TITLE
feat: display lobby logs

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -59,3 +59,14 @@
   max-width: 300px;
   text-align: center;
 }
+
+.debug-log {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  background: #f8f8f8;
+  font-family: monospace;
+  font-size: 12px;
+  max-height: 150px;
+  overflow-y: auto;
+}

--- a/lobby.html
+++ b/lobby.html
@@ -43,6 +43,7 @@
           <button type="submit">Send</button>
         </form>
       </section>
+      <section id="debugLog" class="debug-log" aria-live="polite"></section>
     </main>
     <script type="module" src="./lobby.js"></script>
   </body>

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
+import { info, error } from '../logger.js';
 
 // Initialize the client only when both URL and key are provided.
 // This avoids hitting Supabase with empty credentials during development
@@ -7,9 +8,10 @@ import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
 export const supabase =
   SUPABASE_URL && SUPABASE_KEY ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
 
-if (!supabase) {
-  // eslint-disable-next-line no-console
-  console.warn('Supabase client not initialized: missing URL or anon key');
+if (supabase) {
+  info('Supabase client initialized');
+} else {
+  error('Supabase client not initialized: missing URL or anon key');
 }
 
 export default supabase;

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -2,6 +2,7 @@ import { initThemeToggle } from './theme.js';
 import { goHome } from './navigation.js';
 import { WS_URL } from './config.js';
 import EventBus from './core/event-bus.js';
+import { info as logInfo, error as logError } from './logger.js';
 
 const bus = new EventBus();
 
@@ -41,11 +42,22 @@ export function renderLobbies(lobbies) {
 async function fetchLobbies() {
   if (!supabase) {
     renderLobbies([]);
+    logError('Supabase not initialized; cannot fetch lobbies');
     return;
   }
-  const { data } = await supabase.from('lobbies').select();
-  currentLobbies.splice(0, currentLobbies.length, ...(data || []));
-  renderLobbies(currentLobbies);
+  try {
+    logInfo('Fetching lobbies from database');
+    const { data, error } = await supabase.from('lobbies').select();
+    if (error) {
+      logError('Error fetching lobbies', error.message);
+      return;
+    }
+    currentLobbies.splice(0, currentLobbies.length, ...(data || []));
+    renderLobbies(currentLobbies);
+    logInfo(`Loaded ${currentLobbies.length} lobbies`);
+  } catch (err) {
+    logError('Unexpected error fetching lobbies', err?.message);
+  }
 }
 
 export function initLobby() {
@@ -105,14 +117,15 @@ export function initLobby() {
   }
   async function createGame(payload, dlg) {
     try {
-      const session = supabase ? await supabase.auth.getSession() : null;
-      console.log('Supabase session:', session); // eslint-disable-line no-console
+      if (supabase) {
+        await supabase.auth.getSession();
+        logInfo('Requested Supabase session');
+      }
     } catch (err) {
-      console.error('Supabase getSession error:', err); // eslint-disable-line no-console
+      logError('Supabase getSession error', err?.message);
     }
     const url = WS_URL;
-    console.log('Create Game URL:', url); // eslint-disable-line no-console
-    console.log('Create Game payload:', payload); // eslint-disable-line no-console
+    logInfo('Creating new game lobby');
     try {
       if (!url) {
         notifyUser('WebSocket server is not available.');
@@ -131,13 +144,13 @@ export function initLobby() {
               })
             );
           } catch (err2) {
-            console.error('WebSocket send error:', err2); // eslint-disable-line no-console
+            logError('WebSocket send error', err2?.message);
             notifyUser(err2 instanceof Error ? err2.message : String(err2));
           }
         };
         ws.onmessage = e => handleMessage(e, dlg);
         ws.onerror = errEvent => {
-          console.error('WebSocket connection error:', errEvent); // eslint-disable-line no-console
+          logError('WebSocket connection error', errEvent?.message);
           notifyUser('WebSocket connection error.');
         };
         ws.onclose = () => notifyUser('WebSocket connection closed.');
@@ -152,7 +165,7 @@ export function initLobby() {
         );
       }
     } catch (err) {
-      console.error('createGame failed:', err); // eslint-disable-line no-console
+      logError('createGame failed', err?.message);
       notifyUser(err instanceof Error ? err.message : String(err));
     }
   }
@@ -210,7 +223,11 @@ export function initLobby() {
       } else {
         supabase = mod;
       }
-      if (!supabase) return;
+      if (!supabase) {
+        logError('Supabase client not initialized');
+        return;
+      }
+      logInfo('Supabase client ready on lobby page');
       fetchLobbies();
       supabase
         .channel('public:lobbies')
@@ -220,7 +237,9 @@ export function initLobby() {
         .subscribe();
       bus.on('lobbiesChanged', fetchLobbies);
     })
-    .catch(() => {});
+    .catch(err => {
+      logError('Failed to load Supabase client', err?.message);
+    });
 
   function addChatMessage(id, text, time = new Date()) {
     if (!chatMessages) return;
@@ -235,14 +254,19 @@ export function initLobby() {
     if (chatHistoryLoaded || !supabase || !currentCode) return;
     chatHistoryLoaded = true;
     try {
-      const { data } = await supabase
+      logInfo(`Loading chat history for ${currentCode}`);
+      const { data, error } = await supabase
         .from('lobby_chat')
         .select()
         .eq('code', currentCode)
         .order('created_at', { ascending: true });
+      if (error) {
+        logError('Error loading chat history', error.message);
+        return;
+      }
       (data || []).forEach(row => addChatMessage(row.id, row.text, new Date(row.created_at)));
-    } catch {
-      // ignore fetch errors
+    } catch (err) {
+      logError('Unexpected error loading chat history', err?.message);
     }
   }
 
@@ -253,7 +277,7 @@ export function initLobby() {
     } catch {
       return;
     }
-    console.log('WS response:', msg); // eslint-disable-line no-console
+    logInfo(`WS response type: ${msg.type}`);
     switch (msg.type) {
       case 'joined': {
         currentCode = msg.code;

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,5 @@
 let overlay;
+let logBox;
 if (typeof document !== "undefined") {
   overlay = document.createElement("div");
   overlay.id = "error-overlay";
@@ -17,6 +18,7 @@ if (typeof document !== "undefined") {
   overlay.classList.add("hidden");
   document.addEventListener("DOMContentLoaded", () => {
     document.body.appendChild(overlay);
+    logBox = document.getElementById("debugLog");
   });
 }
 
@@ -27,16 +29,31 @@ function showError(message) {
   }
 }
 
+function appendLog(level, args) {
+  if (typeof document === "undefined") return;
+  if (!logBox) logBox = document.getElementById("debugLog");
+  if (!logBox) return;
+  const line = document.createElement("div");
+  const text = args
+    .map(a => (typeof a === "string" ? a : JSON.stringify(a)))
+    .join(" ");
+  line.textContent = `[${level}] ${text}`;
+  logBox.appendChild(line);
+}
+
 export function info(...args) {
   console.log("[INFO]", ...args);
+  appendLog("INFO", args);
 }
 
 export function warn(...args) {
   console.warn("[WARN]", ...args);
+  appendLog("WARN", args);
 }
 
 export function error(...args) {
   console.error("[ERROR]", ...args);
+  appendLog("ERROR", args);
 }
 
 if (typeof window !== "undefined") {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,7 @@
 import { WebSocketServer } from "ws";
 import { randomBytes } from "crypto";
 import supabase from "../init/supabase-client.js";
+import { info, error } from "../logger.js";
 import {
   isValidMap,
   publicPlayers,
@@ -39,6 +40,12 @@ export function createLobbyServer({
     supabase,
   };
 
+  if (supabase) {
+    info("Supabase client available for lobby server");
+  } else {
+    error("Supabase client not configured; database features disabled");
+  }
+
   const handlers = {
     createLobby: handleCreateLobby,
     joinLobby: handleJoinLobby,
@@ -54,6 +61,7 @@ export function createLobbyServer({
 
   wss.on("connection", ws => {
     const state = { currentLobby: null, currentPlayer: null };
+    info("Client connected to lobby server");
 
     ws.on("message", async raw => {
       let msg;
@@ -71,6 +79,7 @@ export function createLobbyServer({
       const handler = handlers[data.type];
       if (handler) {
         await handler(ctx, ws, data, state);
+        info(`Handled message of type ${data.type}`);
       }
     });
 
@@ -95,9 +104,9 @@ export function createLobbyServer({
             const idx = lobby.players.indexOf(player);
             lobby.players.splice(idx, 1);
             if (lobby.host === player.id) {
-              lobby.host = lobby.players[0]?.id || null;
-            }
-            await persistLobby(lobby);
+          lobby.host = lobby.players[0]?.id || null;
+        }
+        await persistLobby(lobby);
             broadcast(lobby, {
               type: "lobby",
               code: lobby.code,
@@ -118,6 +127,5 @@ export function createLobbyServer({
 if (typeof require !== "undefined" && require.main === module) {
   const port = 8081;
   createLobbyServer({ port });
-  // eslint-disable-next-line no-console
-  console.log(`Multiplayer server listening on port ${port}`);
+  info(`Multiplayer server listening on port ${port}`);
 }

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { z } from "zod";
 import supabase from "../init/supabase-client.js";
+import { info, error } from "../logger.js";
 
 // Load available map ids from manifest
 let validMaps = [];
@@ -50,24 +51,25 @@ export const persistLobby = async (lobby) => {
     max_players: lobby.maxPlayers,
   };
   try {
+    info(`Persisting lobby ${lobby.code}`);
     await supabase.from("lobbies").upsert(row, { onConflict: "code" });
+    info(`Lobby ${lobby.code} persisted`);
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error("Supabase upsert error", err);
+    error(`Supabase upsert error for lobby ${lobby.code}`, err?.message);
   }
 };
 
 export const loadLobby = async (lobbies, code, offlinePlayerTimeout) => {
   let lobby = lobbies.get(code);
   if (!lobby && supabase) {
-    const { data, error } = await supabase
+    info(`Loading lobby ${code} from database`);
+    const { data, error: loadError } = await supabase
       .from("lobbies")
       .select()
       .eq("code", code)
       .maybeSingle();
-    if (error) {
-      // eslint-disable-next-line no-console
-      console.error("Supabase load error", error);
+    if (loadError) {
+      error(`Supabase load error for lobby ${code}`, loadError?.message);
     }
     if (data) {
       lobby = {
@@ -85,6 +87,7 @@ export const loadLobby = async (lobbies, code, offlinePlayerTimeout) => {
         (p) => !p.lastSeen || p.lastSeen > cutoff,
       );
       lobbies.set(code, lobby);
+      info(`Lobby ${code} loaded from database`);
     }
   }
   return lobby;


### PR DESCRIPTION
## Summary
- show realtime debug log on lobby page
- style debug log area
- pipe logger output to in-browser log panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b139d06f14832ca7a7ce7842cd18f5