### PR TITLE
Aggiorna guida Codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A full-stack workspace for the netrisk strategy platform. The repository is orga
 
 ## Getting started
 
-- **GitHub Codespaces**: Follow the zero-install workflow in [README_Codespaces.md](README_Codespaces.md) to spin up a cloud development environment with the client and server already bootstrapped and publicly accessible URLs preconfigured.
+- **Codespaces**: Consulta la guida "NetRisk — Avvio solo online con GitHub Codespaces" in [README_Codespaces.md](README_Codespaces.md) per attivare l'ambiente cloud con servizi già configurati e pronti alla condivisione tramite URL pubblici.
 - **Local development**: Install the prerequisites below and run the installation steps on your machine.
 
 ## Project structure

--- a/README_Codespaces.md
+++ b/README_Codespaces.md
@@ -1,32 +1,9 @@
-# GitHub Codespaces guide
+# NetRisk — Avvio solo online con GitHub Codespaces
 
-This document explains how to work on the netrisk monorepo entirely inside GitHub Codespaces—from spinning up the container to exposing the running services publicly.
+1. Apri la pagina del repository su GitHub, premi **Code** e seleziona **Create codespace on &lt;branch&gt;** per generare un ambiente cloud sul ramo desiderato.
+2. Attendi che il devcontainer completi la configurazione automatica: il sistema abilita Corepack, imposta `pnpm@10.5.2` e installa tutte le dipendenze necessarie senza interventi locali.
+3. Una volta avviata la shell del codespace, esegui `pnpm dev` per far partire in parallelo client Next.js e API NestJS già pronte all'uso.
+4. Apri il pannello **Ports**, rendi pubbliche le porte esposte (3000 per il client, 3001 per l'API) e utilizza gli URL `*.github.dev` generati da GitHub per test e condivisione.
+5. Se client e server girano su porte diverse, imposta `NEXT_PUBLIC_API_BASE`, `CLIENT_URL` e `API_URL` sugli indirizzi pubblici per mantenere attivi REST e Socket.IO con CORS correttamente configurato.
 
-## Zero-install requirements
-
-- **GitHub access** – Any GitHub account with Codespaces enabled can launch the workspace; no local Node.js or PNPM setup is required.
-- **Devcontainer tooling** – The repository ships a ready-to-use devcontainer that provisions a Node.js 20 environment. When the codespace boots it uses the [`mcr.microsoft.com/devcontainers/javascript-node:20` image](.devcontainer/devcontainer.json) and runs the [`start-dev.sh` bootstrap script](.devcontainer/start-dev.sh). That script enables Corepack, activates the workspace-pinned `pnpm@10.5.2`, and installs all dependencies with `pnpm install` so everything is preconfigured on first launch.
-
-## Launching a Codespace
-
-1. Navigate to the repository on GitHub and click the green **Code** button.
-2. Open the **Codespaces** tab and choose **Create codespace on &lt;branch&gt;** (pick the branch you want to work from).
-3. Accept the default machine type unless you know you need more resources, then wait for the devcontainer to build and run the post-create commands.
-
-## First boot and dev servers
-
-Once the container finishes bootstrapping, open a terminal inside VS Code for the Web or the Codespaces desktop connection. The dependencies are already installed, so you can immediately start the full stack:
-
-```bash
-pnpm dev
-```
-
-The Turborepo `dev` pipeline launches the Next.js client (`pnpm --filter @netrisk/client dev`) and the NestJS API (`pnpm --filter @netrisk/server dev`) in parallel. By default the client serves on port 3000 and the server listens on port 3000 unless you override `PORT` (e.g., `PORT=3001 pnpm --filter @netrisk/server dev`). The Docker Compose configuration exposes the client on port 3000 and the server on port 3001 in production builds, which are the same ports you will typically forward from Codespaces.
-
-## Accessing forwarded URLs
-
-After `pnpm dev` starts, open the **Ports** panel in the Codespaces interface. Codespaces detects active listeners and forwards them automatically. Mark the client port (3000) and server port (3001 if you moved the API off 3000) as **Public** to receive shareable URLs in the form `https://<codespace-name>-3000.app.github.dev`.
-
-## CORS and `NEXT_PUBLIC_API_BASE`
-
-The NestJS application configures CORS to allow any `.github.dev` origin alongside the optional `CLIENT_URL` and `API_URL` environment variables, and it applies the same policy to Socket.IO connections so that Codespaces URLs work out of the box. When the client and server run on different forwarded hosts or ports, export `NEXT_PUBLIC_API_BASE` for the Next.js app and point it at the publicly forwarded API URL (for example, `https://<codespace-name>-3001.app.github.dev`). Keeping `CLIENT_URL` and `API_URL` in sync with those public addresses ensures REST and WebSocket calls respect the CORS allowlist.
+Note finali: Codespaces fornisce un ambiente completamente online; non è necessario installare Node.js o PNPM in locale. Verifica però che il tuo account GitHub disponga di minuti Codespaces sufficienti e chiudi i workspace inattivi per evitare costi indesiderati.


### PR DESCRIPTION
## Summary
- replace README_Codespaces.md with an Italian quickstart focused on avvio online in GitHub Codespaces
- update README.md to reference the new Codespaces section and wording

## Testing
- turbo run lint