### PR TITLE
Add username login using Supabase

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <h1 id="pageTitle">About &amp; Settings</h1>

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -13,7 +13,8 @@ export default defineConfig({
         lobby: resolve(__dirname, '../lobby.html'),
         setup: resolve(__dirname, '../setup.html'),
         howToPlay: resolve(__dirname, '../how-to-play.html'),
-        howto: resolve(__dirname, '../howto.html')
+        howto: resolve(__dirname, '../howto.html'),
+        login: resolve(__dirname, '../login.html')
       }
     }
   },

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <nav>

--- a/howto.html
+++ b/howto.html
@@ -17,6 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <nav>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <a href="./setup.html">Setup</a>
         <a href="./how-to-play.html">How To</a>
         <a href="./about.html">About</a>
+        <a href="./login.html">Login</a>
       </nav>
       <button
         id="themeToggle"

--- a/lobby.html
+++ b/lobby.html
@@ -25,6 +25,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <main>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login - NetRisk</title>
+    <link rel="stylesheet" href="./css/base.css" />
+    <link rel="stylesheet" href="./css/layout.css" />
+    <link rel="stylesheet" href="./css/components.css" />
+    <link rel="stylesheet" href="./css/theme.css" />
+  </head>
+  <body>
+    <header class="main-header">
+      <a href="index.html" class="logo">NetRisk</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="setup.html">Setup</a>
+        <a href="how-to-play.html">How To</a>
+        <a href="about.html">About</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </header>
+    <main>
+      <h1>Login</h1>
+      <form id="loginForm">
+        <label>
+          Username:
+          <input type="text" id="username" required />
+        </label>
+        <label>
+          Password:
+          <input type="password" id="password" required />
+        </label>
+        <button type="submit" class="btn">Login</button>
+        <button type="button" id="registerBtn" class="btn">Register</button>
+      </form>
+      <p id="message" role="alert"></p>
+    </main>
+    <script type="module" src="./login.js"></script>
+  </body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,1 @@
+import './src/login.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.56.0",
+        "bcryptjs": "^2.4.3",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -4096,6 +4097,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.0",
+    "bcryptjs": "^2.4.3",
     "zod": "^3.25.76"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 const http = require('http');
 const { readFile } = require('fs/promises');
 const path = require('path');
+const bcrypt = require('bcryptjs');
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 
 const distDir = path.join(__dirname, 'dist');
 
@@ -25,6 +29,69 @@ const mimeTypes = {
 
 const server = http.createServer(async (req, res) => {
   const urlPath = req.url.split('?')[0];
+
+  if (req.method === 'POST' && (urlPath === '/api/register' || urlPath === '/api/login')) {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', async () => {
+      try {
+        const { username, password } = JSON.parse(body || '{}');
+        if (!username || !password) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Username and password required' }));
+          return;
+        }
+        if (urlPath === '/api/register') {
+          const hash = await bcrypt.hash(password, 10);
+          const response = await fetch(`${SUPABASE_URL}/rest/v1/users`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              apikey: SUPABASE_SERVICE_KEY,
+              Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+              Prefer: 'return=minimal',
+            },
+            body: JSON.stringify({ username, password_hash: hash }),
+          });
+          if (!response.ok) {
+            const err = await response.json().catch(() => ({}));
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: err.message || 'Registration failed' }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        const response = await fetch(
+          `${SUPABASE_URL}/rest/v1/users?select=password_hash&username=eq.${encodeURIComponent(username)}`,
+          {
+            headers: {
+              apikey: SUPABASE_SERVICE_KEY,
+              Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+            },
+          }
+        );
+        const rows = await response.json();
+        const valid = rows.length > 0 && (await bcrypt.compare(password, rows[0].password_hash));
+        if (!valid) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid username or password' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Server error' }));
+      }
+    });
+    return;
+  }
+
   let fileName = routes[urlPath] || urlPath;
   fileName = fileName.replace(/^\/+/, '');
   const filePath = path.resolve(distDir, fileName);

--- a/setup.html
+++ b/setup.html
@@ -19,6 +19,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
+        <a href="login.html">Login</a>
       </nav>
     </header>
     <h1>Player Setup</h1>

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,29 @@
+const form = document.getElementById('loginForm');
+const message = document.getElementById('message');
+const usernameInput = document.getElementById('username');
+const passwordInput = document.getElementById('password');
+const registerBtn = document.getElementById('registerBtn');
+
+async function postJson(url, body) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = usernameInput.value.trim();
+  const password = passwordInput.value;
+  const result = await postJson('/api/login', { username, password });
+  message.textContent = result.error || 'Login successful';
+});
+
+registerBtn.addEventListener('click', async () => {
+  const username = usernameInput.value.trim();
+  const password = passwordInput.value;
+  const result = await postJson('/api/register', { username, password });
+  message.textContent = result.error || 'Registration successful';
+});

--- a/supabase/migrations/000000000001_add_users.sql
+++ b/supabase/migrations/000000000001_add_users.sql
@@ -1,0 +1,11 @@
+create table if not exists users (
+  id uuid primary key default gen_random_uuid(),
+  username text unique not null,
+  password_hash text not null,
+  created_at timestamptz default now()
+);
+
+alter table users enable row level security;
+
+create policy "user_select_self" on users for select using (auth.uid() = id);
+create policy "user_insert_self" on users for insert with check (auth.uid() = id);


### PR DESCRIPTION
## Summary
- tighten RLS policies so users can only access their own row
- move registration and login to server-side endpoints with bcrypt hashing
- drop client-side password hash reads and fetch login/register via secure API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18788217c832c91332f67d80d2397