### PR TITLE
[codex] Fix protected lobby reads and auth datastore reuse

### DIFF
--- a/backend/auth.cjs
+++ b/backend/auth.cjs
@@ -179,9 +179,8 @@ function buildProfile(username, email, protector) {
 }
 
 function createAuthStore(options = {}) {
-  const datastore = createAuthRepository({
+  const datastore = options.datastore || createAuthRepository({
     driver: options.driver || process.env.DATASTORE_DRIVER || "local",
-    datastore: options.datastore,
     dbFile: options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite"),
     dataFile: options.dataFile || path.join(__dirname, "..", "data", "users.json"),
     sessionsFile: options.sessionsFile || path.join(__dirname, "..", "data", "sessions.json"),

--- a/backend/authorization.cjs
+++ b/backend/authorization.cjs
@@ -55,10 +55,6 @@ function canReadGame(actor, game, state) {
     return true;
   }
 
-  if (game.phase === "lobby") {
-    return true;
-  }
-
   if (game.creatorUserId && game.creatorUserId === actor.id) {
     return true;
   }


### PR DESCRIPTION
## What changed
- restored protected game read authorization so lobby spectator access only applies to explicit game opening, not full state reads
- made the auth store reuse the app datastore instance when one is already provided, keeping auth/session traffic on the configured remote datastore path

## Why
Recent auth and spectator changes introduced two concrete regressions:
- protected lobby games could be read by any authenticated user
- the Supabase-backed app path no longer reused the injected datastore, breaking the remote auth/session flow

## Impact
- protected game state now stays member-only again
- remote datastore auth/session wiring works again without falling back to a separate local path

## Validation
- `node scripts/run-tests.cjs`
