### PR TITLE
feat: support clean URLs for game pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple browser-based Risk-inspired game",
   "scripts": {
     "lint": "eslint .",
-    "start": "vite build --config config/vite.config.js && http-server dist",
+    "start": "vite build --config config/vite.config.js && node server.js",
     "dev": "vite --config config/vite.config.js",
     "build": "vite build --config config/vite.config.js",
     "preview": "vite preview --config config/vite.config.js",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+import http from 'http';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const distDir = path.join(__dirname, 'dist');
+
+const routes = {
+  '/': 'index.html',
+  '/setup': 'setup.html',
+  '/how-to-play': 'how-to-play.html',
+  '/game': 'game.html'
+};
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon'
+};
+
+const server = http.createServer(async (req, res) => {
+  const urlPath = req.url.split('?')[0];
+  const fileName = routes[urlPath] || urlPath;
+  const filePath = path.join(distDir, fileName);
+  try {
+    const data = await readFile(filePath);
+    const ext = path.extname(filePath);
+    res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
+    res.end(data);
+  } catch {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+});
+
+const port = process.env.PORT || 8080;
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});
+


### PR DESCRIPTION
## Summary
- add lightweight HTTP server to map clean paths to built HTML files
- run new server in start script to eliminate 404s on direct navigation

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b13ce2b124832ca37cf252feb0f172