### PR TITLE
fix: add zod import map for browser modules

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './about.js'];

--- a/account.html
+++ b/account.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './account.js'];

--- a/forgot.html
+++ b/forgot.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './forgot.js'];

--- a/game.html
+++ b/game.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <link rel="stylesheet" href="./css/game.css" />
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./main.js'];

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js'];

--- a/importmap.json
+++ b/importmap.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "@supabase/supabase-js": "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"
+    "@supabase/supabase-js": "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm",
+    "zod": "https://cdn.jsdelivr.net/npm/zod@4.1.5/+esm"
   }
 }

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './home.js'];

--- a/lobby.html
+++ b/lobby.html
@@ -10,6 +10,7 @@
     <title>Lobby - NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './lobby.js'];

--- a/login.html
+++ b/login.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './login.js'];

--- a/preview-index.html
+++ b/preview-index.html
@@ -9,6 +9,7 @@
         padding: 1rem;
       }
     </style>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = [];

--- a/register.html
+++ b/register.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './register.js'];

--- a/setup.html
+++ b/setup.html
@@ -11,6 +11,7 @@
     <title>Setup NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="importmap" src="importmap.json"></script>
     <script>
       (function () {
         const modules = ['./auth.js', './setup.js'];


### PR DESCRIPTION
## Summary
- map `zod` to CDN in import map
- load shared import map on all HTML pages

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npm run test:e2e:smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b736cf4500832c9dbaa7ab59cae048