### PR TITLE
fix map URL resolution

### DIFF
--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -64,10 +64,16 @@ export default function initTerritorySelection({
   function loadMap(paths) {
     if (!paths.length) {
       boardEl.textContent = 'Invalid map';
-      throw new Error('Map SVG missing .map-territory elements');
+      throw new Error(`Map "${mapName}" could not be loaded`);
     }
     const [path, ...rest] = paths;
-    return fetch(path)
+    const base = typeof document !== 'undefined' ? document.baseURI : undefined;
+    const url = new URL(path, base);
+    const fetchPath =
+      typeof window !== 'undefined' && url.origin === window.location.origin
+        ? url.pathname + url.search + url.hash
+        : url.href;
+    return fetch(fetchPath)
       .then((r) => (r.ok ? r.text() : null))
       .then((text) => {
         if (text) {
@@ -174,6 +180,6 @@ export default function initTerritorySelection({
       }
     })
     .catch((err) => {
-      logger.error(err);
+      logger.error(`Failed to load map "${mapName}"`, err);
     });
 }


### PR DESCRIPTION
## Summary
- resolve map SVG URLs relative to `document.baseURI`
- log a clear error when map loading fails

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat`


------
https://chatgpt.com/codex/tasks/task_e_68b74288aa10832c87037d420c287e1e