### PR TITLE
Use absolute map paths

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,14 +2,20 @@
 // server-side or test environments can inject the same values without
 // relying on the bundler replacement.
 const rawApiBaseUrl =
-  import.meta.env?.VITE_API_BASE_URL ?? process.env.VITE_API_BASE_URL ?? '';
+  import.meta.env?.VITE_API_BASE_URL ??
+  (typeof process !== 'undefined' ? process.env.VITE_API_BASE_URL : '') ??
+  '';
 const rawSupabaseUrl =
-  import.meta.env?.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
+  import.meta.env?.VITE_SUPABASE_URL ??
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_URL : '') ??
+  '';
 export const API_BASE_URL = rawApiBaseUrl.replace(/\/+$/, '');
 export const SUPABASE_URL = rawSupabaseUrl.replace(/\/+$/, '');
 export const SUPABASE_KEY =
   import.meta.env?.VITE_SUPABASE_ANON_KEY ??
-  process.env.VITE_SUPABASE_ANON_KEY ??
+  (typeof process !== 'undefined'
+    ? process.env.VITE_SUPABASE_ANON_KEY
+    : '') ??
   '';
 export const WS_URL = (() => {
   if (!SUPABASE_URL) return '';

--- a/src/init/game-loader.js
+++ b/src/init/game-loader.js
@@ -6,7 +6,12 @@ import * as logger from "../logger.js";
 let territoryPositions = {};
 
 async function loadMap(mapName) {
-  const paths = [`./src/data/${mapName}.json`, `./data/${mapName}.json`];
+  const paths = [
+    `/src/data/${mapName}.json`,
+    `/data/${mapName}.json`,
+    `./src/data/${mapName}.json`,
+    `./data/${mapName}.json`,
+  ];
   for (const p of paths) {
     try {
       const res = await fetch(p);

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -123,7 +123,6 @@ export default function initTerritorySelection({
         terrs.forEach((t) => {
           const terrEl = document.createElement("button");
           terrEl.type = "button";
-          terrEl.id = t.id;
           terrEl.className = "territory";
           terrEl.dataset.id = t.id;
           if (t.name) {

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -87,18 +87,22 @@ export default function initTerritorySelection({
   }
 
   loadMap([
+    `/assets/maps/${mapName}.svg`,
     `assets/maps/${mapName}.svg`,
     `public/assets/maps/${mapName}.svg`,
   ])
     .then((svg) => {
       boardEl.innerHTML = svg;
       const map = boardEl.querySelector("#map");
-      map
-        ?.querySelectorAll(".map-territory")
-        .forEach((el) => {
-          el.setAttribute("tabindex", "0");
-          el.setAttribute("role", "button");
-        });
+      const territoryEls = map?.querySelectorAll(".map-territory") || [];
+      if (!territoryEls.length) {
+        boardEl.textContent = "Invalid map";
+        throw new Error("Map SVG missing .map-territory elements");
+      }
+      territoryEls.forEach((el) => {
+        el.setAttribute("tabindex", "0");
+        el.setAttribute("role", "button");
+      });
 
       function computeFallbackPosition(id) {
         const selector =

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -72,14 +72,25 @@ export default function initTerritorySelection({
 
   function loadMap(paths) {
     if (!paths.length) {
-      boardEl.textContent = "Error loading map";
-      throw new Error("Failed to load map");
+      boardEl.textContent = "Invalid map";
+      throw new Error("Map SVG missing .map-territory elements");
     }
     const [path, ...rest] = paths;
     return fetch(path)
-      .then((r) => {
-        if (r.ok) {
-          return r.text();
+      .then((r) => (r.ok ? r.text() : null))
+      .then((text) => {
+        if (text) {
+          const parser =
+            typeof DOMParser !== "undefined" ? new DOMParser() : null;
+          const doc = parser
+            ? parser.parseFromString(text, "image/svg+xml")
+            : null;
+          const hasTerritories = doc
+            ? doc.querySelector(".map-territory")
+            : text.includes("map-territory");
+          if (hasTerritories) {
+            return text;
+          }
         }
         return loadMap(rest);
       })
@@ -95,10 +106,6 @@ export default function initTerritorySelection({
       boardEl.innerHTML = svg;
       const map = boardEl.querySelector("#map");
       const territoryEls = map?.querySelectorAll(".map-territory") || [];
-      if (!territoryEls.length) {
-        boardEl.textContent = "Invalid map";
-        throw new Error("Map SVG missing .map-territory elements");
-      }
       territoryEls.forEach((el) => {
         el.setAttribute("tabindex", "0");
         el.setAttribute("role", "button");

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -34,7 +34,7 @@ describe('Accessibility features', () => {
     ];
     initTerritorySelection({ territories, territoryPositions: {} });
     await flushPromises();
-    const btnA = document.querySelector('button#A');
+    const btnA = document.querySelector('button.territory[data-id="A"]');
     expect(btnA.getAttribute('aria-label')).toBe('Alpha');
     const pathA = document.querySelector('#map #A');
     expect(pathA.getAttribute('tabindex')).toBe('0');

--- a/tests/game-loader.uat.test.js
+++ b/tests/game-loader.uat.test.js
@@ -46,7 +46,7 @@ describe("game loader", () => {
     );
 
     const { game, territoryPositions } = await loadGame();
-    expect(global.fetch).toHaveBeenCalledWith("./src/data/custom.json");
+    expect(global.fetch).toHaveBeenCalledWith("/src/data/custom.json");
     expect(game).toBeTruthy();
     expect(game.players[0].name).toBe("Red");
     expect(territoryPositions).toEqual({ t1: { x: 1, y: 2 } });

--- a/tests/map3.test.js
+++ b/tests/map3.test.js
@@ -64,7 +64,7 @@ describe('territory-selection with map3', () => {
     const init = require('../src/territory-selection.js').default;
     init({ territories: map.territories, territoryPositions: {} });
     await flushPromises();
-    expect(fetch).toHaveBeenCalledWith('assets/maps/map3.svg');
+    expect(fetch).toHaveBeenCalledWith('/assets/maps/map3.svg');
     const buttons = document.querySelectorAll('button.territory');
     expect(buttons).toHaveLength(map.territories.length);
   });


### PR DESCRIPTION
## Summary
- use absolute URLs for map SVG loading and ensure fetched SVG contains `.map-territory`
- fetch map JSON via absolute URLs with relative fallbacks
- guard config against missing `process` in browsers

## Testing
- `timeout 5 npm run test:uat` *(terminated: no output, environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c10c524832c86f5775300e7573d