### PR TITLE
refactor: load env synchronously from correct base path

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,15 +11,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/account.html
+++ b/account.html
@@ -11,15 +11,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/forgot.html
+++ b/forgot.html
@@ -11,15 +11,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/game.html
+++ b/game.html
@@ -12,19 +12,21 @@
     <link rel="stylesheet" href="./css/game.css" />
     <script>
       (function () {
-        document.write('<script src="build.js"><\/script>');
-        var v = Date.now();
-        document.write(
-          '<script src="env.js?v=' +
-            v +
-            '" onerror="console.error(\'[ENV] env.js failed to load\')"><\/script>',
-        );
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -11,15 +11,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -12,15 +12,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-        document.write('<script src="build.js"><\/script>');
-        var v = Date.now();
-        document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/lobby.html
+++ b/lobby.html
@@ -12,15 +12,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/login.html
+++ b/login.html
@@ -11,15 +11,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/preview-index.html
+++ b/preview-index.html
@@ -11,15 +11,21 @@
     </style>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/public/404.html
+++ b/public/404.html
@@ -28,15 +28,21 @@
     </script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/register.html
+++ b/register.html
@@ -11,15 +11,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>

--- a/setup.html
+++ b/setup.html
@@ -13,15 +13,21 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       (function () {
-          document.write('<script src="build.js"><\/script>');
-          var v = Date.now();
-          document.write('<script src="env.js?v=' + v + '" onerror="console.error(\\'[ENV] env.js failed to load\\')"><\/script>');
-      })();
-    </script>
-    <script>
-      (function () {
-        if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-          console.error('[ENV] Missing keys in env.js');
+        const base = location.pathname.replace(/[^/]*$/, '');
+        try {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', base + 'env.js?' + Date.now(), false);
+          xhr.send(null);
+          if (xhr.status >= 200 && xhr.status < 300) {
+            (0, eval)(xhr.responseText);
+            if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
+              console.error('[ENV] Missing keys in env.js');
+            }
+          } else {
+            console.error('[ENV] env.js failed to load');
+          }
+        } catch (e) {
+          console.error('[ENV] env.js failed to load');
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- fetch env.js synchronously before modules to avoid race conditions
- compute base path from `location.pathname` and bust cache with `Date.now()`
- apply loader across all Supabase-enabled pages

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*


------
https://chatgpt.com/codex/tasks/task_e_68b70fab88d8832c84145d9ff86e3b82