### PR TITLE
Align map territory IDs with game data

### DIFF
--- a/public/assets/maps/map-roman.svg
+++ b/public/assets/maps/map-roman.svg
@@ -2,7 +2,7 @@
   <rect width="600" height="400" fill="#e0d8b0" />
   <!-- Hispania -->
   <path
-    id="hispania"
+    id="t1"
     class="map-territory"
     data-name="Hispania"
     d="M60 170 L120 140 L140 180 L90 200 Z"
@@ -10,7 +10,7 @@
   />
   <!-- Gaul -->
   <path
-    id="gaul"
+    id="t2"
     class="map-territory"
     data-name="Gaul"
     d="M130 120 L190 110 L200 150 L150 170 Z"
@@ -18,7 +18,7 @@
   />
   <!-- Italia -->
   <path
-    id="italia"
+    id="t3"
     class="map-territory"
     data-name="Italia"
     d="M210 130 L250 140 L240 180 L210 170 Z"
@@ -26,7 +26,7 @@
   />
   <!-- Greece -->
   <path
-    id="greece"
+    id="t4"
     class="map-territory"
     data-name="Greece"
     d="M260 170 L300 180 L290 220 L250 210 Z"
@@ -34,7 +34,7 @@
   />
   <!-- Asia Minor -->
   <path
-    id="asia-minor"
+    id="t5"
     class="map-territory"
     data-name="Asia Minor"
     d="M320 150 L380 150 L380 190 L320 190 Z"
@@ -42,7 +42,7 @@
   />
   <!-- Egypt -->
   <path
-    id="egypt"
+    id="t6"
     class="map-territory"
     data-name="Egypt"
     d="M300 220 L360 230 L350 280 L290 270 Z"

--- a/public/assets/maps/map.svg
+++ b/public/assets/maps/map.svg
@@ -2,7 +2,7 @@
   <rect width="600" height="400" fill="#87ceeb" />
   <!-- North America -->
   <path
-    id="north-america"
+    id="t1"
     class="map-territory"
     data-name="North America"
     d="M50 60 L150 40 L200 100 L160 140 L120 160 L80 120 Z"
@@ -10,7 +10,7 @@
   />
   <!-- South America -->
   <path
-    id="south-america"
+    id="t2"
     class="map-territory"
     data-name="South America"
     d="M120 160 L160 180 L180 260 L140 350 L100 300 Z"
@@ -18,7 +18,7 @@
   />
   <!-- Europe/Asia -->
   <path
-    id="eurasia"
+    id="t3"
     class="map-territory"
     data-name="Eurasia"
     d="M220 60 L560 60 L580 140 L520 180 L400 160 L300 140 L250 100 Z"
@@ -26,7 +26,7 @@
   />
   <!-- Africa -->
   <path
-    id="africa"
+    id="t4"
     class="map-territory"
     data-name="Africa"
     d="M300 140 L360 180 L380 260 L340 340 L300 280 L280 200 Z"
@@ -34,10 +34,18 @@
   />
   <!-- Australia -->
   <path
-    id="australia"
+    id="t5"
     class="map-territory"
     data-name="Australia"
     d="M470 260 L540 260 L560 300 L520 340 L460 320 Z"
+    fill="#c8e6c9"
+  />
+  <!-- Antarctica -->
+  <path
+    id="t6"
+    class="map-territory"
+    data-name="Antarctica"
+    d="M200 360 L400 360 L380 390 L220 390 Z"
     fill="#c8e6c9"
   />
 </svg>

--- a/public/assets/maps/map2.svg
+++ b/public/assets/maps/map2.svg
@@ -2,7 +2,7 @@
   <rect width="600" height="400" fill="#f4a460" />
   <!-- North America -->
   <path
-    id="north-america"
+    id="t1"
     class="map-territory"
     data-name="North America"
     d="M50 60 L150 40 L200 100 L160 140 L120 160 L80 120 Z"
@@ -10,7 +10,7 @@
   />
   <!-- South America -->
   <path
-    id="south-america"
+    id="t2"
     class="map-territory"
     data-name="South America"
     d="M120 160 L160 180 L180 260 L140 350 L100 300 Z"
@@ -18,7 +18,7 @@
   />
   <!-- Europe/Asia -->
   <path
-    id="eurasia"
+    id="t3"
     class="map-territory"
     data-name="Eurasia"
     d="M220 60 L560 60 L580 140 L520 180 L400 160 L300 140 L250 100 Z"
@@ -26,7 +26,7 @@
   />
   <!-- Africa -->
   <path
-    id="africa"
+    id="t4"
     class="map-territory"
     data-name="Africa"
     d="M300 140 L360 180 L380 260 L340 340 L300 280 L280 200 Z"
@@ -34,10 +34,18 @@
   />
   <!-- Australia -->
   <path
-    id="australia"
+    id="t5"
     class="map-territory"
     data-name="Australia"
     d="M470 260 L540 260 L560 300 L520 340 L460 320 Z"
+    fill="#c8e6c9"
+  />
+  <!-- Antarctica -->
+  <path
+    id="t6"
+    class="map-territory"
+    data-name="Antarctica"
+    d="M200 360 L400 360 L380 390 L220 390 Z"
     fill="#c8e6c9"
   />
 </svg>

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -14,9 +14,9 @@ test.describe('UAT checklist', () => {
     page.on('pageerror', (err) => errors.push(err.message));
 
     await page.goto('/game.html');
-    await page.waitForSelector('#north-america');
+    await page.waitForSelector('#t1');
 
-    const terrs = ['#north-america', '#south-america', '#africa'];
+    const terrs = ['#t1', '#t2', '#t4'];
     for (const sel of terrs) {
       await page.evaluate((s) => {
         const el = document.querySelector(s);


### PR DESCRIPTION
## Summary
- Update map SVGs to use territory identifiers matching game data
- Add missing Antarctica territory to base maps to cover six IDs
- Normalize Roman map territories to sequential IDs
- Adjust UAT smoke test selectors for new territory IDs

## Testing
- `npm test`
- `npm run test:uat` *(fails: browser binaries not installed; `npx playwright install`/`install-deps` blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a33a2f10832c9a6a58611280a562