### PR TITLE
feat: keep tokens visible in all overlays

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -102,6 +102,8 @@
   background: #fff;
   pointer-events: none;
   transform: translate(-50%, -50%);
+  transform-origin: center;
+  z-index: 1000;
 }
 
 .territory {
@@ -120,6 +122,8 @@
   user-select: none;
   transition: transform 0.3s;
   transform: translate(-50%, -50%);
+  transform-origin: center;
+  z-index: 1000;
 }
 
 .territory.selected { outline: 4px solid #ff0; }


### PR DESCRIPTION
## Summary
- ensure tokens and territory markers render above fog/grid overlays
- center transforms for predictable scaling behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1984bf894832c87e9248874938d01