### PR TITLE
fix: include auth and home in build

### DIFF
--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -18,6 +18,11 @@ export default defineConfig({
         forgot: resolve(__dirname, '../forgot.html'),
         register: resolve(__dirname, '../register.html'),
         account: resolve(__dirname, '../account.html'),
+        auth: resolve(__dirname, '../auth.js'),
+        home: resolve(__dirname, '../home.js'),
+      },
+      output: {
+        entryFileNames: '[name].js',
       },
     },
   },


### PR DESCRIPTION
## Summary
- include auth.js and home.js in Vite build inputs
- keep entry file names stable to avoid 404 errors

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: executable doesn't exist at chromium_headless_shell-1187; attempted `npx playwright install chromium` but got 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b954751f94832c97049b62e7eb30f4