### PR TITLE
Use global sign-out and show logout banner

### DIFF
--- a/src/account.js
+++ b/src/account.js
@@ -1,4 +1,6 @@
 import supabase from './init/supabase-client.js';
+import { navigateTo } from './navigation.js';
+import { renderUserMenu } from './auth.js';
 
 const userNameEl = document.getElementById('userName');
 const userEmailEl = document.getElementById('userEmail');
@@ -86,7 +88,13 @@ async function loadUser() {
 logoutBtn?.addEventListener('click', async () => {
   if (!supabase) return;
   await supabase.auth.signOut({ scope: 'global' });
-  window.location.href = 'index.html';
+  await renderUserMenu();
+  try {
+    sessionStorage.setItem('flashMessage', 'Sei uscito dall\'account');
+  } catch {
+    // ignore storage errors
+  }
+  navigateTo('index.html');
 });
 
 changePasswordBtn?.addEventListener('click', async () => {

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,7 @@
 import supabase from './init/supabase-client.js';
+import { navigateTo } from './navigation.js';
 
-async function renderUserMenu() {
+export async function renderUserMenu() {
   const menu = document.getElementById('userMenu');
   if (!menu || !supabase) return;
 
@@ -28,8 +29,14 @@ async function renderUserMenu() {
     logout.textContent = 'Esci';
     logout.addEventListener('click', async (e) => {
       e.preventDefault();
-      await supabase.auth.signOut();
-      window.location.href = 'index.html';
+      await supabase.auth.signOut({ scope: 'global' });
+      await renderUserMenu();
+      try {
+        sessionStorage.setItem('flashMessage', 'Sei uscito dall\'account');
+      } catch {
+        // ignore storage errors
+      }
+      navigateTo('index.html');
     });
 
     menu.append(avatar, profile, logout);
@@ -48,4 +55,25 @@ async function renderUserMenu() {
 
 renderUserMenu();
 supabase?.auth.onAuthStateChange(renderUserMenu);
+
+try {
+  const msg = sessionStorage.getItem('flashMessage');
+  if (msg) {
+    const banner = document.createElement('div');
+    banner.textContent = msg;
+    banner.style.background = '#cfc';
+    banner.style.color = '#000';
+    banner.style.padding = '1em';
+    banner.style.textAlign = 'center';
+    banner.style.position = 'fixed';
+    banner.style.top = '0';
+    banner.style.left = '0';
+    banner.style.right = '0';
+    banner.style.zIndex = '9999';
+    document.body?.prepend(banner);
+    sessionStorage.removeItem('flashMessage');
+  }
+} catch {
+  // ignore storage errors
+}
 


### PR DESCRIPTION
## Summary
- Sign users out globally from header menu and account page
- Display a banner on next page load indicating the user has logged out
- Redirect to the home page and refresh header state on logout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b485a7aa60832c8991bfd441c6d33d