### PR TITLE
Enable CI test workflows

### DIFF
--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -17,4 +17,5 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npx playwright install --with-deps
       - run: npx playwright test --config config/playwright.config.ts --reporter=github

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -17,4 +17,4 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npx playwright test --reporter=github
+      - run: npx playwright test --config config/playwright.config.ts --reporter=github

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   tests:
-    if: false
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/playwright:v1.46.0-jammy
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   tests:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -15,7 +15,7 @@ test.describe('UAT checklist', () => {
     page.on('pageerror', (err) => errors.push(err.message));
 
     await page.goto('/game.html');
-    await page.waitForSelector('#board .map-territory');
+    await page.waitForSelector('#board .map-territory', { timeout: 60000 });
     const terrs = await page.$$eval(
       '#board .map-territory',
       (els) => els.slice(0, 3).map((el) => `#${el.id}`),
@@ -57,7 +57,7 @@ test.describe('UAT checklist', () => {
 
     await page.goto('/game.html');
     // Wait for at least one territory to load so the accessibility hooks run.
-    await page.waitForSelector('#board .map-territory');
+    await page.waitForSelector('#board .map-territory', { timeout: 60000 });
 
     // These accessibility classes are applied asynchronously after game init,
     // so allow extra time for slower environments.


### PR DESCRIPTION
## Summary
- Run CI tests for normal and container jobs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b35a0ceb2c832cbd029e4965f81c34