### PR TITLE
feat: add fallback territory anchors

### DIFF
--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -8,6 +8,7 @@ export default function initTerritorySelection({
   gameState,
   attachTerritoryHandlers,
   updateUI,
+  territoryPositions = {},
 }) {
   let selectedTerritory = null;
   let possibleMoveEls = [];
@@ -98,11 +99,23 @@ export default function initTerritorySelection({
           el.setAttribute("tabindex", "0");
           el.setAttribute("role", "button");
         });
+
+      function computeFallbackPosition(id) {
+        const selector =
+          typeof CSS !== "undefined" && CSS.escape ? `#${CSS.escape(id)}` : `#${id}`;
+        const terrPath = map?.querySelector(selector);
+        if (!terrPath || typeof terrPath.getBBox !== "function") return null;
+        const { x, y, width, height } = terrPath.getBBox();
+        return { x: x + width / 2, y: y + height / 2 };
+      }
+
       const tokenEl = document.createElement("div");
       tokenEl.id = "token";
       tokenEl.className = "token";
       const terrs = territories || game?.territories;
       if (terrs) {
+        const viewBox = map?.viewBox?.baseVal;
+        const margin = 10;
         terrs.forEach((t) => {
           const terrEl = document.createElement("button");
           terrEl.type = "button";
@@ -113,6 +126,17 @@ export default function initTerritorySelection({
             terrEl.setAttribute("aria-label", t.name);
           }
           boardEl.appendChild(terrEl);
+          if (!territoryPositions[t.id]) {
+            const pos = computeFallbackPosition(t.id);
+            if (pos) {
+              let { x, y } = pos;
+              if (viewBox) {
+                x = Math.min(Math.max(x, margin), viewBox.width - margin);
+                y = Math.min(Math.max(y, margin), viewBox.height - margin);
+              }
+              territoryPositions[t.id] = { x, y };
+            }
+          }
         });
         attachTerritoryHandlers?.();
         updateUI?.();

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -464,6 +464,7 @@ async function initGame() {
     gameState,
     attachTerritoryHandlers,
     updateUI,
+    territoryPositions,
   });
 
   updateUI();

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -32,7 +32,7 @@ describe('Accessibility features', () => {
       { id: 'A', name: 'Alpha' },
       { id: 'B', name: 'Beta' },
     ];
-    initTerritorySelection({ territories });
+    initTerritorySelection({ territories, territoryPositions: {} });
     await flushPromises();
     const btnA = document.querySelector('button#A');
     expect(btnA.getAttribute('aria-label')).toBe('Alpha');

--- a/tests/map3.test.js
+++ b/tests/map3.test.js
@@ -62,7 +62,7 @@ describe('territory-selection with map3', () => {
       Promise.resolve({ ok: true, text: () => Promise.resolve(svg) }),
     );
     const init = require('../src/territory-selection.js').default;
-    init({ territories: map.territories });
+    init({ territories: map.territories, territoryPositions: {} });
     await flushPromises();
     expect(fetch).toHaveBeenCalledWith('assets/maps/map3.svg');
     const buttons = document.querySelectorAll('button.territory');
@@ -77,7 +77,7 @@ describe('territory-selection with map3', () => {
       Promise.resolve({ ok: true, text: () => Promise.resolve(svg) }),
     );
     const init = require('../src/territory-selection.js').default;
-    init({ territories: map.territories });
+    init({ territories: map.territories, territoryPositions: {} });
     await flushPromises();
     const board = document.getElementById('board');
     const token = document.getElementById('token');

--- a/tests/territory-selection.moves.test.js
+++ b/tests/territory-selection.moves.test.js
@@ -19,7 +19,7 @@ test('selecting territory highlights possible moves', async () => {
     getPhase: () => ATTACK,
     territoryById: (id) => territories.find((t) => t.id === id),
   };
-  initTerritorySelection({ game, territories });
+  initTerritorySelection({ game, territories, territoryPositions: {} });
   await flushPromises();
   const aPath = document.getElementById('A');
   aPath.dispatchEvent(new Event('click', { bubbles: true }));

--- a/tests/territory-selection.uat.test.js
+++ b/tests/territory-selection.uat.test.js
@@ -51,7 +51,7 @@ describe('territory selection user flow', () => {
       territoryById: (id) => territories.find((t) => t.id === id),
     };
 
-    initTerritorySelection({ game, territories });
+    initTerritorySelection({ game, territories, territoryPositions: {} });
     await flushPromises();
 
     const aPath = document.getElementById('A');


### PR DESCRIPTION
## Summary
- anchor tokens to territories using provided coordinates or fallback to territory centroid within map bounds
- forward territoryPositions to the territory selection module
- adjust tests for territory anchor changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b19f5b9b28832c91cc5773b82a43ba