### PR TITLE
Add codespace script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "format": "turbo run format",
-    "prepare": "husky"
+    "prepare": "husky",
+    "codespace": "bash .devcontainer/start-dev.sh"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,md,css,scss,html}": [


### PR DESCRIPTION
## Summary
- add a `codespace` package script that runs the devcontainer startup script so Codespaces can use the same launcher

## Testing
- pnpm codespace