### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/andreame-code/netrisk/security/code-scanning/1](https://github.com/andreame-code/netrisk/security/code-scanning/1)

To fix the problem, you should explicitly set the permissions for your workflow by adding a `permissions` block. Since this is a linting job that only reads repository code, the minimal required privilege is `contents: read`. You can set this at the workflow root (applies to all jobs) or within the `eslint` job itself. The best approach is to set it globally right under the `name:` line so that all jobs are limited to read-only permissions unless a future job needs more. 

Edit the `.github/workflows/lint.yml` file to add the following block:

```yaml
permissions:
  contents: read
```

It should be positioned immediately after the `name: Lint` line. No additional methods, imports, or definitions are needed; this is a native YAML change specific to GitHub Actions workflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
