### PR TITLE
Adjust devcontainer bootstrap commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
       "version": "20"
     }
   },
-  "updateContentCommand": "bash .devcontainer/start-dev.sh",
-  "postStartCommand": "pnpm install",
+  "updateContentCommand": "corepack enable pnpm && pnpm install",
+  "postAttachCommand": "bash .devcontainer/start-dev.sh",
   "forwardPorts": [3000, 3001],
   "portsAttributes": {
     "3000": {


### PR DESCRIPTION
## Summary
- replace the updateContentCommand with an installation bootstrap that enables pnpm and installs dependencies
- move dev server startup to postAttachCommand so it runs only after the container is ready

## Testing
- not run (configuration change)