### PR TITLE
Add match flow integration test

### DIFF
--- a/tests/integration/__snapshots__/match-flow.test.js.snap
+++ b/tests/integration/__snapshots__/match-flow.test.js.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`match flow transitions 1`] = `
+{
+  "currentPlayer": 0,
+  "log": [],
+  "phase": "reinforce",
+  "players": [
+    {
+      "color": "red",
+      "name": "P1",
+    },
+    {
+      "color": "blue",
+      "name": "P2",
+    },
+  ],
+  "selectedTerritory": null,
+  "territories": [
+    {
+      "armies": 3,
+      "id": "a",
+      "neighbors": [
+        "b",
+      ],
+      "owner": 0,
+    },
+    {
+      "armies": 1,
+      "id": "b",
+      "neighbors": [
+        "a",
+      ],
+      "owner": 1,
+    },
+  ],
+  "tokenPosition": null,
+  "turnNumber": 1,
+}
+`;
+
+exports[`match flow transitions 2`] = `
+{
+  "currentPlayer": 0,
+  "log": [],
+  "phase": "attack",
+  "players": [
+    {
+      "color": "red",
+      "name": "P1",
+    },
+    {
+      "color": "blue",
+      "name": "P2",
+    },
+  ],
+  "selectedTerritory": null,
+  "territories": [
+    {
+      "armies": 4,
+      "id": "a",
+      "neighbors": [
+        "b",
+      ],
+      "owner": 0,
+    },
+    {
+      "armies": 1,
+      "id": "b",
+      "neighbors": [
+        "a",
+      ],
+      "owner": 1,
+    },
+  ],
+  "tokenPosition": null,
+  "turnNumber": 1,
+}
+`;
+
+exports[`match flow transitions 3`] = `
+{
+  "currentPlayer": 0,
+  "log": [],
+  "phase": "fortify",
+  "players": [
+    {
+      "color": "red",
+      "name": "P1",
+    },
+    {
+      "color": "blue",
+      "name": "P2",
+    },
+  ],
+  "selectedTerritory": null,
+  "territories": [
+    {
+      "armies": 3,
+      "id": "a",
+      "neighbors": [
+        "b",
+      ],
+      "owner": 0,
+    },
+    {
+      "armies": 1,
+      "id": "b",
+      "neighbors": [
+        "a",
+      ],
+      "owner": 0,
+    },
+  ],
+  "tokenPosition": null,
+  "turnNumber": 1,
+}
+`;
+
+exports[`match flow transitions 4`] = `
+{
+  "currentPlayer": 0,
+  "log": [],
+  "phase": "gameover",
+  "players": [
+    {
+      "color": "red",
+      "name": "P1",
+    },
+    {
+      "color": "blue",
+      "name": "P2",
+    },
+  ],
+  "selectedTerritory": null,
+  "territories": [
+    {
+      "armies": 2,
+      "id": "a",
+      "neighbors": [
+        "b",
+      ],
+      "owner": 0,
+    },
+    {
+      "armies": 2,
+      "id": "b",
+      "neighbors": [
+        "a",
+      ],
+      "owner": 0,
+    },
+  ],
+  "tokenPosition": null,
+  "turnNumber": 1,
+}
+`;

--- a/tests/integration/match-flow.test.js
+++ b/tests/integration/match-flow.test.js
@@ -1,0 +1,62 @@
+import {
+  initGameState,
+  gameState,
+  reinforce,
+  attack,
+  move,
+} from "../../src/game/index.js";
+import { REINFORCE, ATTACK, FORTIFY, GAME_OVER } from "../../src/phases.js";
+
+function sync(state, phase) {
+  initGameState({ ...state, getPhase: () => phase });
+  return gameState.getSnapshot();
+}
+
+test("match flow transitions", () => {
+  let state = {
+    currentPlayer: 0,
+    players: [
+      { name: "P1", color: "red" },
+      { name: "P2", color: "blue" },
+    ],
+    territories: [
+      { id: "a", neighbors: ["b"], owner: 0, armies: 3 },
+      { id: "b", neighbors: ["a"], owner: 1, armies: 1 },
+    ],
+    reinforcements: 1,
+    phase: REINFORCE,
+  };
+
+  // Reinforce phase
+  let snap = sync(state, state.phase);
+  expect(snap.phase).toBe(REINFORCE);
+  expect(snap).toMatchSnapshot();
+
+  const reinforced = reinforce({ ...snap, reinforcements: 1 }, "a").state;
+  reinforced.phase = ATTACK;
+  snap = sync(reinforced, reinforced.phase);
+  expect(snap.phase).toBe(ATTACK);
+  expect(snap).toMatchSnapshot();
+
+  // Mock dice so attacker always wins
+  const randMock = jest
+    .spyOn(Math, "random")
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.9)
+    .mockReturnValueOnce(0.1)
+    .mockReturnValueOnce(0.1);
+  const attacked = attack(snap, "a", "b").state;
+  randMock.mockRestore();
+  attacked.phase = FORTIFY;
+  snap = sync(attacked, attacked.phase);
+  expect(snap.phase).toBe(FORTIFY);
+  expect(snap).toMatchSnapshot();
+
+  const moved = move(snap, "a", "b", 1).state;
+  const ownedByP1 = moved.territories.every((t) => t.owner === 0);
+  moved.phase = ownedByP1 ? GAME_OVER : REINFORCE;
+  snap = sync(moved, moved.phase);
+  expect(snap.phase).toBe(GAME_OVER);
+  expect(snap).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary
- add integration test covering phase transitions from reinforce through game over
- snapshot game state after each phase using public game APIs

## Testing
- `npm test tests/integration/match-flow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5ea5e8c08832c984cb5d355aa06da