### PR TITLE
refactor: inject auth port into UI

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,7 +1,6 @@
 import { navigateTo } from "./navigation.js";
 import { info, error } from "./logger.js";
 import { createAuthAdapter } from "./infra/supabase/auth.adapter.ts";
-import { createAuthModel } from "./features/auth/model.js";
 import {
   renderUserMenu as renderUserMenuUi,
   showFlashMessage,
@@ -9,10 +8,9 @@ import {
 import { registerAuthListener } from "./init/supabase-client.js";
 
 const authPort = createAuthAdapter();
-const model = createAuthModel(authPort);
 
 export async function renderUserMenu() {
-  await renderUserMenuUi({ model, navigateTo, info, error });
+  await renderUserMenuUi({ authPort, navigateTo, info, error });
 }
 
 renderUserMenu();

--- a/src/features/auth/ui.js
+++ b/src/features/auth/ui.js
@@ -1,4 +1,4 @@
-export function renderUserMenu({ model, navigateTo, info, error }) {
+export function renderUserMenu({ authPort, navigateTo, info, error }) {
   info?.("[AUTH] renderMenu");
   const menu = document.getElementById("userMenu");
   if (!menu) return;
@@ -36,8 +36,8 @@ export function renderUserMenu({ model, navigateTo, info, error }) {
     logout.addEventListener("click", async (e) => {
       e.preventDefault();
       try {
-        await model.logout();
-        renderUserMenu({ model, navigateTo, info, error });
+        await authPort.logout({});
+        renderUserMenu({ authPort, navigateTo, info, error });
       } catch (err) {
         error?.("[AUTH] logout", err);
         return;
@@ -55,8 +55,8 @@ export function renderUserMenu({ model, navigateTo, info, error }) {
     menu.classList.remove("loading");
   };
 
-  return model
-    .currentUser()
+  return authPort
+    .currentUser({})
     .then((user) => {
       if (user) {
         showLoggedIn(user);

--- a/src/home.js
+++ b/src/home.js
@@ -1,8 +1,8 @@
 import { initThemeToggle } from "./theme.js";
 import { navigateTo } from "./navigation.js";
-import supabase from "./init/supabase-client.js";
+import { createAuthAdapter } from "./infra/supabase/auth.adapter.ts";
 
-export function initHome() {
+export function initHome({ authPort }) {
   initThemeToggle();
   const mapping = [
     ["playBtn", "./game.html"],
@@ -22,7 +22,7 @@ export function initHome() {
     multiBtn.addEventListener("click", async () => {
       let user = null;
       try {
-        ({ data: { user } = {} } = await supabase.auth.getUser());
+        user = await authPort.currentUser({});
       } catch {
         user = null;
       }
@@ -55,6 +55,7 @@ export function initHome() {
   }
 }
 
-initHome();
+const authPort = createAuthAdapter();
+initHome({ authPort });
 
 export default { initHome };

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -56,7 +56,7 @@ describe("auth menu", () => {
   });
 
   test("shows user menu when session exists and logs out on click", async () => {
-    const model = {
+    const authPort = {
       currentUser: jest.fn().mockResolvedValue({
         id: "u1",
         email: "foo@example.com",
@@ -67,7 +67,7 @@ describe("auth menu", () => {
     const navigateTo = jest.fn();
     const { renderUserMenu } = require("../src/features/auth/ui.js");
 
-    await renderUserMenu({ model, navigateTo });
+    await renderUserMenu({ authPort, navigateTo });
 
     const avatar = document.querySelector("#userMenu .avatar");
     const profile = document.querySelector('#userMenu a[href="account.html"]');
@@ -81,7 +81,7 @@ describe("auth menu", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(model.logout).toHaveBeenCalled();
+    expect(authPort.logout).toHaveBeenCalled();
     expect(sessionStorage.setItem).toHaveBeenCalledWith(
       "flashMessage",
       "Sei uscito dall'account",

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -1,13 +1,10 @@
 jest.mock("../src/theme.js", () => ({ initThemeToggle: jest.fn() }));
 jest.mock("../src/navigation.js", () => ({ navigateTo: jest.fn() }));
-const mockSupabase = {
-  auth: {
-    getUser: jest.fn().mockResolvedValue({ data: { user: {} } }),
-  },
+const mockAuthPort = {
+  currentUser: jest.fn().mockResolvedValue({}),
 };
-jest.mock("../src/init/supabase-client.js", () => ({
-  __esModule: true,
-  default: mockSupabase,
+jest.mock("../src/infra/supabase/auth.adapter.ts", () => ({
+  createAuthAdapter: () => mockAuthPort,
 }));
 
 describe("home page initialization", () => {
@@ -39,7 +36,7 @@ describe("home page initialization", () => {
 
   test("multiplayer click shows auth dialog when not logged in", async () => {
     const { navigateTo } = require("../src/navigation.js");
-    mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null } });
+    mockAuthPort.currentUser.mockResolvedValueOnce(null);
     require("../src/home.js");
     document.getElementById("multiplayerBtn").click();
     await Promise.resolve();
@@ -53,6 +50,7 @@ describe("home page initialization", () => {
 
   test("multiplayer click navigates when user present", async () => {
     const { navigateTo } = require("../src/navigation.js");
+    mockAuthPort.currentUser.mockResolvedValueOnce({ id: "u1" });
     require("../src/home.js");
     document.getElementById("multiplayerBtn").click();
     await Promise.resolve();

--- a/tests/home.uat.test.js
+++ b/tests/home.uat.test.js
@@ -1,11 +1,10 @@
 jest.mock("../src/theme.js", () => ({ initThemeToggle: jest.fn() }));
 jest.mock("../src/navigation.js", () => ({ navigateTo: jest.fn() }));
-const mockSupabase = {
-  auth: { getUser: jest.fn().mockResolvedValue({ data: { user: {} } }) },
+const mockAuthPort = {
+  currentUser: jest.fn().mockResolvedValue({ id: "u" }),
 };
-jest.mock("../src/init/supabase-client.js", () => ({
-  __esModule: true,
-  default: mockSupabase,
+jest.mock("../src/infra/supabase/auth.adapter.ts", () => ({
+  createAuthAdapter: () => mockAuthPort,
 }));
 
 describe("home page UAT", () => {

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -3,12 +3,11 @@ jest.mock("../src/navigation.js", () => ({
   goHome: jest.fn(),
   exitGame: jest.fn(),
 }));
-const mockSupabase = {
-  auth: { getUser: jest.fn().mockResolvedValue({ data: { user: {} } }) },
+const mockAuthPort = {
+  currentUser: jest.fn().mockResolvedValue({ id: "u" }),
 };
-jest.mock("../src/init/supabase-client.js", () => ({
-  __esModule: true,
-  default: mockSupabase,
+jest.mock("../src/infra/supabase/auth.adapter.ts", () => ({
+  createAuthAdapter: () => mockAuthPort,
 }));
 
 describe("home navigation", () => {


### PR DESCRIPTION
## Summary
- inject AuthPort into auth UI and home screen instead of supabase
- remove direct supabase calls from auth/menu rendering
- update tests to use injected ports

## Testing
- `npm test`
- `rg 'supabase' src/features`


------
https://chatgpt.com/codex/tasks/task_e_68b5e12a0e04832cb9e8d56c83f66854