### PR TITLE
test: mock supabase in start match e2e

### DIFF
--- a/tests/e2e/start-match.spec.ts
+++ b/tests/e2e/start-match.spec.ts
@@ -8,6 +8,40 @@ test.describe('start match flow', () => {
       style.innerHTML = '* { transition: none !important; animation: none !important; }';
       document.head.appendChild(style);
     });
+    await page.route('**/src/init/supabase-client.js*', (route) =>
+      route.fulfill({
+        body: `
+          let user = null;
+          let session = null;
+          const listeners = [];
+          const supabase = {
+            auth: {
+              storage: window.sessionStorage,
+              onAuthStateChange: (cb) => { listeners.push(cb); },
+              async signInWithPassword({ email }) {
+                user = { id: 'u1', email };
+                session = { access_token: 'token', user };
+                listeners.forEach((cb) => cb('SIGNED_IN', { user, session }));
+                return { data: { user, session }, error: null };
+              },
+              async setSession(s) { session = s; return { data: { session }, error: null }; },
+              async getSession() { return { data: { session }, error: null }; },
+              async getUser() { return { data: { user }, error: null }; },
+              async signOut() {
+                user = null;
+                session = null;
+                listeners.forEach((cb) => cb('SIGNED_OUT', {}));
+                return { error: null };
+              },
+            },
+          };
+          export { supabase };
+          export function registerAuthListener(handler) { listeners.push(handler); }
+          export default supabase;
+        `,
+        contentType: 'application/javascript',
+      }),
+    );
     await page.route('**/supabase.co/**', (route) => {
       route.fulfill({
         status: 200,
@@ -19,6 +53,7 @@ test.describe('start match flow', () => {
 
   test('two players start a match and enter reinforce phase', async ({ page }) => {
     await authenticate(page);
+    await expect(page.getByText('Unable to load data')).toHaveCount(0);
     await setupLobby(page);
     await page.goto('/setup.html');
     await expect(page.getByText('Unable to load data')).toHaveCount(0);


### PR DESCRIPTION
## Summary
- mock supabase client in start match e2e
- assert no "Unable to load data" appears after login

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npm run test:e2e:smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b6ee80b4832c92d9afc1a7102f9f