### PR TITLE
fix: redirect Supabase signup confirmations to login

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -13,6 +13,13 @@ form.addEventListener('submit', async (e) => {
     message.textContent = 'Supabase not configured';
     return;
   }
-  const { error } = await supabase.auth.signUp({ email: username, password });
+  const redirectUrl = new URL('login.html', window.location.href).href;
+  const { error } = await supabase.auth.signUp({
+    email: username,
+    password,
+    options: {
+      emailRedirectTo: redirectUrl,
+    },
+  });
   message.textContent = error ? error.message : 'Registration successful';
 });


### PR DESCRIPTION
## Summary
- derive Supabase signup confirmation redirect from current location to support deployments under subpaths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2eb00e304832c87f6ad48ff660e72