### PR TITLE
ci: inject env sha script for pages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 supabase/
+dist/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,24 +47,45 @@ jobs:
 
       - name: Stage static files
         run: |
-          if [ -d dist ]; then true; elif [ -d build ]; then mv build dist; elif [ -d out ]; then mv out dist; else mkdir -p dist; fi
+          mkdir -p dist
           cp -r supabase dist/
 
-      - name: Genera env.js per Pages
+      - name: Generate env.${{ github.sha }}.js
         working-directory: dist
         run: |
-          cat > env.js <<'EOENV'
+          cat > env.${GITHUB_SHA}.js <<EOENV
           // Auto-generated at build time. Do NOT commit real keys.
           window.__env = {
             SUPABASE_URL: "${{ secrets.SUPABASE_URL }}",
-            SUPABASE_ANON_KEY: "${{ secrets.SUPABASE_ANON_KEY }}"
+            SUPABASE_ANON_KEY: "${{ secrets.SUPABASE_ANON_KEY }}",
+            SHA: "${GITHUB_SHA}"
+          };
+          console.log('[ENV CHECK] loaded: OK');
+          EOENV
+          cat > env.js <<EOENV
+          window.__env = {
+            SUPABASE_URL: "${{ secrets.SUPABASE_URL }}",
+            SUPABASE_ANON_KEY: "${{ secrets.SUPABASE_ANON_KEY }}",
+            SHA: "${GITHUB_SHA}"
           };
           EOENV
+
+      - name: Patch index.html with env script
+        working-directory: dist
+        run: |
+          sed -i "s#</head>#  <script src=\"env.${GITHUB_SHA}.js\"></script>\n</head>#" index.html
+
+      - name: Verify env file
+        run: |
+          test -f dist/env.${GITHUB_SHA}.js
+          grep -q "window.__env" dist/env.${GITHUB_SHA}.js
+          grep -Eq "SUPABASE_URL: \"[^\"]+\"" dist/env.${GITHUB_SHA}.js
+          grep -Eq "SUPABASE_ANON_KEY: \"[^\"]+\"" dist/env.${GITHUB_SHA}.js
 
       - name: Upload artifact (Pages)
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist
+          path: dist
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- generate env.${GITHUB_SHA}.js with Supabase secrets and SHA during Pages build
- patch built index.html to load commit-specific env script and verify contents
- ignore dist/ from eslint

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7d0670d50832c81cc9ba8f4e17d25