### PR TITLE
Show loading state while fetching auth session

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -5,14 +5,18 @@ export async function renderUserMenu() {
   const menu = document.getElementById('userMenu');
   if (!menu || !supabase) return;
 
+  const nav = menu.closest('nav') || menu;
+
   menu.innerHTML = '';
-  menu.classList.add('loading');
+  nav.classList.add('loading');
 
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
 
-  menu.classList.remove('loading');
+  nav.classList.remove('loading');
+
+  const user = session?.user;
 
   if (user) {
     const avatar = document.createElement('span');


### PR DESCRIPTION
## Summary
- Add loading class to nav while fetching session
- Delay menu rendering until Supabase session is resolved

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b49b10ba50832c8629d676341a2178