### PR TITLE
refactor: load env.js without commit hash

### DIFF
--- a/about.html
+++ b/about.html
@@ -52,10 +52,7 @@
         </div>
       </section>
     </div>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./about.js"></script>
   </body>

--- a/account.html
+++ b/account.html
@@ -46,10 +46,7 @@
         </div>
       </section>
     </main>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./account.js"></script>
   </body>

--- a/forgot.html
+++ b/forgot.html
@@ -32,10 +32,7 @@
       </form>
       <p id="message" role="alert"></p>
     </main>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./forgot.js"></script>
   </body>

--- a/game.html
+++ b/game.html
@@ -85,10 +85,7 @@
         </div>
       </div>
     </div>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -185,10 +185,7 @@
       }
       render();
     </script>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -39,10 +39,7 @@
         About/Settings
       </button>
     </main>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./home.js"></script>
   </body>

--- a/lobby.html
+++ b/lobby.html
@@ -64,10 +64,7 @@
       </section>
       <section id="debugLog" class="debug-log" aria-live="polite"></section>
     </main>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./lobby.js"></script>
   </body>

--- a/login.html
+++ b/login.html
@@ -45,10 +45,7 @@
       </form>
       <p id="message" role="alert" data-testid="login-message"></p>
     </main>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./login.js"></script>
   </body>

--- a/preview-index.html
+++ b/preview-index.html
@@ -31,9 +31,6 @@
       }
       loadBranches();
     </script>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -28,9 +28,6 @@
     </script>
   </head>
   <body>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
   </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -36,10 +36,7 @@
       </form>
       <p id="message" role="alert"></p>
     </main>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./register.js"></script>
   </body>

--- a/setup.html
+++ b/setup.html
@@ -55,10 +55,7 @@
       <div id="players"></div>
       <button type="submit" class="btn">Start</button>
     </form>
-    <script
-      src="./env.js?sha=%VITE_COMMIT_SHA%"
-      onerror="document.write('<script src=&quot;./env.js&quot;><\/script>')"
-    ></script>
+    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./setup.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- reference `/env.js` without commit hash across HTML pages
- load env.js using relative path to support subdirectory deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67296839c832cb20fb8bc44722552