### PR TITLE
fix: load Supabase module in lobby via import map

### DIFF
--- a/lobby.html
+++ b/lobby.html
@@ -9,6 +9,13 @@
     <link rel="stylesheet" href="./css/theme.css" />
     <title>Lobby - NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+    <script type="importmap">
+      {
+        "imports": {
+          "@supabase/supabase-js": "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"
+        }
+      }
+    </script>
   </head>
   <body class="lobby-page">
     <header class="main-header">


### PR DESCRIPTION
## Summary
- include an import map in lobby.html so the browser resolves `@supabase/supabase-js` to a CDN bundle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b16ae0a7a0832cb401f9b8c937bf78