### PR TITLE
fix: pass supabase secrets in build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
       VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
     steps:
@@ -43,7 +45,9 @@ jobs:
         run: |
           [ -n "$VITE_SUPABASE_URL" ] || { echo "❌ Missing VITE_SUPABASE_URL"; exit 1; }
           [ -n "$VITE_SUPABASE_ANON_KEY" ] || { echo "❌ Missing VITE_SUPABASE_ANON_KEY"; exit 1; }
-          echo "✅ VITE env vars present"
+          [ -n "$SUPABASE_URL" ] || { echo "❌ Missing SUPABASE_URL"; exit 1; }
+          [ -n "$SUPABASE_ANON_KEY" ] || { echo "❌ Missing SUPABASE_ANON_KEY"; exit 1; }
+          echo "✅ Env vars present"
 
       - name: Install deps
         run: npm ci

--- a/.github/workflows/preview-per-branch.yml
+++ b/.github/workflows/preview-per-branch.yml
@@ -12,6 +12,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
       VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
     steps:
@@ -26,6 +28,14 @@ jobs:
 
       - name: Install deps
         run: npm ci
+
+      - name: Verify env vars presence
+        run: |
+          [ -n "$VITE_SUPABASE_URL" ] || { echo "❌ Missing VITE_SUPABASE_URL"; exit 1; }
+          [ -n "$VITE_SUPABASE_ANON_KEY" ] || { echo "❌ Missing VITE_SUPABASE_ANON_KEY"; exit 1; }
+          [ -n "$SUPABASE_URL" ] || { echo "❌ Missing SUPABASE_URL"; exit 1; }
+          [ -n "$SUPABASE_ANON_KEY" ] || { echo "❌ Missing SUPABASE_ANON_KEY"; exit 1; }
+          echo "✅ Env vars present"
 
       - name: Write env file
         run: |

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,16 @@
-export const API_BASE_URL = (import.meta.env?.VITE_API_BASE_URL || '').replace(/\/+$/, '');
-export const SUPABASE_URL = (import.meta.env?.VITE_SUPABASE_URL || '').replace(/\/+$/, '');
-export const SUPABASE_KEY = import.meta.env?.VITE_SUPABASE_ANON_KEY || '';
+// Prefer Vite-provided variables but fall back to process.env so that
+// server-side or test environments can inject the same values without
+// relying on the bundler replacement.
+const rawApiBaseUrl =
+  import.meta.env?.VITE_API_BASE_URL ?? process.env.VITE_API_BASE_URL ?? '';
+const rawSupabaseUrl =
+  import.meta.env?.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
+export const API_BASE_URL = rawApiBaseUrl.replace(/\/+$/, '');
+export const SUPABASE_URL = rawSupabaseUrl.replace(/\/+$/, '');
+export const SUPABASE_KEY =
+  import.meta.env?.VITE_SUPABASE_ANON_KEY ??
+  process.env.VITE_SUPABASE_ANON_KEY ??
+  '';
 export const WS_URL = (() => {
   if (!SUPABASE_URL) return '';
   try {


### PR DESCRIPTION
## Summary
- allow config to read Supabase settings from process env for tests/builds
- expose Supabase secrets to Pages and preview workflows and verify their presence

## Testing
- `npm test`
- `npm run lint`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b32f955ce0832c851b1ac012a81cc1