### PR TITLE
chore: ignore dynamic env imports in Vite

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/account.html
+++ b/account.html
@@ -15,7 +15,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/forgot.html
+++ b/forgot.html
@@ -15,7 +15,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/game.html
+++ b/game.html
@@ -16,7 +16,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/how-to-play.html
+++ b/how-to-play.html
@@ -15,7 +15,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         await Promise.all([import('./auth.js'), import('./home.js')]);
       };
       try {
-        await import(`${basePath}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${basePath}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/lobby.html
+++ b/lobby.html
@@ -16,7 +16,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/login.html
+++ b/login.html
@@ -15,7 +15,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/preview-index.html
+++ b/preview-index.html
@@ -13,7 +13,7 @@
       const loadModules = async () => {};
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/public/404.html
+++ b/public/404.html
@@ -30,7 +30,7 @@
       const loadModules = async () => {};
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/register.html
+++ b/register.html
@@ -15,7 +15,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }

--- a/setup.html
+++ b/setup.html
@@ -17,7 +17,7 @@
       };
       const base = location.pathname.replace(/[^/]*$/, '');
       try {
-        await import(`${base}env.js?${Date.now()}`);
+        await import(/* @vite-ignore */ `${base}env.js?${Date.now()}`);
         if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
           console.error('[ENV] Missing keys in env.js');
         }


### PR DESCRIPTION
## Summary
- prevent Vite from inlining dynamic env imports across HTML entry points

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b97ed4ebc4832c995eb3c297b4ff34