### PR TITLE
feat: add auth UI test ids

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,7 +18,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <h1 id="pageTitle">About &amp; Settings</h1>

--- a/account.html
+++ b/account.html
@@ -18,7 +18,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <main>

--- a/forgot.html
+++ b/forgot.html
@@ -18,7 +18,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <main>
@@ -30,7 +30,7 @@
         </label>
         <button type="submit" class="btn">Invia</button>
       </form>
-      <p id="message" role="alert"></p>
+      <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
     <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -18,7 +18,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <nav>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         <a href="./setup.html">Setup</a>
         <a href="./how-to-play.html">How To</a>
         <a href="./about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
       <button id="themeToggle" class="btn" aria-label="Toggle high contrast mode" accesskey="c">
         High Contrast
@@ -28,7 +28,13 @@
     <main id="mainMenu">
       <h1>NetRisk</h1>
       <button id="playBtn" class="btn" aria-label="Play game" accesskey="p">Play</button>
-      <button id="multiplayerBtn" class="btn" aria-label="Multiplayer game" accesskey="m">
+      <button
+        id="multiplayerBtn"
+        class="btn"
+        aria-label="Multiplayer game"
+        accesskey="m"
+        data-testid="lobby-link"
+      >
         Multiplayer
       </button>
       <button id="setupBtn" class="btn" aria-label="Player setup" accesskey="s">Setup</button>

--- a/lobby.html
+++ b/lobby.html
@@ -19,7 +19,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <main>

--- a/login.html
+++ b/login.html
@@ -18,15 +18,15 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <main>
       <h1>Login</h1>
       <form id="loginForm">
         <label>
-          Username:
-          <input type="text" id="username" required data-testid="login-username" />
+          Email:
+          <input type="email" id="username" required data-testid="login-email" />
         </label>
         <label>
           Password:
@@ -43,7 +43,8 @@
         </button>
         <a href="./forgot.html">Password dimenticata?</a>
       </form>
-      <p id="message" role="alert" data-testid="login-message"></p>
+      <p id="authGuardMessage" role="alert" data-testid="auth-guard-msg"></p>
+      <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
     <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>

--- a/register.html
+++ b/register.html
@@ -18,7 +18,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <main>
@@ -34,7 +34,7 @@
         </label>
         <button type="submit" class="btn">Create Account</button>
       </form>
-      <p id="message" role="alert"></p>
+      <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
     <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>

--- a/setup.html
+++ b/setup.html
@@ -20,7 +20,7 @@
         <a href="setup.html">Setup</a>
         <a href="how-to-play.html">How To</a>
         <a href="about.html">About</a>
-        <span id="userMenu" class="user-menu loading"></span>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
       </nav>
     </header>
     <h1>Player Setup</h1>

--- a/src/features/auth/ui.js
+++ b/src/features/auth/ui.js
@@ -12,6 +12,7 @@ export async function renderUserMenu({ authPort, navigateTo, info, error }) {
     const login = document.createElement('a');
     login.href = 'login.html';
     login.textContent = 'Accedi';
+    login.dataset.testid = 'login-btn';
 
     const register = document.createElement('a');
     register.href = 'register.html';
@@ -30,10 +31,17 @@ export async function renderUserMenu({ authPort, navigateTo, info, error }) {
     const profile = document.createElement('a');
     profile.href = 'account.html';
     profile.textContent = 'Profilo';
+    profile.dataset.testid = 'profile-link';
+
+    const lobby = document.createElement('a');
+    lobby.href = 'lobby.html';
+    lobby.textContent = 'Lobby';
+    lobby.dataset.testid = 'lobby-link';
 
     const logout = document.createElement('a');
     logout.href = '#';
     logout.textContent = 'Esci';
+    logout.dataset.testid = 'logout-btn';
     logout.addEventListener('click', async (e) => {
       e.preventDefault();
       try {
@@ -51,7 +59,7 @@ export async function renderUserMenu({ authPort, navigateTo, info, error }) {
       navigateTo('index.html');
     });
 
-    menu.append(avatar, profile, logout);
+    menu.append(avatar, profile, lobby, logout);
   };
 
   try {

--- a/src/utils/auth-forms.js
+++ b/src/utils/auth-forms.js
@@ -3,9 +3,10 @@ import supabase from '../init/supabase-client.js';
 export function setupAuthForm(formId, handler) {
   const form = document.getElementById(formId);
   const message = document.getElementById('message');
+  const guardMsg = document.querySelector('[data-testid="auth-guard-msg"]');
   const params = new URLSearchParams(window.location.search);
   const initialMsg = params.get('message');
-  if (initialMsg) message.textContent = initialMsg;
+  if (initialMsg && guardMsg) guardMsg.textContent = initialMsg;
   const submitBtn = form?.querySelector('button[type="submit"]');
   form?.addEventListener('submit', async (e) => {
     e.preventDefault();

--- a/tests/auth-forms.test.js
+++ b/tests/auth-forms.test.js
@@ -6,6 +6,7 @@ describe('auth form utility', () => {
       <form id="testForm">
         <button type="submit">Go</button>
       </form>
+      <p id="authGuard" data-testid="auth-guard-msg"></p>
       <p id="message"></p>
     `;
   });
@@ -46,7 +47,7 @@ describe('auth form utility', () => {
     }));
     const { setupAuthForm } = require('../src/utils/auth-forms.js');
     setupAuthForm('testForm', jest.fn());
-    expect(document.getElementById('message').textContent).toBe('hello');
+    expect(document.querySelector('[data-testid="auth-guard-msg"]').textContent).toBe('hello');
     window.history.pushState({}, '', originalUrl);
   });
 });

--- a/tests/e2e/create-lobby.spec.ts
+++ b/tests/e2e/create-lobby.spec.ts
@@ -132,7 +132,7 @@ test.describe('lobby creation', () => {
 
     await page.goto('/login.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);
-    await page.fill('[data-testid="login-username"]', 'testuser@example.com');
+    await page.fill('[data-testid="login-email"]', 'testuser@example.com');
     await page.fill('[data-testid="login-password"]', 'password');
     await page.click('[data-testid="login-submit"]');
 

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -97,7 +97,7 @@ test.describe('login', () => {
   test('redirects to account after login', async ({ page }) => {
     await page.goto('/login.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);
-    await page.fill('[data-testid="login-username"]', 'user@example.com');
+    await page.fill('[data-testid="login-email"]', 'user@example.com');
     await page.fill('[data-testid="login-password"]', 'password');
     await page.click('[data-testid="login-submit"]');
     await page.waitForURL('**/account.html');

--- a/tests/e2e/smoke-auth.spec.ts
+++ b/tests/e2e/smoke-auth.spec.ts
@@ -35,7 +35,7 @@ test.describe('smoke auth', () => {
     await expect(page.locator('#userMenu')).toContainText('Profilo');
     await expect(page.locator('#userMenu')).toContainText('Esci');
     await expect(page.locator('#playBtn')).toBeVisible();
-    await expect(page.locator('#multiplayerBtn')).toBeVisible();
+    await expect(page.locator('[data-testid="lobby-link"]')).toBeVisible();
     await expect(page.locator('#setupBtn')).toBeVisible();
     await expect(page.locator('#howToPlayBtn')).toBeVisible();
     await expect(page.locator('#aboutBtn')).toBeVisible();

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -21,8 +21,8 @@ test.describe('smoke flow', () => {
   test('login, lobby, start game', async ({ page }) => {
     await page.goto('/login.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);
-    await expect(page.locator('[data-testid="login-username"]')).toBeVisible();
-    await page.fill('[data-testid="login-username"]', 'user@example.com');
+    await expect(page.locator('[data-testid="login-email"]')).toBeVisible();
+    await page.fill('[data-testid="login-email"]', 'user@example.com');
     await page.fill('[data-testid="login-password"]', 'password');
     await page.click('[data-testid="login-submit"]');
 

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -3,8 +3,8 @@ import { Page, expect } from '@playwright/test';
 export async function authenticate(page: Page) {
   await page.goto('/login.html');
   await expect(page.getByText('Unable to load data')).toHaveCount(0);
-  await expect(page.locator('[data-testid="login-username"]')).toBeVisible();
-  await page.fill('[data-testid="login-username"]', 'user@example.com');
+  await expect(page.locator('[data-testid="login-email"]')).toBeVisible();
+  await page.fill('[data-testid="login-email"]', 'user@example.com');
   await page.fill('[data-testid="login-password"]', 'password');
   await page.click('[data-testid="login-submit"]');
 }


### PR DESCRIPTION
## Summary
- expose data-testid hooks for login form messages and fields
- instrument auth menu links for login, logout, profile, and lobby
- support auth guard messages in shared auth form helper
- format auth forms test to satisfy Prettier

## Testing
- `npx prettier --check .`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b692cd0140832cacf018497c22657e