### PR TITLE
Guard Copilot review workflow for forks

### DIFF
--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -1,0 +1,43 @@
+name: Request GitHub Copilot Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  request-review:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review from GitHub Copilot
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: ["github-copilot"],
+              });
+              core.info("Requested review from GitHub Copilot.");
+            } catch (error) {
+              if (error.status === 422) {
+                core.info("Review request already exists or reviewer unavailable.");
+              } else if (error.status === 404) {
+                core.warning("GitHub Copilot reviewer is not available for this repository.");
+              } else if (error.status === 403) {
+                core.info("Skipping review request because the workflow token lacks permission (likely a forked PR).");
+              } else {
+                throw error;
+              }
+            }
+


### PR DESCRIPTION
## Summary
- add the Copilot review workflow with a guard to skip forked pull requests
- log a friendly message when the workflow token lacks permission instead of failing

## Testing
- not run (workflow change only)