### PR TITLE
Add username login using Supabase

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <h1 id="pageTitle">About &amp; Settings</h1>

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <nav>

--- a/howto.html
+++ b/howto.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <nav>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <a href="./setup.html">Setup</a>
         <a href="./how-to-play.html">How To</a>
         <a href="./about.html">About</a>
+        <a href="./login.html">Login</a>
       </nav>
       <button
         id="themeToggle"

--- a/lobby.html
+++ b/lobby.html
@@ -25,6 +25,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <main>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login - NetRisk</title>
+    <link rel="stylesheet" href="./css/base.css" />
+    <link rel="stylesheet" href="./css/layout.css" />
+    <link rel="stylesheet" href="./css/components.css" />
+    <link rel="stylesheet" href="./css/theme.css" />
+  </head>
+  <body>
+    <header class="main-header">
+      <a href="index.html" class="logo">NetRisk</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="setup.html">Setup</a>
+        <a href="how-to-play.html">How To</a>
+        <a href="about.html">About</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </header>
+    <main>
+      <h1>Login</h1>
+      <form id="loginForm">
+        <label>
+          Username:
+          <input type="text" id="username" required />
+        </label>
+        <label>
+          Password:
+          <input type="password" id="password" required />
+        </label>
+        <button type="submit" class="btn">Login</button>
+        <button type="button" id="registerBtn" class="btn">Register</button>
+      </form>
+      <p id="message" role="alert"></p>
+    </main>
+    <script type="module" src="./login.js"></script>
+  </body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,1 @@
+import './src/login.js';

--- a/setup.html
+++ b/setup.html
@@ -19,6 +19,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <h1>Player Setup</h1>

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,50 @@
+import supabase from './init/supabase-client.js';
+
+function usernameToEmail(username) {
+  const clean = username.trim().toLowerCase();
+  return `${clean}@example.com`;
+}
+
+const form = document.getElementById('loginForm');
+const message = document.getElementById('message');
+const usernameInput = document.getElementById('username');
+const passwordInput = document.getElementById('password');
+const registerBtn = document.getElementById('registerBtn');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  if (!supabase) {
+    message.textContent = 'Supabase not configured';
+    return;
+  }
+  const username = usernameInput.value;
+  const password = passwordInput.value;
+  const { error } = await supabase.auth.signInWithPassword({
+    email: usernameToEmail(username),
+    password,
+  });
+  if (error) {
+    message.textContent = error.message;
+    return;
+  }
+  message.textContent = 'Login successful';
+});
+
+registerBtn.addEventListener('click', async () => {
+  if (!supabase) {
+    message.textContent = 'Supabase not configured';
+    return;
+  }
+  const username = usernameInput.value;
+  const password = passwordInput.value;
+  const { error } = await supabase.auth.signUp({
+    email: usernameToEmail(username),
+    password,
+    options: { data: { username } },
+  });
+  if (error) {
+    message.textContent = error.message;
+    return;
+  }
+  message.textContent = 'Registration successful';
+});


### PR DESCRIPTION
## Summary
- add Login page with username/password auth backed by Supabase
- wire navigation to include Login entry
- implement registration and sign in using Supabase auth

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18788217c832c91332f67d80d2397