### PR TITLE
feat: allow lobby creation

### DIFF
--- a/supabase/migrations/000000000000_init.sql
+++ b/supabase/migrations/000000000000_init.sql
@@ -61,6 +61,8 @@ create policy "allow_select_players" on players for select using (true);
 create policy "allow_select_game_states" on game_states for select using (true);
 create policy "allow_select_events" on events for select using (true);
 create policy "allow_select_lobbies" on lobbies for select using (true);
+create policy "allow_insert_lobbies" on lobbies for insert with check (true);
+create policy "allow_update_lobbies" on lobbies for update using (true) with check (true);
 create policy "allow_select_lobby_chat" on lobby_chat for select using (true);
 create policy "allow_insert_lobby_chat" on lobby_chat for insert with check (true);
 

--- a/supabase/migrations/20250829104100_add_lobby_write_policies.sql
+++ b/supabase/migrations/20250829104100_add_lobby_write_policies.sql
@@ -1,0 +1,21 @@
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'lobbies'
+      and polname = 'allow_insert_lobbies'
+  ) then
+    create policy "allow_insert_lobbies" on lobbies for insert with check (true);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'lobbies'
+      and polname = 'allow_update_lobbies'
+  ) then
+    create policy "allow_update_lobbies" on lobbies for update using (true) with check (true);
+  end if;
+end
+$$;


### PR DESCRIPTION
## Summary
- allow creating and updating lobbies by loosening RLS
- add upgrade migration to apply policies to existing databases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b181832f54832c8fba87cd303df66c