### PR TITLE
feat: add supabase adapters

### DIFF
--- a/src/infra/supabase/auth.adapter.ts
+++ b/src/infra/supabase/auth.adapter.ts
@@ -1,0 +1,47 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import supabase from '../../init/supabase-client.js';
+import {
+  AuthPort,
+  loginInputSchema,
+  loginOutputSchema,
+  logoutInputSchema,
+  logoutOutputSchema,
+  currentUserInputSchema,
+  currentUserOutputSchema
+} from '../../shared/ports/auth';
+
+export const createAuthAdapter = (client: SupabaseClient | null = supabase): AuthPort => {
+  const supa = client;
+  return {
+    async login(input) {
+      const { email, password } = loginInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { data, error } = await supa.auth.signInWithPassword({ email, password });
+      if (error || !data.session || !data.user) throw error || new Error('Invalid login response');
+      return loginOutputSchema.parse({
+        userId: data.user.id,
+        token: data.session.access_token
+      });
+    },
+    async logout(input) {
+      logoutInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { error } = await supa.auth.signOut({ scope: 'global' });
+      if (error) throw error;
+      return logoutOutputSchema.parse({});
+    },
+    async currentUser(input) {
+      currentUserInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { data, error } = await supa.auth.getUser();
+      if (error || !data.user) throw error || new Error('No user');
+      return currentUserOutputSchema.parse({
+        id: data.user.id,
+        email: data.user.email ?? undefined,
+        name: (data.user.user_metadata as any)?.name
+      });
+    }
+  };
+};
+
+export default createAuthAdapter;

--- a/src/infra/supabase/lobby.adapter.ts
+++ b/src/infra/supabase/lobby.adapter.ts
@@ -1,0 +1,66 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import supabase from '../../init/supabase-client.js';
+import {
+  LobbyPort,
+  createLobbyInputSchema,
+  createLobbyOutputSchema,
+  listLobbiesInputSchema,
+  listLobbiesOutputSchema,
+  lobbySchema,
+  joinLobbyInputSchema,
+  joinLobbyOutputSchema,
+  leaveLobbyInputSchema,
+  leaveLobbyOutputSchema
+} from '../../shared/ports/lobby';
+
+export const createLobbyAdapter = (client: SupabaseClient | null = supabase): LobbyPort => {
+  const supa = client;
+  return {
+    async createLobby(input) {
+      const { name, maxPlayers } = createLobbyInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { data, error } = await supa
+        .from('lobbies')
+        .insert({ name, max_players: maxPlayers })
+        .select()
+        .single();
+      if (error || !data) throw error || new Error('Create lobby failed');
+      return createLobbyOutputSchema.parse({
+        id: data.id ?? data.code ?? '',
+        name: data.name,
+        maxPlayers: data.max_players ?? data.maxPlayers
+      });
+    },
+    async listLobbies(input) {
+      listLobbiesInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { data, error } = await supa.from('lobbies').select();
+      if (error || !data) throw error || new Error('List lobbies failed');
+      const lobbies = data.map((row: any) =>
+        lobbySchema.parse({
+          id: row.id ?? row.code ?? '',
+          name: row.name,
+          maxPlayers: row.max_players ?? row.maxPlayers,
+          playerCount: row.player_count ?? row.playerCount ?? 0
+        })
+      );
+      return listLobbiesOutputSchema.parse({ lobbies });
+    },
+    async join(input) {
+      const { lobbyId } = joinLobbyInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { error } = await supa.rpc('join_lobby', { lobby_id: lobbyId });
+      if (error) throw error;
+      return joinLobbyOutputSchema.parse({ lobbyId });
+    },
+    async leave(input) {
+      const { lobbyId } = leaveLobbyInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { error } = await supa.rpc('leave_lobby', { lobby_id: lobbyId });
+      if (error) throw error;
+      return leaveLobbyOutputSchema.parse({ lobbyId });
+    }
+  };
+};
+
+export default createLobbyAdapter;

--- a/src/infra/supabase/profile.adapter.ts
+++ b/src/infra/supabase/profile.adapter.ts
@@ -1,0 +1,51 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import supabase from '../../init/supabase-client.js';
+import {
+  ProfilePort,
+  getProfileInputSchema,
+  getProfileOutputSchema,
+  updateProfileInputSchema,
+  updateProfileOutputSchema
+} from '../../shared/ports/profile';
+
+export const createProfileAdapter = (client: SupabaseClient | null = supabase): ProfilePort => {
+  const supa = client;
+  return {
+    async getProfile(input) {
+      const { userId } = getProfileInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { data, error } = await supa
+        .from('profiles')
+        .select()
+        .eq('user_id', userId)
+        .single();
+      if (error || !data) throw error || new Error('Profile not found');
+      return getProfileOutputSchema.parse({
+        userId: data.user_id ?? data.userId,
+        name: data.name,
+        avatarUrl: data.avatar_url ?? data.avatarUrl
+      });
+    },
+    async updateProfile(input) {
+      const profile = updateProfileInputSchema.parse(input);
+      if (!supa) throw new Error('Supabase client not initialized');
+      const { data, error } = await supa
+        .from('profiles')
+        .upsert({
+          user_id: profile.userId,
+          name: profile.name,
+          avatar_url: profile.avatarUrl
+        })
+        .select()
+        .single();
+      if (error || !data) throw error || new Error('Update profile failed');
+      return updateProfileOutputSchema.parse({
+        userId: data.user_id ?? data.userId,
+        name: data.name,
+        avatarUrl: data.avatar_url ?? data.avatarUrl
+      });
+    }
+  };
+};
+
+export default createProfileAdapter;

--- a/src/infra/supabase/realtime.adapter.ts
+++ b/src/infra/supabase/realtime.adapter.ts
@@ -1,0 +1,39 @@
+import { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js';
+import supabase from '../../init/supabase-client.js';
+import {
+  RealtimePort,
+  subscribeInputSchema,
+  subscribeOutputSchema,
+  unsubscribeInputSchema,
+  unsubscribeOutputSchema
+} from '../../shared/ports/realtime';
+
+export const createRealtimeAdapter = (
+  client: SupabaseClient | null = supabase
+): RealtimePort => {
+  if (!client) throw new Error('Supabase client not initialized');
+  const channels = new Map<string, RealtimeChannel>();
+
+  return {
+    async subscribe(input) {
+      const { channel } = subscribeInputSchema.parse(input);
+      const ch = client.channel(channel);
+      await ch.subscribe();
+      const id = ch.topic;
+      channels.set(id, ch);
+      return subscribeOutputSchema.parse({ subscriptionId: id });
+    },
+    async unsubscribe(input) {
+      const { subscriptionId } = unsubscribeInputSchema.parse(input);
+      const ch = channels.get(subscriptionId);
+      if (!ch) {
+        return unsubscribeOutputSchema.parse({ success: false });
+      }
+      await client.removeChannel(ch);
+      channels.delete(subscriptionId);
+      return unsubscribeOutputSchema.parse({ success: true });
+    }
+  };
+};
+
+export default createRealtimeAdapter;


### PR DESCRIPTION
## Summary
- add Supabase-backed auth, lobby, realtime, and profile adapters
- expose factory functions for dependency injection
- leverage Zod for DTO validation and mapping

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ba46f45c832c9e4b6bbb4b65c3e5