### PR TITLE
Add password reset flow

### DIFF
--- a/forgot.html
+++ b/forgot.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Forgot Password - NetRisk</title>
+    <link rel="stylesheet" href="./css/base.css" />
+    <link rel="stylesheet" href="./css/layout.css" />
+    <link rel="stylesheet" href="./css/components.css" />
+    <link rel="stylesheet" href="./css/theme.css" />
+  </head>
+  <body>
+    <header class="main-header">
+      <a href="index.html" class="logo">NetRisk</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="setup.html">Setup</a>
+        <a href="how-to-play.html">How To</a>
+        <a href="about.html">About</a>
+        <span id="userMenu" class="user-menu loading"></span>
+      </nav>
+    </header>
+    <main>
+      <h1>Recupera password</h1>
+      <form id="forgotForm">
+        <label>
+          Email:
+          <input type="email" id="email" required />
+        </label>
+        <button type="submit" class="btn">Invia</button>
+      </form>
+      <p id="message" role="alert"></p>
+    </main>
+    <script src="./env.%VITE_COMMIT_SHA%.js"></script>
+    <script type="module" src="./auth.js"></script>
+    <script type="module" src="./forgot.js"></script>
+  </body>
+</html>

--- a/forgot.js
+++ b/forgot.js
@@ -1,0 +1,1 @@
+import './src/forgot.js';

--- a/login.html
+++ b/login.html
@@ -40,6 +40,7 @@
         <button type="submit" class="btn" data-testid="login-submit">Login</button>
         <a id="registerBtn" class="btn" href="./register.html">Register</a>
         <button type="button" id="anonymousBtn" class="btn" data-testid="login-anon">Login anonymously</button>
+        <a href="./forgot.html">Password dimenticata?</a>
       </form>
       <p id="message" role="alert" data-testid="login-message"></p>
     </main>

--- a/src/forgot.js
+++ b/src/forgot.js
@@ -1,0 +1,24 @@
+import supabase from './init/supabase-client.js';
+import { navigateTo } from './navigation.js';
+
+const form = document.getElementById('forgotForm');
+const message = document.getElementById('message');
+const emailInput = document.getElementById('email');
+const submitBtn = form?.querySelector('button[type="submit"]');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = emailInput.value.trim();
+  if (!supabase) {
+    message.textContent = 'Supabase non configurato';
+    return;
+  }
+  submitBtn.disabled = true;
+  message.textContent = '';
+  await supabase.auth.resetPasswordForEmail(email);
+  const msg = "Se l'email esiste, riceverai un link per reimpostare la password";
+  message.textContent = msg;
+  setTimeout(() => {
+    navigateTo(`login.html?message=${encodeURIComponent(msg)}`);
+  }, 1000);
+});


### PR DESCRIPTION
## Summary
- add forgot password page and link from login
- trigger Supabase password reset and redirect back with confirmation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b44c9fae08832cb0aa2691fc3a8a16