### PR TITLE
Add username login using Supabase

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <h1 id="pageTitle">About &amp; Settings</h1>

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -13,7 +13,8 @@ export default defineConfig({
         lobby: resolve(__dirname, '../lobby.html'),
         setup: resolve(__dirname, '../setup.html'),
         howToPlay: resolve(__dirname, '../how-to-play.html'),
-        howto: resolve(__dirname, '../howto.html')
+        howto: resolve(__dirname, '../howto.html'),
+        login: resolve(__dirname, '../login.html')
       }
     }
   },

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <nav>

--- a/howto.html
+++ b/howto.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <nav>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <a href="./setup.html">Setup</a>
         <a href="./how-to-play.html">How To</a>
         <a href="./about.html">About</a>
+        <a href="./login.html">Login</a>
       </nav>
       <button
         id="themeToggle"

--- a/lobby.html
+++ b/lobby.html
@@ -25,6 +25,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <main>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login - NetRisk</title>
+    <link rel="stylesheet" href="./css/base.css" />
+    <link rel="stylesheet" href="./css/layout.css" />
+    <link rel="stylesheet" href="./css/components.css" />
+    <link rel="stylesheet" href="./css/theme.css" />
+  </head>
+  <body>
+    <header class="main-header">
+      <a href="index.html" class="logo">NetRisk</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="setup.html">Setup</a>
+        <a href="how-to-play.html">How To</a>
+        <a href="about.html">About</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </header>
+    <main>
+      <h1>Login</h1>
+      <form id="loginForm">
+        <label>
+          Username:
+          <input type="text" id="username" required />
+        </label>
+        <label>
+          Password:
+          <input type="password" id="password" required />
+        </label>
+        <button type="submit" class="btn">Login</button>
+        <button type="button" id="registerBtn" class="btn">Register</button>
+      </form>
+      <p id="message" role="alert"></p>
+    </main>
+    <script type="module" src="./login.js"></script>
+  </body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,1 @@
+import './src/login.js';

--- a/setup.html
+++ b/setup.html
@@ -19,6 +19,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <h1>Player Setup</h1>

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,54 @@
+import supabase from './init/supabase-client.js';
+
+async function hashPassword(password) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+const form = document.getElementById('loginForm');
+const message = document.getElementById('message');
+const usernameInput = document.getElementById('username');
+const passwordInput = document.getElementById('password');
+const registerBtn = document.getElementById('registerBtn');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  if (!supabase) {
+    message.textContent = 'Supabase not configured';
+    return;
+  }
+  const username = usernameInput.value.trim();
+  const password = passwordInput.value;
+  const hashed = await hashPassword(password);
+  const { data, error } = await supabase
+    .from('users')
+    .select('password_hash')
+    .eq('username', username)
+    .single();
+  if (error || !data || data.password_hash !== hashed) {
+    message.textContent = 'Invalid username or password';
+    return;
+  }
+  message.textContent = 'Login successful';
+});
+
+registerBtn.addEventListener('click', async () => {
+  if (!supabase) {
+    message.textContent = 'Supabase not configured';
+    return;
+  }
+  const username = usernameInput.value.trim();
+  const password = passwordInput.value;
+  const hashed = await hashPassword(password);
+  const { error } = await supabase
+    .from('users')
+    .insert({ username, password_hash: hashed });
+  if (error) {
+    message.textContent = error.message;
+    return;
+  }
+  message.textContent = 'Registration successful';
+});

--- a/supabase/migrations/000000000001_add_users.sql
+++ b/supabase/migrations/000000000001_add_users.sql
@@ -1,0 +1,11 @@
+create table if not exists users (
+  id uuid primary key default gen_random_uuid(),
+  username text unique not null,
+  password_hash text not null,
+  created_at timestamptz default now()
+);
+
+alter table users enable row level security;
+
+create policy "allow_select_users" on users for select using (true);
+create policy "allow_insert_users" on users for insert with check (true);


### PR DESCRIPTION
## Summary
- add Login page with username/password auth backed by Supabase
- wire navigation to include Login entry
- include login page in Vite build inputs
- implement custom username auth table and client-side password hashing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18788217c832c91332f67d80d2397