### PR TITLE
chore: add systemd update timer test

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo "update $(date +%s)" >> "$HOME/chatpi-update.log"
+systemctl --user restart chatpi.service

--- a/systemd/chatpi-update.service
+++ b/systemd/chatpi-update.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run ChatPi update script
+After=chatpi.service
+
+[Service]
+Type=oneshot
+ExecStart=%h/.config/systemd/user/update.sh
+
+[Install]
+WantedBy=default.target

--- a/systemd/chatpi-update.timer
+++ b/systemd/chatpi-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule ChatPi update
+
+[Timer]
+OnBootSec=1s
+OnUnitActiveSec=1s
+Unit=chatpi-update.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/chatpi.service
+++ b/systemd/chatpi.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=ChatPi dummy service
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -c 'echo "start $(date +%s)" >> %h/chatpi.log; exec sleep infinity'
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/tests/chatpi-update.test.js
+++ b/tests/chatpi-update.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync, execSync } = require('child_process');
+const os = require('os');
+
+const hasSystemd = spawnSync('systemd-run', ['--user', '--wait', '--pipe', 'true']);
+
+(hasSystemd.status !== 0 ? describe.skip : describe)('chatpi systemd update', () => {
+  const home = os.homedir();
+  const systemdDir = path.join(home, '.config/systemd/user');
+  const repoRoot = path.resolve(__dirname, '..');
+  const systemdRepoDir = path.join(repoRoot, 'systemd');
+
+  beforeAll(() => {
+    fs.mkdirSync(systemdDir, { recursive: true });
+    fs.copyFileSync(
+      path.join(systemdRepoDir, 'chatpi.service'),
+      path.join(systemdDir, 'chatpi.service'),
+    );
+    fs.copyFileSync(
+      path.join(systemdRepoDir, 'chatpi-update.service'),
+      path.join(systemdDir, 'chatpi-update.service'),
+    );
+    fs.copyFileSync(
+      path.join(systemdRepoDir, 'chatpi-update.timer'),
+      path.join(systemdDir, 'chatpi-update.timer'),
+    );
+    fs.copyFileSync(
+      path.join(repoRoot, 'scripts', 'update.sh'),
+      path.join(systemdDir, 'update.sh'),
+    );
+    fs.chmodSync(path.join(systemdDir, 'update.sh'), 0o755);
+    execSync('systemctl --user daemon-reload');
+  });
+
+  afterAll(() => {
+    try {
+      execSync('systemctl --user stop chatpi-update.timer');
+      execSync('systemctl --user stop chatpi.service');
+    } catch (err) {
+      // ignore cleanup errors
+    }
+  });
+
+  test('timer triggers update script and restarts chatpi', () => {
+    execSync('systemctl --user start chatpi.service');
+    const logPath = path.join(home, 'chatpi.log');
+    const initialLines = fs.existsSync(logPath)
+      ? fs.readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean).length
+      : 0;
+
+    execSync('systemctl --user start chatpi-update.timer');
+    const status = execSync('systemctl --user is-active chatpi-update.timer').toString().trim();
+    expect(status).toBe('active');
+
+    execSync('sleep 2');
+    const updateLog = fs.readFileSync(path.join(home, 'chatpi-update.log'), 'utf8');
+    expect(updateLog).toMatch(/update/);
+
+    const afterLines = fs.readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean).length;
+    expect(afterLines).toBeGreaterThan(initialLines);
+  });
+});


### PR DESCRIPTION
## Summary
- add chatpi systemd service and timer for automated updates
- provide update script that restarts chatpi after running
- include systemd e2e test that installs units and verifies restart

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:uat` *(fails: browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d0baaa18832c81dd8a75c76533fd