### PR TITLE
fix: ensure lobby retry callback invoked

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -39,8 +39,9 @@ function hideLobbyError() {
 
 if (retryBtn) {
   retryBtn.addEventListener('click', () => {
+    const action = retryAction;
     hideLobbyError();
-    if (typeof retryAction === 'function') retryAction();
+    if (typeof action === 'function') action();
   });
 }
 


### PR DESCRIPTION
## Summary
- preserve retry callback before clearing so Retry triggers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b154041980832cbdcce193acdb424b