### PR TITLE
Fix UAT selectors and guard env access

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,9 +2,13 @@
 // server-side or test environments can inject the same values without
 // relying on the bundler replacement.
 const rawApiBaseUrl =
-  import.meta.env?.VITE_API_BASE_URL ?? process.env.VITE_API_BASE_URL ?? '';
+  import.meta.env?.VITE_API_BASE_URL ??
+  (typeof process !== 'undefined' ? process.env.VITE_API_BASE_URL : '') ??
+  '';
 const rawSupabaseUrl =
-  import.meta.env?.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
+  import.meta.env?.VITE_SUPABASE_URL ??
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_URL : '') ??
+  '';
 export const API_BASE_URL = rawApiBaseUrl.replace(/\/+$/, '');
 export const SUPABASE_URL = rawSupabaseUrl.replace(/\/+$/, '');
 if (!SUPABASE_URL) {
@@ -14,7 +18,7 @@ if (!SUPABASE_URL) {
 }
 export const SUPABASE_KEY =
   import.meta.env?.VITE_SUPABASE_ANON_KEY ??
-  process.env.VITE_SUPABASE_ANON_KEY ??
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_ANON_KEY : '') ??
   '';
 export const WS_URL = (() => {
   if (!SUPABASE_URL) return '';

--- a/tests/uat/uat.spec.ts
+++ b/tests/uat/uat.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('UAT checklist', () => {
+  test.describe.configure({ timeout: 120000 });
+
   test('@smoke basic gameplay flow', async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('netriskPlayers', JSON.stringify([
@@ -21,12 +23,13 @@ test.describe('UAT checklist', () => {
       (els) => els.slice(0, 3).map((el) => `#${el.id}`),
     );
     for (const sel of terrs) {
+      const boardSel = `#board .map-territory${sel}`;
       await page.evaluate((s) => {
         const el = document.querySelector(s);
         el?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }, sel);
-      const name = await page.getAttribute(sel, 'data-name');
-      await expect(page.locator(sel)).toHaveClass(/selected/);
+      }, boardSel);
+      const name = await page.getAttribute(boardSel, 'data-name');
+      await expect(page.locator(boardSel)).toHaveClass(/selected/);
       await expect(page.locator('#selectedTerritory')).toHaveText(name!);
     }
     await page.evaluate(async () => {


### PR DESCRIPTION
## Summary
- Guard config against undefined `process` when env vars are missing
- Stabilize UAT gameplay tests with higher timeout and stricter selectors

## Testing
- `npx playwright test tests/uat/uat.spec.ts --config config/playwright.config.ts --reporter=list`
- `npm test >/tmp/jest.log && tail -n 20 /tmp/jest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b363d93c50832c93af97ea282023cc