### PR TITLE
Add unit tests for GameGateway

### DIFF
--- a/apps/server/src/game/game.gateway.spec.ts
+++ b/apps/server/src/game/game.gateway.spec.ts
@@ -1,0 +1,110 @@
+import 'reflect-metadata';
+import { Test } from '@nestjs/testing';
+import { PIPES_METADATA } from '@nestjs/common/constants';
+import type { ValidationPipe } from '@nestjs/common';
+import type { Server, Socket } from 'socket.io';
+import { GameGateway } from './game.gateway';
+import { GameService } from './game.service';
+import { JoinGameDto } from './dto/join-game.dto';
+
+describe('GameGateway', () => {
+  let gameService: { getLobbyState: jest.Mock; recordJoin: jest.Mock };
+  let gateway: GameGateway;
+
+  beforeEach(() => {
+    gameService = {
+      getLobbyState: jest.fn(),
+      recordJoin: jest.fn(),
+    };
+    gateway = new GameGateway(gameService as unknown as GameService);
+  });
+
+  it('retrieves the lobby state on connection and emits it to the client', async () => {
+    const lobbyState = { id: 'game-123', code: 'TEST' };
+    const client: Partial<Socket> = { emit: jest.fn() };
+    gameService.getLobbyState.mockResolvedValue(lobbyState);
+
+    await gateway.handleConnection(client as Socket);
+
+    expect(gameService.getLobbyState).toHaveBeenCalledTimes(1);
+    expect(client.emit).toHaveBeenCalledWith('lobby:update', lobbyState);
+  });
+
+  it('records a join, broadcasts the new state, and resolves with the lobby snapshot', async () => {
+    const payload: JoinGameDto = {
+      gameCode: 'ABCD',
+      player: {
+        id: 'player-1',
+        name: 'Alice',
+        color: '#ff0000',
+        role: 'attacker',
+      },
+    };
+    const updatedState = { id: 'game-123', code: 'ABCD', players: [] };
+    const callOrder: string[] = [];
+
+    gameService.recordJoin.mockImplementation(async () => {
+      callOrder.push('recordJoin');
+      return updatedState;
+    });
+
+    const emitSpy = jest.fn(() => {
+      callOrder.push('emit');
+    });
+
+    gateway.server = { emit: emitSpy } as unknown as Server;
+
+    await expect(gateway.joinGame(payload)).resolves.toBe(updatedState);
+
+    expect(gameService.recordJoin).toHaveBeenCalledWith(payload);
+    expect(emitSpy).toHaveBeenCalledWith('lobby:update', updatedState);
+    expect(callOrder).toEqual(['recordJoin', 'emit']);
+  });
+
+  it('rejects invalid join payloads through the configured ValidationPipe', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        GameGateway,
+        {
+          provide: GameService,
+          useValue: {
+            getLobbyState: jest.fn(),
+            recordJoin: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    moduleRef.get(GameGateway);
+
+    const pipes =
+      (Reflect.getMetadata(
+        PIPES_METADATA,
+        GameGateway.prototype,
+        'joinGame',
+      ) as ValidationPipe[] | undefined) ??
+      (Reflect.getMetadata(PIPES_METADATA, GameGateway.prototype.joinGame) as
+        | ValidationPipe[]
+        | undefined);
+
+    expect(pipes).toBeDefined();
+    expect(pipes).toHaveLength(1);
+
+    const [validationPipe] = pipes!;
+
+    await expect(
+      validationPipe.transform(
+        {
+          gameCode: 'bad code',
+          player: {
+            id: '',
+            name: '',
+            color: 'not-a-color',
+            role: 'spy',
+          },
+        },
+        { type: 'body', metatype: JoinGameDto },
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/server/src/game/game.service.spec.ts
+++ b/apps/server/src/game/game.service.spec.ts
@@ -10,7 +10,9 @@ jest.mock('@netrisk/core', () => ({
 
 describe('GameService', () => {
   const mockCreateInitialGameState =
-    createInitialGameState as jest.MockedFunction<typeof createInitialGameState>;
+    createInitialGameState as jest.MockedFunction<
+      typeof createInitialGameState
+    >;
   const mockJoinGameRequestSchemaParse =
     joinGameRequestSchema.parse as jest.MockedFunction<
       typeof joinGameRequestSchema.parse
@@ -228,8 +230,8 @@ describe('GameService', () => {
 
       expect(mockJoinGameRequestSchemaParse).toHaveBeenCalledWith(request);
       expect(prisma.upsertPlayer).toHaveBeenCalledTimes(1);
-      const [payloadArg, rulesArg, timestampArg] = prisma.upsertPlayer.mock
-        .calls[0];
+      const [payloadArg, rulesArg, timestampArg] =
+        prisma.upsertPlayer.mock.calls[0];
       expect(payloadArg).toBe(parsedPayload);
       expect(rulesArg).toBe(seedState.rules);
       expect(timestampArg).toEqual(now);


### PR DESCRIPTION
## Summary
- add focused unit coverage for GameGateway connection, join flow, and validation behaviour
- format the existing GameService spec to satisfy the current Prettier rules

## Testing
- pnpm --filter @netrisk/server test -- game.gateway.spec.ts