### PR TITLE
docs: add e2e test setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Per valutare l'equilibrio dell'IA, esegui una serie di partite automatizzate:
 npm run simulate
 ```
 
+Per la configurazione dei test end-to-end e le variabili richieste consulta
+[docs/e2e.md](docs/e2e.md).
+
 ## Deploy
 
 Genera la build destinata alla produzione:

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,40 @@
+# End-to-End Testing
+
+This guide covers the setup required to run the Playwright end-to-end suites.
+
+## Create a test user in Supabase
+
+1. Open the Supabase dashboard and select your project.
+2. Navigate to **Authentication → Users** and click **Add user**.
+3. Provide an email and password for the test account and choose **Add user** (no invitation).
+   The account is created and confirmed immediately.
+4. Use these credentials in the `E2E_TEST_EMAIL` and `E2E_TEST_PASSWORD` secrets.
+
+## Repository secrets and variables
+
+In the GitHub repository go to **Settings → Secrets and variables → Actions** and create:
+
+- **Secrets**
+  - `E2E_TEST_EMAIL` – email address of the test user.
+  - `E2E_TEST_PASSWORD` – password of the test user.
+- **Variables**
+  - `E2E_BASE_URL` – base URL that Playwright should target (e.g. the preview deployment URL).
+
+These values are read by the CI workflows before running the end‑to‑end suites.
+
+## Running tests locally with BASE_URL overrides
+
+By default the Playwright configuration points to `http://localhost:5173`.  
+You can run the E2E suites against any URL by passing `--base-url`:
+
+```bash
+npm run test:e2e:smoke -- --base-url http://localhost:5173
+npm run test:e2e:full -- --base-url https://example.com
+```
+
+You may also export the value once and reuse it:
+
+```bash
+export BASE_URL=http://localhost:5173
+npm run test:e2e:smoke -- --base-url "$BASE_URL"
+```


### PR DESCRIPTION
## Summary
- document steps to create a Supabase test user
- explain required E2E secrets and variables
- show how to override BASE_URL when running E2E tests locally

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d059db90832ca99c928cab3410c9