### PR TITLE
fix: load Supabase without import maps

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/account.html
+++ b/account.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/forgot.html
+++ b/forgot.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body class="home-page">
     <header class="main-header">

--- a/lobby.html
+++ b/lobby.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="./css/theme.css" />
     <title>Lobby - NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body class="lobby-page">
     <header class="main-header">

--- a/login.html
+++ b/login.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/register.html
+++ b/register.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./css/layout.css" />
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/setup.html
+++ b/setup.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="./css/game.css" />
     <title>Setup NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
-    <script type="importmap" src="./importmap.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
     <header class="main-header">

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -1,6 +1,16 @@
-import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
 import { info, error } from '../logger.js';
+
+// Support both Node (tests/server) and browser environments.
+// In the browser we expect the Supabase script to expose a global object.
+let createClient;
+if (typeof window === 'undefined' || !window.supabase) {
+  // Node/test environment: load from installed package
+  ({ createClient } = require('@supabase/supabase-js'));
+} else {
+  // Browser: use the global provided by the CDN script
+  ({ createClient } = window.supabase);
+}
 
 // Initialize the client only when both URL and key are provided.
 // This avoids hitting Supabase with empty credentials during development


### PR DESCRIPTION
## Summary
- load Supabase client from CDN on all HTML pages
- initialize Supabase client using global object or Node package

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c242b498832cbf0df3a3d5d7acb9