### PR TITLE
Ensure Copilot review workflow has required permissions

### DIFF
--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -12,6 +12,9 @@ jobs:
   request-review:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Request review from GitHub Copilot
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- grant the Copilot review workflow explicit permissions to read contents and write pull request metadata when requesting reviewers

## Testing
- turbo run lint