### PR TITLE
Align UAT basic gameplay flow with two-step end turn

### DIFF
--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -26,8 +26,16 @@ test.describe('UAT checklist', () => {
       await expect(page.locator(sel)).toHaveClass(/selected/);
       await expect(page.locator('#selectedTerritory')).toHaveText(name!);
     }
+    await page.evaluate(async () => {
+      const mod = await import('/src/main.js');
+      mod.game.reinforcements = 0;
+      mod.game.phase = 'attack';
+      const ui = await import('/src/ui.js');
+      ui.updateUI();
+    });
 
     const turnBefore = await page.locator('#turnNumber').textContent();
+    await page.click('#endTurn');
     await page.click('#endTurn');
     await expect(page.locator('#turnNumber')).not.toHaveText(turnBefore!);
     await expect(page.locator('#actionLog')).toContainText('ends turn');


### PR DESCRIPTION
## Summary
- update basic gameplay UAT to force attack phase and click **End Turn** twice before verifying the turn advances

## Testing
- `npm run lint`
- `npm test`
- `npm run test:uat`


------
https://chatgpt.com/codex/tasks/task_e_68b14a5d2368832c989fafc623c34830