### PR TITLE
Add optional persistent login session

### DIFF
--- a/login.html
+++ b/login.html
@@ -31,6 +31,12 @@
           Password:
           <input type="password" id="password" required data-testid="login-password" />
         </label>
+        <label>
+          <input type="checkbox" id="stayLoggedIn" /> Resta connesso
+        </label>
+        <p class="help-text">
+          Se selezionato, l'accesso rimarrà attivo anche dopo la chiusura del browser.
+        </p>
         <button type="submit" class="btn" data-testid="login-submit">Login</button>
         <a id="registerBtn" class="btn" href="./register.html">Register</a>
         <button type="button" id="anonymousBtn" class="btn" data-testid="login-anon">Login anonymously</button>

--- a/src/login.js
+++ b/src/login.js
@@ -12,6 +12,7 @@ const usernameInput = document.getElementById('username');
 const passwordInput = document.getElementById('password');
 const anonymousBtn = document.getElementById('anonymousBtn');
 const submitBtn = form?.querySelector('button[type="submit"]');
+const stayLoggedIn = document.getElementById('stayLoggedIn');
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -28,6 +29,10 @@ form.addEventListener('submit', async (e) => {
   if (error) {
     message.textContent = 'Credenziali non valide';
     return;
+  }
+  if (data?.session) {
+    supabase.auth.storage = stayLoggedIn?.checked ? window.localStorage : window.sessionStorage;
+    await supabase.auth.setSession(data.session);
   }
   const name = data.user?.email?.split('@')[0] || username;
   message.textContent = `Benvenuto, ${name} 👋`;

--- a/tests/home.uat.test.js
+++ b/tests/home.uat.test.js
@@ -1,5 +1,9 @@
 jest.mock('../src/theme.js', () => ({ initThemeToggle: jest.fn() }));
 jest.mock('../src/navigation.js', () => ({ navigateTo: jest.fn() }));
+const mockSupabase = {
+  auth: { getUser: jest.fn().mockResolvedValue({ data: { user: {} } }) },
+};
+jest.mock('../src/init/supabase-client.js', () => ({ __esModule: true, default: mockSupabase }));
 
 describe('home page UAT', () => {
   beforeEach(() => {
@@ -7,7 +11,7 @@ describe('home page UAT', () => {
     jest.clearAllMocks();
   });
 
-  test('initHome wires up all buttons to navigation', () => {
+  test('initHome wires up all buttons to navigation', async () => {
     document.body.innerHTML = `
       <button id="playBtn"></button>
       <button id="multiplayerBtn"></button>
@@ -21,6 +25,7 @@ describe('home page UAT', () => {
 
     document.getElementById('playBtn').click();
     document.getElementById('multiplayerBtn').click();
+    await Promise.resolve();
     document.getElementById('setupBtn').click();
     document.getElementById('howToPlayBtn').click();
     document.getElementById('aboutBtn').click();

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -21,6 +21,7 @@ describe('login page', () => {
         auth: {
           signInWithPassword: jest.fn().mockResolvedValue({}),
           signInAnonymously: jest.fn().mockResolvedValue({}),
+          setSession: jest.fn().mockResolvedValue({}),
         },
       },
     }));
@@ -37,6 +38,7 @@ describe('login page', () => {
       default: {
         auth: {
           signInWithPassword: jest.fn().mockResolvedValue({}),
+          setSession: jest.fn().mockResolvedValue({}),
         },
       },
     }));
@@ -60,6 +62,7 @@ describe('login page', () => {
           signInWithPassword: jest
             .fn()
             .mockResolvedValue({ data: { user: { email: 'foo@example.com' } }, error: null }),
+          setSession: jest.fn().mockResolvedValue({}),
         },
       },
     }));
@@ -87,6 +90,7 @@ describe('login page', () => {
           signInWithPassword: jest
             .fn()
             .mockResolvedValue({ data: { user: { email: 'foo@example.com' } }, error: null }),
+          setSession: jest.fn().mockResolvedValue({}),
         },
       },
     }));
@@ -113,6 +117,7 @@ describe('login page', () => {
         auth: {
           signInWithPassword: jest.fn().mockResolvedValue({}),
           signInAnonymously: jest.fn().mockResolvedValue({}),
+          setSession: jest.fn().mockResolvedValue({}),
         },
       },
     }));

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -3,6 +3,10 @@ jest.mock('../src/navigation.js', () => ({
   goHome: jest.fn(),
   exitGame: jest.fn(),
 }));
+const mockSupabase = {
+  auth: { getUser: jest.fn().mockResolvedValue({ data: { user: {} } }) },
+};
+jest.mock('../src/init/supabase-client.js', () => ({ __esModule: true, default: mockSupabase }));
 
 describe('home navigation', () => {
   beforeEach(() => {
@@ -16,11 +20,12 @@ describe('home navigation', () => {
     `;
   });
 
-  test('buttons navigate to pages', () => {
+  test('buttons navigate to pages', async () => {
     const { navigateTo } = require('../src/navigation.js');
     require('../src/home.js');
     document.getElementById('playBtn').click();
     document.getElementById('multiplayerBtn').click();
+    await Promise.resolve();
     document.getElementById('setupBtn').click();
     document.getElementById('howToPlayBtn').click();
     document.getElementById('aboutBtn').click();


### PR DESCRIPTION
## Summary
- add "Resta connesso" checkbox on login page with explanatory text
- persist Supabase session in localStorage when checked, otherwise use sessionStorage
- adjust tests to handle new persistence and mock Supabase user for navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4483a77d8832cab0b5332adb2a19b