### PR TITLE
Enforce CORS origin whitelist and add tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,20 @@ const bcrypt = require('bcryptjs');
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 
+const allowedOrigins = ['https://andreame-code.github.io'];
+
+const getRequestOrigin = (req) => {
+  if (req.headers.origin) return req.headers.origin;
+  if (req.headers.referer) {
+    try {
+      return new URL(req.headers.referer).origin;
+    } catch {
+      return '';
+    }
+  }
+  return '';
+};
+
 const distDir = path.join(__dirname, 'dist');
 
 const routes = {
@@ -31,11 +45,20 @@ const server = http.createServer(async (req, res) => {
   const urlPath = req.url.split('?')[0];
 
   if (urlPath === '/api/register' || urlPath === '/api/login') {
+    const origin = getRequestOrigin(req);
+    if (origin && !allowedOrigins.includes(origin)) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Origin not allowed' }));
+      return;
+    }
+
     const corsHeaders = {
-      'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
     };
+    if (origin) {
+      corsHeaders['Access-Control-Allow-Origin'] = origin;
+    }
 
     if (req.method === 'OPTIONS') {
       res.writeHead(204, corsHeaders);
@@ -133,4 +156,6 @@ const port = process.env.PORT || 8080;
 server.listen(port, () => {
   console.log(`Server running at http://localhost:${port}`);
 });
+
+module.exports = server;
 

--- a/tests/api-cors.test.js
+++ b/tests/api-cors.test.js
@@ -14,7 +14,7 @@ describe('API CORS', () => {
     server.close(done);
   });
 
-  const send = (method, origin) =>
+  const send = (method, headers = {}) =>
     new Promise((resolve, reject) => {
       const port = server.address().port;
       const req = http.request(
@@ -23,10 +23,7 @@ describe('API CORS', () => {
           port,
           path: '/api/login',
           method,
-          headers: {
-            'Content-Type': 'application/json',
-            Origin: origin,
-          },
+          headers: { 'Content-Type': 'application/json', ...headers },
         },
         (res) => {
           res.on('data', () => {});
@@ -41,13 +38,36 @@ describe('API CORS', () => {
     });
 
   test('allows requests from whitelisted origin', async () => {
-    const res = await send('POST', 'https://andreame-code.github.io');
+    const res = await send('POST', {
+      Origin: 'https://andreame-code.github.io',
+    });
     expect(res.statusCode).not.toBe(403);
-    expect(res.headers['access-control-allow-origin']).toBe('https://andreame-code.github.io');
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://andreame-code.github.io'
+    );
   });
 
   test('rejects requests from unapproved origin', async () => {
-    const res = await send('OPTIONS', 'https://evil.example.com');
+    const res = await send('OPTIONS', {
+      Origin: 'https://evil.example.com',
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('allows requests when referer is whitelisted', async () => {
+    const res = await send('POST', {
+      Referer: 'https://andreame-code.github.io/some/page',
+    });
+    expect(res.statusCode).not.toBe(403);
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://andreame-code.github.io'
+    );
+  });
+
+  test('rejects requests from unapproved referer', async () => {
+    const res = await send('POST', {
+      Referer: 'https://evil.example.com/path',
+    });
     expect(res.statusCode).toBe(403);
   });
 });

--- a/tests/api-cors.test.js
+++ b/tests/api-cors.test.js
@@ -1,0 +1,54 @@
+const http = require('http');
+
+describe('API CORS', () => {
+  let server;
+
+  beforeAll((done) => {
+    process.env.PORT = 0;
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: async () => [] }));
+    server = require('../server');
+    server.on('listening', done);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  const send = (method, origin) =>
+    new Promise((resolve, reject) => {
+      const port = server.address().port;
+      const req = http.request(
+        {
+          hostname: 'localhost',
+          port,
+          path: '/api/login',
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: origin,
+          },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('end', () => resolve(res));
+        }
+      );
+      req.on('error', reject);
+      if (method === 'POST') {
+        req.write(JSON.stringify({ username: 'a', password: 'b' }));
+      }
+      req.end();
+    });
+
+  test('allows requests from whitelisted origin', async () => {
+    const res = await send('POST', 'https://andreame-code.github.io');
+    expect(res.statusCode).not.toBe(403);
+    expect(res.headers['access-control-allow-origin']).toBe('https://andreame-code.github.io');
+  });
+
+  test('rejects requests from unapproved origin', async () => {
+    const res = await send('OPTIONS', 'https://evil.example.com');
+    expect(res.statusCode).toBe(403);
+  });
+});
+


### PR DESCRIPTION
## Summary
- restrict API CORS headers to whitelisted origin and verify Origin/Referer
- return 403 for unapproved origins
- add tests for allowed and disallowed origin requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3566922a4832c93027e37226508cd