### PR TITLE
feat: allow configurable API base URL

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,22 @@
+export const API_BASE_URL = (import.meta.env?.VITE_API_BASE_URL || '').replace(/\/+$/, '');
 export const SUPABASE_URL = (import.meta.env?.VITE_SUPABASE_URL || '').replace(/\/+$/, '');
 export const SUPABASE_KEY = import.meta.env?.VITE_SUPABASE_ANON_KEY || '';
 export const WS_URL = (() => {
   if (!SUPABASE_URL) return '';
-  try { const u = new URL(SUPABASE_URL); return `wss://${u.host}/functions/v1/netrisk`; } catch { return ''; }
+  try {
+    const u = new URL(SUPABASE_URL);
+    return `wss://${u.host}/functions/v1/netrisk`;
+  } catch {
+    return '';
+  }
 })();
 // Log diagnostico (mascherato)
 if (typeof window !== 'undefined') {
-  console.info('[ENV]', { SUPABASE_URL, SUPABASE_KEY: SUPABASE_KEY ? '***present***' : '(empty)', WS_URL });
+  console.info('[ENV]', {
+    API_BASE_URL,
+    SUPABASE_URL,
+    SUPABASE_KEY: SUPABASE_KEY ? '***present***' : '(empty)',
+    WS_URL,
+  });
 }
 

--- a/src/login.js
+++ b/src/login.js
@@ -1,3 +1,5 @@
+import { API_BASE_URL } from './config.js';
+
 const form = document.getElementById('loginForm');
 const message = document.getElementById('message');
 const usernameInput = document.getElementById('username');
@@ -27,13 +29,13 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = usernameInput.value.trim();
   const password = passwordInput.value;
-  const result = await postJson('/api/login', { username, password });
+  const result = await postJson(`${API_BASE_URL}/api/login`, { username, password });
   message.textContent = result.error || 'Login successful';
 });
 
 registerBtn.addEventListener('click', async () => {
   const username = usernameInput.value.trim();
   const password = passwordInput.value;
-  const result = await postJson('/api/register', { username, password });
+  const result = await postJson(`${API_BASE_URL}/api/register`, { username, password });
   message.textContent = result.error || 'Registration successful';
 });


### PR DESCRIPTION
## Summary
- support custom API_BASE_URL via env in config
- direct login/register requests to configured API host

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2613650832c9623a0a53583271f