### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -1,4 +1,6 @@
 name: UAT
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/andreame-code/netrisk/security/code-scanning/5](https://github.com/andreame-code/netrisk/security/code-scanning/5)

To fix this issue, add an explicit `permissions` block to the workflow. Since the steps in the job only check out code and install/run dependencies/tests—they do not write to the repository or use the API to create or approve anything—the least privileges required are read-only access to repository contents. Therefore, add the following block at the workflow root (recommended, since there is only one job): 

```yaml
permissions:
  contents: read
```

This ensures the job does not get unnecessary permissions.

Edit the `.github/workflows/uat.yml` file to insert these lines directly below the `name` field and above the `on` block. No extra methods, imports, or other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
