### PR TITLE
Add playCard rule unit tests

### DIFF
--- a/tests/unit/play-card.rule.test.js
+++ b/tests/unit/play-card.rule.test.js
@@ -1,0 +1,61 @@
+import playCard from "../../src/game/rules/play-card.js";
+
+describe("playCard", () => {
+  test("awards +5 reinforcements for three of the same type", () => {
+    const state = {
+      currentPlayer: 0,
+      hands: [
+        [
+          { type: "infantry" },
+          { type: "infantry" },
+          { type: "infantry" },
+        ],
+      ],
+      reinforcements: 0,
+    };
+
+    const result = playCard(state, [0, 1, 2]);
+
+    expect(result.played).toBe(true);
+    expect(result.state.reinforcements).toBe(5);
+  });
+
+  test("awards +5 reinforcements for one of each type", () => {
+    const state = {
+      currentPlayer: 0,
+      hands: [
+        [
+          { type: "infantry" },
+          { type: "cavalry" },
+          { type: "artillery" },
+        ],
+      ],
+      reinforcements: 0,
+    };
+
+    const result = playCard(state, [0, 1, 2]);
+
+    expect(result.played).toBe(true);
+    expect(result.state.reinforcements).toBe(5);
+  });
+
+  test("returns played false for duplicates or missing cards", () => {
+    const state = {
+      currentPlayer: 0,
+      hands: [
+        [
+          { type: "infantry" },
+          { type: "infantry" },
+          { type: "cavalry" },
+        ],
+      ],
+      reinforcements: 0,
+    };
+
+    const duplicate = playCard(state, [0, 1, 2]);
+    expect(duplicate.played).toBe(false);
+
+    const missing = playCard(state, [0, 1, 3]);
+    expect(missing.played).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for playCard rule
- ensure valid same-type or mixed sets grant 5 reinforcements
- ensure duplicate or missing cards prevent playing

## Testing
- `npm test tests/unit/play-card.rule.test.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ea5924b8832c8d65be267c5c31ab