### PR TITLE
Fix Supabase init route in smoke auth test

### DIFF
--- a/tests/e2e/smoke-auth.spec.ts
+++ b/tests/e2e/smoke-auth.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('smoke auth', () => {
   test('anonymous auth flow', async ({ page }) => {
-    await page.route('**/init/supabase-client.js*', (route) =>
+    await page.route('**/src/init/supabase-client.js*', (route) =>
       route.fulfill({
         body: `
           export const supabase = {


### PR DESCRIPTION
## Summary
- intercept Supabase init script from src path in smoke auth test

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch executable doesn't exist)*
- `npm run test:e2e:smoke` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b9974deb88832cb19ce2c04e57d27c