### PR TITLE
feat: add Supabase status badge

### DIFF
--- a/lobby.html
+++ b/lobby.html
@@ -65,6 +65,77 @@
       <section id="debugLog" class="debug-log" aria-live="polite"></section>
     </main>
     <script src="./env.js"></script>
+    <script>
+      (function () {
+        const badge = document.createElement('div');
+        badge.setAttribute('role', 'status');
+        badge.setAttribute('aria-live', 'polite');
+        badge.setAttribute('data-supabadge', '');
+        badge.textContent = '⏳ Checking…';
+        badge.style.cssText =
+          'position:fixed;top:10px;right:10px;padding:6px 10px;border-radius:4px;font-size:14px;font-family:sans-serif;color:#fff;background:#666;z-index:9999;box-shadow:0 2px 4px rgba(0,0,0,0.2);pointer-events:none';
+        document.body.appendChild(badge);
+
+        const params = new URLSearchParams(location.search);
+        const debug = params.get('supadebug') === '1';
+        if (debug) badge.style.pointerEvents = 'auto';
+
+        let detail = '';
+        function finish(text, color, ok, msg, det) {
+          badge.textContent = text;
+          badge.style.background = color;
+          detail = det || msg;
+          (ok ? console.info : console.error)('Supabase badge:', msg);
+        }
+
+        const env = window.__env;
+        if (!env) {
+          finish('❌ no env', '#e74c3c', false, 'no env');
+          return;
+        }
+        const url = env.SUPABASE_URL;
+        const key = env.SUPABASE_ANON_KEY;
+        if (!url || !key) {
+          finish('❌ missing key', '#e74c3c', false, 'missing key');
+          return;
+        }
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 3000);
+        fetch(url + '/auth/v1/settings', {
+          headers: { apikey: key },
+          signal: controller.signal,
+        })
+          .then((res) => {
+            clearTimeout(timer);
+            if (res.status === 200) {
+              finish('✅ Supabase OK', '#2ecc71', true, 'Supabase OK', 'status 200');
+            } else {
+              finish(
+                '❌ ' + res.status,
+                '#e74c3c',
+                false,
+                String(res.status),
+                'status ' + res.status,
+              );
+            }
+          })
+          .catch((err) => {
+            clearTimeout(timer);
+            if (err.name === 'AbortError') {
+              finish('❌ timeout', '#e74c3c', false, 'timeout');
+            } else {
+              finish('❌ error', '#e74c3c', false, 'error', err.message);
+            }
+          });
+
+        if (debug) {
+          badge.addEventListener('click', () => {
+            alert('Supabase: ' + detail);
+          });
+        }
+      })();
+    </script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./lobby.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add mobile-friendly Supabase status badge to lobby
- perform 3-second health check for Supabase env and endpoint
- format lobby page using Prettier for code style compliance

## Testing
- `npx prettier --check .`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b69b283ad8832ca35dfa76e97bd67e