### PR TITLE
[codex] Preserve current game id during game list refresh

### DIFF
--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -1072,7 +1072,7 @@ async function loadGameList() {
       || activeGame.creatorUserId === state.user?.id;
     if (!requestedId) {
       state.currentGameId = canAutoSelectActiveGame ? (data.activeGameId || state.currentGameId) : null;
-    } else {
+    } else if (state.currentGameId && !state.gameList.some((game) => game.id === state.currentGameId)) {
       state.currentGameId = null;
     }
     syncCurrentGameName();


### PR DESCRIPTION
## Summary
- preserve `state.currentGameId` during `loadGameList()` when a route-requested game is already selected
- only clear the current game id if it no longer exists in the refreshed game list
- keep VERSION_CONFLICT recovery action requests pinned to the correct game on `/game/:id`

## Root cause
`loadGameList()` unconditionally nulled `state.currentGameId` whenever `requestedId` was present. During `send()` VERSION_CONFLICT recovery, the client first restored `state.currentGameId` from the server state and then immediately called `loadGameList()`, which wiped that id again on routed game pages. Subsequent action requests could then omit `gameId` and fall back to the server active game.

## Validation
- inspected the recovery path in `send()` and the route-open flow in `loadGameList()` / `openRequestedGameIfNeeded()`
- verified the staged diff is limited to the single conditional in `frontend/public/app.js`
