### PR TITLE
feat: add game state serialization

### DIFF
--- a/src/game/state/index.js
+++ b/src/game/state/index.js
@@ -1,4 +1,5 @@
 import { REINFORCE } from "../../phases.js";
+import { z } from "zod";
 
 // Factory for encapsulated game state. Consumers interact via
 // getters/setters rather than mutating a shared object directly.
@@ -80,6 +81,19 @@ class GameState {
 
 const gameState = new GameState();
 
+// --- Serialization helpers ---
+
+const gameStateSchema = z.object({
+  turnNumber: z.number(),
+  currentPlayer: z.number(),
+  players: z.array(z.any()),
+  territories: z.array(z.any()),
+  selectedTerritory: z.any().nullable(),
+  tokenPosition: z.any().nullable(),
+  phase: z.string(),
+  log: z.array(z.any()),
+});
+
 function initGameState(game) {
   gameState.initFromGame(game);
 }
@@ -89,11 +103,17 @@ function setSelectedTerritory(selected) {
 }
 
 function serialize(state) {
-  return JSON.stringify(state);
+  const snapshot =
+    typeof state?.getSnapshot === "function" ? state.getSnapshot() : state;
+  return gameStateSchema.parse(snapshot);
 }
 
-function deserialize(str) {
-  return JSON.parse(str);
+function deserialize(json) {
+  const data = typeof json === "string" ? JSON.parse(json) : json;
+  const parsed = gameStateSchema.parse(data);
+  const gs = new GameState();
+  gs._state = { ...parsed };
+  return gs;
 }
 
 export {

--- a/src/netrisk-api.ts
+++ b/src/netrisk-api.ts
@@ -1,5 +1,6 @@
 import { SUPABASE_URL, SUPABASE_KEY } from "./config.js";
 import type { Match, Player, GameState, Event } from "./types/netrisk";
+import { deserialize as deserializeGameState } from "./game/state/index.js";
 
 // Request/response types for the NetRisk API
 export interface CreateMatchRequest {
@@ -64,7 +65,7 @@ export const startMatch = (matchId: string) =>
   call<StartMatchResponse, StartMatchRequest>({
     action: "start_match",
     matchId,
-  });
+  }).then((state) => deserializeGameState(state));
 
 export const sendAction = <
   TAction extends Record<string, unknown>,

--- a/src/netrisk-realtime.ts
+++ b/src/netrisk-realtime.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { SUPABASE_URL, SUPABASE_KEY } from "./config.js";
 import type { GameState, Event } from "./types/netrisk";
+import { deserialize as deserializeGameState } from "./game/state/index.js";
 
 // Types for realtime subscription requests and payloads
 export interface MatchSubscriptionHandlers<S extends GameState, A, R> {
@@ -31,7 +32,9 @@ export function subscribeToMatch<
         filter: `match_id=eq.${matchId}`,
       },
       (payload: RealtimePayload<{ state: S }>) =>
-        handlers.onState?.(payload.new.state),
+        handlers.onState?.(
+          deserializeGameState(payload.new.state) as unknown as S,
+        ),
     );
   }
 

--- a/tests/game-state.serialize.test.js
+++ b/tests/game-state.serialize.test.js
@@ -1,0 +1,25 @@
+import { GameState, serialize, deserialize } from "../src/game/state/index.js";
+import { REINFORCE } from "../src/phases.js";
+
+test("serialize returns plain object and deserialize hydrates", () => {
+  const gs = new GameState();
+  gs.setSelectedTerritory("t1");
+  const obj = serialize(gs);
+  expect(obj).toEqual({
+    turnNumber: 1,
+    currentPlayer: 0,
+    players: [],
+    territories: [],
+    selectedTerritory: "t1",
+    tokenPosition: null,
+    phase: REINFORCE,
+    log: [],
+  });
+  const restored = deserialize(obj);
+  expect(restored).toBeInstanceOf(GameState);
+  expect(restored.getSnapshot()).toEqual(obj);
+});
+
+test("deserialize validates structure", () => {
+  expect(() => deserialize({ foo: "bar" })).toThrow();
+});

--- a/tests/netrisk-api.uat.test.ts
+++ b/tests/netrisk-api.uat.test.ts
@@ -50,6 +50,19 @@ describe("netriskApi", () => {
   });
 
   test("startMatch sends correct payload", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        turnNumber: 1,
+        currentPlayer: 0,
+        players: [],
+        territories: [],
+        selectedTerritory: null,
+        tokenPosition: null,
+        phase: "lobby",
+        log: [],
+      }),
+    });
     await startMatch("m1");
     expect(fetchMock).toHaveBeenCalledWith(functionUrl, {
       method: "POST",

--- a/tests/netrisk-realtime.test.ts
+++ b/tests/netrisk-realtime.test.ts
@@ -29,8 +29,20 @@ describe("netriskRealtime", () => {
     const channel = client.channel.mock.results[0].value;
 
     // simulate incoming messages
-    stateHandlers.cb({ new: { state: { turn: 1 } } });
-    expect(onState).toHaveBeenCalledWith({ turn: 1 });
+    const state = {
+      turnNumber: 1,
+      currentPlayer: 0,
+      players: [],
+      territories: [],
+      selectedTerritory: null,
+      tokenPosition: null,
+      phase: "lobby",
+      log: [],
+    };
+    stateHandlers.cb({ new: { state } });
+    expect(onState).toHaveBeenCalled();
+    const received = onState.mock.calls[0][0];
+    expect(received.getSnapshot()).toEqual(state);
 
     const ev: Event<{ move: string }, { ok: boolean }> = {
       id: "e1",


### PR DESCRIPTION
## Summary
- add Zod-based serialize/deserialize for GameState
- hydrate API and realtime adapters with validated state
- cover serialization with dedicated unit tests
- fix realtime subscription to cast deserialized state safely

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e3da9930832c881d5a5fbf3d5284