### PR TITLE
test: add start match e2e

### DIFF
--- a/tests/e2e/start-match.spec.ts
+++ b/tests/e2e/start-match.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+import { authenticate, setupLobby } from "./utils";
+
+test.describe("start match flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const style = document.createElement("style");
+      style.innerHTML =
+        "* { transition: none !important; animation: none !important; }";
+      document.head.appendChild(style);
+    });
+    await page.route("**/supabase.co/**", (route) => {
+      route.fulfill({
+        status: 200,
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      });
+    });
+  });
+
+  test("two players start a match and enter reinforce phase", async ({
+    page,
+  }) => {
+    await authenticate(page);
+    await setupLobby(page);
+    await page.goto("/setup.html");
+    await expect(page.getByText("Unable to load data")).toHaveCount(0);
+    await expect(page.locator("#name0")).toHaveValue("Red");
+    await expect(page.locator("#name1")).toHaveValue("Blue");
+    await page.waitForSelector("#mapGrid .map-item");
+    await page.click('button[type="submit"]');
+    await page.goto("/game.html");
+    await expect(page.locator("#status")).toHaveText("reinforce");
+  });
+});

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -1,0 +1,23 @@
+import { Page, expect } from "@playwright/test";
+
+export async function authenticate(page: Page) {
+  await page.goto("/login.html");
+  await expect(page.getByText("Unable to load data")).toHaveCount(0);
+  await expect(page.locator('[data-testid="login-username"]')).toBeVisible();
+  await page.fill('[data-testid="login-username"]', "user@example.com");
+  await page.fill('[data-testid="login-password"]', "password");
+  await page.click('[data-testid="login-submit"]');
+}
+
+export async function setupLobby(
+  page: Page,
+  players = [
+    { name: "Red", color: "#f00" },
+    { name: "Blue", color: "#00f" },
+  ],
+) {
+  await page.addInitScript((ps) => {
+    window.localStorage.setItem("netriskPlayers", JSON.stringify(ps));
+    window.localStorage.setItem("netriskMap", "map3");
+  }, players);
+}


### PR DESCRIPTION
## Summary
- extract auth and lobby setup helpers into shared e2e utils
- use shared helpers in start match test to verify reinforce phase

## Testing
- `npx prettier --check .`
- `npx playwright test -c config/playwright.e2e.config.ts tests/e2e/start-match.spec.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ea685af0832c9e7d9041dbc78259