### PR TITLE
Fix: Deploy stabile su GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Build and Deploy (GitHub Pages)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Run linter (if available)
+        run: npm run -s lint --if-present
+      - name: Run type-check (if available)
+        run: npm run -s type-check --if-present
+      - name: Run tests (if available)
+        run: npm run -s test --if-present
+      - name: Run UAT tests (if available)
+        run: npm run -s test:uat --if-present
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_WS_URL: ${{ secrets.WS_URL }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ tests/e2e/*-snapshots/
 test-results/
 
 env.js
+
+# Env files
+.env*
+!.env.example

--- a/404.html
+++ b/404.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NetRisk</title>
+    <meta http-equiv="Cache-Control" content="no-cache, no-transform" />
+    <link rel="stylesheet" href="./css/base.css" />
+    <link rel="stylesheet" href="./css/layout.css" />
+    <link rel="stylesheet" href="./css/components.css" />
+    <link rel="stylesheet" href="./css/theme.css" />
+    <link
+      rel="icon"
+      href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAOox8JkAAAAASUVORK5CYII="
+    />
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script type="module">
+      const basePath = new URL('.', location.href).pathname;
+      const loadModules = async () => {
+        await Promise.all([import('./auth.js'), import('./home.js')]);
+      };
+      try {
+        await import(/* @vite-ignore */ `${basePath}env.js?${Date.now()}`);
+        if (!window.__env?.SUPABASE_URL || !window.__env?.SUPABASE_ANON_KEY) {
+          console.error('[ENV] Missing keys in env.js');
+        }
+      } catch {
+        console.error('[ENV] env.js failed to load');
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', loadModules);
+      } else {
+        loadModules();
+      }
+    </script>
+  </head>
+  <body class="home-page">
+    <header class="main-header">
+      <a href="./index.html" class="logo">NetRisk</a>
+      <nav>
+        <a href="./index.html">Home</a>
+        <a href="./setup.html">Setup</a>
+        <a href="./how-to-play.html">How To</a>
+        <a href="./about.html">About</a>
+        <span id="userMenu" class="user-menu loading" data-testid="user-status"></span>
+      </nav>
+      <button id="themeToggle" class="btn" aria-label="Toggle high contrast mode" accesskey="c">
+        High Contrast
+      </button>
+    </header>
+    <main id="mainMenu">
+      <h1>NetRisk</h1>
+      <button id="playBtn" class="btn" aria-label="Play game" accesskey="p">Play</button>
+      <button
+        id="multiplayerBtn"
+        class="btn"
+        aria-label="Multiplayer game"
+        accesskey="m"
+        data-testid="lobby-link"
+      >
+        Multiplayer
+      </button>
+      <button id="setupBtn" class="btn" aria-label="Player setup" accesskey="s">Setup</button>
+      <button id="howToPlayBtn" class="btn" aria-label="How to play" accesskey="h">
+        How to Play
+      </button>
+      <button id="aboutBtn" class="btn" aria-label="About and settings" accesskey="a">
+        About/Settings
+      </button>
+    </main>
+  </body>
+</html>

--- a/assets/.keep
+++ b/assets/.keep
@@ -1,0 +1,1 @@
+<!-- placeholder -->

--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,21 @@ export const API_BASE_URL = String(rawApiBaseUrl).replace(/\/+$/, '');
 export const SUPABASE_URL = String(rawSupabaseUrl).replace(/\/+$/, '');
 export const SUPABASE_KEY = String(rawSupabaseKey);
 
+if (typeof window === 'undefined') {
+  const required = {
+    VITE_SUPABASE_URL: SUPABASE_URL,
+    VITE_SUPABASE_ANON_KEY: SUPABASE_KEY,
+  };
+  const missingVars = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missingVars.length) {
+    throw new Error(
+      `Missing required environment variables: ${missingVars.join(', ')}. Hint: set repo Secrets SUPABASE_URL and SUPABASE_ANON_KEY (mapped to VITE_* in the build job).`,
+    );
+  }
+}
+
 export const ENV_STAMP = (typeof window !== 'undefined' && window.__env?.STAMP) || '';
 export const ENV_SHA = (typeof window !== 'undefined' && window.__env?.SHA) || '';
 export const WS_URL = (() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,49 @@
+import { defineConfig, loadEnv } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const isDev = mode === 'development';
+
+  return {
+    // Necessario per GitHub Pages repo "netrisk"
+    base: '/netrisk/',
+
+    server: {
+      port: 8080,
+      host: true,
+      open: isDev,
+    },
+
+    build: {
+      outDir: 'dist',
+      sourcemap: isDev,
+      minify: !isDev,
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'index.html'),
+          setup: resolve(__dirname, 'setup.html'),
+        },
+      },
+    },
+
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src'),
+        // '@assets': resolve(__dirname, 'assets'), // abilita solo se esiste
+        '@components': resolve(__dirname, 'src/components'),
+        '@utils': resolve(__dirname, 'src/utils'),
+      },
+    },
+
+    plugins: [],
+
+    define: {
+      __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+    },
+
+    optimizeDeps: {
+      include: ['@supabase/supabase-js'], // pacchetto corretto
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- configure Vite for GitHub Pages with `/netrisk/` base and SPA build
- add explicit env var error message and ignore local `.env` files
- add gh-pages workflow, 404 fallback and `.nojekyll`
- ensure Pages workflow fails when lint/tests fail instead of skipping

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browser download 403)*
- `npm run test:e2e:smoke` *(fails: missing system dependencies)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf90169744832c9b5d8ebf33782c65