### PR TITLE
Add Playwright E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,41 @@
+name: E2E
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ vars.BASE_URL }}
+      TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run dev &
+      - run: npx wait-on http://localhost:5173
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- run Playwright end-to-end tests via new workflow
- start dev server before running tests so Playwright can reach app

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `TEST_EMAIL=test@example.com TEST_PASSWORD=secret BASE_URL=http://localhost npm run test:uat` *(fails: browser executable doesn't exist)*
- `BASE_URL=http://localhost TEST_EMAIL=test@example.com TEST_PASSWORD=secret npm run test:e2e:smoke` *(fails: host system missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e034fb00832cbfdf8494549e6b76