### PR TITLE
feat: raspberry/chatpi simulation mode (keyboard/headless)

### DIFF
--- a/common/prompts/system_it.txt
+++ b/common/prompts/system_it.txt
@@ -1,0 +1,1 @@
+Sei ChatPi, un assistente vocale in italiano.

--- a/raspberry/chatpi/.env.example
+++ b/raspberry/chatpi/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/raspberry/chatpi/README.md
+++ b/raspberry/chatpi/README.md
@@ -1,0 +1,28 @@
+# ChatPi
+
+ChatPi è un semplice assistente vocale. Questo modulo supporta una modalità di
+simulazione pensata per GitHub Codespaces.
+
+## Setup
+
+```bash
+cd raspberry/chatpi
+./scripts/install.sh
+```
+
+## Esecuzione in simulazione
+
+```bash
+HEADLESS=1 SIMULATION=keyboard ./scripts/run.sh
+```
+
+Lo stato dell'interfaccia viene stampato in console e le risposte sono simulate
+se manca la chiave `OPENAI_API_KEY`.
+
+Per eseguire un autotest non interattivo:
+
+```bash
+./scripts/selftest.sh
+```
+
+I file in `systemd/` sono solo segnaposto per futuri sviluppi.

--- a/raspberry/chatpi/app.py
+++ b/raspberry/chatpi/app.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover
+    def load_dotenv() -> None:
+        pass
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover
+    OpenAI = None
+
+from ui import UI
+
+
+def load_system_prompt() -> str:
+    root = Path(__file__).resolve().parents[2]
+    path = root / "common" / "prompts" / "system_it.txt"
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "Sei ChatPi, un assistente vocale."
+
+
+def chat(client: Any, system_prompt: str, user_text: str) -> str:
+    if client:
+        try:
+            resp = client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_text},
+                ],
+            )
+            return resp.choices[0].message.content.strip()
+        except Exception as exc:  # pragma: no cover
+            return f"(errore API) {exc}"
+    return "(simulazione) Ciao!"
+
+
+def main() -> None:
+    load_dotenv()
+    system_prompt = load_system_prompt()
+    ui = UI()
+    sim_mode = os.getenv("SIMULATION")
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = OpenAI(api_key=api_key) if api_key and OpenAI else None
+
+    ui.set_state("idle")
+
+    if sim_mode == "keyboard":
+        while True:
+            ui.set_state("listening")
+            try:
+                user_text = input(">> ")
+            except EOFError:
+                break
+            if user_text.strip().lower() in {"stop", "esci", "spegni"}:
+                break
+            ui.set_state("thinking")
+            reply = chat(client, system_prompt, user_text)
+            ui.set_state("speaking")
+            print(f"[TTS] {reply}")
+            ui.set_state("idle")
+
+
+if __name__ == "__main__":
+    main()

--- a/raspberry/chatpi/requirements.txt
+++ b/raspberry/chatpi/requirements.txt
@@ -1,0 +1,5 @@
+openai>=1.30
+python-dotenv
+pyttsx3
+pillow
+numpy

--- a/raspberry/chatpi/scripts/install.sh
+++ b/raspberry/chatpi/scripts/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi

--- a/raspberry/chatpi/scripts/run.sh
+++ b/raspberry/chatpi/scripts/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+. .venv/bin/activate
+python app.py

--- a/raspberry/chatpi/scripts/selftest.sh
+++ b/raspberry/chatpi/scripts/selftest.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+HEADLESS=1 SIMULATION=keyboard python app.py <<'INPUT'
+ciao
+stop
+INPUT

--- a/raspberry/chatpi/scripts/update.sh
+++ b/raspberry/chatpi/scripts/update.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo TODO update

--- a/raspberry/chatpi/systemd/chatpi-update.service
+++ b/raspberry/chatpi/systemd/chatpi-update.service
@@ -1,0 +1,1 @@
+# Placeholder systemd service for ChatPi update

--- a/raspberry/chatpi/systemd/chatpi-update.timer
+++ b/raspberry/chatpi/systemd/chatpi-update.timer
@@ -1,0 +1,1 @@
+# Placeholder systemd timer for ChatPi update

--- a/raspberry/chatpi/systemd/chatpi.service
+++ b/raspberry/chatpi/systemd/chatpi.service
@@ -1,0 +1,1 @@
+# Placeholder systemd service for ChatPi

--- a/raspberry/chatpi/ui.py
+++ b/raspberry/chatpi/ui.py
@@ -1,0 +1,13 @@
+import os
+
+
+class UI:
+    def __init__(self) -> None:
+        self.headless = os.getenv("HEADLESS") == "1"
+
+    def set_state(self, state: str) -> None:
+        if self.headless:
+            print(f"[UI] {state}")
+        else:
+            # GUI placeholder
+            pass


### PR DESCRIPTION
## Summary
- add ChatPi simulation module with keyboard input and headless UI
- provide setup scripts, systemd placeholders and docs for Codespaces

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browserType.launch: Executable doesn't exist at ...; `npx playwright install` blocked by domain policy)*
- `./raspberry/chatpi/scripts/selftest.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb6106ca88832c96b1c76b28073e00