### PR TITLE
feat: add port interfaces with Zod schemas

### DIFF
--- a/src/shared/ports/auth.ts
+++ b/src/shared/ports/auth.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const loginInputSchema = z.object({
+  email: z.string().email(),
+  password: z.string()
+});
+export const loginOutputSchema = z.object({
+  userId: z.string(),
+  token: z.string()
+});
+export type LoginInputDto = z.infer<typeof loginInputSchema>;
+export type LoginOutputDto = z.infer<typeof loginOutputSchema>;
+
+export const logoutInputSchema = z.object({});
+export const logoutOutputSchema = z.object({});
+export type LogoutInputDto = z.infer<typeof logoutInputSchema>;
+export type LogoutOutputDto = z.infer<typeof logoutOutputSchema>;
+
+export const currentUserInputSchema = z.object({});
+export const currentUserOutputSchema = z.object({
+  id: z.string(),
+  email: z.string().email().optional(),
+  name: z.string().optional()
+});
+export type CurrentUserInputDto = z.infer<typeof currentUserInputSchema>;
+export type CurrentUserOutputDto = z.infer<typeof currentUserOutputSchema>;
+
+export interface AuthPort {
+  login(input: LoginInputDto): Promise<LoginOutputDto>;
+  logout(input: LogoutInputDto): Promise<LogoutOutputDto>;
+  currentUser(input: CurrentUserInputDto): Promise<CurrentUserOutputDto>;
+}

--- a/src/shared/ports/lobby.ts
+++ b/src/shared/ports/lobby.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const createLobbyInputSchema = z.object({
+  name: z.string(),
+  maxPlayers: z.number().int().positive()
+});
+export const createLobbyOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  maxPlayers: z.number().int().positive()
+});
+export type CreateLobbyInputDto = z.infer<typeof createLobbyInputSchema>;
+export type CreateLobbyOutputDto = z.infer<typeof createLobbyOutputSchema>;
+
+export const listLobbiesInputSchema = z.object({});
+export const lobbySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  maxPlayers: z.number().int().positive(),
+  playerCount: z.number().int().nonnegative()
+});
+export const listLobbiesOutputSchema = z.object({
+  lobbies: z.array(lobbySchema)
+});
+export type ListLobbiesInputDto = z.infer<typeof listLobbiesInputSchema>;
+export type ListLobbiesOutputDto = z.infer<typeof listLobbiesOutputSchema>;
+
+export const joinLobbyInputSchema = z.object({
+  lobbyId: z.string()
+});
+export const joinLobbyOutputSchema = z.object({
+  lobbyId: z.string()
+});
+export type JoinLobbyInputDto = z.infer<typeof joinLobbyInputSchema>;
+export type JoinLobbyOutputDto = z.infer<typeof joinLobbyOutputSchema>;
+
+export const leaveLobbyInputSchema = z.object({
+  lobbyId: z.string()
+});
+export const leaveLobbyOutputSchema = z.object({
+  lobbyId: z.string()
+});
+export type LeaveLobbyInputDto = z.infer<typeof leaveLobbyInputSchema>;
+export type LeaveLobbyOutputDto = z.infer<typeof leaveLobbyOutputSchema>;
+
+export interface LobbyPort {
+  createLobby(input: CreateLobbyInputDto): Promise<CreateLobbyOutputDto>;
+  listLobbies(input: ListLobbiesInputDto): Promise<ListLobbiesOutputDto>;
+  join(input: JoinLobbyInputDto): Promise<JoinLobbyOutputDto>;
+  leave(input: LeaveLobbyInputDto): Promise<LeaveLobbyOutputDto>;
+}

--- a/src/shared/ports/profile.ts
+++ b/src/shared/ports/profile.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const getProfileInputSchema = z.object({
+  userId: z.string()
+});
+export const profileSchema = z.object({
+  userId: z.string(),
+  name: z.string().optional(),
+  avatarUrl: z.string().url().optional()
+});
+export const getProfileOutputSchema = profileSchema;
+export type GetProfileInputDto = z.infer<typeof getProfileInputSchema>;
+export type GetProfileOutputDto = z.infer<typeof getProfileOutputSchema>;
+
+export const updateProfileInputSchema = profileSchema;
+export const updateProfileOutputSchema = profileSchema;
+export type UpdateProfileInputDto = z.infer<typeof updateProfileInputSchema>;
+export type UpdateProfileOutputDto = z.infer<typeof updateProfileOutputSchema>;
+
+export interface ProfilePort {
+  getProfile(input: GetProfileInputDto): Promise<GetProfileOutputDto>;
+  updateProfile(input: UpdateProfileInputDto): Promise<UpdateProfileOutputDto>;
+}

--- a/src/shared/ports/realtime.ts
+++ b/src/shared/ports/realtime.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const subscribeInputSchema = z.object({
+  channel: z.string()
+});
+export const subscribeOutputSchema = z.object({
+  subscriptionId: z.string()
+});
+export type SubscribeInputDto = z.infer<typeof subscribeInputSchema>;
+export type SubscribeOutputDto = z.infer<typeof subscribeOutputSchema>;
+
+export const unsubscribeInputSchema = z.object({
+  subscriptionId: z.string()
+});
+export const unsubscribeOutputSchema = z.object({
+  success: z.boolean()
+});
+export type UnsubscribeInputDto = z.infer<typeof unsubscribeInputSchema>;
+export type UnsubscribeOutputDto = z.infer<typeof unsubscribeOutputSchema>;
+
+export interface RealtimePort {
+  subscribe(input: SubscribeInputDto): Promise<SubscribeOutputDto>;
+  unsubscribe(input: UnsubscribeInputDto): Promise<UnsubscribeOutputDto>;
+}


### PR DESCRIPTION
## Summary
- add shared ports for auth, lobby, realtime, and profile
- include Zod-based input/output DTOs for each method

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b4b8ceeba8832ca98c1e20fa99f624