### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/andreame-code/netrisk/security/code-scanning/4](https://github.com/andreame-code/netrisk/security/code-scanning/4)

The recommended fix is to add an explicit `permissions` block set to the minimal required value at the top level of the workflow file. This ensures that all jobs (including disabled or future ones) will only receive the `contents: read` permission by default, unless more is needed.  
This can be accomplished by adding:  

```yaml
permissions:
  contents: read
```

to the workflow, immediately after the `name: CI` and before `on:`.  
No additional imports or custom code are required. Only the `.github/workflows/test.yml` file needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
