### PR TITLE
refactor: centralize auth listener

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -92,7 +92,6 @@ export async function renderUserMenu() {
 }
 
 renderUserMenu();
-supabase?.auth.onAuthStateChange(renderUserMenu);
 
 try {
   const msg = sessionStorage.getItem('flashMessage');

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -8,8 +8,19 @@ import { info, error } from '../logger.js';
 export const supabase =
   SUPABASE_URL && SUPABASE_KEY ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
 
+let authListenerRegistered = false;
+
 if (supabase) {
   info('Supabase client initialized');
+  if (!authListenerRegistered) {
+    authListenerRegistered = true;
+    supabase.auth.onAuthStateChange(async (event) => {
+      if (event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
+        const { renderUserMenu } = await import('../auth.js');
+        await renderUserMenu();
+      }
+    });
+  }
 } else {
   error('Supabase client not initialized: missing URL or anon key');
 }

--- a/tests/e2e/smoke-auth.spec.ts
+++ b/tests/e2e/smoke-auth.spec.ts
@@ -12,6 +12,10 @@ test.describe('smoke auth', () => {
               signOut: async () => { globalThis.__user = null; globalThis.__auth_cb?.('SIGNED_OUT', { user: null }); },
             },
           };
+          supabase.auth.onAuthStateChange(async () => {
+            const { renderUserMenu } = await import('../auth.js');
+            await renderUserMenu();
+          });
           export default supabase;
         `,
         contentType: 'application/javascript',


### PR DESCRIPTION
## Summary
- move auth state listener into supabase client with a single initialization guard
- update auth module and tests for new listener location

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b49fbac844832c8822f9707effe1d1