### PR TITLE
Require authentication for multiplayer and lobby access

### DIFF
--- a/src/home.js
+++ b/src/home.js
@@ -1,11 +1,11 @@
 import { initThemeToggle } from "./theme.js";
 import { navigateTo } from "./navigation.js";
+import supabase from "./init/supabase-client.js";
 
 export function initHome() {
   initThemeToggle();
   const mapping = [
     ["playBtn", "./game.html"],
-    ["multiplayerBtn", "./lobby.html"],
     ["setupBtn", "./setup.html"],
     ["howToPlayBtn", "./how-to-play.html"],
     ["aboutBtn", "./about.html"],
@@ -16,6 +16,39 @@ export function initHome() {
       btn.addEventListener("click", () => navigateTo(url));
     }
   });
+
+  const multiBtn = document.getElementById("multiplayerBtn");
+  if (multiBtn) {
+    multiBtn.addEventListener("click", async () => {
+      let user = null;
+      try {
+        ({ data: { user } = {} } = (await supabase.auth.getUser()));
+      } catch {
+        user = null;
+      }
+      if (user) {
+        navigateTo("./lobby.html");
+        return;
+      }
+      const dialog = document.createElement("dialog");
+      dialog.innerHTML = `
+        <p>Serve un account per giocare online</p>
+        <div>
+          <button id="loginDialogBtn">Accedi</button>
+          <button id="registerDialogBtn">Registrati</button>
+        </div>
+      `;
+      document.body.appendChild(dialog);
+      dialog.querySelector("#loginDialogBtn")?.addEventListener("click", () =>
+        navigateTo("login.html?redirect=lobby.html")
+      );
+      dialog.querySelector("#registerDialogBtn")?.addEventListener("click", () =>
+        navigateTo("register.html?redirect=lobby.html")
+      );
+      if (dialog.showModal) dialog.showModal();
+      else dialog.setAttribute("open", "");
+    });
+  }
 }
 
 initHome();

--- a/src/lobby.js
+++ b/src/lobby.js
@@ -1,5 +1,5 @@
 import { initThemeToggle } from './theme.js';
-import { goHome } from './navigation.js';
+import { goHome, navigateTo } from './navigation.js';
 import { WS_URL } from './config.js';
 import EventBus from './core/event-bus.js';
 import { info as logInfo, error as logError } from './logger.js';
@@ -264,7 +264,6 @@ export function initLobby() {
       showLobbyError('Server multiplayer non disponibile. Riprova.', () => location.reload());
     }
   }
-  fetchLobbies();
   import('./init/supabase-client.js')
     .then(async mod => {
       if (mod && Object.prototype.hasOwnProperty.call(mod, 'default')) {
@@ -277,6 +276,19 @@ export function initLobby() {
         return;
       }
       logInfo('Supabase client ready on lobby page');
+      try {
+        const { data: { user } = {} } = await supabase.auth.getUser();
+        if (!user) {
+          const redirectPath = window.location.pathname + window.location.search;
+          navigateTo(`login.html?redirect=${encodeURIComponent(redirectPath)}`);
+          return;
+        }
+      } catch (err) {
+        logError('Supabase getUser error', err?.message);
+        const redirectPath = window.location.pathname + window.location.search;
+        navigateTo(`login.html?redirect=${encodeURIComponent(redirectPath)}`);
+        return;
+      }
       fetchLobbies();
       supabase
         .channel('public:lobbies')

--- a/src/login.js
+++ b/src/login.js
@@ -7,6 +7,7 @@ const message = document.getElementById('message');
 const params = new URLSearchParams(window.location.search);
 const initialMsg = params.get('message');
 if (initialMsg) message.textContent = initialMsg;
+const redirectParam = params.get('redirect');
 const usernameInput = document.getElementById('username');
 const passwordInput = document.getElementById('password');
 const anonymousBtn = document.getElementById('anonymousBtn');
@@ -30,10 +31,28 @@ form.addEventListener('submit', async (e) => {
   }
   const name = data.user?.email?.split('@')[0] || username;
   message.textContent = `Benvenuto, ${name} 👋`;
-  const ref = getSafeReferrer();
+  let ref = null;
+  if (redirectParam) {
+    try {
+      const decoded = decodeURIComponent(redirectParam);
+      const url = new URL(decoded, window.location.href);
+      if (url.origin === window.location.origin) {
+        ref = url.pathname.replace(/^\//, '') + url.search + url.hash;
+      }
+    } catch {
+      ref = null;
+    }
+  }
+  if (!ref) {
+    const safeRef = getSafeReferrer();
+    if (safeRef) {
+      const url = new URL(safeRef, window.location.href);
+      ref = url.pathname.replace(/^\//, '') + url.search + url.hash;
+    }
+  }
   setTimeout(() => {
     if (ref) {
-      window.location.href = ref;
+      navigateTo(ref);
     } else {
       navigateTo('account.html');
     }
@@ -57,10 +76,28 @@ anonymousBtn?.addEventListener('click', async () => {
     return;
   }
   message.textContent = 'Benvenuto, giocatore 👋';
-  const ref = getSafeReferrer();
+  let ref = null;
+  if (redirectParam) {
+    try {
+      const decoded = decodeURIComponent(redirectParam);
+      const url = new URL(decoded, window.location.href);
+      if (url.origin === window.location.origin) {
+        ref = url.pathname.replace(/^\//, '') + url.search + url.hash;
+      }
+    } catch {
+      ref = null;
+    }
+  }
+  if (!ref) {
+    const safeRef = getSafeReferrer();
+    if (safeRef) {
+      const url = new URL(safeRef, window.location.href);
+      ref = url.pathname.replace(/^\//, '') + url.search + url.hash;
+    }
+  }
   setTimeout(() => {
     if (ref) {
-      window.location.href = ref;
+      navigateTo(ref);
     } else {
       navigateTo('account.html');
     }

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -1,5 +1,11 @@
 jest.mock('../src/theme.js', () => ({ initThemeToggle: jest.fn() }));
 jest.mock('../src/navigation.js', () => ({ navigateTo: jest.fn() }));
+const mockSupabase = {
+  auth: {
+    getUser: jest.fn().mockResolvedValue({ data: { user: {} } }),
+  },
+};
+jest.mock('../src/init/supabase-client.js', () => ({ __esModule: true, default: mockSupabase }));
 
 describe('home page initialization', () => {
   beforeEach(() => {
@@ -26,5 +32,27 @@ describe('home page initialization', () => {
     expect(navigateTo).toHaveBeenCalledWith('./game.html');
     expect(navigateTo).toHaveBeenCalledWith('./about.html');
     expect(navigateTo).toHaveBeenCalledTimes(2);
+  });
+
+  test('multiplayer click shows auth dialog when not logged in', async () => {
+    const { navigateTo } = require('../src/navigation.js');
+    mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null } });
+    require('../src/home.js');
+    document.getElementById('multiplayerBtn').click();
+    await Promise.resolve();
+    expect(navigateTo).not.toHaveBeenCalled();
+    const dlg = document.querySelector('dialog');
+    expect(dlg).not.toBeNull();
+    expect(dlg.textContent).toContain('Serve un account per giocare online');
+    dlg.querySelector('#loginDialogBtn').click();
+    expect(navigateTo).toHaveBeenCalledWith('login.html?redirect=lobby.html');
+  });
+
+  test('multiplayer click navigates when user present', async () => {
+    const { navigateTo } = require('../src/navigation.js');
+    require('../src/home.js');
+    document.getElementById('multiplayerBtn').click();
+    await Promise.resolve();
+    expect(navigateTo).toHaveBeenCalledWith('./lobby.html');
   });
 });

--- a/tests/lobby.test.js
+++ b/tests/lobby.test.js
@@ -1,4 +1,4 @@
-jest.mock('../src/navigation.js', () => ({ goHome: jest.fn() }));
+jest.mock('../src/navigation.js', () => ({ goHome: jest.fn(), navigateTo: jest.fn() }));
 jest.mock('../src/theme.js', () => ({ initThemeToggle: jest.fn() }));
 const mockSupabase = {
   auth: {
@@ -59,6 +59,14 @@ describe('lobby screen', () => {
     delete global.fetch;
     delete global.alert;
     localStorage.clear();
+  });
+
+  test('redirects to login when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null } });
+    const { navigateTo } = require('../src/navigation.js');
+    require('../src/lobby.js');
+    await new Promise(r => setTimeout(r, 0));
+    expect(navigateTo).toHaveBeenCalledWith('login.html?redirect=%2F');
   });
 
   test('does not show error when lobbies load successfully', async () => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -75,5 +75,56 @@ describe('login page', () => {
     jest.useRealTimers();
     Object.defineProperty(document, 'referrer', { value: '', configurable: true });
   });
+
+  test('redirects to path from query after login', async () => {
+    jest.useFakeTimers();
+    const navigateTo = jest.fn();
+    jest.doMock('../src/navigation.js', () => ({ navigateTo }));
+    jest.doMock('../src/init/supabase-client.js', () => ({
+      __esModule: true,
+      default: {
+        auth: {
+          signInWithPassword: jest
+            .fn()
+            .mockResolvedValue({ data: { user: { email: 'foo@example.com' } }, error: null }),
+        },
+      },
+    }));
+    const originalUrl = window.location.href;
+    window.history.pushState({}, '', 'http://localhost/login.html?redirect=%2Flobby.html');
+    require('../src/login.js');
+    document.getElementById('username').value = 'foo@example.com';
+    document.getElementById('password').value = 'pass';
+    document.getElementById('loginForm').dispatchEvent(new Event('submit'));
+    await Promise.resolve();
+    jest.runAllTimers();
+    expect(navigateTo).toHaveBeenCalledWith('lobby.html');
+    jest.useRealTimers();
+    window.history.pushState({}, '', originalUrl);
+  });
+
+  test('anonymous login redirects to path from query', async () => {
+    jest.useFakeTimers();
+    const navigateTo = jest.fn();
+    jest.doMock('../src/navigation.js', () => ({ navigateTo }));
+    jest.doMock('../src/init/supabase-client.js', () => ({
+      __esModule: true,
+      default: {
+        auth: {
+          signInWithPassword: jest.fn().mockResolvedValue({}),
+          signInAnonymously: jest.fn().mockResolvedValue({}),
+        },
+      },
+    }));
+    const originalUrl = window.location.href;
+    window.history.pushState({}, '', 'http://localhost/login.html?redirect=%2Flobby.html');
+    require('../src/login.js');
+    document.getElementById('anonymousBtn').click();
+    await Promise.resolve();
+    jest.runAllTimers();
+    expect(navigateTo).toHaveBeenCalledWith('lobby.html');
+    jest.useRealTimers();
+    window.history.pushState({}, '', originalUrl);
+  });
 });
 


### PR DESCRIPTION
## Summary
- Prompt users to log in or register when selecting multiplayer from home page
- Redirect unauthenticated visitors to login before loading lobby
- Support redirecting back to intended lobby after successful login
- Fix redirect handling to avoid malformed URLs

## Testing
- `npm test tests/home.test.js tests/login.test.js tests/lobby.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b44263017c832c94042403ba3e7415