### PR TITLE
Fix: Deploy stabile su GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Build and Deploy (GitHub Pages)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Run linter (if available)
+        run: npm run -s lint --if-present
+      - name: Run type-check (if available)
+        run: npm run -s type-check --if-present
+      - name: Run tests (if available)
+        run: npm run -s test --if-present
+      - name: Run UAT tests (if available)
+        run: npm run -s test:uat --if-present
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_WS_URL: ${{ secrets.WS_URL }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ tests/e2e/*-snapshots/
 test-results/
 
 env.js
+
+# Env files
+.env*
+!.env.example

--- a/assets/.keep
+++ b/assets/.keep
@@ -1,0 +1,1 @@
+<!-- placeholder -->

--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,21 @@ export const API_BASE_URL = String(rawApiBaseUrl).replace(/\/+$/, '');
 export const SUPABASE_URL = String(rawSupabaseUrl).replace(/\/+$/, '');
 export const SUPABASE_KEY = String(rawSupabaseKey);
 
+if (typeof window === 'undefined') {
+  const required = {
+    VITE_SUPABASE_URL: SUPABASE_URL,
+    VITE_SUPABASE_ANON_KEY: SUPABASE_KEY,
+  };
+  const missingVars = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missingVars.length) {
+    throw new Error(
+      `Missing required environment variables: ${missingVars.join(', ')}. Hint: set repo Secrets SUPABASE_URL and SUPABASE_ANON_KEY (mapped to VITE_* in the build job).`,
+    );
+  }
+}
+
 export const ENV_STAMP = (typeof window !== 'undefined' && window.__env?.STAMP) || '';
 export const ENV_SHA = (typeof window !== 'undefined' && window.__env?.SHA) || '';
 export const WS_URL = (() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,56 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig(({ mode }) => {
+  const isDev = mode === 'development';
+
+  return {
+    base: '/netrisk/',
+
+    server: {
+      port: 8080,
+      host: true,
+      open: isDev,
+    },
+
+    build: {
+      outDir: 'dist',
+      sourcemap: isDev,
+      minify: !isDev,
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'index.html'),
+          about: resolve(__dirname, 'about.html'),
+          game: resolve(__dirname, 'game.html'),
+          lobby: resolve(__dirname, 'lobby.html'),
+          setup: resolve(__dirname, 'setup.html'),
+          howToPlay: resolve(__dirname, 'how-to-play.html'),
+          login: resolve(__dirname, 'login.html'),
+          forgot: resolve(__dirname, 'forgot.html'),
+          register: resolve(__dirname, 'register.html'),
+          account: resolve(__dirname, 'account.html'),
+        },
+      },
+    },
+
+    resolve: {
+      alias: {
+        '@app': resolve(__dirname, 'src'),
+        '@game': resolve(__dirname, 'src/game'),
+        '@features': resolve(__dirname, 'src/features'),
+        '@shared': resolve(__dirname, 'src/shared'),
+        '@infra': resolve(__dirname, 'src/infra'),
+      },
+    },
+
+    plugins: [],
+
+    define: {
+      __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+    },
+
+    optimizeDeps: {
+      include: ['@supabase/supabase-js'],
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- configure Vite for GitHub Pages with `/netrisk/` base and build all entry pages
- add explicit env var error message and ignore local `.env` files
- add gh-pages workflow, SPA 404 fallback and `.nojekyll`
- ensure Pages workflow fails when lint/tests fail instead of skipping
- move `.nojekyll` into `public` so fallback files are published

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: Playwright browsers missing)*
- `npm run test:e2e:smoke` *(fails: host missing system dependencies)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf90169744832c9b5d8ebf33782c65