### PR TITLE
Handle missing game graphics gracefully

### DIFF
--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -57,21 +57,58 @@ let phaseTimer;
 const loadErrorEl = document.getElementById("loadError");
 const loadErrorMsg = document.getElementById("loadErrorMsg");
 const retryBtn = document.getElementById("retryLoad");
+let retryAction = () => loadGame();
 
-function showLoadError() {
+function showLoadError(
+  message = "Unable to load game data. Check your connection and try again.",
+  action = () => loadGame(),
+) {
   if (loadErrorEl && loadErrorMsg) {
-    loadErrorMsg.textContent =
-      "Unable to load game data. Check your connection and try again.";
+    loadErrorMsg.textContent = message;
     loadErrorEl.classList.remove("hidden");
+    retryAction = action;
   }
 }
 
 if (retryBtn) {
   retryBtn.addEventListener("click", () => {
     if (loadErrorEl) loadErrorEl.classList.add("hidden");
-    loadGame();
+    retryAction();
   });
 }
+
+function handleImageError(event) {
+  const img = event?.target;
+  if (!img) return;
+  showLoadError(
+    "Some game pieces couldn't be loaded. We'll try again automatically. If the problem continues, press Retry.",
+    () => location.reload(),
+  );
+  if (!img.dataset.retry) {
+    img.dataset.retry = "1";
+    img.addEventListener(
+      "load",
+      () => {
+        if (loadErrorEl) loadErrorEl.classList.add("hidden");
+      },
+      { once: true },
+    );
+    setTimeout(() => {
+      const sep = img.src.includes("?") ? "&" : "?";
+      img.src = `${img.src}${sep}retry=${Date.now()}`;
+    }, 1000);
+  }
+}
+
+window.addEventListener(
+  "error",
+  (e) => {
+    if (e?.target?.tagName === "IMG") {
+      handleImageError(e);
+    }
+  },
+  true,
+);
 
 function checkForVictory() {
   const winner = game.checkVictory();

--- a/tests/image-error.test.js
+++ b/tests/image-error.test.js
@@ -1,0 +1,91 @@
+jest.mock("../src/territory-selection.js", () => jest.fn());
+jest.mock("../src/logger.js", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+jest.mock("../src/move-prompt.js", () => jest.fn());
+jest.mock("../src/navigation.js", () => ({
+  navigateTo: jest.fn(),
+  exitGame: jest.fn(),
+}));
+jest.mock("../src/audio.js", () => ({
+  playEffect: jest.fn(),
+  preloadEffects: jest.fn(),
+  setMasterVolume: jest.fn(),
+  getMasterVolume: jest.fn(() => 1),
+  setEffectsVolume: jest.fn(),
+  getEffectsVolume: jest.fn(() => 1),
+  setMuted: jest.fn(),
+  isMuted: jest.fn(() => false),
+  setMusicEnabled: jest.fn(),
+  isMusicEnabled: jest.fn(() => false),
+  setLevelMusic: jest.fn(),
+}));
+jest.mock("../src/phases.js", () => ({
+  REINFORCE: 0,
+  ATTACK: 1,
+  FORTIFY: 2,
+  GAME_OVER: 3,
+}));
+jest.mock("../src/stats.js", () => ({
+  attachStatsListeners: jest.fn(),
+  exportStats: jest.fn(),
+}));
+jest.mock("../src/ui.js", () => ({
+  initUI: jest.fn(),
+  updateInfoPanel: jest.fn(),
+  addLogEntry: jest.fn(),
+  animateMove: jest.fn(),
+  animateAttack: jest.fn(),
+  animateReinforce: jest.fn(),
+  showVictoryModal: jest.fn(),
+  updateUI: jest.fn(),
+  destroyUI: jest.fn(),
+  resetSelectedCards: jest.fn(),
+  getSelectedCards: jest.fn(() => []),
+  exportLog: jest.fn(),
+}));
+jest.mock("../src/phase-timer.js", () => jest.fn(() => ({ stop: jest.fn() })));
+jest.mock("../src/config.js", () => ({ WS_URL: "ws://test" }));
+jest.mock("../src/init/game-loader.js", () => ({
+  loadGame: jest.fn(() => Promise.resolve({ game: null, territoryPositions: {} })),
+}));
+jest.mock("../src/state/storage.js", () => ({
+  updateGameState: jest.fn(),
+  clearSavedData: jest.fn(),
+  hasSavedPlayers: jest.fn(() => true),
+  hasSavedGame: jest.fn(() => true),
+  getMapName: jest.fn(() => "map"),
+}));
+jest.mock("../src/data/level-accessibility.js", () => ({
+  applyLevelAccessibility: jest.fn(),
+}));
+jest.mock("../src/state/game.js", () => ({
+  gameState: { turnNumber: 1 },
+  initGameState: jest.fn(),
+}));
+jest.mock("../src/ai-logging.js", () => jest.fn());
+
+
+describe("image load errors", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML =
+      '<div id="loadError" class="hidden"><p id="loadErrorMsg"></p><button id="retryLoad"></button></div>' +
+      '<button id="endTurn"></button><img id="piece" src="img.png" />';
+    // eslint-disable-next-line global-require
+    require("../src/ui-init.js");
+  });
+
+  test("shows message and retries when image fails to load", () => {
+    const img = document.getElementById("piece");
+    img.dispatchEvent(new Event("error", { bubbles: true }));
+    const errorEl = document.getElementById("loadError");
+    expect(errorEl.classList.contains("hidden")).toBe(false);
+    const msg = document.getElementById("loadErrorMsg").textContent;
+    expect(/pieces/i.test(msg)).toBe(true);
+    jest.runAllTimers();
+    expect(img.src).toMatch(/retry=/);
+  });
+});


### PR DESCRIPTION
## Summary
- show a non-technical message when game images fail to load and retry automatically
- allow retrying with a page reload via the existing retry button
- add regression test for image load errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1a6044400832ca8b14dddd8c61138