### PR TITLE
Limit undo to reinforcement phase

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -239,6 +239,8 @@ class Game {
             player: this.currentPlayer,
           });
           if (this.reinforcements === 0) {
+            this.undoStack = [];
+            this.redoStack = [];
             this.phase = ATTACK;
             this.emit('phaseChange', {
               phase: this.phase,
@@ -353,17 +355,18 @@ class Game {
   }
 
   pushUndoState() {
+    if (this.phase !== REINFORCE) return;
     this.undoStack.push(this.serialize());
     if (this.undoStack.length > this.maxUndo) this.undoStack.shift();
     this.redoStack = [];
   }
 
   canUndo() {
-    return this.undoStack.length > 0;
+    return this.phase === REINFORCE && this.undoStack.length > 0;
   }
 
   canRedo() {
-    return this.redoStack.length > 0;
+    return this.phase === REINFORCE && this.redoStack.length > 0;
   }
 
   restoreState(stateStr) {
@@ -384,6 +387,10 @@ class Game {
   }
 
   undo() {
+    if (this.phase !== REINFORCE) {
+      this.emit('undoUnavailable', { phase: this.phase });
+      return false;
+    }
     if (!this.canUndo()) return false;
     const prev = this.undoStack.pop();
     this.redoStack.push(this.serialize());

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -287,6 +287,10 @@ if (undoBtn) {
           game.selectedFrom ? game.selectedFrom.id : null,
         );
         updateInfoPanel();
+      } else {
+        addLogEntry("Undo is only available during reinforcement phase", {
+          type: "undo",
+        });
       }
     } catch (err) {
       logger.error(err);
@@ -399,6 +403,11 @@ async function initGame() {
   game.on("turnStart", () => {
     if (!firstTurn) playEffect("endTurn");
     firstTurn = false;
+  });
+  game.on("undoUnavailable", () => {
+    addLogEntry("Undo is only available during reinforcement phase", {
+      type: "undo",
+    });
   });
   const resetBtn = document.createElement("button");
   resetBtn.id = "resetGame";

--- a/tests/game.uat.test.js
+++ b/tests/game.uat.test.js
@@ -82,14 +82,12 @@ describe("game user flows", () => {
     expect(game.territoryById("c").armies).toBe(3);
   });
 
-  test("undo and redo revert state", () => {
+  test("undo not available outside reinforcement", () => {
     game.setPhase(FORTIFY);
     game.moveArmies("a", "c", 2);
-    expect(game.canUndo()).toBe(true);
-    game.undo();
-    expect(game.territoryById("a").armies).toBe(3);
-    expect(game.territoryById("c").armies).toBe(1);
-    game.redo();
+    expect(game.canUndo()).toBe(false);
+    const result = game.undo();
+    expect(result).toBe(false);
     expect(game.territoryById("a").armies).toBe(1);
     expect(game.territoryById("c").armies).toBe(3);
   });

--- a/tests/undo.test.js
+++ b/tests/undo.test.js
@@ -1,5 +1,5 @@
 import Game from "../src/game.js";
-import { ATTACK, FORTIFY } from "../src/phases.js";
+import { FORTIFY } from "../src/phases.js";
 
 describe("undo functionality", () => {
   const createGame = (maxUndo = 10) => {
@@ -20,63 +20,42 @@ describe("undo functionality", () => {
 
   test("undo and redo reinforcement", () => {
     const game = createGame();
-    game.reinforcements = 1;
+    game.reinforcements = 2;
     game.handleTerritoryClick("a");
     expect(game.territories[0].armies).toBe(6);
-    expect(game.reinforcements).toBe(0);
+    expect(game.reinforcements).toBe(1);
     expect(game.canUndo()).toBe(true);
     game.undo();
     expect(game.territories[0].armies).toBe(5);
-    expect(game.reinforcements).toBe(1);
+    expect(game.reinforcements).toBe(2);
     game.redo();
     expect(game.territories[0].armies).toBe(6);
-    expect(game.reinforcements).toBe(0);
+    expect(game.reinforcements).toBe(1);
   });
 
-  test("undo move armies", () => {
+  test("undo not available outside reinforcement", () => {
     const game = createGame();
     game.setPhase(FORTIFY);
-    game.handleTerritoryClick("a");
-    game.handleTerritoryClick("b");
     game.moveArmies("a", "b", 3);
     expect(game.territories[0].armies).toBe(2);
     expect(game.territories[1].armies).toBe(4);
-    game.undo();
-    expect(game.territories[0].armies).toBe(5);
-    expect(game.territories[1].armies).toBe(1);
-  });
-
-  test("undo attack selection", () => {
-    const territories = [
-      { id: "a", neighbors: ["b"], owner: 0, armies: 3 },
-      { id: "b", neighbors: ["a"], owner: 1, armies: 2 },
-    ];
-    const game = new Game([{ name: "P1" }, { name: "P2" }], territories, [], [], false, false);
-    game.setPhase(ATTACK);
-    game.handleTerritoryClick("a");
-    expect(game.getSelectedFrom().id).toBe("a");
-    game.undo();
-    expect(game.getSelectedFrom()).toBeNull();
+    expect(game.canUndo()).toBe(false);
+    const result = game.undo();
+    expect(result).toBe(false);
+    expect(game.territories[0].armies).toBe(2);
+    expect(game.territories[1].armies).toBe(4);
   });
 
   test("undo stack limit", () => {
     const game = createGame(2);
-    game.reinforcements = 3;
+    game.reinforcements = 4;
     game.handleTerritoryClick("a"); // 6
     game.handleTerritoryClick("a"); // 7
     game.handleTerritoryClick("a"); // 8 (first state dropped)
+    expect(game.territories[0].armies).toBe(8);
     game.undo(); // 7
     game.undo(); // 6, cannot undo to 5
     expect(game.territories[0].armies).toBe(6);
-  });
-
-  test("endTurn clears undo stack", () => {
-    const game = createGame();
-    game.reinforcements = 1;
-    game.handleTerritoryClick("a");
-    expect(game.canUndo()).toBe(true);
-    game.setPhase(FORTIFY);
-    game.endTurn();
     expect(game.canUndo()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- allow undo only during reinforcement and clear undo history when phase changes
- notify players when undo isn't available outside reinforcement
- adjust tests for new undo behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b1e0059c832cad54df1ebea4647e