### PR TITLE
Align map territory IDs with game data

### DIFF
--- a/public/assets/maps/map-roman.svg
+++ b/public/assets/maps/map-roman.svg
@@ -3,6 +3,7 @@
   <!-- Hispania -->
   <path
     id="hispania"
+    data-territory="t1"
     class="map-territory"
     data-name="Hispania"
     d="M60 170 L120 140 L140 180 L90 200 Z"
@@ -11,6 +12,7 @@
   <!-- Gaul -->
   <path
     id="gaul"
+    data-territory="t2"
     class="map-territory"
     data-name="Gaul"
     d="M130 120 L190 110 L200 150 L150 170 Z"
@@ -19,6 +21,7 @@
   <!-- Italia -->
   <path
     id="italia"
+    data-territory="t3"
     class="map-territory"
     data-name="Italia"
     d="M210 130 L250 140 L240 180 L210 170 Z"
@@ -27,6 +30,7 @@
   <!-- Greece -->
   <path
     id="greece"
+    data-territory="t4"
     class="map-territory"
     data-name="Greece"
     d="M260 170 L300 180 L290 220 L250 210 Z"
@@ -35,6 +39,7 @@
   <!-- Asia Minor -->
   <path
     id="asia-minor"
+    data-territory="t5"
     class="map-territory"
     data-name="Asia Minor"
     d="M320 150 L380 150 L380 190 L320 190 Z"
@@ -43,6 +48,7 @@
   <!-- Egypt -->
   <path
     id="egypt"
+    data-territory="t6"
     class="map-territory"
     data-name="Egypt"
     d="M300 220 L360 230 L350 280 L290 270 Z"

--- a/public/assets/maps/map.svg
+++ b/public/assets/maps/map.svg
@@ -3,6 +3,7 @@
   <!-- North America -->
   <path
     id="north-america"
+    data-territory="t1"
     class="map-territory"
     data-name="North America"
     d="M50 60 L150 40 L200 100 L160 140 L120 160 L80 120 Z"
@@ -11,6 +12,7 @@
   <!-- South America -->
   <path
     id="south-america"
+    data-territory="t2"
     class="map-territory"
     data-name="South America"
     d="M120 160 L160 180 L180 260 L140 350 L100 300 Z"
@@ -19,6 +21,7 @@
   <!-- Europe/Asia -->
   <path
     id="eurasia"
+    data-territory="t3"
     class="map-territory"
     data-name="Eurasia"
     d="M220 60 L560 60 L580 140 L520 180 L400 160 L300 140 L250 100 Z"
@@ -27,6 +30,7 @@
   <!-- Africa -->
   <path
     id="africa"
+    data-territory="t4"
     class="map-territory"
     data-name="Africa"
     d="M300 140 L360 180 L380 260 L340 340 L300 280 L280 200 Z"
@@ -35,9 +39,19 @@
   <!-- Australia -->
   <path
     id="australia"
+    data-territory="t5"
     class="map-territory"
     data-name="Australia"
     d="M470 260 L540 260 L560 300 L520 340 L460 320 Z"
+    fill="#c8e6c9"
+  />
+  <!-- Antarctica -->
+  <path
+    id="antarctica"
+    data-territory="t6"
+    class="map-territory"
+    data-name="Antarctica"
+    d="M200 360 L400 360 L380 390 L220 390 Z"
     fill="#c8e6c9"
   />
 </svg>

--- a/public/assets/maps/map2.svg
+++ b/public/assets/maps/map2.svg
@@ -3,6 +3,7 @@
   <!-- North America -->
   <path
     id="north-america"
+    data-territory="t1"
     class="map-territory"
     data-name="North America"
     d="M50 60 L150 40 L200 100 L160 140 L120 160 L80 120 Z"
@@ -11,6 +12,7 @@
   <!-- South America -->
   <path
     id="south-america"
+    data-territory="t2"
     class="map-territory"
     data-name="South America"
     d="M120 160 L160 180 L180 260 L140 350 L100 300 Z"
@@ -19,6 +21,7 @@
   <!-- Europe/Asia -->
   <path
     id="eurasia"
+    data-territory="t3"
     class="map-territory"
     data-name="Eurasia"
     d="M220 60 L560 60 L580 140 L520 180 L400 160 L300 140 L250 100 Z"
@@ -27,6 +30,7 @@
   <!-- Africa -->
   <path
     id="africa"
+    data-territory="t4"
     class="map-territory"
     data-name="Africa"
     d="M300 140 L360 180 L380 260 L340 340 L300 280 L280 200 Z"
@@ -35,9 +39,19 @@
   <!-- Australia -->
   <path
     id="australia"
+    data-territory="t5"
     class="map-territory"
     data-name="Australia"
     d="M470 260 L540 260 L560 300 L520 340 L460 320 Z"
+    fill="#c8e6c9"
+  />
+  <!-- Antarctica -->
+  <path
+    id="antarctica"
+    data-territory="t6"
+    class="map-territory"
+    data-name="Antarctica"
+    d="M200 360 L400 360 L380 390 L220 390 Z"
     fill="#c8e6c9"
   />
 </svg>

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -20,14 +20,15 @@ export default function initTerritorySelection({
     }
     clearPossibleMoves();
     if (el) {
-      const name = el.dataset.name || el.id;
+      const id = el.dataset.territory || el.id;
+      const name = el.dataset.name || id;
       el.classList.add("selected");
-      selectedTerritory = { id: el.id, name, el };
+      selectedTerritory = { id, name, el };
       infoPanel.textContent = name;
       logger.info(
         `Selected territory: ${selectedTerritory.id} (${selectedTerritory.name})`,
       );
-      highlightPossibleMoves(el.id);
+      highlightPossibleMoves(id);
     } else {
       selectedTerritory = null;
       infoPanel.textContent = "";
@@ -102,7 +103,9 @@ export default function initTerritorySelection({
 
       function computeFallbackPosition(id) {
         const selector =
-          typeof CSS !== "undefined" && CSS.escape ? `#${CSS.escape(id)}` : `#${id}`;
+          typeof CSS !== "undefined" && CSS.escape
+            ? `[data-territory="${CSS.escape(id)}"]`
+            : `[data-territory="${id}"]`;
         const terrPath = map?.querySelector(selector);
         if (!terrPath || typeof terrPath.getBBox !== "function") return null;
         const { x, y, width, height } = terrPath.getBBox();

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -14,9 +14,9 @@ test.describe('UAT checklist', () => {
     page.on('pageerror', (err) => errors.push(err.message));
 
     await page.goto('/game.html');
-    await page.waitForSelector('#north-america');
+    await page.waitForSelector('#t1');
 
-    const terrs = ['#north-america', '#south-america', '#africa'];
+    const terrs = ['#t1', '#t2', '#t4'];
     for (const sel of terrs) {
       await page.evaluate((s) => {
         const el = document.querySelector(s);


### PR DESCRIPTION
## Summary
- Ensure map SVG path IDs are unique while retaining territory links via `data-territory` attributes
- Use `data-territory` in territory selection logic and fallback positioning to match updated SVGs

## Testing
- `npm test`
- `npm run test:uat` *(fails: Playwright browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a33a2f10832c9a6a58611280a562