### PR TITLE
Add account page with dynamic login status

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,7 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <a href="login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
     </header>
     <h1 id="pageTitle">About &amp; Settings</h1>
@@ -62,6 +62,7 @@
         </div>
       </section>
     </div>
+    <script type="module" src="./auth.js"></script>
     <script type="module" src="./about.js"></script>
   </body>
 </html>

--- a/account.html
+++ b/account.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login - NetRisk</title>
+    <title>Account - NetRisk</title>
     <link rel="stylesheet" href="./css/base.css" />
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
@@ -21,23 +21,12 @@
       </nav>
     </header>
     <main>
-      <h1>Login</h1>
-      <form id="loginForm">
-        <label>
-          Username:
-          <input type="text" id="username" required />
-        </label>
-        <label>
-          Password:
-          <input type="password" id="password" required />
-        </label>
-        <button type="submit" class="btn">Login</button>
-        <a id="registerBtn" class="btn" href="./register.html">Register</a>
-        <button type="button" id="anonymousBtn" class="btn">Login anonymously</button>
-      </form>
-      <p id="message" role="alert"></p>
+      <h1>Account</h1>
+      <p>Name: <span id="userName"></span></p>
+      <p>Email: <span id="userEmail"></span></p>
+      <button id="logoutBtn" class="btn">Logout</button>
     </main>
     <script type="module" src="./auth.js"></script>
-    <script type="module" src="./login.js"></script>
+    <script type="module" src="./account.js"></script>
   </body>
 </html>

--- a/account.js
+++ b/account.js
@@ -1,0 +1,1 @@
+import './src/account.js';

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,1 @@
+import './src/auth.js';

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
         howto: resolve(__dirname, '../howto.html'),
         login: resolve(__dirname, '../login.html'),
         register: resolve(__dirname, '../register.html'),
+        account: resolve(__dirname, '../account.html'),
       }
     }
   },

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -17,7 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <a href="login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
     </header>
     <nav>
@@ -180,5 +180,6 @@
       }
       render();
     </script>
+    <script type="module" src="./auth.js"></script>
   </body>
 </html>

--- a/howto.html
+++ b/howto.html
@@ -17,7 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <a href="login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
     </header>
     <nav>
@@ -180,5 +180,6 @@
       }
       render();
     </script>
+    <script type="module" src="./auth.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <a href="./setup.html">Setup</a>
         <a href="./how-to-play.html">How To</a>
         <a href="./about.html">About</a>
-        <a href="./login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
       <button
         id="themeToggle"
@@ -57,6 +57,7 @@
         About/Settings
       </button>
     </main>
-      <script type="module" src="./home.js"></script>
+    <script type="module" src="./auth.js"></script>
+    <script type="module" src="./home.js"></script>
   </body>
 </html>

--- a/lobby.html
+++ b/lobby.html
@@ -25,7 +25,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <a href="login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
     </header>
     <main>
@@ -57,6 +57,7 @@
       </section>
       <section id="debugLog" class="debug-log" aria-live="polite"></section>
     </main>
+    <script type="module" src="./auth.js"></script>
     <script type="module" src="./lobby.js"></script>
   </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -17,7 +17,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <a href="login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
     </header>
     <main>
@@ -35,6 +35,7 @@
       </form>
       <p id="message" role="alert"></p>
     </main>
+    <script type="module" src="./auth.js"></script>
     <script type="module" src="./register.js"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -26,7 +26,8 @@ const routes = {
   '/': 'index.html',
   '/setup': 'setup.html',
   '/how-to-play': 'how-to-play.html',
-  '/game': 'game.html'
+  '/game': 'game.html',
+  '/account': 'account.html'
 };
 
 const mimeTypes = {

--- a/setup.html
+++ b/setup.html
@@ -19,7 +19,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <a href="login.html">Login</a>
+        <a id="authLink" href="login.html">Login</a>
       </nav>
     </header>
     <h1>Player Setup</h1>
@@ -54,6 +54,7 @@
       <div id="players"></div>
       <button type="submit" class="btn">Start</button>
     </form>
+    <script type="module" src="./auth.js"></script>
     <script type="module" src="./setup.js"></script>
   </body>
 </html>

--- a/src/account.js
+++ b/src/account.js
@@ -1,0 +1,26 @@
+import supabase from './init/supabase-client.js';
+
+const userNameEl = document.getElementById('userName');
+const userEmailEl = document.getElementById('userEmail');
+const logoutBtn = document.getElementById('logoutBtn');
+
+async function loadUser() {
+  if (!supabase) return;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    window.location.href = 'login.html';
+    return;
+  }
+  userNameEl.textContent = user.user_metadata?.name || 'N/A';
+  userEmailEl.textContent = user.email || 'N/A';
+}
+
+logoutBtn?.addEventListener('click', async () => {
+  if (!supabase) return;
+  await supabase.auth.signOut();
+  window.location.href = 'index.html';
+});
+
+loadUser();

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,25 @@
+import supabase from './init/supabase-client.js';
+
+async function updateAuthLink() {
+  const authLink = document.getElementById('authLink');
+  if (!authLink || !supabase) return;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) {
+    authLink.textContent = 'Logout';
+    authLink.href = '#';
+    authLink.onclick = async (e) => {
+      e.preventDefault();
+      await supabase.auth.signOut();
+      window.location.href = 'index.html';
+    };
+  } else {
+    authLink.textContent = 'Login';
+    authLink.href = 'login.html';
+    authLink.onclick = null;
+  }
+}
+
+updateAuthLink();
+supabase?.auth.onAuthStateChange(updateAuthLink);

--- a/src/login.js
+++ b/src/login.js
@@ -15,7 +15,11 @@ form.addEventListener('submit', async (e) => {
     return;
   }
   const { error } = await supabase.auth.signInWithPassword({ email: username, password });
-  message.textContent = error ? error.message : 'Login successful';
+  if (error) {
+    message.textContent = error.message;
+  } else {
+    window.location.href = 'account.html';
+  }
 });
 
 anonymousBtn?.addEventListener('click', async () => {
@@ -28,5 +32,9 @@ anonymousBtn?.addEventListener('click', async () => {
     return;
   }
   const { error } = await supabase.auth.signInAnonymously();
-  message.textContent = error ? error.message : 'Login successful';
+  if (error) {
+    message.textContent = error.message;
+  } else {
+    window.location.href = 'account.html';
+  }
 });


### PR DESCRIPTION
## Summary
- add account page displaying user info and logout option
- show login or logout in header based on auth state
- redirect authenticated users to the account page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b36009b29c832c93110abbede50816