### PR TITLE
Handle missing Supabase config

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,14 +1,11 @@
 import supabase from './init/supabase-client.js';
 import { navigateTo } from './navigation.js';
-import { SUPABASE_URL, SUPABASE_KEY } from './config.js';
 
 export async function renderUserMenu() {
   const menu = document.getElementById('userMenu');
   if (!menu) return;
 
   const nav = menu.closest('nav') || menu;
-  menu.innerHTML = '';
-  nav.classList.add('loading');
 
   const showLoggedOut = () => {
     menu.innerHTML = '';
@@ -25,24 +22,13 @@ export async function renderUserMenu() {
     menu.classList.remove('loading');
   };
 
-  if (!supabase) {
+  if (supabase === null) {
     showLoggedOut();
-    if (!SUPABASE_URL || !SUPABASE_KEY) {
-      const banner = document.createElement('div');
-      banner.textContent = 'Servizio temporaneamente non disponibile, riprova';
-      banner.style.background = '#fcc';
-      banner.style.color = '#000';
-      banner.style.padding = '1em';
-      banner.style.textAlign = 'center';
-      banner.style.position = 'fixed';
-      banner.style.top = '0';
-      banner.style.left = '0';
-      banner.style.right = '0';
-      banner.style.zIndex = '9999';
-      document.body?.prepend(banner);
-    }
     return;
   }
+
+  menu.innerHTML = '';
+  nav.classList.add('loading');
 
   const timeout = setTimeout(showLoggedOut, 5000);
 

--- a/src/config.js
+++ b/src/config.js
@@ -35,22 +35,26 @@ export const WS_URL = (() => {
     return '';
   }
 })();
-// Log diagnostico e banner se l'ambiente manca
+// Log diagnostico e banner se la configurazione manca
+const showServiceUnavailableBanner = () => {
+  const banner = document.createElement('div');
+  banner.textContent = 'Servizio temporaneamente non disponibile, riprova';
+  banner.style.background = '#fcc';
+  banner.style.color = '#000';
+  banner.style.padding = '1em';
+  banner.style.textAlign = 'center';
+  banner.style.position = 'fixed';
+  banner.style.top = '0';
+  banner.style.left = '0';
+  banner.style.right = '0';
+  banner.style.zIndex = '9999';
+  document.body?.prepend(banner);
+};
+
 if (typeof window !== 'undefined') {
   console.info('[ENV]', { STAMP: ENV_STAMP, SHA: ENV_SHA });
-  if (!window.__env) {
-    const banner = document.createElement('div');
-    banner.textContent = 'Servizio temporaneamente non disponibile, riprova';
-    banner.style.background = '#fcc';
-    banner.style.color = '#000';
-    banner.style.padding = '1em';
-    banner.style.textAlign = 'center';
-    banner.style.position = 'fixed';
-    banner.style.top = '0';
-    banner.style.left = '0';
-    banner.style.right = '0';
-    banner.style.zIndex = '9999';
-    document.body?.prepend(banner);
+  if (!window.__env || !SUPABASE_URL || !SUPABASE_KEY) {
+    showServiceUnavailableBanner();
   }
 }
 


### PR DESCRIPTION
## Summary
- Show a service-unavailable banner when Supabase URL or key are missing
- Render logged-out user menu immediately if Supabase client isn't initialized

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a23fc7c8832cb191783bc9fff109