### PR TITLE
chore: bootstrap repo root

### DIFF
--- a/andreame-devices/.env.example
+++ b/andreame-devices/.env.example
@@ -1,0 +1,8 @@
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+VOSK_MODEL_URL=https://alphacephei.com/vosk/models/vosk-model-small-it-0.22.zip
+LANG=it_IT
+# Simulazione
+SIMULATION=keyboard
+HEADLESS=1
+SAMPLES_DIR=./raspberry/chatpi/samples

--- a/andreame-devices/.gitignore
+++ b/andreame-devices/.gitignore
@@ -1,0 +1,10 @@
+python
+venv
+__pycache__
+.env
+models/
+.pio/
+.vscode/
+build/
+dist/
+*.bin

--- a/andreame-devices/README.md
+++ b/andreame-devices/README.md
@@ -1,0 +1,8 @@
+# andreame-devices
+
+Monorepo multi-device per gestire diversi progetti hardware e software.
+
+## Come usare questi prompt
+
+Questa sezione conterrà istruzioni su come utilizzare i prompt comuni;
+arriveranno step successivi per integrarli nei dispositivi.

--- a/andreame-devices/common/docs/devices.md
+++ b/andreame-devices/common/docs/devices.md
@@ -1,0 +1,8 @@
+# Regole per aggiungere nuovi device
+
+- Crea una cartella dedicata con nome in _kebab-case_.
+- Ogni device deve avere almeno:
+  - un `README.md` con descrizione e requisiti;
+  - script di avvio in `scripts/` se necessari.
+- Riutilizza i prompt comuni dalla cartella `../prompts`.
+- Mantieni la documentazione aggiornata e riferisci eventuali dipendenze.

--- a/andreame-devices/common/prompts/system_it.txt
+++ b/andreame-devices/common/prompts/system_it.txt
@@ -1,0 +1,1 @@
+Assistente domestico su Raspberry; casa con due bambine nate nel 2017 e 2020; parlare in italiano, frasi brevi e gentili; niente parolacce; se una funzione non è disponibile, proporre alternativa semplice.


### PR DESCRIPTION
## Summary
- scaffold `andreame-devices` monorepo with docs, prompts and env example

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch executable doesn't exist, run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f24b894832cbfe025c6621472e7