### PR TITLE
feat: add Playwright config and helpers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+import { existsSync } from 'node:fs';
+
+const PORT = 5173;
+const BASE_URL = `http://localhost:${PORT}`;
+const STORAGE_STATE = 'playwright/.auth/user.json';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: BASE_URL,
+    storageState: existsSync(STORAGE_STATE) ? STORAGE_STATE : undefined,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+      },
+});

--- a/playwright/utils.ts
+++ b/playwright/utils.ts
@@ -1,0 +1,21 @@
+import { Page, expect } from '@playwright/test';
+
+export async function assertLoggedInUI(page: Page) {
+  await expect(page.getByTestId('profile-link')).toBeVisible();
+  await expect(page.getByTestId('lobby-link')).toBeVisible();
+  await expect(page.getByTestId('logout-btn')).toBeVisible();
+  await expect(page.getByTestId('login-btn')).toHaveCount(0);
+}
+
+export async function assertLoggedOutUI(page: Page) {
+  await expect(page.getByTestId('login-btn')).toBeVisible();
+  await expect(page.getByTestId('logout-btn')).toHaveCount(0);
+  await expect(page.getByTestId('profile-link')).toHaveCount(0);
+}
+
+export async function login(page: Page, email = 'user@example.com', password = 'password') {
+  await page.goto('/login.html');
+  await page.getByTestId('login-email').fill(email);
+  await page.getByTestId('login-password').fill(password);
+  await page.getByTestId('login-submit').click();
+}


### PR DESCRIPTION
## Summary
- add root Playwright config with retries, base URL, storage state and optional dev server
- provide Playwright helpers for login and auth state checks
- track auth state folder with .gitkeep
- load auth storage state only when present to avoid failing tests

## Testing
- `npm test`
- `CI=1 npx playwright test tests/e2e/login.spec.ts --list`


------
https://chatgpt.com/codex/tasks/task_e_68b699998ea4832ca78024487b35af5f