### PR TITLE
Add Playwright E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,39 @@
+name: E2E
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ vars.BASE_URL }}
+      TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,12 +17,15 @@ export default defineConfig({
     { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
     { name: 'webkit', use: { ...devices['Desktop Safari'] } },
   ],
-  webServer: process.env.CI
-    ? undefined
-    : {
-        command: 'npm run dev',
-        url: BASE_URL,
-        reuseExistingServer: !process.env.CI,
-        timeout: 120000,
-      },
+  webServer: {
+    command: 'npm run dev',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    env: {
+      VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL ?? 'https://example.supabase.co',
+      VITE_SUPABASE_ANON_KEY: process.env.VITE_SUPABASE_ANON_KEY ?? 'dummy-key',
+      VITE_COMMIT_SHA: process.env.VITE_COMMIT_SHA ?? 'dev',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- run Playwright end-to-end tests via new workflow
- rely on Playwright to start the dev server with placeholder Supabase env
- avoid regenerating visual snapshots to preserve regression detection

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `BASE_URL=http://localhost TEST_EMAIL=test@example.com TEST_PASSWORD=secret npm run test:uat` *(fails: Process from config.webServer exited early)*
- `BASE_URL=http://localhost TEST_EMAIL=test@example.com TEST_PASSWORD=secret npm run test:e2e:smoke` *(fails: missing host dependencies for browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e034fb00832cbfdf8494549e6b76