### PR TITLE
refactor: update env loader snippet

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,39 +9,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './about.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './about.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/account.html
+++ b/account.html
@@ -9,39 +9,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './account.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './account.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/forgot.html
+++ b/forgot.html
@@ -9,39 +9,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './forgot.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './forgot.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/game.html
+++ b/game.html
@@ -10,39 +10,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <link rel="stylesheet" href="./css/game.css" />
-    <script>
-      (function () {
-        const modules = ['./main.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./main.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body class="game-page">

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -9,39 +9,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -10,39 +10,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './home.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './home.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body class="home-page">

--- a/lobby.html
+++ b/lobby.html
@@ -10,39 +10,30 @@
     <title>Lobby - NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './lobby.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './lobby.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body class="lobby-page">

--- a/login.html
+++ b/login.html
@@ -9,39 +9,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './login.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './login.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/preview-index.html
+++ b/preview-index.html
@@ -9,39 +9,30 @@
         padding: 1rem;
       }
     </style>
-    <script>
-      (function () {
-        const modules = [];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = [];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/public/404.html
+++ b/public/404.html
@@ -26,39 +26,30 @@
         window.location.replace(fallback);
       })();
     </script>
-    <script>
-      (function () {
-        const modules = [];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = [];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body></body>

--- a/register.html
+++ b/register.html
@@ -9,39 +9,30 @@
     <link rel="stylesheet" href="./css/components.css" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './register.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './register.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>

--- a/setup.html
+++ b/setup.html
@@ -11,39 +11,30 @@
     <title>Setup NetRisk</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-      (function () {
-        const modules = ['./auth.js', './setup.js'];
-        const base = location.pathname.replace(/[^/]*$/, '');
-        const loadModules = () => {
-          modules.forEach((src) => {
-            const m = document.createElement('script');
-            m.type = 'module';
-            m.src = src;
-            document.head.appendChild(m);
-          });
-        };
-        const init = () => {
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', loadModules);
-          } else {
-            loadModules();
-          }
-        };
-        const s = document.createElement('script');
-        s.src = base + 'env.js?' + Date.now();
-        s.onload = () => {
-          if (!window.__env || !window.__env.SUPABASE_URL || !window.__env.SUPABASE_ANON_KEY) {
-            console.error('[ENV] Missing keys in env.js');
-          }
-          init();
-        };
-        s.onerror = () => {
-          console.error('[ENV] env.js failed to load');
-          init();
-        };
-        document.head.appendChild(s);
-      })();
+    <script type="module">
+      const modules = ['./auth.js', './setup.js'];
+      const loadModules = () => {
+        modules.forEach((src) => {
+          const m = document.createElement('script');
+          m.type = 'module';
+          m.src = src;
+          document.head.appendChild(m);
+        });
+      };
+      const base = location.pathname.replace(/[^/]*$/, '');
+      try {
+        await import(`${base}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- replace script-injected `env.js` loader with top-level await pattern
- keep environment load before Supabase-enabled modules
- ensure no pages reference hashed `env.<sha>.js`

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npm run test:e2e:smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b749174be8832c9d633a241c71ead4