### PR TITLE
Add Vercel + Supabase deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATASTORE_DRIVER=supabase
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key
+SUPABASE_DB_SCHEMA=public
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 npm-debug.log
+.env
+.env.local
+.env.*.local
 data/*.json
 data/*.json.bak
 data/*.sqlite
@@ -16,3 +19,5 @@ test-results/
 data/backups/
 data/*.sqlite-shm
 data/*.sqlite-wal
+
+.vercel

--- a/api/index.cjs
+++ b/api/index.cjs
@@ -1,7 +1,0 @@
-const { createApp } = require("../backend/server.cjs");
-
-const app = createApp();
-
-module.exports = (req, res) => {
-  return app.handleRequest(req, res);
-};

--- a/api/index.cjs
+++ b/api/index.cjs
@@ -1,0 +1,7 @@
+const { createApp } = require("../backend/server.cjs");
+
+const app = createApp();
+
+module.exports = (req, res) => {
+  return app.handleRequest(req, res);
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,5 @@
+const { createApp } = require("../backend/server.cjs");
+
+const app = createApp();
+
+module.exports = (req, res) => app.handleRequest(req, res);

--- a/backend/auth.cjs
+++ b/backend/auth.cjs
@@ -1,6 +1,7 @@
 const path = require("path");
 const crypto = require("crypto");
 const { createDatastore } = require("./datastore.cjs");
+const { chainMaybe, mapMaybe } = require("./maybe-async.cjs");
 
 function passwordRecord(secret) {
   const salt = crypto.randomBytes(16).toString("hex");
@@ -81,47 +82,50 @@ function createAuthStore(options = {}) {
       return { ok: false, error: "Inserisci utente e password." };
     }
 
-    if (findByUsername(cleanedUsername)) {
-      return { ok: false, error: "Utente gia registrato." };
-    }
+    return chainMaybe(findByUsername(cleanedUsername), (existingUser) => {
+      if (existingUser) {
+        return { ok: false, error: "Utente gia registrato." };
+      }
 
-    const user = {
-      id: crypto.randomBytes(8).toString("hex"),
-      username: cleanedUsername,
-      credentials: {
-        password: passwordRecord(cleanedPassword)
-      },
-      role: "user",
-      profile: {
-        displayName: cleanedUsername
-      },
-      createdAt: new Date().toISOString()
-    };
+      const user = {
+        id: crypto.randomBytes(8).toString("hex"),
+        username: cleanedUsername,
+        credentials: {
+          password: passwordRecord(cleanedPassword)
+        },
+        role: "user",
+        profile: {
+          displayName: cleanedUsername
+        },
+        createdAt: new Date().toISOString()
+      };
 
-    return { ok: true, user: publicUser(datastore.createUser(user)) };
+      return mapMaybe(datastore.createUser(user), (createdUser) => ({ ok: true, user: publicUser(createdUser) }));
+    });
   }
 
   function loginWithPassword(username, password) {
-    const user = findByUsername(username);
-    if (!user || !verifyPassword(user.credentials, password)) {
-      return { ok: false, error: "Credenziali non valide." };
-    }
+    return chainMaybe(findByUsername(username), (user) => {
+      if (!user || !verifyPassword(user.credentials, password)) {
+        return { ok: false, error: "Credenziali non valide." };
+      }
 
-    if (typeof user.credentials?.password?.secret === "string") {
-      datastore.updateUserCredentials(user.id, {
-        ...user.credentials,
-        password: passwordRecord(password)
-      });
-    }
+      const sessionToken = crypto.randomBytes(16).toString("hex");
+      const createSession = () => mapMaybe(datastore.createSession(sessionToken, user.id, Date.now()), () => ({
+        ok: true,
+        sessionToken,
+        user: publicUser(user)
+      }));
 
-    const sessionToken = crypto.randomBytes(16).toString("hex");
-    datastore.createSession(sessionToken, user.id, Date.now());
+      if (typeof user.credentials?.password?.secret === "string") {
+        return chainMaybe(datastore.updateUserCredentials(user.id, {
+          ...user.credentials,
+          password: passwordRecord(password)
+        }), createSession);
+      }
 
-    return {
-      ok: true,
-      sessionToken,
-      user: publicUser(user)
-    };
+      return createSession();
+    });
   }
 
   function getUserFromSession(sessionToken) {
@@ -129,18 +133,21 @@ function createAuthStore(options = {}) {
       return null;
     }
 
-    const session = datastore.findSession(sessionToken);
-    if (!session) {
-      return null;
-    }
+    return chainMaybe(datastore.findSession(sessionToken), (session) => {
+      if (!session) {
+        return null;
+      }
 
-    return datastore.findUserById(session.user_id || session.userId) || null;
+      return datastore.findUserById(session.user_id || session.userId) || null;
+    });
   }
 
   function logout(sessionToken) {
     if (sessionToken) {
-      datastore.deleteSession(sessionToken);
+      return datastore.deleteSession(sessionToken);
     }
+
+    return null;
   }
 
   return {

--- a/backend/authorization.cjs
+++ b/backend/authorization.cjs
@@ -46,6 +46,27 @@ function canOpenGame(actor, game, state) {
   return !game.creatorUserId;
 }
 
+function canReadGame(actor, game, state) {
+  if (!actor || !actor.id || !game) {
+    return false;
+  }
+
+  if (actor.role === Roles.ADMIN) {
+    return true;
+  }
+
+  if (game.creatorUserId && game.creatorUserId === actor.id) {
+    return true;
+  }
+
+  const players = Array.isArray(state && state.players) ? state.players : [];
+  if (players.some((player) => player && player.name === actor.username)) {
+    return true;
+  }
+
+  return !game.creatorUserId;
+}
+
 function canStartGame(actor, game) {
   if (!actor || !actor.id || !game) {
     return false;
@@ -91,7 +112,11 @@ function authorize(action, context = {}) {
       throw error;
     }
 
-    if (!canOpenGame(actor, context.game, context.state)) {
+    const allowed = action === "game:read"
+      ? canReadGame(actor, context.game, context.state)
+      : canOpenGame(actor, context.game, context.state);
+
+    if (!allowed) {
       const error = new Error("Puoi aprire solo partite di cui fai parte.");
       error.statusCode = 403;
       error.code = "MEMBER_ONLY";
@@ -129,6 +154,7 @@ module.exports = {
   Roles,
   actorForUser,
   authorize,
+  canReadGame,
   canCreateGame,
   canOpenGame,
   canStartGame

--- a/backend/datastore-supabase.cjs
+++ b/backend/datastore-supabase.cjs
@@ -1,0 +1,441 @@
+const { readJsonFile } = require("./json-file-store.cjs");
+
+function parseJson(value, fallbackValue) {
+  if (value == null || value === "") {
+    return fallbackValue;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return fallbackValue;
+  }
+}
+
+function normalizeUser(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    username: row.username,
+    credentials: parseJson(row.credentials_json, {}),
+    role: row.role || "user",
+    profile: parseJson(row.profile_json, {}),
+    createdAt: row.created_at
+  };
+}
+
+function normalizeGame(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    name: row.name,
+    version: Number.isInteger(row.version) ? row.version : Number(row.version) || 1,
+    creatorUserId: row.creator_user_id || null,
+    state: parseJson(row.state_json, {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function normalizeSession(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    token: row.token,
+    user_id: row.user_id,
+    created_at: row.created_at
+  };
+}
+
+function requiredEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) {
+    throw new Error(`Variabile ambiente mancante: ${name}`);
+  }
+  return value;
+}
+
+function encodeFilterValue(value) {
+  return encodeURIComponent(String(value));
+}
+
+function toQueryString(filters = {}) {
+  const parts = [];
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value == null) {
+      return;
+    }
+
+    parts.push(`${encodeURIComponent(key)}=${encodeFilterValue(value)}`);
+  });
+  return parts.length ? `?${parts.join("&")}` : "";
+}
+
+function createSupabaseDatastore(options = {}) {
+  const supabaseUrl = String(
+    options.supabaseUrl ||
+    process.env.SUPABASE_URL ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    requiredEnv("NEXT_PUBLIC_SUPABASE_URL")
+  ).replace(/\/$/, "");
+  const supabaseKey = String(
+    options.supabaseServiceRoleKey ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    ""
+  ).trim();
+
+  if (!supabaseKey) {
+    throw new Error("Variabile ambiente mancante: SUPABASE_SERVICE_ROLE_KEY");
+  }
+
+  const schema = options.schema || process.env.SUPABASE_DB_SCHEMA || "public";
+  const restBaseUrl = `${supabaseUrl}/rest/v1`;
+  const legacyUsersFile = options.legacyUsersFile || options.dataFile || null;
+  const legacyGamesFile = options.legacyGamesFile || options.gamesFile || null;
+  const legacySessionsFile = options.legacySessionsFile || options.sessionsFile || null;
+  let initialized = false;
+
+  async function request(pathname, init = {}) {
+    const response = await fetch(restBaseUrl + pathname, {
+      method: init.method || "GET",
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        "Content-Type": "application/json",
+        Prefer: init.prefer || "return=representation",
+        "Accept-Profile": schema,
+        "Content-Profile": schema,
+        ...init.headers
+      },
+      body: init.body == null ? undefined : JSON.stringify(init.body)
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Supabase request failed (${response.status}): ${text || pathname}`);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  }
+
+  async function selectOne(tableName, filters = {}, options = {}) {
+    const query = toQueryString({
+      select: options.select || "*",
+      limit: 1,
+      ...filters
+    });
+    const rows = await request(`/${tableName}${query}`, {
+      method: "GET",
+      headers: {
+        Prefer: "count=exact"
+      }
+    });
+    return Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+  }
+
+  async function selectMany(tableName, filters = {}, options = {}) {
+    const query = toQueryString({
+      select: options.select || "*",
+      order: options.order || null,
+      ...filters
+    });
+    const rows = await request(`/${tableName}${query}`, {
+      method: "GET",
+      headers: {
+        Prefer: "count=exact"
+      }
+    });
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  async function upsertRows(tableName, rows, onConflict) {
+    return request(`/${tableName}?on_conflict=${encodeURIComponent(onConflict)}`, {
+      method: "POST",
+      body: rows,
+      prefer: "resolution=merge-duplicates,return=representation"
+    });
+  }
+
+  async function insertRow(tableName, row) {
+    const rows = await request(`/${tableName}`, {
+      method: "POST",
+      body: [row]
+    });
+    return Array.isArray(rows) ? rows[0] || null : rows;
+  }
+
+  async function patchRows(tableName, filters, patch) {
+    const query = toQueryString(filters);
+    const rows = await request(`/${tableName}${query}`, {
+      method: "PATCH",
+      body: patch
+    });
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  async function deleteRows(tableName, filters) {
+    const query = toQueryString(filters);
+    return request(`/${tableName}${query}`, {
+      method: "DELETE",
+      prefer: "return=minimal"
+    });
+  }
+
+  async function countRows(tableName, columnName = "id") {
+    const rows = await selectMany(tableName, {}, { select: columnName, order: `${columnName}.asc` });
+    return rows.length;
+  }
+
+  async function migrateLegacyUsers() {
+    if (!legacyUsersFile) {
+      return;
+    }
+
+    const existing = await countRows("users", "id");
+    if (existing > 0) {
+      return;
+    }
+
+    const users = readJsonFile(legacyUsersFile, [], Array.isArray);
+    if (!users.length) {
+      return;
+    }
+
+    await upsertRows("users", users.map((user) => ({
+      id: user.id,
+      username: user.username,
+      role: user.role === "admin" ? "admin" : "user",
+      profile_json: JSON.stringify(user.profile || {}),
+      credentials_json: JSON.stringify(user.credentials || {}),
+      created_at: user.createdAt || new Date().toISOString()
+    })), "id");
+  }
+
+  async function migrateLegacySessions() {
+    if (!legacySessionsFile) {
+      return;
+    }
+
+    const existing = await countRows("sessions", "token");
+    if (existing > 0) {
+      return;
+    }
+
+    const sessions = readJsonFile(legacySessionsFile, [], Array.isArray);
+    if (!sessions.length) {
+      return;
+    }
+
+    const existingUsers = new Set((await selectMany("users", {}, { select: "id", order: "id.asc" })).map((user) => user.id));
+
+    await upsertRows("sessions", sessions
+      .filter((session) => session && session.token && session.userId && existingUsers.has(session.userId))
+      .map((session) => ({
+        token: session.token,
+        user_id: session.userId,
+        created_at: Number(session.createdAt) || Date.now()
+      })), "token");
+  }
+
+  async function migrateLegacyGames() {
+    if (!legacyGamesFile) {
+      return;
+    }
+
+    const existing = await countRows("games", "id");
+    if (existing > 0) {
+      return;
+    }
+
+    const database = readJsonFile(legacyGamesFile, { games: [], activeGameId: null }, (value) => Boolean(value) && typeof value === "object");
+    const games = Array.isArray(database.games) ? database.games : [];
+    if (!games.length) {
+      return;
+    }
+
+    await upsertRows("games", games.map((game) => ({
+      id: game.id,
+      name: game.name,
+      version: Number.isInteger(game.version) && game.version > 0 ? game.version : 1,
+      creator_user_id: game.creatorUserId || null,
+      state_json: JSON.stringify(game.state || {}),
+      created_at: game.createdAt || new Date().toISOString(),
+      updated_at: game.updatedAt || game.createdAt || new Date().toISOString()
+    })), "id");
+
+    if (database.activeGameId) {
+      await upsertRows("app_state", [{
+        key: "activeGameId",
+        value_json: JSON.stringify(database.activeGameId)
+      }], "key");
+    }
+  }
+
+  async function ensureInitialized() {
+    if (initialized) {
+      return;
+    }
+
+    await migrateLegacyUsers();
+    await migrateLegacyGames();
+    await migrateLegacySessions();
+    initialized = true;
+  }
+
+  return {
+    driver: "supabase",
+    async backupTo() {
+      throw new Error("Il backup file-based non e disponibile con Supabase/Postgres.");
+    },
+    async healthSummary() {
+      await ensureInitialized();
+      return {
+        ok: true,
+        storage: "supabase",
+        url: supabaseUrl,
+        schema,
+        counts: {
+          users: await countRows("users", "id"),
+          games: await countRows("games", "id"),
+          sessions: await countRows("sessions", "token")
+        }
+      };
+    },
+    close() {
+      return undefined;
+    },
+    async findUserByUsername(username) {
+      await ensureInitialized();
+      const row = await selectOne("users", {
+        username: `eq.${username}`
+      });
+      return normalizeUser(row);
+    },
+    async findUserById(userId) {
+      await ensureInitialized();
+      return normalizeUser(await selectOne("users", { id: `eq.${userId}` }));
+    },
+    async listUsers() {
+      await ensureInitialized();
+      return (await selectMany("users", {}, { order: "created_at.asc" })).map(normalizeUser);
+    },
+    async createUser(user) {
+      await ensureInitialized();
+      await insertRow("users", {
+        id: user.id,
+        username: user.username,
+        role: user.role === "admin" ? "admin" : "user",
+        profile_json: JSON.stringify(user.profile || {}),
+        credentials_json: JSON.stringify(user.credentials || {}),
+        created_at: user.createdAt || new Date().toISOString()
+      });
+      return this.findUserById(user.id);
+    },
+    async updateUserCredentials(userId, credentials) {
+      await ensureInitialized();
+      await patchRows("users", { id: `eq.${userId}` }, {
+        credentials_json: JSON.stringify(credentials || {})
+      });
+      return this.findUserById(userId);
+    },
+    async updateUserRoleByUsername(username, role) {
+      await ensureInitialized();
+      await patchRows("users", { username: `eq.${username}` }, {
+        role: role === "admin" ? "admin" : "user"
+      });
+    },
+    async createSession(token, userId, createdAt) {
+      await ensureInitialized();
+      await insertRow("sessions", {
+        token,
+        user_id: userId,
+        created_at: createdAt || Date.now()
+      });
+    },
+    async findSession(token) {
+      await ensureInitialized();
+      return normalizeSession(await selectOne("sessions", { token: `eq.${token}` }));
+    },
+    async deleteSession(token) {
+      await ensureInitialized();
+      await deleteRows("sessions", { token: `eq.${token}` });
+    },
+    async listGames() {
+      await ensureInitialized();
+      return (await selectMany("games", {}, { order: "updated_at.desc" })).map(normalizeGame);
+    },
+    async findGameById(gameId) {
+      await ensureInitialized();
+      return normalizeGame(await selectOne("games", { id: `eq.${gameId}` }));
+    },
+    async createGame(entry) {
+      await ensureInitialized();
+      await insertRow("games", {
+        id: entry.id,
+        name: entry.name,
+        version: Number.isInteger(entry.version) && entry.version > 0 ? entry.version : 1,
+        creator_user_id: entry.creatorUserId || null,
+        state_json: JSON.stringify(entry.state || {}),
+        created_at: entry.createdAt,
+        updated_at: entry.updatedAt
+      });
+      return this.findGameById(entry.id);
+    },
+    async updateGame(entry) {
+      await ensureInitialized();
+      const updated = await patchRows("games", {
+        id: `eq.${entry.id}`,
+        version: `eq.${Number.isInteger(entry.version) && entry.version > 1 ? entry.version - 1 : 1}`
+      }, {
+        name: entry.name,
+        version: Number.isInteger(entry.version) && entry.version > 0 ? entry.version : 1,
+        creator_user_id: entry.creatorUserId || null,
+        state_json: JSON.stringify(entry.state || {}),
+        updated_at: entry.updatedAt
+      });
+
+      if (!updated.length) {
+        const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.");
+        conflict.code = "VERSION_CONFLICT";
+        const current = await this.findGameById(entry.id);
+        conflict.currentVersion = current ? current.version : null;
+        conflict.currentState = current ? current.state : null;
+        throw conflict;
+      }
+
+      return normalizeGame(updated[0]);
+    },
+    async getActiveGameId() {
+      await ensureInitialized();
+      const row = await selectOne("app_state", { key: "eq.activeGameId" });
+      return row ? parseJson(row.value_json, null) : null;
+    },
+    async setActiveGameId(gameId) {
+      await ensureInitialized();
+      await upsertRows("app_state", [{
+        key: "activeGameId",
+        value_json: JSON.stringify(gameId || null)
+      }], "key");
+    }
+  };
+}
+
+module.exports = {
+  createSupabaseDatastore
+};

--- a/backend/datastore.cjs
+++ b/backend/datastore.cjs
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { DatabaseSync, backup } = require("node:sqlite");
 const { readJsonFile } = require("./json-file-store.cjs");
+const { createSupabaseDatastore } = require("./datastore-supabase.cjs");
 
 function ensureDirectory(filePath) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -51,6 +52,12 @@ function normalizeGame(row) {
 }
 
 function createDatastore(options = {}) {
+  const requestedDriver = String(options.driver || process.env.DATASTORE_DRIVER || "").trim().toLowerCase();
+  const shouldUseSupabase = requestedDriver === "supabase" || (requestedDriver !== "sqlite" && Boolean(process.env.SUPABASE_URL));
+  if (shouldUseSupabase) {
+    return createSupabaseDatastore(options);
+  }
+
   const dbFile = options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite");
   const legacyUsersFile = options.legacyUsersFile || options.dataFile || path.join(__dirname, "..", "data", "users.json");
   const legacyGamesFile = options.legacyGamesFile || options.gamesFile || path.join(__dirname, "..", "data", "games.json");

--- a/backend/game-session-store.cjs
+++ b/backend/game-session-store.cjs
@@ -2,6 +2,7 @@ const path = require("path");
 const crypto = require("crypto");
 const { findSupportedMap } = require("../shared/maps/index.cjs");
 const { createDatastore } = require("./datastore.cjs");
+const { chainMaybe, mapMaybe } = require("./maybe-async.cjs");
 
 function safeClone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -55,10 +56,10 @@ function createGameSessionStore(options = {}) {
   });
 
   function listGames() {
-    return datastore.listGames()
+    return mapMaybe(datastore.listGames(), (games) => games
       .slice()
       .sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)))
-      .map(summarizeGame);
+      .map(summarizeGame));
   }
 
   function createGame(initialState, input = {}) {
@@ -66,20 +67,24 @@ function createGameSessionStore(options = {}) {
       throw new Error("La creazione della partita richiede uno stato iniziale valido.");
     }
 
-    const timestamp = new Date().toISOString();
-    const entry = {
-      id: crypto.randomBytes(8).toString("hex"),
-      name: normalizeGameName(input.name, datastore.listGames().length + 1),
-      version: 1,
-      creatorUserId: input.creatorUserId || null,
-      state: safeClone(initialState),
-      createdAt: timestamp,
-      updatedAt: timestamp
-    };
+    return chainMaybe(datastore.listGames(), (games) => {
+      const timestamp = new Date().toISOString();
+      const entry = {
+        id: crypto.randomBytes(8).toString("hex"),
+        name: normalizeGameName(input.name, games.length + 1),
+        version: 1,
+        creatorUserId: input.creatorUserId || null,
+        state: safeClone(initialState),
+        createdAt: timestamp,
+        updatedAt: timestamp
+      };
 
-    const created = datastore.createGame(entry);
-    datastore.setActiveGameId(created.id);
-    return { game: summarizeGame(created), state: safeClone(created.state) };
+      return chainMaybe(datastore.createGame(entry), (created) =>
+        mapMaybe(datastore.setActiveGameId(created.id), () => ({
+          game: summarizeGame(created),
+          state: safeClone(created.state)
+        })));
+    });
   }
 
   function setActiveGame(gameId) {
@@ -87,13 +92,13 @@ function createGameSessionStore(options = {}) {
       throw new Error("Impostare la partita attiva richiede un game id valido.");
     }
 
-    const entry = datastore.findGameById(gameId);
-    if (!entry) {
-      throw new Error(`Partita "${gameId}" non trovata.`);
-    }
+    return chainMaybe(datastore.findGameById(gameId), (entry) => {
+      if (!entry) {
+        throw new Error(`Partita "${gameId}" non trovata.`);
+      }
 
-    datastore.setActiveGameId(gameId);
-    return summarizeGame(entry);
+      return mapMaybe(datastore.setActiveGameId(gameId), () => summarizeGame(entry));
+    });
   }
 
   function getGame(gameId) {
@@ -101,18 +106,19 @@ function createGameSessionStore(options = {}) {
       throw new Error("Leggere una partita richiede un game id valido.");
     }
 
-    const entry = datastore.findGameById(gameId);
-    if (!entry) {
-      throw new Error(`Partita "${gameId}" non trovata.`);
-    }
+    return mapMaybe(datastore.findGameById(gameId), (entry) => {
+      if (!entry) {
+        throw new Error(`Partita "${gameId}" non trovata.`);
+      }
 
-    return {
-      game: {
-        ...summarizeGame(entry),
-        creatorUserId: entry.creatorUserId || null
-      },
-      state: safeClone(entry.state)
-    };
+      return {
+        game: {
+          ...summarizeGame(entry),
+          creatorUserId: entry.creatorUserId || null
+        },
+        state: safeClone(entry.state)
+      };
+    });
   }
 
   function openGame(gameId) {
@@ -120,13 +126,16 @@ function createGameSessionStore(options = {}) {
       throw new Error("Aprire una partita richiede un game id valido.");
     }
 
-    const entry = datastore.findGameById(gameId);
-    if (!entry) {
-      throw new Error(`Partita "${gameId}" non trovata.`);
-    }
+    return chainMaybe(datastore.findGameById(gameId), (entry) => {
+      if (!entry) {
+        throw new Error(`Partita "${gameId}" non trovata.`);
+      }
 
-    datastore.setActiveGameId(gameId);
-    return { game: summarizeGame(entry), state: safeClone(entry.state) };
+      return mapMaybe(datastore.setActiveGameId(gameId), () => ({
+        game: summarizeGame(entry),
+        state: safeClone(entry.state)
+      }));
+    });
   }
 
   function saveGame(gameId, state, expectedVersion) {
@@ -142,45 +151,47 @@ function createGameSessionStore(options = {}) {
       throw new Error("Il salvataggio richiede una expectedVersion valida.");
     }
 
-    const entry = datastore.findGameById(gameId);
-    if (!entry) {
-      throw new Error(`Partita "${gameId}" non trovata.`);
-    }
+    return chainMaybe(datastore.findGameById(gameId), (entry) => {
+      if (!entry) {
+        throw new Error(`Partita "${gameId}" non trovata.`);
+      }
 
-    const currentVersion = Number.isInteger(entry.version) && entry.version > 0 ? entry.version : 1;
-    entry.version = currentVersion;
+      const currentVersion = Number.isInteger(entry.version) && entry.version > 0 ? entry.version : 1;
+      entry.version = currentVersion;
 
-    if (expectedVersion != null && expectedVersion !== currentVersion) {
-      const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.");
-      conflict.code = "VERSION_CONFLICT";
-      conflict.currentVersion = currentVersion;
-      conflict.currentState = safeClone(entry.state);
-      conflict.game = summarizeGame(entry);
-      throw conflict;
-    }
+      if (expectedVersion != null && expectedVersion !== currentVersion) {
+        const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.");
+        conflict.code = "VERSION_CONFLICT";
+        conflict.currentVersion = currentVersion;
+        conflict.currentState = safeClone(entry.state);
+        conflict.game = summarizeGame(entry);
+        throw conflict;
+      }
 
-    entry.state = safeClone(state);
-    entry.version = currentVersion + 1;
-    entry.updatedAt = new Date().toISOString();
-    return summarizeGame(datastore.updateGame(entry));
+      entry.state = safeClone(state);
+      entry.version = currentVersion + 1;
+      entry.updatedAt = new Date().toISOString();
+      return mapMaybe(datastore.updateGame(entry), summarizeGame);
+    });
   }
 
   function ensureActiveGame(createInitialState) {
-    const games = datastore.listGames();
-    const activeGameId = datastore.getActiveGameId();
-    const preferredId = activeGameId && games.some((game) => game.id === activeGameId)
-      ? activeGameId
-      : null;
+    return chainMaybe(datastore.listGames(), (games) =>
+      chainMaybe(datastore.getActiveGameId(), (activeGameId) => {
+        const preferredId = activeGameId && games.some((game) => game.id === activeGameId)
+          ? activeGameId
+          : null;
 
-    if (preferredId) {
-      return openGame(preferredId);
-    }
+        if (preferredId) {
+          return openGame(preferredId);
+        }
 
-    if (games.length > 0) {
-      return openGame(games[0].id);
-    }
+        if (games.length > 0) {
+          return openGame(games[0].id);
+        }
 
-    return createGame(createInitialState(), { name: "Partita 1" });
+        return createGame(createInitialState(), { name: "Partita 1" });
+      }));
   }
 
   return {

--- a/backend/json-file-store.cjs
+++ b/backend/json-file-store.cjs
@@ -23,8 +23,6 @@ function safeReadJson(filePath, fallbackValue) {
 }
 
 function readJsonFile(filePath, fallbackValue, isValid) {
-  ensureDirectory(filePath);
-
   const validate = typeof isValid === "function"
     ? isValid
     : () => true;

--- a/backend/maybe-async.cjs
+++ b/backend/maybe-async.cjs
@@ -1,0 +1,25 @@
+function isPromiseLike(value) {
+  return Boolean(value) && typeof value.then === "function";
+}
+
+function mapMaybe(value, mapper) {
+  if (isPromiseLike(value)) {
+    return value.then(mapper);
+  }
+
+  return mapper(value);
+}
+
+function chainMaybe(value, mapper) {
+  if (isPromiseLike(value)) {
+    return value.then((resolved) => mapper(resolved));
+  }
+
+  return mapper(value);
+}
+
+module.exports = {
+  chainMaybe,
+  isPromiseLike,
+  mapMaybe
+};

--- a/backend/player-profile-store.cjs
+++ b/backend/player-profile-store.cjs
@@ -1,6 +1,7 @@
 const path = require("path");
 const { createDatastore } = require("./datastore.cjs");
 const { findSupportedMap } = require("../shared/maps/index.cjs");
+const { mapMaybe } = require("./maybe-async.cjs");
 
 function readableMapName(mapId) {
   const map = findSupportedMap(mapId);
@@ -99,38 +100,40 @@ function createPlayerProfileStore(options = {}) {
       throw new Error("Il profilo richiede un nome giocatore valido.");
     }
 
-    const relevantGames = datastore.listGames().filter((entry) =>
-      Array.isArray(entry?.state?.players) &&
-      entry.state.players.some((player) => player.name === normalizedUsername)
-    );
+    return mapMaybe(datastore.listGames(), (games) => {
+      const relevantGames = games.filter((entry) =>
+        Array.isArray(entry?.state?.players) &&
+        entry.state.players.some((player) => player.name === normalizedUsername)
+      );
 
-    const completedGames = relevantGames.filter((entry) => entry?.state?.phase === "finished");
-    const gamesInProgress = relevantGames.filter((entry) => entry?.state?.phase === "active" || entry?.state?.phase === "lobby");
-    const wins = completedGames.filter((entry) => {
-      const winner = entry.state.players.find((player) => player.id === entry.state.winnerId);
-      return winner && winner.name === normalizedUsername;
-    }).length;
-    const losses = completedGames.length - wins;
-    const gamesPlayed = completedGames.length;
-    const winRate = gamesPlayed > 0 ? Math.round((wins / gamesPlayed) * 100) : null;
+      const completedGames = relevantGames.filter((entry) => entry?.state?.phase === "finished");
+      const gamesInProgress = relevantGames.filter((entry) => entry?.state?.phase === "active" || entry?.state?.phase === "lobby");
+      const wins = completedGames.filter((entry) => {
+        const winner = entry.state.players.find((player) => player.id === entry.state.winnerId);
+        return winner && winner.name === normalizedUsername;
+      }).length;
+      const losses = completedGames.length - wins;
+      const gamesPlayed = completedGames.length;
+      const winRate = gamesPlayed > 0 ? Math.round((wins / gamesPlayed) * 100) : null;
 
-    return {
-      playerName: normalizedUsername,
-      gamesPlayed,
-      wins,
-      losses,
-      gamesInProgress: gamesInProgress.length,
-      participatingGames: gamesInProgress
-        .slice()
-        .sort((left, right) => String(right?.updatedAt || "").localeCompare(String(left?.updatedAt || "")))
-        .map((entry) => summarizeParticipatingGame(entry, normalizedUsername)),
-      winRate,
-      hasHistory: relevantGames.length > 0,
-      placeholders: {
-        recentGames: false,
-        ranking: false
-      }
-    };
+      return {
+        playerName: normalizedUsername,
+        gamesPlayed,
+        wins,
+        losses,
+        gamesInProgress: gamesInProgress.length,
+        participatingGames: gamesInProgress
+          .slice()
+          .sort((left, right) => String(right?.updatedAt || "").localeCompare(String(left?.updatedAt || "")))
+          .map((entry) => summarizeParticipatingGame(entry, normalizedUsername)),
+        winRate,
+        hasHistory: relevantGames.length > 0,
+        placeholders: {
+          recentGames: false,
+          ranking: false
+        }
+      };
+    });
   }
 
   return {

--- a/backend/server.cjs
+++ b/backend/server.cjs
@@ -8,6 +8,7 @@ const { createGameSessionStore } = require("./game-session-store.cjs");
 const { createPlayerProfileStore } = require("./player-profile-store.cjs");
 const { createConfiguredInitialState, listDiceRuleSets, listSupportedMaps } = require("./new-game-config.cjs");
 const { secureRandom } = require("./random.cjs");
+const { isPromiseLike } = require("./maybe-async.cjs");
 const {
   addPlayer,
   applyFortify,
@@ -137,30 +138,65 @@ function createApp(options = {}) {
     datastore,
     gamesFile
   });
-  const initialGame = gameSessions.ensureActiveGame(createInitialState);
-  activeGameId = initialGame.game.id;
-  activeGameVersion = initialGame.game.version;
-  activeGameName = initialGame.game.name;
-  Object.keys(state).forEach((key) => delete state[key]);
-  Object.assign(state, initialGame.state);
   const auth = createAuthStore({
     datastore,
     dataFile: options.dataFile || path.join(__dirname, "..", "data", "users.json"),
     sessionsFile: options.sessionsFile || path.join(__dirname, "..", "data", "sessions.json")
   });
   const clientsByGameId = new Map();
+  let initPromise = null;
+
+  const eagerInitialGame = gameSessions.ensureActiveGame(createInitialState);
+  if (isPromiseLike(eagerInitialGame)) {
+    initPromise = eagerInitialGame
+      .then((initialGame) => {
+        activeGameId = initialGame.game.id;
+        activeGameVersion = initialGame.game.version;
+        activeGameName = initialGame.game.name;
+        replaceState(initialGame.state);
+      })
+      .finally(() => {
+        initPromise = null;
+      });
+  } else {
+    activeGameId = eagerInitialGame.game.id;
+    activeGameVersion = eagerInitialGame.game.version;
+    activeGameName = eagerInitialGame.game.name;
+    replaceState(eagerInitialGame.state);
+  }
 
   function replaceState(nextState) {
     Object.keys(state).forEach((key) => delete state[key]);
     Object.assign(state, nextState);
   }
 
-  function persistActiveGame(expectedVersion) {
+  async function initializeActiveGame() {
+    if (activeGameId) {
+      return;
+    }
+
+    if (!initPromise) {
+      initPromise = Promise.resolve(gameSessions.ensureActiveGame(createInitialState))
+        .then((initialGame) => {
+          activeGameId = initialGame.game.id;
+          activeGameVersion = initialGame.game.version;
+          activeGameName = initialGame.game.name;
+          replaceState(initialGame.state);
+        })
+        .finally(() => {
+          initPromise = null;
+        });
+    }
+
+    await initPromise;
+  }
+
+  async function persistActiveGame(expectedVersion) {
     if (!activeGameId) {
       return null;
     }
 
-    const savedGame = gameSessions.saveGame(activeGameId, state, expectedVersion);
+    const savedGame = await gameSessions.saveGame(activeGameId, state, expectedVersion);
     activeGameVersion = savedGame.version;
     activeGameName = savedGame.name;
     return savedGame;
@@ -178,7 +214,9 @@ function createApp(options = {}) {
     return body.gameId || (url ? url.searchParams.get("gameId") : null) || activeGameId || null;
   }
 
-  function loadGameContext(gameId) {
+  async function loadGameContext(gameId) {
+    await initializeActiveGame();
+
     if (!gameId || gameId === activeGameId) {
       return {
         gameId: activeGameId,
@@ -188,7 +226,7 @@ function createApp(options = {}) {
       };
     }
 
-    const record = gameSessions.getGame(gameId);
+    const record = await gameSessions.getGame(gameId);
     return {
       gameId: record.game.id,
       gameName: record.game.name,
@@ -197,12 +235,12 @@ function createApp(options = {}) {
     };
   }
 
-  function persistGameContext(gameContext, expectedVersion) {
+  async function persistGameContext(gameContext, expectedVersion) {
     if (!gameContext?.gameId) {
       return null;
     }
 
-    const savedGame = gameSessions.saveGame(gameContext.gameId, gameContext.state, expectedVersion);
+    const savedGame = await gameSessions.saveGame(gameContext.gameId, gameContext.state, expectedVersion);
     gameContext.version = savedGame.version;
     gameContext.gameName = savedGame.name;
 
@@ -254,16 +292,16 @@ function createApp(options = {}) {
     return reports;
   }
 
-  function persistWithAiTurns(gameContext, expectedVersion) {
-    persistGameContext(gameContext, expectedVersion);
+  async function persistWithAiTurns(gameContext, expectedVersion) {
+    await persistGameContext(gameContext, expectedVersion);
     const aiReports = runAiTurnsIfNeeded(gameContext.state);
     if (aiReports.length > 0) {
-      persistGameContext(gameContext, gameContext.version);
+      await persistGameContext(gameContext, gameContext.version);
     }
     return aiReports;
   }
 
-  function resumeAiTurnsForRead(gameContext) {
+  async function resumeAiTurnsForRead(gameContext) {
     if (!gameContext?.state || gameContext.state.phase !== "active" || gameContext.state.winnerId) {
       return [];
     }
@@ -281,9 +319,9 @@ function createApp(options = {}) {
     return cookies[sessionCookieName] || null;
   }
 
-  function requireAuth(req, res, body, url = null) {
+  async function requireAuth(req, res, body, url = null) {
     const sessionToken = extractSessionToken(req, body, url);
-    const user = auth.getUserFromSession(sessionToken);
+    const user = await auth.getUserFromSession(sessionToken);
     if (!user) {
       sendJson(res, 401, { error: "Sessione non valida.", code: "AUTH_REQUIRED" });
       return null;
@@ -292,17 +330,17 @@ function createApp(options = {}) {
     return { sessionToken, user };
   }
 
-  function authorizeGameRead(gameId, req, res, url) {
+  async function authorizeGameRead(gameId, req, res, url) {
     if (!gameId) {
       return { ok: true, user: null, gameRecord: null };
     }
 
-    const gameRecord = gameSessions.getGame(gameId);
+    const gameRecord = await gameSessions.getGame(gameId);
     if (!gameRecord.game.creatorUserId) {
       return { ok: true, user: null, gameRecord };
     }
 
-    const authContext = requireAuth(req, res, {}, url);
+    const authContext = await requireAuth(req, res, {}, url);
     if (!authContext) {
       return null;
     }
@@ -356,8 +394,9 @@ function createApp(options = {}) {
     return nextState.hands[player.id].map((card) => ({ ...card }));
   }
 
-  function healthSnapshot() {
-    const storage = datastore.healthSummary();
+  async function healthSnapshot() {
+    await initializeActiveGame();
+    const storage = await datastore.healthSummary();
     return {
       ok: storage.ok,
       storage,
@@ -368,14 +407,16 @@ function createApp(options = {}) {
   }
 
   async function handleApi(req, res, url) {
+    await initializeActiveGame();
+
     if (req.method === "GET" && url.pathname === "/api/health") {
-      const health = healthSnapshot();
+      const health = await healthSnapshot();
       sendJson(res, health.ok ? 200 : 503, health);
       return;
     }
 
     if (process.env.E2E === "true" && req.method === "POST" && url.pathname === "/api/test/reset") {
-      const resetGame = gameSessions.createGame(createInitialState(), { name: "Partita test" });
+      const resetGame = await gameSessions.createGame(createInitialState(), { name: "Partita test" });
       activeGameId = resetGame.game.id;
       activeGameVersion = resetGame.game.version;
       activeGameName = resetGame.game.name;
@@ -403,13 +444,13 @@ function createApp(options = {}) {
 
     if (req.method === "GET" && url.pathname === "/api/state") {
       const gameId = getTargetGameId({}, url);
-      const access = authorizeGameRead(gameId, req, res, url);
+      const access = await authorizeGameRead(gameId, req, res, url);
       if (access === null) {
         return;
       }
-      const gameContext = loadGameContext(gameId);
-      resumeAiTurnsForRead(gameContext);
-      const sessionUser = access && access.user ? access.user : auth.getUserFromSession(extractSessionToken(req, {}, url));
+      const gameContext = await loadGameContext(gameId);
+      await resumeAiTurnsForRead(gameContext);
+      const sessionUser = access && access.user ? access.user : await auth.getUserFromSession(extractSessionToken(req, {}, url));
       const resolvedPlayer = resolvePlayerForUser(gameContext.state, sessionUser);
       sendJson(res, 200, {
         ...snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName),
@@ -420,7 +461,7 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/games") {
-      sendJson(res, 200, { games: gameSessions.listGames(), activeGameId: getTargetGameId({}, url) });
+      sendJson(res, 200, { games: await gameSessions.listGames(), activeGameId: getTargetGameId({}, url) });
       return;
     }
 
@@ -431,7 +472,7 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/games") {
       const body = await parseBody(req);
-      const authContext = requireAuth(req, res, body);
+      const authContext = await requireAuth(req, res, body);
       if (!authContext) {
         return;
       }
@@ -443,7 +484,7 @@ function createApp(options = {}) {
         if (!creatorJoin.ok) {
           throw new Error(creatorJoin.error || "Impossibile collegare il creatore alla nuova partita.");
         }
-        const created = gameSessions.createGame(configured.state, {
+        const created = await gameSessions.createGame(configured.state, {
           ...configured.gameInput,
           creatorUserId: policy.actor.id
         });
@@ -452,7 +493,7 @@ function createApp(options = {}) {
         activeGameName = created.game.name;
         replaceState(created.state);
         broadcastGame({ gameId: created.game.id, gameName: created.game.name, version: created.game.version, state: created.state });
-        sendJson(res, 201, { ok: true, game: created.game, games: gameSessions.listGames(), activeGameId, state: snapshot(), config: configured.config, playerId: creatorJoin.player.id });
+        sendJson(res, 201, { ok: true, game: created.game, games: await gameSessions.listGames(), activeGameId, state: snapshot(), config: configured.config, playerId: creatorJoin.player.id });
       } catch (error) {
         const statusCode = error.statusCode || 400;
         sendJson(res, statusCode, { error: error.message || "Creazione partita non riuscita.", code: error.code || null });
@@ -462,21 +503,21 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/games/open") {
       const body = await parseBody(req);
-      const authContext = requireAuth(req, res, body);
+      const authContext = await requireAuth(req, res, body);
       if (!authContext) {
         return;
       }
 
       try {
-        const gameRecord = gameSessions.getGame(body.gameId);
+        const gameRecord = await gameSessions.getGame(body.gameId);
         authorize("game:open", { user: authContext.user, game: gameRecord.game, state: gameRecord.state });
-        const opened = gameSessions.openGame(body.gameId);
-        resumeAiTurnsForRead(opened);
+        const opened = await gameSessions.openGame(body.gameId);
+        await resumeAiTurnsForRead(opened);
         const resolvedPlayer = resolvePlayerForUser(opened.state, authContext.user);
         sendJson(res, 200, {
           ok: true,
           game: opened.game,
-          games: gameSessions.listGames(),
+          games: await gameSessions.listGames(),
           activeGameId: opened.game.id,
           state: snapshotForState(opened.state, opened.game.id, opened.game.version, opened.game.name),
           playerId: resolvedPlayer ? resolvedPlayer.id : null
@@ -489,7 +530,7 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/auth/session") {
-      const authContext = requireAuth(req, res, {});
+      const authContext = await requireAuth(req, res, {});
       if (!authContext) {
         return;
       }
@@ -499,13 +540,13 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/profile") {
-      const authContext = requireAuth(req, res, {});
+      const authContext = await requireAuth(req, res, {});
       if (!authContext) {
         return;
       }
 
       try {
-        sendJson(res, 200, { profile: playerProfiles.getPlayerProfile(authContext.user.username) });
+        sendJson(res, 200, { profile: await playerProfiles.getPlayerProfile(authContext.user.username) });
       } catch (error) {
         sendJson(res, 400, { error: error.message || "Profilo non disponibile." });
       }
@@ -514,12 +555,12 @@ function createApp(options = {}) {
 
     if (req.method === "GET" && url.pathname === "/api/events") {
       const gameId = getTargetGameId({}, url);
-      const access = authorizeGameRead(gameId, req, res, url);
+      const access = await authorizeGameRead(gameId, req, res, url);
       if (access === null) {
         return;
       }
-      const gameContext = loadGameContext(gameId);
-      resumeAiTurnsForRead(gameContext);
+      const gameContext = await loadGameContext(gameId);
+      await resumeAiTurnsForRead(gameContext);
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -547,7 +588,7 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/auth/register") {
       const body = await parseBody(req);
-      const result = auth.registerPasswordUser(body.username, body.password);
+      const result = await auth.registerPasswordUser(body.username, body.password);
       if (!result.ok) {
         sendJson(res, 400, { error: result.error });
         return;
@@ -563,7 +604,7 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/auth/login") {
       const body = await parseBody(req);
-      const result = auth.loginWithPassword(body.username, body.password);
+      const result = await auth.loginWithPassword(body.username, body.password);
       if (!result.ok) {
         sendJson(res, 401, { error: result.error });
         return;
@@ -581,7 +622,7 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/auth/logout") {
       const body = await parseBody(req);
-      auth.logout(extractSessionToken(req, body));
+      await auth.logout(extractSessionToken(req, body));
       sendJson(res, 200, { ok: true }, {
         "Set-Cookie": clearSessionCookie(req)
       });
@@ -590,14 +631,14 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/ai/join") {
       const body = await parseBody(req);
-      const gameContext = loadGameContext(getTargetGameId(body, url));
+      const gameContext = await loadGameContext(getTargetGameId(body, url));
       const result = addPlayer(gameContext.state, body.name, { isAi: true });
       if (!result.ok) {
         sendJson(res, 400, { error: result.error });
         return;
       }
 
-      persistGameContext(gameContext);
+      await persistGameContext(gameContext);
       broadcastGame(gameContext);
       sendJson(res, result.rejoined ? 200 : 201, {
         playerId: result.player.id,
@@ -609,19 +650,19 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/join") {
       const body = await parseBody(req);
-      const authContext = requireAuth(req, res, body);
+      const authContext = await requireAuth(req, res, body);
       if (!authContext) {
         return;
       }
 
-      const gameContext = loadGameContext(getTargetGameId(body, url));
+      const gameContext = await loadGameContext(getTargetGameId(body, url));
       const result = addPlayer(gameContext.state, authContext.user.username, { linkedUserId: authContext.user.id });
       if (!result.ok) {
         sendJson(res, 400, { error: result.error });
         return;
       }
 
-      persistGameContext(gameContext);
+      await persistGameContext(gameContext);
       broadcastGame(gameContext);
       sendJson(res, result.rejoined ? 200 : 201, {
         playerId: result.player.id,
@@ -633,12 +674,12 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/cards/trade") {
       const body = await parseBody(req);
-      const authContext = requireAuth(req, res, body);
+      const authContext = await requireAuth(req, res, body);
       if (!authContext) {
         return;
       }
 
-      const gameContext = loadGameContext(getTargetGameId(body, url));
+      const gameContext = await loadGameContext(getTargetGameId(body, url));
       const player = getPlayer(gameContext.state, body.playerId);
       if (!player || !playerBelongsToUser(player, authContext.user)) {
         sendJson(res, 403, { error: "Giocatore non valido." });
@@ -668,7 +709,7 @@ function createApp(options = {}) {
       }
 
       try {
-        persistGameContext(gameContext, expectedVersion);
+        await persistGameContext(gameContext, expectedVersion);
       } catch (error) {
         if (error && error.code === "VERSION_CONFLICT") {
           sendJson(res, 409, {
@@ -690,19 +731,19 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/start") {
       const body = await parseBody(req);
-      const authContext = requireAuth(req, res, body);
+      const authContext = await requireAuth(req, res, body);
       if (!authContext) {
         return;
       }
 
-      const gameContext = loadGameContext(getTargetGameId(body, url));
+      const gameContext = await loadGameContext(getTargetGameId(body, url));
       if (gameContext.state.phase !== "lobby") {
         sendJson(res, 400, { error: "La partita e gia iniziata." });
         return;
       }
 
       try {
-        const activeGame = gameSessions.getGame(gameContext.gameId);
+        const activeGame = await gameSessions.getGame(gameContext.gameId);
         authorize("game:start", { user: authContext.user, game: activeGame.game });
       } catch (error) {
         const statusCode = error.statusCode || 400;
@@ -722,7 +763,7 @@ function createApp(options = {}) {
       }
 
       startGame(gameContext.state);
-      persistWithAiTurns(gameContext);
+      await persistWithAiTurns(gameContext);
       broadcastGame(gameContext);
       sendJson(res, 200, { ok: true, state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName) });
       return;
@@ -730,7 +771,7 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/action") {
       const body = await parseBody(req);
-      const authContext = requireAuth(req, res, body);
+      const authContext = await requireAuth(req, res, body);
       if (!authContext) {
         return;
       }
@@ -743,7 +784,7 @@ function createApp(options = {}) {
         return;
       }
 
-      const gameContext = loadGameContext(getTargetGameId(body, url));
+      const gameContext = await loadGameContext(getTargetGameId(body, url));
       const player = getPlayer(gameContext.state, playerId);
 
       if (!player || !playerBelongsToUser(player, authContext.user)) {
@@ -783,7 +824,7 @@ function createApp(options = {}) {
         }
 
         try {
-          persistGameContext(gameContext, expectedVersion);
+          await persistGameContext(gameContext, expectedVersion);
         } catch (error) {
           if (handleVersionConflict(error)) {
             return;
@@ -818,7 +859,7 @@ function createApp(options = {}) {
         }
 
         try {
-          persistGameContext(gameContext, expectedVersion);
+          await persistGameContext(gameContext, expectedVersion);
         } catch (error) {
           if (handleVersionConflict(error)) {
             return;
@@ -838,7 +879,7 @@ function createApp(options = {}) {
         }
 
         try {
-          persistGameContext(gameContext, expectedVersion);
+          await persistGameContext(gameContext, expectedVersion);
         } catch (error) {
           if (handleVersionConflict(error)) {
             return;
@@ -858,7 +899,7 @@ function createApp(options = {}) {
         }
 
         try {
-          persistGameContext(gameContext, expectedVersion);
+          await persistGameContext(gameContext, expectedVersion);
         } catch (error) {
           if (handleVersionConflict(error)) {
             return;
@@ -878,7 +919,7 @@ function createApp(options = {}) {
         }
 
         try {
-          persistWithAiTurns(gameContext, expectedVersion);
+          await persistWithAiTurns(gameContext, expectedVersion);
         } catch (error) {
           if (handleVersionConflict(error)) {
             return;
@@ -898,7 +939,7 @@ function createApp(options = {}) {
         }
 
         try {
-          persistWithAiTurns(gameContext, expectedVersion);
+          await persistWithAiTurns(gameContext, expectedVersion);
         } catch (error) {
           if (handleVersionConflict(error)) {
             return;
@@ -954,7 +995,7 @@ function createApp(options = {}) {
     });
   }
 
-  const server = http.createServer((req, res) => {
+  function handleRequest(req, res) {
     const url = new URL(req.url, "http://" + req.headers.host);
 
     Promise.resolve()
@@ -969,12 +1010,15 @@ function createApp(options = {}) {
       .catch((error) => {
         sendJson(res, 500, { error: error.message || "Errore interno." });
       });
-  });
+  }
+
+  const server = http.createServer(handleRequest);
 
   return {
     auth,
     datastore,
     handleApi,
+    handleRequest,
     parseBody,
     sendJson,
     server,
@@ -997,6 +1041,7 @@ module.exports = {
   auth: app.auth,
   datastore: app.datastore,
   handleApi: app.handleApi,
+  handleRequest: app.handleRequest,
   server: app.server,
   state: app.state
 };

--- a/backend/server.cjs
+++ b/backend/server.cjs
@@ -30,6 +30,14 @@ const publicDir = path.join(__dirname, "..", "frontend", "public");
 const port = process.env.PORT || 3000;
 const sessionCookieName = "netrisk_session";
 
+function defaultDbFile() {
+  if (process.env.VERCEL) {
+    return path.join("/tmp", "netrisk.sqlite");
+  }
+
+  return path.join(__dirname, "..", "data", "netrisk.sqlite");
+}
+
 function sendJson(res, statusCode, payload, headers = {}) {
   res.writeHead(statusCode, {
     "Content-Type": "application/json; charset=utf-8",
@@ -124,7 +132,7 @@ function createApp(options = {}) {
   let activeGameName = null;
   let nextAttackRolls = null;
   const datastore = createDatastore({
-    dbFile: options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite"),
+    dbFile: options.dbFile || defaultDbFile(),
     legacyUsersFile: options.dataFile || path.join(__dirname, "..", "data", "users.json"),
     legacyGamesFile: options.gamesFile || path.join(__dirname, "..", "data", "games.json"),
     legacySessionsFile: options.sessionsFile || path.join(__dirname, "..", "data", "sessions.json")

--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -145,6 +145,202 @@ function authHeaders(sessionToken) {
   };
 }
 
+function createMockSupabaseResponse(status, payload) {
+  const text = payload == null ? "" : JSON.stringify(payload);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return text;
+    }
+  };
+}
+
+function createMockSupabaseFetch(initialData = {}) {
+  const tables = {
+    users: Array.isArray(initialData.users) ? initialData.users.map((row) => ({ ...row })) : [],
+    games: Array.isArray(initialData.games) ? initialData.games.map((row) => ({ ...row })) : [],
+    sessions: Array.isArray(initialData.sessions) ? initialData.sessions.map((row) => ({ ...row })) : [],
+    app_state: Array.isArray(initialData.app_state) ? initialData.app_state.map((row) => ({ ...row })) : []
+  };
+
+  function decodeFilter(rawValue) {
+    const value = String(rawValue || "");
+    return value.startsWith("eq.") ? decodeURIComponent(value.slice(3)) : decodeURIComponent(value);
+  }
+
+  function cloneRows(rows) {
+    return rows.map((row) => ({ ...row }));
+  }
+
+  function applyFilters(rows, searchParams) {
+    return rows.filter((row) => {
+      for (const [key, value] of searchParams.entries()) {
+        if (key === "select" || key === "limit" || key === "order" || key === "on_conflict") {
+          continue;
+        }
+
+        if (String(row[key] ?? "") !== decodeFilter(value)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }
+
+  function applyOrdering(rows, order) {
+    if (!order) {
+      return rows;
+    }
+
+    const [field, direction = "asc"] = String(order).split(".");
+    const factor = direction === "desc" ? -1 : 1;
+    return [...rows].sort((left, right) => {
+      const a = String(left[field] ?? "");
+      const b = String(right[field] ?? "");
+      return a.localeCompare(b) * factor;
+    });
+  }
+
+  function applySelection(rows, select) {
+    if (!select || select === "*") {
+      return cloneRows(rows);
+    }
+
+    const fields = String(select)
+      .split(",")
+      .map((field) => field.trim())
+      .filter(Boolean);
+
+    return rows.map((row) => {
+      const projected = {};
+      fields.forEach((field) => {
+        projected[field] = row[field];
+      });
+      return projected;
+    });
+  }
+
+  async function fetchMock(url, init = {}) {
+    const requestUrl = new URL(url);
+    const tableName = requestUrl.pathname.split("/").pop();
+    const table = tables[tableName];
+    if (!table) {
+      return createMockSupabaseResponse(404, { error: "unknown_table" });
+    }
+
+    const method = String(init.method || "GET").toUpperCase();
+    const searchParams = requestUrl.searchParams;
+
+    if (method === "GET") {
+      let rows = applyFilters(table, searchParams);
+      rows = applyOrdering(rows, searchParams.get("order"));
+      const limit = Number(searchParams.get("limit"));
+      if (Number.isInteger(limit) && limit > 0) {
+        rows = rows.slice(0, limit);
+      }
+      return createMockSupabaseResponse(200, applySelection(rows, searchParams.get("select")));
+    }
+
+    if (method === "POST") {
+      const payload = JSON.parse(init.body || "[]");
+      const rows = Array.isArray(payload) ? payload : [payload];
+      const onConflict = searchParams.get("on_conflict");
+      const inserted = [];
+
+      rows.forEach((row) => {
+        const nextRow = { ...row };
+        if (onConflict) {
+          const existingIndex = table.findIndex((candidate) => String(candidate[onConflict] ?? "") === String(nextRow[onConflict] ?? ""));
+          if (existingIndex >= 0) {
+            table[existingIndex] = { ...table[existingIndex], ...nextRow };
+            inserted.push({ ...table[existingIndex] });
+            return;
+          }
+        }
+
+        table.push(nextRow);
+        inserted.push({ ...nextRow });
+      });
+
+      return createMockSupabaseResponse(201, inserted);
+    }
+
+    if (method === "PATCH") {
+      const patch = JSON.parse(init.body || "{}");
+      const updated = [];
+      table.forEach((row, index) => {
+        const matches = applyFilters([row], searchParams).length === 1;
+        if (!matches) {
+          return;
+        }
+
+        table[index] = { ...row, ...patch };
+        updated.push({ ...table[index] });
+      });
+
+      return createMockSupabaseResponse(200, updated);
+    }
+
+    if (method === "DELETE") {
+      const remaining = [];
+      table.forEach((row) => {
+        const matches = applyFilters([row], searchParams).length === 1;
+        if (!matches) {
+          remaining.push(row);
+        }
+      });
+      tables[tableName] = remaining;
+      return createMockSupabaseResponse(204, null);
+    }
+
+    return createMockSupabaseResponse(405, { error: "unsupported_method" });
+  }
+
+  return {
+    tables,
+    fetch: fetchMock
+  };
+}
+
+async function withMockSupabase(run, initialData = {}) {
+  const originalFetch = global.fetch;
+  const envKeys = [
+    "DATASTORE_DRIVER",
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY",
+    "SUPABASE_DB_SCHEMA",
+    "VERCEL"
+  ];
+  const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  const mock = createMockSupabaseFetch(initialData);
+
+  process.env.DATASTORE_DRIVER = "supabase";
+  process.env.SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-test-key";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY = "publishable-test-key";
+  process.env.SUPABASE_DB_SCHEMA = "public";
+  delete process.env.VERCEL;
+  global.fetch = mock.fetch;
+
+  try {
+    return await run(mock);
+  } finally {
+    global.fetch = originalFetch;
+    envKeys.forEach((key) => {
+      if (typeof originalEnv[key] === "undefined") {
+        delete process.env[key];
+        return;
+      }
+      process.env[key] = originalEnv[key];
+    });
+  }
+}
+
 async function createAuthenticatedAppSession(app, username) {
   const registered = app.auth.registerPasswordUser(username, "secret");
   assert.equal(registered.ok, true);
@@ -2561,6 +2757,72 @@ register("GET /api/health espone lo stato del datastore sqlite", async () => {
     assert.equal(typeof payload.storage.counts.games, "number");
     assert.equal(typeof payload.storage.counts.sessions, "number");
     assert.equal(payload.hasActiveGame, true);
+  });
+});
+
+register("datastore supabase espone healthSummary async quando configurato via env", async () => {
+  await withMockSupabase(async () => {
+    const datastore = createDatastore({
+      legacyUsersFile: null,
+      legacyGamesFile: null,
+      legacySessionsFile: null
+    });
+
+    const health = await datastore.healthSummary();
+    assert.equal(datastore.driver, "supabase");
+    assert.equal(health.ok, true);
+    assert.equal(health.storage, "supabase");
+    assert.equal(health.url, "https://example.supabase.co");
+    assert.equal(health.schema, "public");
+    assert.deepEqual(health.counts, { users: 0, games: 0, sessions: 0 });
+
+    datastore.close();
+  });
+});
+
+register("app usa Supabase per auth/session e non crea sqlite locale quando il driver e remoto", async () => {
+  await withMockSupabase(async (mock) => {
+    const unique = `${Date.now()}-${uniqueSuffix()}`;
+    const tempFile = path.join(__dirname, `tmp-supabase-users-${unique}.json`);
+    const tempGamesFile = path.join(__dirname, `tmp-supabase-games-${unique}.json`);
+    const tempSessionsFile = path.join(__dirname, `tmp-supabase-sessions-${unique}.json`);
+    const tempDbFile = path.join(__dirname, `tmp-supabase-store-${unique}.sqlite`);
+    const app = createApp({
+      dataFile: tempFile,
+      gamesFile: tempGamesFile,
+      sessionsFile: tempSessionsFile,
+      dbFile: tempDbFile
+    });
+
+    try {
+      const registered = await app.auth.registerPasswordUser("supa_tester", "secret");
+      assert.equal(registered.ok, true);
+
+      const login = await app.auth.loginWithPassword("supa_tester", "secret");
+      assert.equal(login.ok, true);
+      assert.equal(typeof login.sessionToken, "string");
+
+      const sessionResponse = await callApp(app, "GET", "/api/auth/session", undefined, authHeaders(login.sessionToken));
+      assert.equal(sessionResponse.statusCode, 200);
+      assert.equal(sessionResponse.payload.user.username, "supa_tester");
+
+      const healthResponse = await callApp(app, "GET", "/api/health");
+      assert.equal(healthResponse.statusCode, 200);
+      assert.equal(healthResponse.payload.storage.storage, "supabase");
+
+      assert.equal(mock.tables.users.length, 1);
+      assert.equal(mock.tables.sessions.length, 1);
+      assert.equal(typeof JSON.parse(mock.tables.users[0].credentials_json).password.hash, "string");
+      assert.equal(fs.existsSync(tempDbFile), false);
+    } finally {
+      app.datastore.close();
+      [tempFile, tempGamesFile, tempSessionsFile].forEach((target) => {
+        if (fs.existsSync(target)) {
+          fs.unlinkSync(target);
+        }
+      });
+      cleanupSqliteFiles(tempDbFile);
+    }
   });
 });
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,35 @@
+create table if not exists public.users (
+  id text primary key,
+  username text not null unique,
+  role text not null default 'user',
+  profile_json jsonb not null default '{}'::jsonb,
+  credentials_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index if not exists users_username_lower_idx
+  on public.users (lower(username));
+
+create table if not exists public.sessions (
+  token text primary key,
+  user_id text not null references public.users(id) on delete cascade,
+  created_at bigint not null
+);
+
+create table if not exists public.games (
+  id text primary key,
+  name text not null,
+  version integer not null default 1,
+  creator_user_id text references public.users(id) on delete set null,
+  state_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists games_updated_at_idx
+  on public.games (updated_at desc);
+
+create table if not exists public.app_state (
+  key text primary key,
+  value_json jsonb not null
+);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/api/index.cjs"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/api/index.cjs"
+      "destination": "/api/index.js"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Supabase-backed datastore support while preserving the existing SQLite fallback
- add the Vercel serverless entrypoint, routing config, and Supabase schema/bootstrap files
- add regression coverage for the Vercel + Supabase runtime paths

## Verification
- node scripts/run-tests.cjs
- verified Vercel preview `/api/health` reports `storage: supabase`
- verified preview login works against the Supabase-backed deployment

## Notes
- the branch is currently 1 commit behind `main`, so GitHub may ask for a merge/update before final merge