### PR TITLE
Display latest lobby log entries first

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -38,7 +38,8 @@ function appendLog(level, args) {
     .map(a => (typeof a === "string" ? a : JSON.stringify(a)))
     .join(" ");
   line.textContent = `[${level}] ${text}`;
-  logBox.appendChild(line);
+  if (typeof logBox.prepend === "function") logBox.prepend(line);
+  else logBox.insertBefore(line, logBox.firstChild);
 }
 
 export function info(...args) {

--- a/tests/logger.uat.test.js
+++ b/tests/logger.uat.test.js
@@ -9,9 +9,11 @@ describe('logger', () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
+    document.body.innerHTML = '';
     if (overlay) {
       overlay.textContent = '';
       overlay.classList.add('hidden');
+      document.body.appendChild(overlay);
     }
   });
 
@@ -49,5 +51,16 @@ describe('logger', () => {
     expect(errSpy).toHaveBeenCalledWith('[ERROR]', 'async boom');
     expect(overlay.textContent).toBe('async boom');
     expect(overlay.classList.contains('hidden')).toBe(false);
+  });
+
+  test('new log entries appear at top of debug log', () => {
+    document.body.innerHTML = '<section id="debugLog"></section>';
+    info('first');
+    info('second');
+    const lines = Array.from(
+      document.querySelectorAll('#debugLog div'),
+      el => el.textContent
+    );
+    expect(lines).toEqual(['[INFO] second', '[INFO] first']);
   });
 });


### PR DESCRIPTION
## Summary
- Show newest messages at the top of the lobby debug log
- Add tests for log prepending behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b181489324832c97b26521a61e1096