### PR TITLE
feat: add test ids for auth interactions

### DIFF
--- a/forgot.html
+++ b/forgot.html
@@ -30,7 +30,7 @@
         </label>
         <button type="submit" class="btn">Invia</button>
       </form>
-      <p id="message" role="alert"></p>
+      <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
     <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>

--- a/index.html
+++ b/index.html
@@ -27,8 +27,22 @@
     </header>
     <main id="mainMenu">
       <h1>NetRisk</h1>
-      <button id="playBtn" class="btn" aria-label="Play game" accesskey="p">Play</button>
-      <button id="multiplayerBtn" class="btn" aria-label="Multiplayer game" accesskey="m">
+      <button
+        id="playBtn"
+        class="btn"
+        aria-label="Play game"
+        accesskey="p"
+        data-testid="singleplayer-link"
+      >
+        Play
+      </button>
+      <button
+        id="multiplayerBtn"
+        class="btn"
+        aria-label="Multiplayer game"
+        accesskey="m"
+        data-testid="lobby-link"
+      >
         Multiplayer
       </button>
       <button id="setupBtn" class="btn" aria-label="Player setup" accesskey="s">Setup</button>

--- a/lobby.html
+++ b/lobby.html
@@ -24,7 +24,7 @@
     </header>
     <main>
       <h1>Lobby</h1>
-      <div id="lobbyError" class="hidden" data-testid="lobby-error">
+      <div id="lobbyError" class="hidden" data-testid="error-msg">
         <p id="lobbyErrorMsg"></p>
         <button id="retryLobby" class="btn">Retry</button>
       </div>
@@ -34,7 +34,7 @@
         class="btn"
         aria-label="Create new game"
         accesskey="n"
-        data-testid="create-game"
+        data-testid="lobby-create"
       >
         Create game
       </button>

--- a/login.html
+++ b/login.html
@@ -25,8 +25,8 @@
       <h1>Login</h1>
       <form id="loginForm">
         <label>
-          Username:
-          <input type="text" id="username" required data-testid="login-username" />
+          Email:
+          <input type="text" id="username" required data-testid="login-email" />
         </label>
         <label>
           Password:
@@ -43,7 +43,7 @@
         </button>
         <a href="./forgot.html">Password dimenticata?</a>
       </form>
-      <p id="message" role="alert" data-testid="login-message"></p>
+      <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
     <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>

--- a/register.html
+++ b/register.html
@@ -34,7 +34,7 @@
         </label>
         <button type="submit" class="btn">Create Account</button>
       </form>
-      <p id="message" role="alert"></p>
+      <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
     <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>

--- a/src/features/auth/ui.js
+++ b/src/features/auth/ui.js
@@ -9,6 +9,7 @@ export function renderUserMenu({ authPort, navigateTo, info, error }) {
     const login = document.createElement('a');
     login.href = 'login.html';
     login.textContent = 'Accedi';
+    login.dataset.testid = 'login-btn';
 
     const register = document.createElement('a');
     register.href = 'register.html';
@@ -26,13 +27,24 @@ export function renderUserMenu({ authPort, navigateTo, info, error }) {
     const name = user.name || user.email || '';
     avatar.textContent = name.charAt(0).toUpperCase();
 
+    const status = document.createElement('span');
+    status.textContent = user.email || '';
+    status.dataset.testid = 'user-status';
+
     const profile = document.createElement('a');
     profile.href = 'account.html';
     profile.textContent = 'Profilo';
+    profile.dataset.testid = 'profile-link';
+
+    const lobby = document.createElement('a');
+    lobby.href = 'lobby.html';
+    lobby.textContent = 'Lobby';
+    lobby.dataset.testid = 'lobby-link';
 
     const logout = document.createElement('a');
     logout.href = '#';
     logout.textContent = 'Esci';
+    logout.dataset.testid = 'logout-btn';
     logout.addEventListener('click', async (e) => {
       e.preventDefault();
       try {
@@ -50,7 +62,7 @@ export function renderUserMenu({ authPort, navigateTo, info, error }) {
       navigateTo('index.html');
     });
 
-    menu.append(avatar, profile, logout);
+    menu.append(avatar, status, profile, lobby, logout);
     nav.classList.remove('loading');
     menu.classList.remove('loading');
   };

--- a/tests/e2e/create-lobby.spec.ts
+++ b/tests/e2e/create-lobby.spec.ts
@@ -132,7 +132,7 @@ test.describe('lobby creation', () => {
 
     await page.goto('/login.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);
-    await page.fill('[data-testid="login-username"]', 'testuser@example.com');
+    await page.fill('[data-testid="login-email"]', 'testuser@example.com');
     await page.fill('[data-testid="login-password"]', 'password');
     await page.click('[data-testid="login-submit"]');
 
@@ -141,7 +141,7 @@ test.describe('lobby creation', () => {
     const list = page.locator('[data-testid="lobby-list"] li');
     await expect(list).toHaveCount(0);
 
-    await page.click('[data-testid="create-game"]');
+    await page.click('[data-testid="lobby-create"]');
     await page.fill('#roomName', 'Test Lobby');
     await page.fill('#maxPlayers', '3');
     await page.selectOption('#map', 'map1');

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -97,7 +97,7 @@ test.describe('login', () => {
   test('redirects to account after login', async ({ page }) => {
     await page.goto('/login.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);
-    await page.fill('[data-testid="login-username"]', 'user@example.com');
+    await page.fill('[data-testid="login-email"]', 'user@example.com');
     await page.fill('[data-testid="login-password"]', 'password');
     await page.click('[data-testid="login-submit"]');
     await page.waitForURL('**/account.html');

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -21,8 +21,8 @@ test.describe('smoke flow', () => {
   test('login, lobby, start game', async ({ page }) => {
     await page.goto('/login.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);
-    await expect(page.locator('[data-testid="login-username"]')).toBeVisible();
-    await page.fill('[data-testid="login-username"]', 'user@example.com');
+    await expect(page.locator('[data-testid="login-email"]')).toBeVisible();
+    await page.fill('[data-testid="login-email"]', 'user@example.com');
     await page.fill('[data-testid="login-password"]', 'password');
     await page.click('[data-testid="login-submit"]');
 

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -3,8 +3,8 @@ import { Page, expect } from '@playwright/test';
 export async function authenticate(page: Page) {
   await page.goto('/login.html');
   await expect(page.getByText('Unable to load data')).toHaveCount(0);
-  await expect(page.locator('[data-testid="login-username"]')).toBeVisible();
-  await page.fill('[data-testid="login-username"]', 'user@example.com');
+  await expect(page.locator('[data-testid="login-email"]')).toBeVisible();
+  await page.fill('[data-testid="login-email"]', 'user@example.com');
   await page.fill('[data-testid="login-password"]', 'password');
   await page.click('[data-testid="login-submit"]');
 }

--- a/tests/integration/lobby-flow.test.js
+++ b/tests/integration/lobby-flow.test.js
@@ -122,7 +122,7 @@ describe('lobby flow', () => {
   test('creates lobby, exchanges chat, and shows error', async () => {
     await import('../../lobby.js');
 
-    screen.getByTestId('create-game').click();
+    screen.getByTestId('lobby-create').click();
     screen.getByLabelText(/Room name/i).value = 'Room';
     screen.getByLabelText(/Max players/i).value = '4';
     document.getElementById('createForm').dispatchEvent(new Event('submit'));
@@ -145,7 +145,7 @@ describe('lobby flow', () => {
 
     wsInstances[0].onmessage({ data: JSON.stringify({ type: 'error' }) });
     await waitFor(() =>
-      expect(screen.getByTestId('lobby-error').classList.contains('hidden')).toBe(false),
+      expect(screen.getByTestId('error-msg').classList.contains('hidden')).toBe(false),
     );
   });
 
@@ -165,6 +165,6 @@ describe('lobby flow', () => {
     });
 
     await waitFor(() => expect(localStorage.getItem('lobbyCode')).toBe('ABCD'));
-    expect(screen.getByTestId('lobby-error').classList.contains('hidden')).toBe(true);
+    expect(screen.getByTestId('error-msg').classList.contains('hidden')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- rename login username test id to login-email and expose error messages
- tag user menu, home, and lobby controls with stable test ids
- update tests for new data-testid attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b687cd89f0832cab24ead0f8b24162