### PR TITLE
Disallow force pushes to main branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,17 @@
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_status_checks:
+        strict: true
+        contexts:
+          - "Lint / eslint"
+          - "CI / tests"
+          - "CI (Playwright Container) / tests"
+          - "UAT / uat"
+      allow_force_pushes: false
+      restrictions:
+        users: []
+        teams: []
+        apps: []

--- a/README.md
+++ b/README.md
@@ -217,12 +217,25 @@ new behaviours or UI integrations without touching the core logic.
 
 ## Contributing
 
-Contributions are welcome! Fork the repository and open a pull request with
-your changes. Please run the test suite and linter before submitting:
+Contributions are welcome! Fork the repository and open a pull request with your changes.
+
+All changes to `main` go through a protected branch:
+
+- At least one approving pull request review is required.
+- The following checks must succeed before merging:
+  - `Lint / eslint`
+  - `CI / tests`
+  - `CI (Playwright Container) / tests`
+  - `UAT / uat`
+- Direct pushes to `main` are disabled.
+- Force pushes to `main` are disabled.
+
+Please run the test suite and linter before submitting:
 
 ```bash
 npm test
 npm run lint
+npm run type-check
 ```
 
 ## Wiki


### PR DESCRIPTION
## Summary
- disable force pushes in branch protection for `main`
- document that direct and force pushes to `main` are blocked

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:smoke`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist...)*

------
https://chatgpt.com/codex/tasks/task_e_68b3791aedd0832c9b716b5b2e68fc6f