### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -1,4 +1,6 @@
 name: CI (Playwright Container)
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/andreame-code/netrisk/security/code-scanning/2](https://github.com/andreame-code/netrisk/security/code-scanning/2)

The best way to address this issue is to add a `permissions` block to the workflow. Since the workflow is only checking out code and running Playwright tests (which does not appear to require any token write access), the minimal necessary permissions are `contents: read`. This can be set at the top level of the workflow (which applies to all jobs), or inside the specific job if needed. To avoid any confusion and to future-proof the workflow, add the following just after the workflow `name` and before the `on` key in `.github/workflows/test-container.yml`:

```yaml
permissions:
  contents: read
```

This makes it explicit that the job(s) only have read access to repository contents, following the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
