### PR TITLE
Fix token positioning for 8-player map

### DIFF
--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -1,5 +1,5 @@
 import { ATTACK, FORTIFY } from "./phases.js";
-import { getBoardScale } from "./ui.js";
+import { getBoardScale, getElement } from "./ui.js";
 import * as logger from "./logger.js";
 
 export default function initTerritorySelection({
@@ -55,7 +55,7 @@ export default function initTerritorySelection({
       );
     }
     targets.forEach((tid) => {
-      const btn = document.getElementById(tid);
+      const btn = getElement(tid);
       if (btn) {
         btn.classList.add("possible-move");
         possibleMoveEls.push(btn);

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -35,6 +35,7 @@ import {
   resetSelectedCards,
   getSelectedCards,
   exportLog,
+  getElement,
 } from "./ui.js";
 import initPhaseTimer from "./phase-timer.js";
 import { WS_URL } from "./config.js";
@@ -149,8 +150,8 @@ function attachTerritoryHandlers() {
           const playerName = game.players[prevPlayer].name;
           if (result.type === ATTACK) {
             logger.info(`${playerName} attacks ${result.to} from ${result.from}`);
-            const fromEl = document.getElementById(result.from);
-            const toEl = document.getElementById(result.to);
+            const fromEl = getElement(result.from);
+            const toEl = getElement(result.to);
             fromEl.classList.add("attack", "animate__animated", "animate__shakeX");
             toEl.classList.add("attack", "animate__animated", "animate__shakeX");
             setTimeout(() => {
@@ -212,7 +213,10 @@ function attachTerritoryHandlers() {
         updateUI();
         if (result && result.type === "select") {
           logger.info(`${game.players[game.currentPlayer].name} selects ${result.territory}`);
-          document.getElementById(result.territory).classList.add("selected");
+          const selEl = getElement(result.territory);
+          if (selEl) {
+            selEl.classList.add("selected");
+          }
         }
         updateGameState(
           gameState,

--- a/src/ui.js
+++ b/src/ui.js
@@ -10,7 +10,13 @@ function createElementCache() {
   return {
     get(id) {
       if (!cache[id]) {
-        cache[id] = document.getElementById(id);
+        const esc =
+          typeof CSS !== "undefined" && typeof CSS.escape === "function"
+            ? CSS.escape(id)
+            : id;
+        cache[id] =
+          document.querySelector(`.territory[data-id="${esc}"]`) ||
+          document.getElementById(id);
       }
       return cache[id];
     },
@@ -499,4 +505,5 @@ function destroyUI() {
     getLog,
     exportLog,
     copyLog,
+    getElement,
   };

--- a/tests/territory-selection.moves.test.js
+++ b/tests/territory-selection.moves.test.js
@@ -23,6 +23,6 @@ test('selecting territory highlights possible moves', async () => {
   await flushPromises();
   const aPath = document.getElementById('A');
   aPath.dispatchEvent(new Event('click', { bubbles: true }));
-  const buttonB = document.getElementById('B');
+  const buttonB = document.querySelector('.territory[data-id="B"]');
   expect(buttonB.classList.contains('possible-move')).toBe(true);
 });

--- a/tests/territory-selection.uat.test.js
+++ b/tests/territory-selection.uat.test.js
@@ -57,9 +57,9 @@ describe('territory selection user flow', () => {
     const aPath = document.getElementById('A');
     aPath.dispatchEvent(new Event('click', { bubbles: true }));
 
-    const bPath = document.getElementById('B');
+    const bButton = document.querySelector('.territory[data-id="B"]');
     expect(aPath.classList.contains('selected')).toBe(true);
-    expect(bPath.classList.contains('possible-move')).toBe(true);
+    expect(bButton.classList.contains('possible-move')).toBe(true);
     expect(document.getElementById('selectedTerritory').textContent).toBe('Alpha');
 
     // clicking outside map clears selection


### PR DESCRIPTION
## Summary
- ensure DOM lookups return territory tokens instead of SVG paths
- use helper getElement in selection handlers
- adjust tests for new territory query method

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a6b5f5ac832c8810d7055998272e