### PR TITLE
Improve map loading robustness

### DIFF
--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -61,18 +61,18 @@ export default function initTerritorySelection({
     (typeof localStorage !== 'undefined' && localStorage.getItem('netriskMap')) || 'map';
   const boardEl = document.getElementById('board');
 
-  function loadMap(paths) {
-    if (!paths.length) {
-      boardEl.textContent = 'Invalid map';
-      throw new Error(`Map "${mapName}" could not be loaded`);
+  function loadMap(urls) {
+    if (!urls.length) {
+      const msg = `Map "${mapName}" could not be loaded`;
+      boardEl.innerHTML = `<p role="alert">${msg}</p>`;
+      throw new Error(msg);
     }
-    const [path, ...rest] = paths;
-    const base = typeof document !== 'undefined' ? document.baseURI : undefined;
-    const url = new URL(path, base);
+    const [url, ...rest] = urls;
+    const u = new URL(url, typeof document !== 'undefined' ? document.baseURI : undefined);
     const fetchPath =
-      typeof window !== 'undefined' && url.origin === window.location.origin
-        ? url.pathname + url.search + url.hash
-        : url.href;
+      typeof window !== 'undefined' && u.origin === window.location.origin
+        ? u.pathname + u.search + u.hash
+        : u.href;
     return fetch(fetchPath)
       .then((r) => (r.ok ? r.text() : null))
       .then((text) => {
@@ -91,11 +91,23 @@ export default function initTerritorySelection({
       .catch(() => loadMap(rest));
   }
 
-  loadMap([
-    `/assets/maps/${mapName}.svg`,
-    `assets/maps/${mapName}.svg`,
-    `public/assets/maps/${mapName}.svg`,
-  ])
+  const mapUrls = [];
+  if (typeof document !== 'undefined') {
+    const base = document.baseURI;
+    mapUrls.push(new URL(`./assets/maps/${mapName}.svg`, base).href);
+    mapUrls.push(new URL(`./public/assets/maps/${mapName}.svg`, base).href);
+  }
+  let moduleUrl;
+  try {
+    moduleUrl = new Function('return import.meta.url')();
+  } catch {
+    moduleUrl = undefined;
+  }
+  if (moduleUrl) {
+    mapUrls.push(new URL(`../public/assets/maps/${mapName}.svg`, moduleUrl).href);
+  }
+
+  loadMap(mapUrls)
     .then((svg) => {
       boardEl.innerHTML = svg;
       const map = boardEl.querySelector('#map');

--- a/src/territory-selection.js
+++ b/src/territory-selection.js
@@ -61,10 +61,19 @@ export default function initTerritorySelection({
     (typeof localStorage !== 'undefined' && localStorage.getItem('netriskMap')) || 'map';
   const boardEl = document.getElementById('board');
 
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function loadMap(urls) {
     if (!urls.length) {
       const msg = `Map "${mapName}" could not be loaded`;
-      boardEl.innerHTML = `<p role="alert">${msg}</p>`;
+      boardEl.innerHTML = `<p role="alert">${escapeHtml(msg)}</p>`;
       throw new Error(msg);
     }
     const [url, ...rest] = urls;


### PR DESCRIPTION
## Summary
- build map URLs relative to document or module to support non-root hosting
- show a visible error message when map fetching fails

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist)*
- `npm run test:e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b7d26c8f74832c8e38d45b5c039642