### PR TITLE
Show placeholder when player list is empty

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -3,4 +3,5 @@
 The `ui` module exposes browser helpers:
 
 - `initClient(url, key)` creates a Supabase client.
-- `renderPlayers(element, players)` appends player names to a list element.
+- `renderPlayers(element, players)` appends player names to a list element and
+  shows a "No players yet" message when the list is empty.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <title>Netrisk</title>
+    <style>
+      .empty {
+        color: #666;
+        font-style: italic;
+      }
+    </style>
   </head>
   <body>
     <ul id="players"></ul>

--- a/tests/ui/main.test.js
+++ b/tests/ui/main.test.js
@@ -13,6 +13,12 @@ describe('ui helpers', () => {
     ])
   })
 
+  it('renders a placeholder when no players', () => {
+    const ul = document.createElement('ul')
+    renderPlayers(ul, [])
+    expect(ul.textContent).toBe('No players yet')
+  })
+
   it('initializes a supabase client', async () => {
     const client = await initClient('https://example.supabase.co', 'anon')
     expect(client).toHaveProperty('from')

--- a/ui/main.js
+++ b/ui/main.js
@@ -8,6 +8,13 @@ export async function initClient(url, key) {
 
 export function renderPlayers(element, players) {
   element.innerHTML = ''
+  if (players.length === 0) {
+    const li = document.createElement('li')
+    li.className = 'empty'
+    li.textContent = 'No players yet'
+    element.appendChild(li)
+    return
+  }
   for (const name of players) {
     const li = document.createElement('li')
     li.textContent = name


### PR DESCRIPTION
## Summary
- render placeholder message when player list is empty
- document empty state behavior
- style and test the empty state

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57079cc20832ca9fa5e563fe81a16