### PR TITLE
Add Playwright auth tests

### DIFF
--- a/playwright/anonymous-access.spec.ts
+++ b/playwright/anonymous-access.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { assertLoggedInUI, assertLoggedOutUI, mockSupabase } from './utils';
+
+test.describe('anonymous access', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSupabase(page);
+  });
+
+  test('anonymous user sees allowed features only', async ({ page }) => {
+    await page.goto('/index.html');
+    await assertLoggedOutUI(page);
+    await expect(page.getByTestId('lobby-link')).toHaveCount(0);
+    await page.goto('/login.html');
+    await page.getByTestId('login-anon').click();
+    await page.waitForURL('**/account.html');
+    await page.goto('/index.html');
+    await assertLoggedInUI(page);
+    await expect(page.getByTestId('lobby-link')).toBeVisible();
+  });
+});

--- a/playwright/auth-nav.spec.ts
+++ b/playwright/auth-nav.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { login, assertLoggedInUI, assertLoggedOutUI, mockSupabase } from './utils';
+
+test.describe('auth navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSupabase(page);
+  });
+
+  test('redirects unauthenticated user to login', async ({ page }) => {
+    await page.goto('/account.html');
+    await page.waitForURL('**/login.html?message=*');
+    await expect(page.getByTestId('auth-guard-msg')).toHaveText('Accedi per vedere il tuo profilo');
+    await assertLoggedOutUI(page);
+  });
+
+  test('allows authenticated navigation persistence', async ({ page }) => {
+    await login(page);
+    await page.waitForURL('**/account.html');
+    await assertLoggedInUI(page);
+    await page.goto('/index.html');
+    await assertLoggedInUI(page);
+    await page.reload();
+    await assertLoggedInUI(page);
+    await page.goto('/account.html');
+    await expect(page).toHaveURL(/account\.html$/);
+    await assertLoggedInUI(page);
+  });
+});

--- a/playwright/login.spec.ts
+++ b/playwright/login.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { login, assertLoggedInUI, assertLoggedOutUI, mockSupabase } from './utils';
+
+test.describe('login flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSupabase(page);
+  });
+
+  test('valid login', async ({ page }) => {
+    await login(page);
+    await page.waitForURL('**/account.html');
+    await assertLoggedInUI(page);
+  });
+
+  test('invalid login', async ({ page }) => {
+    await login(page, 'user@example.com', 'wrong');
+    await expect(page.getByTestId('error-msg')).toHaveText('Credenziali non valide');
+    await assertLoggedOutUI(page);
+  });
+
+  test('logout resets state', async ({ page }) => {
+    await login(page);
+    await page.waitForURL('**/account.html');
+    await assertLoggedInUI(page);
+    await page.getByTestId('logout-btn').click();
+    await page.waitForURL('**/index.html');
+    await assertLoggedOutUI(page);
+  });
+});

--- a/playwright/session-expiry.spec.ts
+++ b/playwright/session-expiry.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { login, mockSupabase } from './utils';
+
+test.describe('session expiry', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSupabase(page);
+  });
+
+  test('prompts re-login after token expiration', async ({ page }) => {
+    await login(page);
+    await page.waitForURL('**/account.html');
+    await page.evaluate(() => {
+      sessionStorage.removeItem('mockSession');
+      sessionStorage.removeItem('mockUser');
+    });
+    await page.reload();
+    await page.waitForURL('**/login.html?message=*');
+    await expect(page.getByTestId('auth-guard-msg')).toHaveText('Accedi per vedere il tuo profilo');
+  });
+});

--- a/playwright/utils.ts
+++ b/playwright/utils.ts
@@ -19,3 +19,78 @@ export async function login(page: Page, email = 'user@example.com', password = '
   await page.getByTestId('login-password').fill(password);
   await page.getByTestId('login-submit').click();
 }
+
+export async function mockSupabase(page: Page) {
+  await page.route('**/src/init/supabase-client.js*', (route) =>
+    route.fulfill({
+      body: `
+        let storedUser = null;
+        let storedSession = null;
+        try {
+          storedUser = JSON.parse(sessionStorage.getItem('mockUser'));
+          storedSession = JSON.parse(sessionStorage.getItem('mockSession'));
+        } catch {}
+        const state = { user: storedUser, session: storedSession };
+        const listeners = [];
+        const supabase = {
+          auth: {
+            storage: window.sessionStorage,
+            onAuthStateChange: (cb) => { listeners.push(cb); },
+            getSession: async () => ({ data: { session: state.session }, error: null }),
+            getUser: async () => ({ data: { user: state.session ? state.user : null }, error: null }),
+            signInWithPassword: async ({ email, password }) => {
+              if (password === 'password') {
+                state.user = { id: '1', email };
+                state.session = { access_token: 'token' };
+                try {
+                  sessionStorage.setItem('mockUser', JSON.stringify(state.user));
+                  sessionStorage.setItem('mockSession', JSON.stringify(state.session));
+                } catch {}
+                listeners.forEach((cb) => cb('SIGNED_IN', { user: state.user, session: state.session }));
+                return { data: { user: state.user, session: state.session }, error: null };
+              }
+              return { data: { user: null, session: null }, error: { message: 'Invalid' } };
+            },
+            signInAnonymously: async () => {
+              state.user = { id: 'anon', email: null };
+              state.session = { access_token: 'anon' };
+              try {
+                sessionStorage.setItem('mockUser', JSON.stringify(state.user));
+                sessionStorage.setItem('mockSession', JSON.stringify(state.session));
+              } catch {}
+              listeners.forEach((cb) => cb('SIGNED_IN', { user: state.user, session: state.session }));
+              return { data: { user: state.user, session: state.session }, error: null };
+            },
+            setSession: async (session) => {
+              state.session = session;
+              try { sessionStorage.setItem('mockSession', JSON.stringify(state.session)); } catch {}
+              return { data: { session: state.session }, error: null };
+            },
+            signOut: async () => {
+              state.user = null;
+              state.session = null;
+              try {
+                sessionStorage.removeItem('mockUser');
+                sessionStorage.removeItem('mockSession');
+              } catch {}
+              listeners.forEach((cb) => cb('SIGNED_OUT', {}));
+              return { error: null };
+            },
+          },
+          from: () => ({
+            select() { return this; },
+            eq() { return this; },
+            contains() { return this; },
+            limit: async () => ({ data: [] }),
+          }),
+        };
+        export function registerAuthListener(handler) { listeners.push(handler); }
+        export default supabase;
+      `,
+      contentType: 'application/javascript',
+    }),
+  );
+  await page.route('**/supabase.co/**', (route) =>
+    route.fulfill({ status: 200, body: '{}', headers: { 'content-type': 'application/json' } }),
+  );
+}


### PR DESCRIPTION
## Summary
- add login flow tests for valid, invalid, and logout scenarios
- cover protected-route navigation and persistence
- simulate session expiration and anonymous access checks
- initialize mock Supabase session from storage to persist auth across navigations
- centralize session-aware Supabase mock for all Playwright specs
- include email field for anonymous sign-in so mock matches client expectations

## Testing
- `npx playwright install --with-deps chromium` *(fails: Invalid response from proxy: HTTP/1.1 403 Forbidden)*
- `npx playwright test -c playwright.config.ts` *(fails: browserType.launch: Executable doesn't exist; run ‘npx playwright install’)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a9ad97d4832cb7cb0d2bece20e47