### PR TITLE
Prioritize Vite env vars for Supabase config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,15 +8,18 @@ const rawApiBaseUrl =
   (typeof process !== 'undefined' ? process.env.VITE_API_BASE_URL : '') ??
   '';
 
+// Supabase configuration prioritizes variables injected by Vite at build time
+// while still allowing runtime overrides via `window.__env` or Node's
+// `process.env` (for tests or server-side usage).
 const rawSupabaseUrl =
-  (typeof window !== 'undefined' && window.__env?.SUPABASE_URL) ??
   import.meta.env?.VITE_SUPABASE_URL ??
+  (typeof window !== 'undefined' && window.__env?.SUPABASE_URL) ??
   (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_URL : '') ??
   '';
 
 const rawSupabaseKey =
-  (typeof window !== 'undefined' && window.__env?.SUPABASE_ANON_KEY) ??
   import.meta.env?.VITE_SUPABASE_ANON_KEY ??
+  (typeof window !== 'undefined' && window.__env?.SUPABASE_ANON_KEY) ??
   (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_ANON_KEY : '') ??
   '';
 

--- a/tests/multiplayer-server.test.js
+++ b/tests/multiplayer-server.test.js
@@ -36,7 +36,7 @@ test('lobby server manages lifecycle', async () => {
       maxPlayers: 5,
     }),
   );
-  await wait(50);
+  await wait(100);
   const lobbyMsg = q1.shift();
   const code = lobbyMsg.code;
   expect(lobbyMsg.maxPlayers).toBe(5);


### PR DESCRIPTION
## Summary
- Use Vite-provided Supabase URL and anon key before `window.__env` overrides in config
- Extend multiplayer server lifecycle test wait to handle slower setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66eeb14a0832c8bd84d8b1e5be000