### PR TITLE
ci: expose supabase secrets to Vite build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,9 @@ jobs:
         run: sed -i "s/%VITE_COMMIT_SHA%/${GITHUB_SHA}/g" public/sw.js
 
       - name: Build (Vite, production mode)
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: npm run build -- --mode production
 
       - name: Stage static files


### PR DESCRIPTION
## Summary
- inject Supabase URL and anon key into the GitHub Pages workflow so Vite receives them at build time

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: needs Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f5a87684832c935e41c98ebf881e