### PR TITLE
guard realtime client on missing env

### DIFF
--- a/src/netrisk-realtime.ts
+++ b/src/netrisk-realtime.ts
@@ -13,12 +13,35 @@ interface RealtimePayload<T> {
   new: T;
 }
 
-const client = createClient(SUPABASE_URL, SUPABASE_KEY);
+// Initialize Supabase client only when URL and key are available.
+// Read from config constants first but allow runtime overrides via
+// `window.__env` to support deployments where values are injected at
+// runtime instead of build time.
+export const client = (() => {
+  const url =
+    SUPABASE_URL || (typeof window !== 'undefined' && (window as any).__env?.SUPABASE_URL) || '';
+  const key =
+    SUPABASE_KEY ||
+    (typeof window !== 'undefined' && (window as any).__env?.SUPABASE_ANON_KEY) ||
+    '';
+
+  if (!url || !key) {
+    console.warn('[Supabase] missing URL or anon key – realtime disabled');
+    return null;
+  }
+
+  return createClient(url, key);
+})();
 
 export function subscribeToMatch<S extends GameState = GameState, A = unknown, R = unknown>(
   matchId: string,
   handlers: MatchSubscriptionHandlers<S, A, R>,
 ) {
+  if (!client) {
+    console.warn('[Supabase] subscribeToMatch called without client – ignoring');
+    return () => {};
+  }
+
   const channel = client.channel(`netrisk:${matchId}`);
 
   if (handlers.onState) {

--- a/tests/netrisk-realtime.test.ts
+++ b/tests/netrisk-realtime.test.ts
@@ -1,4 +1,3 @@
-import { subscribeToMatch } from '../src/netrisk-realtime.ts';
 import type { Event } from '../src/types/netrisk';
 
 // Mock Supabase client
@@ -18,6 +17,11 @@ jest.mock('@supabase/supabase-js', () => ({
     removeChannel: jest.fn(),
   })),
 }));
+
+process.env.VITE_SUPABASE_URL = 'http://localhost';
+process.env.VITE_SUPABASE_ANON_KEY = 'anon';
+
+const { subscribeToMatch } = require('../src/netrisk-realtime.ts');
 
 describe('netriskRealtime', () => {
   test('subscribeToMatch forwards realtime payloads', () => {


### PR DESCRIPTION
## Summary
- avoid initializing Supabase realtime client when URL or anon key are absent
- warn and return no-op subscription when client missing
- ensure tests provide Supabase env vars before loading realtime module

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68b734640574832caf3d4d7d76b4006b