### PR TITLE
Add Playwright E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E
+permissions:
+  contents: read
+  actions: write
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ vars.BASE_URL }}
+      TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      VITE_SUPABASE_URL: https://example.supabase.co
+      VITE_SUPABASE_ANON_KEY: dummy-key
+      VITE_COMMIT_SHA: dev
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - name: Run E2E tests
+        run: |
+          npm run dev &
+          npx wait-on http://localhost:5173
+          npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ const STORAGE_STATE = 'playwright/.auth/user.json';
 
 export default defineConfig({
   testDir: './tests/e2e',
+  testIgnore: process.env.CI ? /visual\.spec\.ts/ : undefined,
   retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: BASE_URL,
@@ -24,5 +25,10 @@ export default defineConfig({
         url: BASE_URL,
         reuseExistingServer: !process.env.CI,
         timeout: 120000,
+        env: {
+          VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL ?? 'https://example.supabase.co',
+          VITE_SUPABASE_ANON_KEY: process.env.VITE_SUPABASE_ANON_KEY ?? 'dummy-key',
+          VITE_COMMIT_SHA: process.env.VITE_COMMIT_SHA ?? 'dev',
+        },
       },
 });


### PR DESCRIPTION
## Summary
- run Playwright end-to-end tests via new workflow
- start dev server in CI and rely on Playwright for local runs
- skip visual suite in CI since baselines aren't present

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: Host system is missing dependencies to run browsers)*
- `npm run test:e2e:smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e034fb00832cbfdf8494549e6b76