### PR TITLE
Add websocket e2e coverage for game gateway

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -53,6 +53,7 @@
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
     "prisma": "^5.22.0",
+    "socket.io-client": "^4.8.1",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/apps/server/test/game.gateway.e2e-spec.ts
+++ b/apps/server/test/game.gateway.e2e-spec.ts
@@ -1,0 +1,212 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddressInfo } from 'net';
+import { io, Socket } from 'socket.io-client';
+import type { Game, GamePlayer } from '@prisma/client';
+import {
+  GameState,
+  JoinGameRequest,
+  createInitialGameState,
+} from '@netrisk/core';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+class InMemoryPrismaServiceStub
+  implements
+    Pick<
+      PrismaService,
+      'findLatestGame' | 'upsertPlayer' | 'onModuleInit' | 'onModuleDestroy'
+    >
+{
+  public readonly joins: Array<{
+    payload: JoinGameRequest;
+    rules: unknown;
+    timestamp: Date;
+  }> = [];
+
+  private latestGame: (Game & { players: GamePlayer[] }) | null = null;
+
+  async onModuleInit() {}
+
+  async onModuleDestroy() {}
+
+  async findLatestGame(): Promise<(Game & { players: GamePlayer[] }) | null> {
+    return this.latestGame;
+  }
+
+  async upsertPlayer(
+    payload: JoinGameRequest,
+    rules: unknown,
+    timestamp: Date,
+  ): Promise<void> {
+    this.joins.push({ payload, rules, timestamp });
+    this.latestGame = {
+      id: `stub-${timestamp.getTime()}`,
+      code: payload.gameCode,
+      phase: 'lobby',
+      rules,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      players: [
+        {
+          id: `stub-player-${timestamp.getTime()}`,
+          gameId: `stub-${timestamp.getTime()}`,
+          externalId: payload.player.id,
+          gameCode: payload.gameCode,
+          name: payload.player.name,
+          color: payload.player.color,
+          role: payload.player.role,
+          status: 'online',
+          territories: 0,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        } as GamePlayer,
+      ],
+    } as Game & { players: GamePlayer[] };
+  }
+}
+
+describe('GameGateway (e2e)', () => {
+  let app: INestApplication;
+  let httpServerUrl: string;
+  let client: Socket | undefined;
+  let prismaStub: InMemoryPrismaServiceStub;
+
+  beforeAll(async () => {
+    prismaStub = new InMemoryPrismaServiceStub();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(prismaStub)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.listen(0);
+
+    const address = app.getHttpServer().address();
+    if (typeof address === 'string' || !address) {
+      throw new Error('Failed to determine HTTP server address for tests');
+    }
+
+    httpServerUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await new Promise<void>((resolve) => {
+        if (client?.connected) {
+          client.once('disconnect', () => resolve());
+          client.disconnect();
+        } else {
+          client.disconnect();
+          resolve();
+        }
+      });
+      client.removeAllListeners();
+      client = undefined;
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('streams lobby updates and echoes join acknowledgements', async () => {
+    client = io(httpServerUrl, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    });
+
+    const initialLobbyPromise = new Promise<GameState>((resolve, reject) => {
+      client!.once('lobby:update', (state: GameState) => resolve(state));
+      client!.once('connect_error', (error) => reject(error));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      if (client!.connected) {
+        resolve();
+        return;
+      }
+
+      client!.once('connect', () => resolve());
+      client!.once('connect_error', (error) => reject(error));
+    });
+
+    const initialState = await initialLobbyPromise;
+    const baseline = createInitialGameState('LOBBY');
+
+    expect(initialState).toMatchObject({
+      code: baseline.code,
+      phase: baseline.phase,
+      players: [],
+      rules: baseline.rules,
+    });
+    expect(initialState.id).toEqual(expect.any(String));
+    expect(initialState.createdAt).toEqual(expect.any(String));
+    expect(initialState.updatedAt).toEqual(initialState.createdAt);
+
+    const lobbyUpdatePromise = new Promise<GameState>((resolve) => {
+      client!.once('lobby:update', (state: GameState) => resolve(state));
+    });
+
+    const joinPayload: JoinGameRequest = {
+      gameCode: 'RISK2024',
+      player: {
+        id: 'player-123',
+        name: 'Strategist',
+        color: '#3366ff',
+        role: 'defender',
+      },
+    };
+
+    const joinResponse = await new Promise<GameState>((resolve, reject) => {
+      client!.emit('game:join', joinPayload, (state: GameState) =>
+        resolve(state),
+      );
+      client!.once('connect_error', (error) => reject(error));
+    });
+
+    const broadcastState = await lobbyUpdatePromise;
+
+    expect(joinResponse.id).toEqual(expect.any(String));
+    expect(joinResponse.createdAt).toEqual(expect.any(String));
+    expect(new Date(joinResponse.updatedAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(initialState.updatedAt).getTime(),
+    );
+    expect(new Date(joinResponse.updatedAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(joinResponse.createdAt).getTime(),
+    );
+    expect(joinResponse).toMatchObject({
+      code: joinPayload.gameCode,
+      players: [
+        {
+          profile: {
+            id: joinPayload.player.id,
+            name: joinPayload.player.name,
+            color: joinPayload.player.color,
+            role: joinPayload.player.role,
+          },
+          status: 'online',
+          territories: 0,
+        },
+      ],
+      rules: initialState.rules,
+    });
+
+    expect(broadcastState).toEqual(joinResponse);
+
+    expect(prismaStub.joins).toHaveLength(1);
+    expect(prismaStub.joins[0].payload).toEqual(joinPayload);
+    expect(prismaStub.joins[0].rules).toEqual(joinResponse.rules);
+    expect(
+      Math.abs(
+        prismaStub.joins[0].timestamp.getTime() -
+          new Date(joinResponse.updatedAt).getTime(),
+      ),
+    ).toBeLessThan(1000);
+  });
+});

--- a/apps/server/test/jest-e2e.json
+++ b/apps/server/test/jest-e2e.json
@@ -5,5 +5,9 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@netrisk/core$": "<rootDir>/../../../packages/core/dist/index.cjs",
+    "^@netrisk/core/(.*)$": "<rootDir>/../../../packages/core/dist/$1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       prisma:
         specifier: ^5.22.0
         version: 5.22.0
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.1
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -2821,6 +2824,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  engine.io-client@6.6.3:
+    resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
+
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
@@ -4849,6 +4855,10 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
+  socket.io-client@4.8.1:
+    resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
     engines: {node: '>=10.0.0'}
@@ -5599,6 +5609,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -8308,6 +8322,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  engine.io-client@6.6.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   engine.io-parser@5.2.3: {}
 
   engine.io@6.6.4:
@@ -8521,7 +8547,7 @@ snapshots:
       '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       eslint: 9.36.0(jiti@2.6.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.36.0(jiti@2.6.0))
       eslint-plugin-react: 7.37.5(eslint@9.36.0(jiti@2.6.0))
@@ -8545,7 +8571,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8560,14 +8586,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       eslint: 9.36.0(jiti@2.6.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8582,7 +8608,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@2.6.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11066,6 +11092,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.1:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-client: 6.6.3
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -11920,6 +11957,8 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- add socket.io-client to the server app devDependencies for websocket e2e coverage
- create a new GameGateway e2e test that uses an in-memory Prisma stub and socket.io-client to verify lobby updates
- extend the server e2e Jest config so @netrisk/core resolves to the built distribution

## Testing
- pnpm --filter @netrisk/server test:e2e