### PR TITLE
Clarify Supabase configuration requirement for multiplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ per il workflow `supabase-deploy.yml`.
 
 ## Multiplayer
 
+To enable multiplayer features you must provide both `VITE_SUPABASE_URL` and
+`VITE_SUPABASE_ANON_KEY`. Without these environment variables the lobby and
+relay server remain disabled.
+
 NetRisk ships with a very small WebSocket relay and a plugin that keeps the
 game state in sync across browser tabs or machines.
 

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,11 @@ const rawSupabaseUrl =
   import.meta.env?.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
 export const API_BASE_URL = rawApiBaseUrl.replace(/\/+$/, '');
 export const SUPABASE_URL = rawSupabaseUrl.replace(/\/+$/, '');
+if (!SUPABASE_URL) {
+  console.error(
+    '[CONFIG] VITE_SUPABASE_URL is missing. Supabase features are disabled.'
+  );
+}
 export const SUPABASE_KEY =
   import.meta.env?.VITE_SUPABASE_ANON_KEY ??
   process.env.VITE_SUPABASE_ANON_KEY ??

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -133,7 +133,10 @@ export function initLobby() {
   })();
   if (!WS_URL && createBtn) {
     createBtn.disabled = true;
-    showLobbyError('Multiplayer server is not available.', () => location.reload());
+    showLobbyError(
+      'Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to use multiplayer.',
+      () => location.reload()
+    );
   }
   if (createBtn && dialog) {
     createBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- log an explicit error when `VITE_SUPABASE_URL` is missing
- inform lobby users about required Supabase env vars
- note in README that `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are required for multiplayer

## Testing
- `npm test`
- `npm run lint`
- `npm run test:uat` *(fails: page.waitForSelector timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b3608dbc68832cb0c94f019a80c612