### PR TITLE
feat: add anonymous supabase login

### DIFF
--- a/login.html
+++ b/login.html
@@ -33,6 +33,7 @@
         </label>
         <button type="submit" class="btn">Login</button>
         <a id="registerBtn" class="btn" href="./register.html">Register</a>
+        <button type="button" id="anonymousBtn" class="btn">Login anonymously</button>
       </form>
       <p id="message" role="alert"></p>
     </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "netrisk",
       "version": "1.0.0",
       "dependencies": {
-        "@supabase/supabase-js": "^2.56.0",
+        "@supabase/supabase-js": "^2.56.1",
         "bcryptjs": "^2.4.3",
         "zod": "^3.25.76"
       },
@@ -3589,9 +3589,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.1.tgz",
-      "integrity": "sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.4.tgz",
+      "integrity": "sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.13",
@@ -3610,16 +3610,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.56.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.56.0.tgz",
-      "integrity": "sha512-XqwhHSyVnkjdliPN61CmXsmFGnFHTX2WDdwjG3Ukvdzuu3Trix+dXupYOQ3BueIyYp7B6t0yYpdQtJP2hIInyg==",
+      "version": "2.56.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.56.1.tgz",
+      "integrity": "sha512-cb/kS0d6G/qbcmUFItkqVrQbxQHWXzfRZuoiSDv/QiU6RbGNTn73XjjvmbBCZ4MMHs+5teihjhpEVluqbXISEg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.5",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.21.3",
-        "@supabase/realtime-js": "2.15.1",
+        "@supabase/realtime-js": "2.15.4",
         "@supabase/storage-js": "^2.10.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ws": "^8.17.0"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.56.0",
+    "@supabase/supabase-js": "^2.56.1",
     "bcryptjs": "^2.4.3",
     "zod": "^3.25.76"
   }

--- a/src/login.js
+++ b/src/login.js
@@ -4,6 +4,7 @@ const form = document.getElementById('loginForm');
 const message = document.getElementById('message');
 const usernameInput = document.getElementById('username');
 const passwordInput = document.getElementById('password');
+const anonymousBtn = document.getElementById('anonymousBtn');
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -14,5 +15,18 @@ form.addEventListener('submit', async (e) => {
     return;
   }
   const { error } = await supabase.auth.signInWithPassword({ email: username, password });
+  message.textContent = error ? error.message : 'Login successful';
+});
+
+anonymousBtn?.addEventListener('click', async () => {
+  if (!supabase) {
+    message.textContent = 'Supabase not configured';
+    return;
+  }
+  if (typeof supabase.auth.signInAnonymously !== 'function') {
+    message.textContent = 'Anonymous login not supported';
+    return;
+  }
+  const { error } = await supabase.auth.signInAnonymously();
   message.textContent = error ? error.message : 'Login successful';
 });

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,49 @@
+describe('login page', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <form id="loginForm">
+        <input id="username" />
+        <input id="password" />
+        <button type="submit" class="btn">Login</button>
+        <a id="registerBtn" class="btn" href="./register.html">Register</a>
+        <button type="button" id="anonymousBtn" class="btn">Login anonymously</button>
+      </form>
+      <p id="message" role="alert"></p>
+    `;
+  });
+
+  test('anonymous login uses supabase', () => {
+    jest.doMock('../src/init/supabase-client.js', () => ({
+      __esModule: true,
+      default: {
+        auth: {
+          signInWithPassword: jest.fn().mockResolvedValue({}),
+          signInAnonymously: jest.fn().mockResolvedValue({}),
+        },
+      },
+    }));
+
+    const { default: supabase } = require('../src/init/supabase-client.js');
+    require('../src/login.js');
+    document.getElementById('anonymousBtn').click();
+    expect(supabase.auth.signInAnonymously).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows message when anonymous login unsupported', () => {
+    jest.doMock('../src/init/supabase-client.js', () => ({
+      __esModule: true,
+      default: {
+        auth: {
+          signInWithPassword: jest.fn().mockResolvedValue({}),
+        },
+      },
+    }));
+
+    require('../src/login.js');
+    document.getElementById('anonymousBtn').click();
+    expect(document.getElementById('message').textContent).toBe('Anonymous login not supported');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add "Login anonymously" option to login page
- handle anonymous auth via Supabase in login script
- test anonymous login handler
- upgrade Supabase and guard against missing anonymous login API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb748c3c832c8af5edd90650fb9a