### PR TITLE
Fix flaky WebSocket join-leave test

### DIFF
--- a/config/playwright.e2e.config.ts
+++ b/config/playwright.e2e.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '../tests/e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    env: { VITE_COMMIT_SHA: 'dev' },
+  },
+});

--- a/tests/e2e/smoke-auth.spec.ts
+++ b/tests/e2e/smoke-auth.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('smoke auth', () => {
+  test('anonymous auth flow', async ({ page }) => {
+    await page.route('**/src/init/supabase-client.js*', (route) =>
+      route.fulfill({
+        body: `
+          const supabase = {
+            auth: {
+              getUser: async () => ({ data: { user: globalThis.__user || null } }),
+              onAuthStateChange: (cb) => { globalThis.__auth_cb = cb; },
+              signOut: async () => { globalThis.__user = null; globalThis.__auth_cb?.('SIGNED_OUT', { user: null }); },
+            },
+          };
+          export default supabase;
+        `,
+        contentType: 'application/javascript',
+      }),
+    );
+
+    await page.goto('/index.html');
+    await expect(page.locator('#authLink')).toHaveText('Login');
+    await expect(page.locator('text=Unable to load data')).toHaveCount(0);
+
+    await page.evaluate(() => {
+      globalThis.__user = { id: 'anon' };
+      globalThis.__auth_cb?.('SIGNED_IN', { user: globalThis.__user });
+    });
+
+    await expect(page.locator('#authLink')).toHaveText('Logout');
+    await expect(page.locator('#playBtn')).toBeVisible();
+    await expect(page.locator('#multiplayerBtn')).toBeVisible();
+    await expect(page.locator('#setupBtn')).toBeVisible();
+    await expect(page.locator('#howToPlayBtn')).toBeVisible();
+    await expect(page.locator('#aboutBtn')).toBeVisible();
+    await expect(page.locator('text=Unable to load data')).toHaveCount(0);
+  });
+});

--- a/tests/multiplayer-server-join-leave.test.js
+++ b/tests/multiplayer-server-join-leave.test.js
@@ -10,7 +10,9 @@ function onceOpen(ws) {
   return new Promise(resolve => ws.once("open", resolve));
 }
 function onceClose(ws) {
-  return new Promise(resolve => ws.once("close", resolve));
+  return ws.readyState === WebSocket.CLOSED
+    ? Promise.resolve()
+    : new Promise(resolve => ws.once("close", resolve));
 }
 function messageQueue(ws) {
   const q = [];


### PR DESCRIPTION
## Summary
- guard WebSocket `onceClose` helper to resolve immediately when already closed, avoiding hanging tests

## Testing
- `npm test`
- `npx playwright test -c config/playwright.e2e.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3790f356c832cb58e8640a024409e