### PR TITLE
Localize auth forms and add redirect logic

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -1,40 +1,65 @@
 import supabase from './init/supabase-client.js';
+import { navigateTo } from './navigation.js';
+import { getSafeReferrer } from './utils/referrer.js';
 
 const form = document.getElementById('loginForm');
 const message = document.getElementById('message');
 const usernameInput = document.getElementById('username');
 const passwordInput = document.getElementById('password');
 const anonymousBtn = document.getElementById('anonymousBtn');
+const submitBtn = form?.querySelector('button[type="submit"]');
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = usernameInput.value.trim();
   const password = passwordInput.value;
   if (!supabase) {
-    message.textContent = 'Supabase not configured';
+    message.textContent = 'Supabase non configurato';
     return;
   }
-  const { error } = await supabase.auth.signInWithPassword({ email: username, password });
+  submitBtn.disabled = true;
+  message.textContent = '';
+  const { data, error } = await supabase.auth.signInWithPassword({ email: username, password });
+  submitBtn.disabled = false;
   if (error) {
-    message.textContent = error.message;
-  } else {
-    window.location.href = 'account.html';
+    message.textContent = 'Credenziali non valide';
+    return;
   }
+  const name = data.user?.email?.split('@')[0] || username;
+  message.textContent = `Benvenuto, ${name} 👋`;
+  const ref = getSafeReferrer();
+  setTimeout(() => {
+    if (ref) {
+      window.location.href = ref;
+    } else {
+      navigateTo('account.html');
+    }
+  }, 1000);
 });
 
 anonymousBtn?.addEventListener('click', async () => {
   if (!supabase) {
-    message.textContent = 'Supabase not configured';
+    message.textContent = 'Supabase non configurato';
     return;
   }
   if (typeof supabase.auth.signInAnonymously !== 'function') {
-    message.textContent = 'Anonymous login not supported';
+    message.textContent = 'Accesso anonimo non supportato';
     return;
   }
+  anonymousBtn.disabled = true;
   const { error } = await supabase.auth.signInAnonymously();
+  anonymousBtn.disabled = false;
   if (error) {
-    message.textContent = error.message;
-  } else {
-    window.location.href = 'account.html';
+    message.textContent = 'Errore di accesso anonimo';
+    return;
   }
+  message.textContent = 'Benvenuto, giocatore 👋';
+  const ref = getSafeReferrer();
+  setTimeout(() => {
+    if (ref) {
+      window.location.href = ref;
+    } else {
+      navigateTo('account.html');
+    }
+  }, 1000);
 });

--- a/src/register.js
+++ b/src/register.js
@@ -1,25 +1,44 @@
 import supabase from './init/supabase-client.js';
+import { navigateTo } from './navigation.js';
+import { getSafeReferrer } from './utils/referrer.js';
 
 const form = document.getElementById('registerForm');
 const message = document.getElementById('message');
 const usernameInput = document.getElementById('username');
 const passwordInput = document.getElementById('password');
+const submitBtn = form?.querySelector('button[type="submit"]');
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = usernameInput.value.trim();
   const password = passwordInput.value;
   if (!supabase) {
-    message.textContent = 'Supabase not configured';
+    message.textContent = 'Supabase non configurato';
     return;
   }
+  submitBtn.disabled = true;
+  message.textContent = '';
   const redirectUrl = new URL('login.html', window.location.href).href;
-  const { error } = await supabase.auth.signUp({
+  const { data, error } = await supabase.auth.signUp({
     email: username,
     password,
     options: {
       emailRedirectTo: redirectUrl,
     },
   });
-  message.textContent = error ? error.message : 'Registration successful';
+  submitBtn.disabled = false;
+  if (error) {
+    message.textContent = 'Registrazione non riuscita';
+    return;
+  }
+  const name = data.user?.email?.split('@')[0] || username;
+  message.textContent = `Benvenuto, ${name} 👋`;
+  const ref = getSafeReferrer();
+  setTimeout(() => {
+    if (ref) {
+      window.location.href = ref;
+    } else {
+      navigateTo('account.html');
+    }
+  }, 1000);
 });

--- a/src/utils/referrer.js
+++ b/src/utils/referrer.js
@@ -1,0 +1,13 @@
+export function getSafeReferrer() {
+  try {
+    const ref = document.referrer;
+    if (!ref) return null;
+    const url = new URL(ref, window.location.href);
+    if (url.origin === window.location.origin) {
+      return url.href;
+    }
+  } catch {
+    // ignore invalid referrers
+  }
+  return null;
+}

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -43,7 +43,37 @@ describe('login page', () => {
 
     require('../src/login.js');
     document.getElementById('anonymousBtn').click();
-    expect(document.getElementById('message').textContent).toBe('Anonymous login not supported');
+    expect(document.getElementById('message').textContent).toBe('Accesso anonimo non supportato');
+  });
+
+  test('falls back to account page for external referrer after login', async () => {
+    Object.defineProperty(document, 'referrer', { value: 'https://evil.com/', configurable: true });
+    jest.useFakeTimers();
+
+    const navigateTo = jest.fn();
+    jest.doMock('../src/navigation.js', () => ({ navigateTo }));
+
+    jest.doMock('../src/init/supabase-client.js', () => ({
+      __esModule: true,
+      default: {
+        auth: {
+          signInWithPassword: jest
+            .fn()
+            .mockResolvedValue({ data: { user: { email: 'foo@example.com' } }, error: null }),
+        },
+      },
+    }));
+
+    require('../src/login.js');
+    document.getElementById('username').value = 'foo@example.com';
+    document.getElementById('password').value = 'pass';
+    document.getElementById('loginForm').dispatchEvent(new Event('submit'));
+    await Promise.resolve();
+    jest.runAllTimers();
+
+    expect(navigateTo).toHaveBeenCalledWith('account.html');
+    jest.useRealTimers();
+    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
   });
 });
 

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -1,0 +1,44 @@
+describe('register page', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <form id="registerForm">
+        <input id="username" />
+        <input id="password" />
+        <button type="submit" class="btn">Register</button>
+      </form>
+      <p id="message" role="alert"></p>
+    `;
+  });
+
+  test('falls back to account page for external referrer after registration', async () => {
+    Object.defineProperty(document, 'referrer', { value: 'https://evil.com/', configurable: true });
+    jest.useFakeTimers();
+
+    const navigateTo = jest.fn();
+    jest.doMock('../src/navigation.js', () => ({ navigateTo }));
+
+    jest.doMock('../src/init/supabase-client.js', () => ({
+      __esModule: true,
+      default: {
+        auth: {
+          signUp: jest
+            .fn()
+            .mockResolvedValue({ data: { user: { email: 'foo@example.com' } }, error: null }),
+        },
+      },
+    }));
+
+    require('../src/register.js');
+    document.getElementById('username').value = 'foo@example.com';
+    document.getElementById('password').value = 'pass';
+    document.getElementById('registerForm').dispatchEvent(new Event('submit'));
+    await Promise.resolve();
+    jest.runAllTimers();
+
+    expect(navigateTo).toHaveBeenCalledWith('account.html');
+    jest.useRealTimers();
+    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Disable auth form submit buttons while processing
- Localize login/register feedback and welcome users in Italian
- Redirect to previous page after auth success or account page if none, validating referrer origin
- Update login test for Italian message and guard against external referrer
- Share safe referrer helper and apply to registration flow to avoid open redirects
- Add registration test for external referrer fallback

## Testing
- `npm test` *(fails: tests/multiplayer-server-join-leave.test.js exceeded timeout)*
- `npm test tests/login.test.js tests/register.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4256d7608832c981a8d69b295d7f2