### PR TITLE
chore: enforce layer import boundaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,9 +21,30 @@
   },
   "overrides": [
     {
+      "files": ["src/game/**/*.{js,ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@app/*", "@features/*", "@infra/*"] }]
+      }
+    },
+    {
       "files": ["src/features/**/*.{js,ts,tsx}"],
       "rules": {
         "no-restricted-imports": ["error", { "patterns": ["@app/*", "@infra/*"] }]
+      }
+    },
+    {
+      "files": ["src/shared/**/*.{js,ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          { "patterns": ["@app/*", "@game/*", "@features/*", "@infra/*"] }
+        ]
+      }
+    },
+    {
+      "files": ["src/infra/**/*.{js,ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@app/*", "@features/*", "@game/*"] }]
       }
     },
     {

--- a/docs/layer-imports.md
+++ b/docs/layer-imports.md
@@ -1,0 +1,21 @@
+# Layer Import Rules
+
+The project is organized into the following layers using path aliases in `tsconfig.json`:
+
+- `@app`
+- `@game`
+- `@features`
+- `@shared`
+- `@infra`
+
+To keep the architecture maintainable, each layer has explicit dependencies enforced by ESLint.
+
+| Layer       | Can import from                           | Can be imported by                     |
+| ----------- | ----------------------------------------- | -------------------------------------- |
+| `@app`      | `@features`, `@game`, `@shared`, `@infra` | _No other layer_                       |
+| `@game`     | `@shared`                                 | `@app`, `@features`                    |
+| `@features` | `@game`, `@shared`                        | `@app`                                 |
+| `@shared`   | `@shared`                                 | `@app`, `@game`, `@features`, `@infra` |
+| `@infra`    | `@shared`                                 | `@app`                                 |
+
+These rules are enforced via `no-restricted-imports` in `.eslintrc.json`. Updating a dependency edge requires adjusting both ESLint configuration and this document.


### PR DESCRIPTION
## Summary
- enforce layer-specific import boundaries with `no-restricted-imports`
- document allowed incoming/outgoing dependencies for each layer
- format ESLint config and layer-import docs with Prettier

## Testing
- `npx prettier --check .`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b662e9b890832c9031b0dfcbe3eb9e