### PR TITLE
feat: add anonymous supabase login

### DIFF
--- a/login.html
+++ b/login.html
@@ -33,6 +33,7 @@
         </label>
         <button type="submit" class="btn">Login</button>
         <a id="registerBtn" class="btn" href="./register.html">Register</a>
+        <button type="button" id="anonymousBtn" class="btn">Login anonymously</button>
       </form>
       <p id="message" role="alert"></p>
     </main>

--- a/src/login.js
+++ b/src/login.js
@@ -4,6 +4,7 @@ const form = document.getElementById('loginForm');
 const message = document.getElementById('message');
 const usernameInput = document.getElementById('username');
 const passwordInput = document.getElementById('password');
+const anonymousBtn = document.getElementById('anonymousBtn');
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -14,5 +15,14 @@ form.addEventListener('submit', async (e) => {
     return;
   }
   const { error } = await supabase.auth.signInWithPassword({ email: username, password });
+  message.textContent = error ? error.message : 'Login successful';
+});
+
+anonymousBtn?.addEventListener('click', async () => {
+  if (!supabase) {
+    message.textContent = 'Supabase not configured';
+    return;
+  }
+  const { error } = await supabase.auth.signInAnonymously();
   message.textContent = error ? error.message : 'Login successful';
 });

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,33 @@
+jest.mock('../src/init/supabase-client.js', () => ({
+  __esModule: true,
+  default: {
+    auth: {
+      signInWithPassword: jest.fn().mockResolvedValue({}),
+      signInAnonymously: jest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+describe('login page', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <form id="loginForm">
+        <input id="username" />
+        <input id="password" />
+        <button type="submit" class="btn">Login</button>
+        <a id="registerBtn" class="btn" href="./register.html">Register</a>
+        <button type="button" id="anonymousBtn" class="btn">Login anonymously</button>
+      </form>
+      <p id="message" role="alert"></p>
+    `;
+  });
+
+  test('anonymous login uses supabase', () => {
+    const { default: supabase } = require('../src/init/supabase-client.js');
+    require('../src/login.js');
+    document.getElementById('anonymousBtn').click();
+    expect(supabase.auth.signInAnonymously).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add "Login anonymously" option to login page
- handle anonymous auth via Supabase in login script
- test anonymous login handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb748c3c832c8af5edd90650fb9a