### PR TITLE
chore: run impacted tests before push

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,9 @@
+echo "husky - DEPRECATED
+
+Please remove the following two lines from $0:
+
+#!/usr/bin/env sh
+. \"\$(dirname -- \"\$0\")/_/husky.sh\"
+
+They WILL FAIL in v10.0.0
+"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+node scripts/pre-push.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "http-server": "^14.1.1",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.5",
         "prettier": "^3.2.5",
@@ -5476,6 +5477,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "simulate": "node src/simulate.js",
     "test": "jest --config config/jest.config.js",
     "type-check": "tsc --noEmit -p config/tsconfig.json",
-    "test:uat": "playwright test -c config/playwright.config.ts"
+    "test:uat": "playwright test -c config/playwright.config.ts",
+    "test:smoke": "jest --config config/jest.config.js tests/smoke",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.0",
@@ -24,6 +26,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "http-server": "^14.1.1",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.5",
     "prettier": "^3.2.5",

--- a/scripts/pre-push.js
+++ b/scripts/pre-push.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+function run(cmd, args = [], opts = {}) {
+  execFileSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+
+function getChangedFiles() {
+  try {
+    let base = 'origin/main';
+    try {
+      execFileSync('git', ['rev-parse', '--verify', base], { stdio: 'ignore' });
+    } catch {
+      base = 'main';
+    }
+    const output = execFileSync(
+      'git',
+      ['diff', '--name-only', '--diff-filter=d', `${base}...HEAD`],
+      { encoding: 'utf8' }
+    );
+    return output
+      .split('\n')
+      .map((f) => f.trim())
+      .filter((f) => f && fs.existsSync(f));
+  } catch (err) {
+    console.error('Failed to determine changed files');
+    process.exit(1);
+  }
+}
+
+function getRelatedTests(files) {
+  if (files.length === 0) return [];
+  try {
+    const output = execFileSync(
+      'npx',
+      [
+        'jest',
+        '--config',
+        'config/jest.config.js',
+        '--findRelatedTests',
+        '--listTests',
+        ...files,
+      ],
+      { encoding: 'utf8' }
+    );
+    return output
+      .split('\n')
+      .map((f) => f.trim())
+      .filter(Boolean);
+  } catch (err) {
+    // If jest fails while listing tests, treat as failure
+    process.exit(1);
+  }
+}
+
+const changedFiles = getChangedFiles();
+const relatedTests = getRelatedTests(changedFiles);
+
+if (relatedTests.length > 0) {
+  run('npx', [
+    'jest',
+    '--config',
+    'config/jest.config.js',
+    '--findRelatedTests',
+    ...changedFiles,
+  ]);
+} else {
+  run('npm', ['run', 'test:smoke']);
+}
+
+run('npx', [
+  'playwright',
+  'test',
+  '-c',
+  'config/playwright.config.ts',
+  '--grep',
+  '@smoke',
+]);
+

--- a/tests/smoke/smoke.test.js
+++ b/tests/smoke/smoke.test.js
@@ -1,0 +1,4 @@
+test('smoke test', () => {
+  expect(true).toBe(true);
+});
+

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('UAT checklist', () => {
-  test('basic gameplay flow', async ({ page }) => {
+  test('@smoke basic gameplay flow', async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('netriskPlayers', JSON.stringify([
         { name: 'Red', color: '#f00' },
@@ -35,7 +35,7 @@ test.describe('UAT checklist', () => {
     expect(errors).toEqual([]);
   });
 
-  test('level 3 extras', async ({ page }) => {
+  test('@smoke level 3 extras', async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('netriskPlayers', JSON.stringify([
         { name: 'Red', color: '#f00' },


### PR DESCRIPTION
## Summary
- run tests for changed files before pushing
- ensure default smoke tests and Playwright smoke suite run
- skip deleted paths so hook won't fail on file removals
- guard pre-push hook against shell injection by using execFileSync argument arrays

## Testing
- `npm run test:smoke`
- `npx playwright install chromium` *(fails: Download failed: server returned code 403; host dependencies missing)*
- `npx playwright test -c config/playwright.config.ts --grep @smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b14e7634bc832c86df9ea09354dfef