### PR TITLE
Fix missing tokens on 8-player map

### DIFF
--- a/public/assets/maps/world8.svg
+++ b/public/assets/maps/world8.svg
@@ -1,4 +1,4 @@
-<svg id="world8" viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+<svg id="map" viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
   <rect width="600" height="400" fill="#87ceeb" />
   <!-- North America -->
   <path id="north-america" class="map-territory" data-name="North America"

--- a/tests/map-schema.test.js
+++ b/tests/map-schema.test.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const validateMap = require('../src/validate-map.js');
 
 const maps = ['map.json', 'map2.json', 'map3.json', 'map-roman.json', 'world8.json'];
@@ -31,5 +33,12 @@ describe('map schema validation', () => {
         expect(byId[n].neighbors).toContain(terr.id);
       }
     }
+  });
+
+  test('world8 SVG root element uses expected id', () => {
+    const svgPath = path.join(__dirname, '..', 'public', 'assets', 'maps', 'world8.svg');
+    const svgContent = fs.readFileSync(svgPath, 'utf8');
+    const match = svgContent.match(/<svg[^>]*id="([^"]+)"/);
+    expect(match && match[1]).toBe('map');
   });
 });


### PR DESCRIPTION
## Summary
- ensure world8 map SVG uses standard `map` id so tokens display correctly
- add regression test confirming the SVG root id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b14cd666d0832ca73a883ec09c93ce