### PR TITLE
ci: handle missing gh-pages branch

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -22,12 +22,23 @@ jobs:
           echo "Branch '${BRANCH_NAME}' is protected or uses gh-pages. Skipping cleanup."
           exit 0
 
+      - name: Check gh-pages branch
+        id: gh-pages
+        run: |
+          if git ls-remote --exit-code origin gh-pages; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout gh-pages
+        if: steps.gh-pages.outputs.exists == 'true'
         uses: actions/checkout@v4
         with:
           ref: gh-pages
 
       - name: Remove preview folder
+        if: steps.gh-pages.outputs.exists == 'true'
         id: remove
         run: |
           echo "Processing branch '${BRANCH_NAME}'"
@@ -41,7 +52,7 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: steps.remove.outputs.removed == 'true'
+        if: steps.gh-pages.outputs.exists == 'true' && steps.remove.outputs.removed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/preview-per-branch.yml
+++ b/.github/workflows/preview-per-branch.yml
@@ -42,6 +42,22 @@ jobs:
           cp -r supabase dist/
           cp public/404.html dist/404.html
 
+      - name: Ensure gh-pages branch exists
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages; then
+            echo "Creating empty gh-pages branch"
+            tmpdir=$(mktemp -d)
+            git init "$tmpdir"
+            cd "$tmpdir"
+            git checkout -b gh-pages
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit --allow-empty -m "ci: initial gh-pages"
+            git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+            git push origin gh-pages
+            cd -
+          fi
+
       - name: Checkout gh-pages
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- ensure gh-pages branch created for preview deployments
- guard cleanup workflow when gh-pages branch is absent
- configure git identity before seeding gh-pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2aee32dc4832c9ac903ff47693531