### PR TITLE
Check auth session before allowing lobby creation

### DIFF
--- a/src/lobby.js
+++ b/src/lobby.js
@@ -266,7 +266,7 @@ export function initLobby() {
   }
   fetchLobbies();
   import('./init/supabase-client.js')
-    .then(mod => {
+    .then(async mod => {
       if (mod && Object.prototype.hasOwnProperty.call(mod, 'default')) {
         supabase = mod.default;
       } else {
@@ -285,6 +285,15 @@ export function initLobby() {
         })
         .subscribe();
       bus.on('lobbiesChanged', fetchLobbies);
+      try {
+        const { data: { session } = {} } = await supabase.auth.getSession();
+        if (!session) {
+          if (createBtn) createBtn.disabled = true;
+          showLobbyError('Effettua il login per creare una lobby.');
+        }
+      } catch (err) {
+        logError('Supabase getSession error', err?.message);
+      }
     })
     .catch(err => {
       logError('Failed to load Supabase client', err?.message);

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -2,7 +2,7 @@ jest.mock('../src/navigation.js', () => ({ goHome: jest.fn() }));
 jest.mock('../src/theme.js', () => ({ initThemeToggle: jest.fn() }));
 const mockSupabase = {
   auth: {
-    getSession: jest.fn().mockResolvedValue({}),
+    getSession: jest.fn().mockResolvedValue({ data: { session: {} } }),
     getUser: jest.fn().mockResolvedValue({
       data: { user: { user_metadata: { username: 'testuser' }, email: 'test@example.com' } },
     }),
@@ -209,6 +209,25 @@ describe('lobby screen', () => {
     require('../src/lobby.js');
     expect(document.getElementById('createBtn').disabled).toBe(true);
     expect(document.getElementById('lobbyError').classList.contains('hidden')).toBe(false);
+  });
+
+  test('disables create button when session is invalid', async () => {
+    jest.resetModules();
+    const noSessionSupabase = {
+      ...mockSupabase,
+      auth: {
+        ...mockSupabase.auth,
+        getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      },
+    };
+    jest.doMock('../src/init/supabase-client.js', () => ({ __esModule: true, default: noSessionSupabase }));
+    jest.doMock('../src/config.js', () => ({ WS_URL: 'ws://test' }));
+    require('../src/lobby.js');
+    await new Promise(r => setTimeout(r, 0));
+    expect(document.getElementById('createBtn').disabled).toBe(true);
+    expect(document.getElementById('lobbyErrorMsg').textContent).toBe(
+      'Effettua il login per creare una lobby.'
+    );
   });
 
   test('notifies user on websocket error', async () => {


### PR DESCRIPTION
## Summary
- verify Supabase auth session after client initialization
- disable lobby creation and prompt login when session missing
- cover missing session case with unit test

## Testing
- `npm test tests/lobby.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b37d32c9f0832ca7587f410dd00014