### PR TITLE
feat: runtime env for supabase

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,25 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: github-pages
-    env:
-      VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: 'Guard: env usage'
-        shell: bash
+      - name: 'Guard-rails: verifica secrets presenti'
         run: |
-          set -e
-          if grep -RIn --include='*.html' 'src="./env.js' . >/dev/null; then
-            echo "USE_ENV_JS=true" >> $GITHUB_ENV
-          else
-            grep -R "import.meta.env" -n src >/dev/null || { echo 'missing import.meta.env'; exit 1; }
-            echo "USE_ENV_JS=false" >> $GITHUB_ENV
-          fi
-          grep -RIn --include='*.html' '<script[^>]*src="src/' . && { echo 'direct src/ script reference'; exit 1; } || true
-          echo 'Guard passed'
+          test -n "${{ secrets.SUPABASE_URL }}" || (echo "Missing SUPABASE_URL" && exit 1)
+          test -n "${{ secrets.SUPABASE_ANON_KEY }}" || (echo "Missing SUPABASE_ANON_KEY" && exit 1)
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -46,36 +36,8 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Generate env.js if needed
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        env:
-          SHA: ${{ github.sha }}
-        run: |
-          set -e
-          if [ "$USE_ENV_JS" = "true" ]; then
-            [ -n "$VITE_SUPABASE_URL" ] || { echo '❌ Missing VITE_SUPABASE_URL'; exit 1; }
-            [ -n "$VITE_SUPABASE_ANON_KEY" ] || { echo '❌ Missing VITE_SUPABASE_ANON_KEY'; exit 1; }
-            rm -f public/env.js
-            STAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            cat > public/env.js <<EOF
-            window.__env = {
-              SUPABASE_URL: "$VITE_SUPABASE_URL",
-              SUPABASE_ANON_KEY: "$VITE_SUPABASE_ANON_KEY",
-              STAMP: "$STAMP",
-              SHA: "$SHA"
-            };
-            console.log('[ENV]', { STAMP: "$STAMP", SHA: "$SHA" });
-            if ('serviceWorker' in navigator) {
-              navigator.serviceWorker.register('./sw.js?v=$SHA').catch(e => console.error('SW registration failed', e));
-            }
-            EOF
-          else
-            echo 'Skipping env.js generation; using import.meta.env'
-          fi
-          echo "VITE_COMMIT_SHA=$SHA" >> $GITHUB_ENV
-          find . -maxdepth 1 -name '*.html' -exec sed -i "s/%VITE_COMMIT_SHA%/$SHA/g" {} +
-          find public -name '*.html' -exec sed -i "s/%VITE_COMMIT_SHA%/$SHA/g" {} +
-          sed -i "s/%VITE_COMMIT_SHA%/$SHA/g" public/sw.js
+      - name: Replace commit SHA in service worker
+        run: sed -i "s/%VITE_COMMIT_SHA%/${GITHUB_SHA}/g" public/sw.js
 
       - name: Build (Vite, production mode)
         run: npm run build -- --mode production
@@ -84,6 +46,20 @@ jobs:
         run: |
           if [ -d dist ]; then true; elif [ -d build ]; then mv build dist; elif [ -d out ]; then mv out dist; else mkdir -p dist; fi
           cp -r supabase dist/
+
+      - name: Genera env.js per Pages
+        run: |
+          mkdir -p dist
+          cat > dist/env.js <<'EOENV'
+          // Auto-generated at build time. Do NOT commit real keys.
+          (function(){
+            window.__env = {
+              SUPABASE_URL: "${{ secrets.SUPABASE_URL }}",
+              SUPABASE_ANON_KEY: "${{ secrets.SUPABASE_ANON_KEY }}"
+            };
+          })();
+          EOENV
+          echo "(function(){window.__buildSha='${GITHUB_SHA}';})();" > dist/build.js
 
       - name: Upload artifact (Pages)
         uses: actions/upload-pages-artifact@v3

--- a/about.html
+++ b/about.html
@@ -9,6 +9,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -52,7 +73,6 @@
         </div>
       </section>
     </div>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./about.js"></script>
   </body>

--- a/account.html
+++ b/account.html
@@ -9,6 +9,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -46,7 +67,6 @@
         </div>
       </section>
     </main>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./account.js"></script>
   </body>

--- a/forgot.html
+++ b/forgot.html
@@ -9,6 +9,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -32,7 +53,6 @@
       </form>
       <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./forgot.js"></script>
   </body>

--- a/game.html
+++ b/game.html
@@ -10,6 +10,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <link rel="stylesheet" href="./css/game.css" />
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body class="game-page">
     <p id="setupNotice">
@@ -85,7 +106,6 @@
         </div>
       </div>
     </div>
-    <script src="./env.js"></script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -9,6 +9,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -185,7 +206,6 @@
       }
       render();
     </script>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body class="home-page">
     <header class="main-header">
@@ -45,7 +66,6 @@
         About/Settings
       </button>
     </main>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./home.js"></script>
   </body>

--- a/lobby.html
+++ b/lobby.html
@@ -10,6 +10,27 @@
     <title>Lobby - NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body class="lobby-page">
     <header class="main-header">
@@ -64,7 +85,6 @@
       </section>
       <section id="debugLog" class="debug-log" aria-live="polite"></section>
     </main>
-    <script src="./env.js"></script>
     <script>
       (function () {
         const badge = document.createElement('div');

--- a/login.html
+++ b/login.html
@@ -9,6 +9,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -46,7 +67,6 @@
       <p id="authGuardMessage" role="alert" data-testid="auth-guard-msg"></p>
       <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./login.js"></script>
   </body>

--- a/preview-index.html
+++ b/preview-index.html
@@ -9,6 +9,27 @@
         padding: 1rem;
       }
     </style>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <h1>NetRisk Branch Previews</h1>
@@ -31,6 +52,5 @@
       }
       loadBranches();
     </script>
-    <script src="./env.js"></script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -26,8 +26,27 @@
         window.location.replace(fallback);
       })();
     </script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
-  <body>
-    <script src="./env.js"></script>
-  </body>
+  <body></body>
 </html>

--- a/register.html
+++ b/register.html
@@ -9,6 +9,27 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -36,7 +57,6 @@
       </form>
       <p id="message" role="alert" data-testid="error-msg"></p>
     </main>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./register.js"></script>
   </body>

--- a/setup.html
+++ b/setup.html
@@ -11,6 +11,27 @@
     <title>Setup NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>
+      (function () {
+        var b = document.createElement('script');
+        b.src = 'build.js?v=' + Date.now();
+        b.defer = false;
+        document.head.appendChild(b);
+
+        var s = document.createElement('script');
+        s.src = 'env.js?v=' + Date.now();
+        s.defer = false;
+        s.onload = function () {
+          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+            console.error('[ENV] Missing keys in env.js');
+          }
+        };
+        s.onerror = function () {
+          console.error('[ENV] env.js failed to load');
+        };
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <header class="main-header">
@@ -55,7 +76,6 @@
       <div id="players"></div>
       <button type="submit" class="btn">Start</button>
     </form>
-    <script src="./env.js"></script>
     <script type="module" src="./auth.js"></script>
     <script type="module" src="./setup.js"></script>
   </body>

--- a/src/init/supabase-client.js
+++ b/src/init/supabase-client.js
@@ -1,5 +1,5 @@
 import { SUPABASE_URL, SUPABASE_KEY } from '../config.js';
-import { info, error } from '../logger.js';
+import { info, warn } from '../logger.js';
 
 // Support both Node (tests/server) and browser environments.
 // In the browser we expect the Supabase script to expose a global object.
@@ -15,12 +15,15 @@ if (typeof window === 'undefined' || !window.supabase) {
 // Initialize the client only when both URL and key are provided.
 // This avoids hitting Supabase with empty credentials during development
 // or when GitHub Actions secrets are not configured correctly.
-export const supabase =
-  SUPABASE_URL && SUPABASE_KEY ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
+export const supabase = (() => {
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    warn('[Supabase] ENV missing — multiplayer/lobby disabilitati');
+    return null;
+  }
+  return createClient(SUPABASE_URL, SUPABASE_KEY);
+})();
 if (supabase) {
   info('[AUTH] client init ok');
-} else {
-  error('[AUTH] client init ko');
 }
 
 export function registerAuthListener(handler) {


### PR DESCRIPTION
## Summary
- load Supabase configuration from a generated env.js on GitHub Pages
- cache-bust env and build scripts and warn if keys missing
- guard Supabase client initialization when secrets are absent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6be71bf34832c88a9d4fa629e4631