### PR TITLE
fix: guard modulepreload polyfill

### DIFF
--- a/about.js
+++ b/about.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/about.js';

--- a/account.js
+++ b/account.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/account.js';

--- a/auth.js
+++ b/auth.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/auth.js';

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   root: resolve(__dirname, '..'),
   base: './',
   build: {
+    polyfillModulePreload: false,
     rollupOptions: {
       input: {
         main: resolve(__dirname, '../index.html'),

--- a/forgot.js
+++ b/forgot.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/forgot.js';

--- a/home.js
+++ b/home.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/home.js';

--- a/lobby.js
+++ b/lobby.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/lobby.js';

--- a/login.js
+++ b/login.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/login.js';

--- a/main.js
+++ b/main.js
@@ -1,1 +1,2 @@
+import "./src/modulepreload-polyfill.js";
 import "./src/main.js";

--- a/register.js
+++ b/register.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/register.js';

--- a/setup.js
+++ b/setup.js
@@ -1,1 +1,2 @@
+import './src/modulepreload-polyfill.js';
 import './src/setup.js';

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import './modulepreload-polyfill.js';
+
 // Prefer Vite-provided variables but fall back to process.env so that
 // server-side or test environments can inject the same values without
 // relying on the bundler replacement.

--- a/src/modulepreload-polyfill.js
+++ b/src/modulepreload-polyfill.js
@@ -1,0 +1,34 @@
+export default function polyfillModulePreload() {
+  if (typeof document === 'undefined') return;
+  const relList = document.createElement('link').relList;
+  if (relList && relList.supports && relList.supports('modulepreload')) return;
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    process(link);
+  }
+  new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'childList') {
+        for (const node of mutation.addedNodes) {
+          if (node.tagName === 'LINK' && node.rel === 'modulepreload') process(node);
+        }
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === 'use-credentials') fetchOpts.credentials = 'include';
+    else if (link.crossOrigin === 'anonymous') fetchOpts.credentials = 'omit';
+    else fetchOpts.credentials = 'same-origin';
+    return fetchOpts;
+  }
+  function process(link) {
+    if (link.ep) return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}
+
+polyfillModulePreload();


### PR DESCRIPTION
## Summary
- add custom modulepreload polyfill that checks for `document` before running
- import the guarded polyfill across entry points and disable Vite's built-in polyfill

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b62181cc832c8031599c50014430