### PR TITLE
fix: redirect Supabase signup confirmations to login

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -13,6 +13,12 @@ form.addEventListener('submit', async (e) => {
     message.textContent = 'Supabase not configured';
     return;
   }
-  const { error } = await supabase.auth.signUp({ email: username, password });
+  const { error } = await supabase.auth.signUp({
+    email: username,
+    password,
+    options: {
+      emailRedirectTo: `${window.location.origin}/login.html`,
+    },
+  });
   message.textContent = error ? error.message : 'Registration successful';
 });


### PR DESCRIPTION
## Summary
- ensure Supabase signup confirmation links send users back to the login page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2eb00e304832c87f6ad48ff660e72