### PR TITLE
feat: add root tsconfig with aliases

### DIFF
--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -23,5 +23,12 @@ export default defineConfig({
   },
   resolve: {
     extensions: [".js", ".ts"],
+    alias: {
+      "@app": resolve(__dirname, "../src"),
+      "@game": resolve(__dirname, "../src/game"),
+      "@features": resolve(__dirname, "../src/features"),
+      "@shared": resolve(__dirname, "../src/shared"),
+      "@infra": resolve(__dirname, "../src/infra"),
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "server": "node src/multiplayer-server.js",
     "simulate": "node src/simulate.js",
     "test": "jest --config config/jest.config.js",
-    "type-check": "tsc --noEmit -p config/tsconfig.json",
+    "type-check": "tsc --noEmit -p tsconfig.json",
     "test:uat": "playwright test -c config/playwright.config.ts",
     "pretest:e2e:smoke": "PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.download.prss.microsoft.com/dbazure/download/playwright npx playwright install chromium",
     "pretest:e2e:full": "PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.download.prss.microsoft.com/dbazure/download/playwright npx playwright install chromium",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./config/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": "src",
+    "paths": {
+      "@app/*": ["*"],
+      "@game/*": ["game/*"],
+      "@features/*": ["features/*"],
+      "@shared/*": ["shared/*"],
+      "@infra/*": ["infra/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add root TypeScript config extending existing setup
- wire up path aliases in build via Vite
- ensure type checking uses new config

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b603607b24832cad945c6941903248