### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "netrisk-devcontainer",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "postCreateCommand": "/workspaces/netrisk/.devcontainer/start-dev.sh"
+}

--- a/.devcontainer/start-dev.sh
+++ b/.devcontainer/start-dev.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspaces/netrisk
+
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable
+  corepack prepare pnpm@10.5.2 --activate
+fi
+
+pnpm install


### PR DESCRIPTION
## Summary
- add a VS Code devcontainer configuration that uses the Node.js 20 base image and runs the setup script after creation
- add a startup script that enables corepack, activates pnpm 10.5.2, and installs workspace dependencies

## Testing
- not run (configuration change only)