### PR TITLE
Refactor tests to use fixtures and add retry messaging

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -71,7 +71,7 @@ async function fetchLobbies() {
   if (!supabase) {
     renderLobbies([]);
     logError('Supabase not initialized; cannot fetch lobbies');
-    showLobbyError('Unable to load lobby list. Check your connection and try again.', fetchLobbies);
+    showLobbyError('Impossibile caricare la lista delle lobby. Riprova.', fetchLobbies);
     return;
   }
   try {
@@ -79,7 +79,7 @@ async function fetchLobbies() {
     const { data, error } = await supabase.from('lobbies').select();
     if (error) {
       logError('Error fetching lobbies', error.message);
-      showLobbyError('Unable to load lobby list. Check your connection and try again.', fetchLobbies);
+      showLobbyError('Impossibile caricare la lista delle lobby. Riprova.', fetchLobbies);
       return;
     }
     currentLobbies.splice(0, currentLobbies.length, ...(data || []));
@@ -88,7 +88,7 @@ async function fetchLobbies() {
     logInfo(`Loaded ${currentLobbies.length} lobbies`);
   } catch (err) {
     logError('Unexpected error fetching lobbies', err?.message);
-    showLobbyError('Unable to load lobby list. Check your connection and try again.', fetchLobbies);
+    showLobbyError('Impossibile caricare la lista delle lobby. Riprova.', fetchLobbies);
   }
 }
 
@@ -134,7 +134,7 @@ export function initLobby() {
   if (!WS_URL && createBtn) {
     createBtn.disabled = true;
     showLobbyError(
-      'Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to use multiplayer.',
+      'Supabase non è configurato. Riprova.',
       () => location.reload()
     );
   }
@@ -166,7 +166,7 @@ export function initLobby() {
     logInfo('Creating new game lobby');
     try {
       if (!url) {
-        showLobbyError('Multiplayer server is not available.', () => location.reload());
+        showLobbyError('Server multiplayer non disponibile. Riprova.', () => location.reload());
         return;
       }
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -185,16 +185,16 @@ export function initLobby() {
             );
           } catch (err2) {
             logError('WebSocket send error', err2?.message);
-            showLobbyError('Unable to connect to multiplayer server. Please try again.', () => createGame(payload, dlg));
+            showLobbyError('Impossibile connettersi al server multiplayer. Riprova.', () => createGame(payload, dlg));
           }
         };
         ws.onmessage = e => handleMessage(e, dlg);
         ws.onerror = errEvent => {
           logError('WebSocket connection error', errEvent?.message);
-          showLobbyError('Unable to connect to multiplayer server. Please try again.', () => createGame(payload, dlg));
+          showLobbyError('Impossibile connettersi al server multiplayer. Riprova.', () => createGame(payload, dlg));
         };
         ws.onclose = () =>
-          showLobbyError('Connection to multiplayer server lost. Please try again.', () => createGame(payload, dlg));
+          showLobbyError('Connessione al server multiplayer persa. Riprova.', () => createGame(payload, dlg));
       } else {
         ws.send(
           JSON.stringify({
@@ -208,7 +208,7 @@ export function initLobby() {
       }
     } catch (err) {
       logError('createGame failed', err?.message);
-      showLobbyError('Unable to create lobby. Please try again.', () => createGame(payload, dlg));
+      showLobbyError('Impossibile creare la lobby. Riprova.', () => createGame(payload, dlg));
     }
   }
 
@@ -253,15 +253,15 @@ export function initLobby() {
       };
       ws.onmessage = e => handleMessage(e, null);
       ws.onerror = () =>
-        showLobbyError('Unable to connect to multiplayer server. Please try again.', () => {
+        showLobbyError('Impossibile connettersi al server multiplayer. Riprova.', () => {
           location.reload();
         });
       ws.onclose = () =>
-        showLobbyError('Connection to multiplayer server lost. Please try again.', () => {
+        showLobbyError('Connessione al server multiplayer persa. Riprova.', () => {
           location.reload();
         });
     } else {
-      showLobbyError('Multiplayer server is not available.', () => location.reload());
+      showLobbyError('Server multiplayer non disponibile. Riprova.', () => location.reload());
     }
   }
   fetchLobbies();
@@ -366,7 +366,7 @@ export function initLobby() {
         break;
       }
       case 'error': {
-        showLobbyError('An error occurred. Please try again.', () => location.reload());
+        showLobbyError('Si è verificato un errore. Riprova.', () => location.reload());
         break;
       }
       default:

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,16 @@ import {
 import { initThemeToggle } from "./theme.js";
 import { initTutorialButtons } from "./tutorial.js";
 attachNavigationHandlers();
-initGame();
+initGame().catch(() => {
+  const errorEl = document.getElementById('loadError');
+  if (errorEl) {
+    errorEl.classList.remove('hidden');
+    const msg = document.getElementById('loadErrorMsg');
+    if (msg) msg.textContent = 'Riprova';
+  } else if (typeof alert === 'function') {
+    alert('Riprova');
+  }
+});
 initThemeToggle();
 initTutorialButtons();
 

--- a/src/ui-init.js
+++ b/src/ui-init.js
@@ -61,7 +61,7 @@ const retryBtn = document.getElementById("retryLoad");
 let retryAction = () => loadGame();
 
 function showLoadError(
-  message = "Unable to load game data. Check your connection and try again.",
+  message = "Impossibile caricare i dati di gioco. Riprova.",
   action = () => loadGame(),
 ) {
   if (loadErrorEl && loadErrorMsg) {
@@ -82,7 +82,7 @@ function handleImageError(event) {
   const img = event?.target;
   if (!img) return;
   showLoadError(
-    "Some game pieces couldn't be loaded. We'll try again automatically. If the problem continues, press Retry.",
+    "Impossibile caricare alcuni elementi del gioco. Riprova.",
     () => location.reload(),
   );
   if (!img.dataset.retry) {

--- a/tests/event-bus.test.js
+++ b/tests/event-bus.test.js
@@ -1,15 +1,9 @@
 import Game from "../src/game.js";
 import { REINFORCE } from "../src/phases.js";
+// eslint-disable-next-line global-require
+const mapMock = require("./fixtures/maps/basic.json");
 
 describe('Event bus', () => {
-  const mapMock = {
-    territories: [
-      { id: 'a', neighbors: [], owner: 0, x: 0, y: 0 },
-      { id: 'b', neighbors: [], owner: 0, x: 0, y: 0 },
-    ],
-    continents: [],
-    deck: [],
-  };
 
   test('plugin receives reinforce event', () => {
     const game = new Game(null, mapMock.territories, mapMock.continents, mapMock.deck, false);

--- a/tests/fixtures/game/sample-state.json
+++ b/tests/fixtures/game/sample-state.json
@@ -1,0 +1,12 @@
+{
+  "players": [
+    { "name": "P1", "color": "#f00" },
+    { "name": "P2", "color": "#0f0" }
+  ],
+  "territories": [
+    { "id": 0, "neighbors": [1], "x": 0, "y": 0, "owner": 0, "armies": 3 },
+    { "id": 1, "neighbors": [0], "x": 1, "y": 0, "owner": 1, "armies": 3 }
+  ],
+  "continents": [],
+  "deck": []
+}

--- a/tests/fixtures/lobby/default.json
+++ b/tests/fixtures/lobby/default.json
@@ -1,0 +1,8 @@
+{
+  "code": "c",
+  "players": [],
+  "host": "h",
+  "started": false,
+  "map": null,
+  "maxPlayers": 8
+}

--- a/tests/fixtures/maps/basic.json
+++ b/tests/fixtures/maps/basic.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "territories": [
+    { "id": "a", "neighbors": [], "owner": 0, "x": 0, "y": 0 },
+    { "id": "b", "neighbors": [], "owner": 0, "x": 0, "y": 0 }
+  ],
+  "continents": [],
+  "deck": []
+}

--- a/tests/fixtures/maps/world8.json
+++ b/tests/fixtures/maps/world8.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "territories": [
+    { "id": "north-america", "neighbors": ["south-america", "europe"], "x": 110, "y": 90 },
+    { "id": "south-america", "neighbors": ["north-america", "africa", "antarctica"], "x": 140, "y": 260 },
+    { "id": "europe", "neighbors": ["north-america", "asia", "africa", "middle-east"], "x": 280, "y": 90 },
+    { "id": "asia", "neighbors": ["europe", "middle-east", "australia"], "x": 450, "y": 100 },
+    { "id": "middle-east", "neighbors": ["europe", "asia", "africa"], "x": 340, "y": 160 },
+    { "id": "africa", "neighbors": ["south-america", "europe", "middle-east", "antarctica"], "x": 320, "y": 260 },
+    { "id": "australia", "neighbors": ["asia", "antarctica"], "x": 500, "y": 300 },
+    { "id": "antarctica", "neighbors": ["south-america", "africa", "australia"], "x": 300, "y": 380 }
+  ],
+  "continents": [
+    { "name": "North America", "territories": ["north-america"], "bonus": 2 },
+    { "name": "South America", "territories": ["south-america"], "bonus": 2 },
+    { "name": "Europe", "territories": ["europe"], "bonus": 2 },
+    { "name": "Asia", "territories": ["asia"], "bonus": 2 },
+    { "name": "Middle East", "territories": ["middle-east"], "bonus": 2 },
+    { "name": "Africa", "territories": ["africa"], "bonus": 2 },
+    { "name": "Australia", "territories": ["australia"], "bonus": 2 },
+    { "name": "Antarctica", "territories": ["antarctica"], "bonus": 2 }
+  ],
+  "deck": [
+    { "territory": "north-america", "type": "infantry" },
+    { "territory": "north-america", "type": "cavalry" },
+    { "territory": "north-america", "type": "artillery" },
+    { "territory": "south-america", "type": "infantry" },
+    { "territory": "south-america", "type": "cavalry" },
+    { "territory": "south-america", "type": "artillery" },
+    { "territory": "europe", "type": "infantry" },
+    { "territory": "europe", "type": "cavalry" },
+    { "territory": "europe", "type": "artillery" },
+    { "territory": "asia", "type": "infantry" },
+    { "territory": "asia", "type": "cavalry" },
+    { "territory": "asia", "type": "artillery" },
+    { "territory": "middle-east", "type": "infantry" },
+    { "territory": "middle-east", "type": "cavalry" },
+    { "territory": "middle-east", "type": "artillery" },
+    { "territory": "africa", "type": "infantry" },
+    { "territory": "africa", "type": "cavalry" },
+    { "territory": "africa", "type": "artillery" },
+    { "territory": "australia", "type": "infantry" },
+    { "territory": "australia", "type": "cavalry" },
+    { "territory": "australia", "type": "artillery" },
+    { "territory": "antarctica", "type": "infantry" },
+    { "territory": "antarctica", "type": "cavalry" },
+    { "territory": "antarctica", "type": "artillery" }
+  ]
+}

--- a/tests/image-error.test.js
+++ b/tests/image-error.test.js
@@ -84,7 +84,7 @@ describe("image load errors", () => {
     const errorEl = document.getElementById("loadError");
     expect(errorEl.classList.contains("hidden")).toBe(false);
     const msg = document.getElementById("loadErrorMsg").textContent;
-    expect(/pieces/i.test(msg)).toBe(true);
+    expect(msg).toContain('Riprova');
     jest.runAllTimers();
     expect(img.src).toMatch(/retry=/);
   });

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -61,6 +61,12 @@ describe('lobby screen', () => {
     localStorage.clear();
   });
 
+  test('does not show error when lobbies load successfully', async () => {
+    require('../src/lobby.js');
+    await new Promise(r => setTimeout(r, 0));
+    expect(document.getElementById('lobbyError').classList.contains('hidden')).toBe(true);
+  });
+
   test('back button goes home', () => {
     const { goHome } = require('../src/navigation.js');
     require('../src/lobby.js');
@@ -220,7 +226,7 @@ describe('lobby screen', () => {
     wsInstance.onopen();
     wsInstance.onerror();
     expect(document.getElementById('lobbyErrorMsg').textContent).toBe(
-      'Unable to connect to multiplayer server. Please try again.'
+      'Impossibile connettersi al server multiplayer. Riprova.'
     );
     delete global.WebSocket;
   });
@@ -234,7 +240,7 @@ describe('lobby screen', () => {
     require('../src/lobby.js');
     wsInstance.onmessage({ data: JSON.stringify({ type: 'error', error: 'oops' }) });
     expect(document.getElementById('lobbyErrorMsg').textContent).toBe(
-      'An error occurred. Please try again.'
+      'Si è verificato un errore. Riprova.'
     );
     delete global.WebSocket;
   });

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -24,6 +24,7 @@ describe('main DOM interactions', () => {
       localStorage.clear();
     }
     document.body.innerHTML = `
+      <div id="loadError" class="hidden"><p id="loadErrorMsg"></p><button id="retryLoad"></button></div>
       <div id="status"></div>
       <div id="currentPlayer"></div>
       <div id="turnNumber"></div>
@@ -255,6 +256,10 @@ describe('main DOM interactions', () => {
     expect(uiSpy).toHaveBeenCalled();
     perform.mockRestore();
     uiSpy.mockRestore();
+  });
+
+  test('does not show load error on successful init', () => {
+    expect(document.getElementById('loadError').classList.contains('hidden')).toBe(true);
   });
 });
 

--- a/tests/map-schema.test.js
+++ b/tests/map-schema.test.js
@@ -23,7 +23,8 @@ describe('map schema validation', () => {
   });
 
   test('world8 territories have unique ids and reciprocal neighbors', () => {
-    const map = require('../src/data/world8.json');
+    // eslint-disable-next-line global-require
+    const map = require('./fixtures/maps/world8.json');
     const ids = new Set(map.territories.map((t) => t.id));
     expect(ids.size).toBe(map.territories.length);
     const byId = Object.fromEntries(map.territories.map((t) => [t.id, t]));

--- a/tests/map3.test.js
+++ b/tests/map3.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const map = require('../src/data/map3.json');
-const world8 = require('../src/data/world8.json');
+// eslint-disable-next-line global-require
+const world8 = require('./fixtures/maps/world8.json');
 
 const flushPromises = () => new Promise((res) => setTimeout(res, 0));
 

--- a/tests/server-handlers.test.js
+++ b/tests/server-handlers.test.js
@@ -11,6 +11,8 @@ import { handleChat } from "../src/server/handlers/chat.js";
 import { handleReconnect } from "../src/server/handlers/reconnect.js";
 import { handleHeartbeat } from "../src/server/handlers/heartbeat.js";
 import * as utils from "../src/server/utils.js";
+// eslint-disable-next-line global-require
+const baseLobby = require("./fixtures/lobby/default.json");
 
 describe("server handlers", () => {
   test("handleCreateLobby creates lobby", async () => {
@@ -29,38 +31,25 @@ describe("server handlers", () => {
 
   test("handleJoinLobby adds player", async () => {
     const lobbies = new Map();
-      const lobby = {
-        code: "code",
-        players: [],
-        host: "h",
-        started: false,
-        map: null,
-        maxPlayers: 8,
-      };
+    const lobby = { ...baseLobby, code: "code" };
     lobbies.set("code", lobby);
     const ctx = {
       lobbies,
       createCode: () => "p2",
-        maxPlayers: 8,
+      maxPlayers: 8,
       offlinePlayerTimeout: 0,
     };
-      const ws = { send: jest.fn(), readyState: 1 };
-      const state = {};
-      await handleJoinLobby(ctx, ws, { type: "joinLobby", code: "code", player: {} }, state);
-      expect(lobby.players.length).toBe(1);
-      const sent = JSON.parse(ws.send.mock.calls[0][0]);
-      expect(sent).toEqual(expect.objectContaining({ type: "joined", code: "code" }));
+    const ws = { send: jest.fn(), readyState: 1 };
+    const state = {};
+    await handleJoinLobby(ctx, ws, { type: "joinLobby", code: "code", player: {} }, state);
+    expect(lobby.players.length).toBe(1);
+    const sent = JSON.parse(ws.send.mock.calls[0][0]);
+    expect(sent).toEqual(expect.objectContaining({ type: "joined", code: "code" }));
   });
 
   test("handleLeaveLobby removes player", async () => {
     const lobbies = new Map();
-    const lobby = {
-      code: "code",
-      players: [{ id: "p1" }, { id: "p2" }],
-      host: "p1",
-      map: null,
-      started: false,
-    };
+    const lobby = { ...baseLobby, code: "code", players: [{ id: "p1" }, { id: "p2" }], host: "p1" };
     lobbies.set("code", lobby);
     const ctx = {
       lobbies,
@@ -77,7 +66,7 @@ describe("server handlers", () => {
 
   test("handleReady toggles ready", async () => {
     const lobbies = new Map();
-    const lobby = { code: "c", players: [{ id: "p1", ready: false }], host: "p1", map: null, maxPlayers:8 };
+    const lobby = { ...baseLobby, players: [{ id: "p1", ready: false }], host: "p1" };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };
     await handleReady(ctx, {}, { type: "ready", code: "c", id: "p1", ready: true });
@@ -86,7 +75,7 @@ describe("server handlers", () => {
 
   test("handleSelectMap updates map", async () => {
     const lobbies = new Map();
-    const lobby = { code: "c", players: [], host: "h", started: false, map: null, maxPlayers:8 };
+    const lobby = { ...baseLobby };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0, isValidMap: () => true };
     await handleSelectMap(ctx, {}, { type: "selectMap", code: "c", id: "h", map: "m1" });
@@ -96,11 +85,9 @@ describe("server handlers", () => {
   test("handleStart starts game", async () => {
     const lobbies = new Map();
     const lobby = {
-      code: "c",
+      ...baseLobby,
       players: [{ id: "h", ready: true }, { id: "p2", ready: true }],
       host: "h",
-      started: false,
-      map: null,
     };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };
@@ -111,11 +98,10 @@ describe("server handlers", () => {
   test("handleState updates state", async () => {
     const lobbies = new Map();
     const lobby = {
-      code: "c",
+      ...baseLobby,
       players: [],
       started: true,
       state: { currentPlayer: "p1" },
-      map: null,
     };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };
@@ -125,7 +111,7 @@ describe("server handlers", () => {
 
   test("handleChat broadcasts", async () => {
     const lobbies = new Map();
-    const lobby = { code: "c", players: [], map: null };
+    const lobby = { ...baseLobby, players: [], map: null };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0, supabase: null };
     const spy = jest.spyOn(utils, "broadcast").mockImplementation(() => {});
@@ -140,11 +126,9 @@ describe("server handlers", () => {
   test("handleReconnect restores player", async () => {
     const lobbies = new Map();
     const lobby = {
-      code: "c",
+      ...baseLobby,
       players: [{ id: "p1", ws: null, ready: false }],
       host: "p1",
-      map: null,
-      maxPlayers:8,
     };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };
@@ -158,7 +142,7 @@ describe("server handlers", () => {
   test("handleHeartbeat updates lastSeen", async () => {
     const lobbies = new Map();
     const player = { id: "p1" };
-    const lobby = { code: "c", players: [player] };
+    const lobby = { ...baseLobby, players: [player] };
     lobbies.set("c", lobby);
     const ctx = { lobbies, offlinePlayerTimeout: 0 };
     await handleHeartbeat(ctx, {}, { type: "heartbeat", code: "c", id: "p1" });
@@ -168,12 +152,10 @@ describe("server handlers", () => {
   test("allows eight players to join and start", async () => {
     const lobbies = new Map();
     const lobby = {
-      code: "c",
+      ...baseLobby,
       players: [],
       host: "p0",
-      started: false,
       map: "world8",
-      maxPlayers: 8,
     };
     lobbies.set("c", lobby);
     const ctx = {

--- a/tests/ui-init.uat.test.js
+++ b/tests/ui-init.uat.test.js
@@ -88,6 +88,7 @@ describe("ui-init game start and navigation", () => {
       endTurn: jest.fn(),
     };
     document.body.innerHTML = `
+      <div id="loadError" class="hidden"><p id="loadErrorMsg"></p><button id="retryLoad"></button></div>
       <div id="uiPanel"></div>
       <div id="actionLog"></div>
       <div id="diceResults"></div>
@@ -123,5 +124,9 @@ describe("ui-init game start and navigation", () => {
     expect(resetBtn).not.toBeNull();
     resetBtn.click();
     expect(navigation.navigateTo).toHaveBeenCalledWith("setup.html");
+  });
+
+  test("initGame does not show error on success", () => {
+    expect(document.getElementById("loadError").classList.contains("hidden")).toBe(true);
   });
 });

--- a/tests/ui.uat.test.js
+++ b/tests/ui.uat.test.js
@@ -1,6 +1,7 @@
 import * as ui from '../src/ui.js';
 import { GameState } from "../src/state/game.js";
-const world8 = require('../src/data/world8.json');
+// eslint-disable-next-line global-require
+const world8 = require('./fixtures/maps/world8.json');
 
 const { initUI, addLogEntry, updateUI, animateMove, destroyUI } = ui;
 

--- a/tests/websocket-multiplayer-plugin.test.js
+++ b/tests/websocket-multiplayer-plugin.test.js
@@ -3,6 +3,8 @@ import Game from "../src/game.js";
 import { FORTIFY } from "../src/phases.js";
 import createWebSocketMultiplayer from "../src/plugins/websocket-multiplayer-plugin.js";
 import WebSocket, { WebSocketServer } from "ws";
+// eslint-disable-next-line global-require
+const sampleState = require("./fixtures/game/sample-state.json");
 
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -22,17 +24,9 @@ test("syncs game state over websocket", async () => {
 
   global.WebSocket = WebSocket;
 
-  const players = [
-    { name: "P1", color: "#f00" },
-    { name: "P2", color: "#0f0" },
-  ];
-  const territories = [
-    { id: 0, neighbors: [1], x: 0, y: 0, owner: 0, armies: 3 },
-    { id: 1, neighbors: [0], x: 1, y: 0, owner: 1, armies: 3 },
-  ];
-
-  const game1 = new Game(players, territories, [], [], false, false);
-  const game2 = new Game(players, territories, [], [], false, false);
+  const { players, territories, continents, deck } = sampleState;
+  const game1 = new Game(players, territories, continents, deck, false, false);
+  const game2 = new Game(players, territories, continents, deck, false, false);
 
   const events2 = [];
   game2.on("turnStart", e => events2.push(e));


### PR DESCRIPTION
## Summary
- add shared fixtures for maps, lobby, and game state
- display `Riprova` messages for API failures in main flows
- add tests ensuring normal code paths show no error messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37915e3f0832c9ce641a264ecfb0e