### PR TITLE
Fix lobby max-player enforcement and cleanup

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,16 +1,20 @@
 import supabase from './init/supabase-client.js';
 import { navigateTo } from './navigation.js';
 
-export async function renderUserMenu() {
+export async function renderUserMenu(session) {
   const menu = document.getElementById('userMenu');
   if (!menu || !supabase) return;
 
   menu.innerHTML = '';
   menu.classList.add('loading');
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  let user = session?.user;
+  if (session === undefined) {
+    const {
+      data: { user: fetchedUser },
+    } = await supabase.auth.getUser();
+    user = fetchedUser;
+  }
 
   menu.classList.remove('loading');
 
@@ -53,8 +57,21 @@ export async function renderUserMenu() {
   }
 }
 
-renderUserMenu();
-supabase?.auth.onAuthStateChange(renderUserMenu);
+async function init() {
+  const nav = document.querySelector('nav');
+  nav?.classList.add('loading');
+
+  const {
+    data: { session },
+  } = (await supabase?.auth.getSession()) ?? { data: { session: null } };
+  await renderUserMenu(session);
+
+  nav?.classList.remove('loading');
+
+  supabase?.auth.onAuthStateChange((_event, s) => renderUserMenu(s));
+}
+
+init();
 
 try {
   const msg = sessionStorage.getItem('flashMessage');

--- a/src/server/handlers/createLobby.js
+++ b/src/server/handlers/createLobby.js
@@ -13,7 +13,10 @@ export async function handleCreateLobby(ctx, ws, msg, state) {
     ready: false,
     ws,
   };
-  const maxPlayers = Math.max(2, Math.min(8, msg.maxPlayers || 8));
+  const maxPlayers = Math.max(
+    2,
+    Math.min(ctx.maxPlayers, msg.maxPlayers || ctx.maxPlayers),
+  );
   const lobby = {
     code,
     players: [player],

--- a/src/server/handlers/joinLobby.js
+++ b/src/server/handlers/joinLobby.js
@@ -6,7 +6,7 @@ export async function handleJoinLobby(ctx, ws, msg, state) {
     ws.send(JSON.stringify({ type: "error", error: "lobbyNotOpen" }));
     return;
   }
-  if (lobby.players.length >= ctx.maxPlayers) {
+  if (lobby.players.length >= lobby.maxPlayers) {
     ws.send(JSON.stringify({ type: "error", error: "lobbyFull" }));
     return;
   }

--- a/src/server/handlers/leaveLobby.js
+++ b/src/server/handlers/leaveLobby.js
@@ -20,6 +20,7 @@ export async function handleLeaveLobby(ctx, ws, msg, state) {
     host: lobby.host,
     players: publicPlayers(lobby),
     map: lobby.map,
+    maxPlayers: lobby.maxPlayers,
   });
   ws.send(JSON.stringify({ type: "left", code: lobby.code }));
   if (lobby.players.length === 0) {


### PR DESCRIPTION
## Summary
- enforce global max-player limit when creating lobbies
- check each lobby's own max capacity on join
- include maxPlayers in leave-lobby broadcasts

## Testing
- `npm run lint`
- `npx jest --config config/jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68b497a61288832cbfaccef285615848