### PR TITLE
feat: add auth logging

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,8 +1,10 @@
 import supabase from './init/supabase-client.js';
 import { navigateTo } from './navigation.js';
 import { SUPABASE_URL, SUPABASE_KEY } from './config.js';
+import { info, error } from './logger.js';
 
 export async function renderUserMenu() {
+  info('[AUTH] renderMenu');
   const menu = document.getElementById('userMenu');
   if (!menu) return;
 
@@ -47,9 +49,11 @@ export async function renderUserMenu() {
   const timeout = setTimeout(showLoggedOut, 5000);
 
   try {
+    info('[AUTH] getSession start');
     const {
       data: { session },
     } = await supabase.auth.getSession();
+    info('[AUTH] getSession end');
     clearTimeout(timeout);
     nav.classList.remove('loading');
     menu.classList.remove('loading');
@@ -85,7 +89,8 @@ export async function renderUserMenu() {
     } else {
       showLoggedOut();
     }
-  } catch {
+  } catch (err) {
+    error('[AUTH] getSession end', err);
     clearTimeout(timeout);
     showLoggedOut();
   }

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -11,18 +11,19 @@ export const supabase =
 let authListenerRegistered = false;
 
 if (supabase) {
-  info('Supabase client initialized');
+  info('[AUTH] client init ok');
   if (!authListenerRegistered) {
     authListenerRegistered = true;
     supabase.auth.onAuthStateChange(async (event) => {
       if (event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
+        info(`[AUTH] ${event}`);
         const { renderUserMenu } = await import('../auth.js');
         await renderUserMenu();
       }
     });
   }
 } else {
-  error('Supabase client not initialized: missing URL or anon key');
+  error('[AUTH] client init ko');
 }
 
 export default supabase;

--- a/src/server/handlers/leaveLobby.js
+++ b/src/server/handlers/leaveLobby.js
@@ -23,7 +23,7 @@ export async function handleLeaveLobby(ctx, ws, msg, state) {
   });
   ws.send(JSON.stringify({ type: "left", code: lobby.code }));
   if (lobby.players.length === 0) {
-    setTimeout(async () => {
+    const timer = setTimeout(async () => {
       const still = ctx.lobbies.get(lobby.code);
       if (still && still.players.length === 0) {
         ctx.lobbies.delete(lobby.code);
@@ -32,5 +32,6 @@ export async function handleLeaveLobby(ctx, ws, msg, state) {
         }
       }
     }, ctx.closeEmptyLobbiesAfter);
+    timer.unref();
   }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -104,9 +104,9 @@ export function createLobbyServer({
             const idx = lobby.players.indexOf(player);
             lobby.players.splice(idx, 1);
             if (lobby.host === player.id) {
-          lobby.host = lobby.players[0]?.id || null;
-        }
-        await persistLobby(lobby);
+              lobby.host = lobby.players[0]?.id || null;
+            }
+            await persistLobby(lobby);
             broadcast(lobby, {
               type: "lobby",
               code: lobby.code,
@@ -117,6 +117,7 @@ export function createLobbyServer({
             });
           }
         }, offlinePlayerTimeout);
+        player.offlineTimer.unref();
       }
     });
   });


### PR DESCRIPTION
## Summary
- log Supabase client init result and auth events
- trace renderUserMenu and session fetch with AUTH logs
- unref lobby server timers to allow graceful shutdowns and avoid test timeouts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a1d82540832cb4e1a4ebcb959f3f