### PR TITLE
test: allow small visual diffs

### DIFF
--- a/tests/e2e/visual.spec.ts
+++ b/tests/e2e/visual.spec.ts
@@ -53,7 +53,9 @@ test.describe('visual regression', () => {
         await page.waitForSelector('[data-testid="game-board"] .map-territory');
       }
       await page.evaluate(() => document.fonts.ready);
-      await expect(page).toHaveScreenshot(`${p.name}.png`);
+      await expect(page).toHaveScreenshot(`${p.name}.png`, {
+        maxDiffPixels: 100,
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary
- relax visual regression snapshot matching by allowing up to 100 differing pixels

## Testing
- `npm run test:e2e:full` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a6e1cbd4832c840be8b4484001d6