### PR TITLE
test: add safe referrer tests

### DIFF
--- a/tests/referrer.test.js
+++ b/tests/referrer.test.js
@@ -1,0 +1,23 @@
+/** @jest-environment node */
+
+describe('getSafeReferrer', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('returns URL when referrer has same origin', () => {
+    global.window = { location: { href: 'https://example.com/current', origin: 'https://example.com' } };
+    global.document = { referrer: 'https://example.com/previous' };
+    const { getSafeReferrer } = require('../src/utils/referrer.js');
+
+    expect(getSafeReferrer()).toBe('https://example.com/previous');
+  });
+
+  test('returns null when referrer has different origin', () => {
+    global.window = { location: { href: 'https://example.com/current', origin: 'https://example.com' } };
+    global.document = { referrer: 'https://evil.com/attack' };
+    const { getSafeReferrer } = require('../src/utils/referrer.js');
+
+    expect(getSafeReferrer()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for getSafeReferrer to ensure only same-origin referrers are returned

## Testing
- `npm test tests/referrer.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4a72e07c0832cb4a5d66c056756aa