### PR TITLE
Refine game map layout and protect viewport fit

### DIFF
--- a/e2e/layout/game-map-fit.spec.js
+++ b/e2e/layout/game-map-fit.spec.js
@@ -4,7 +4,8 @@ const { registerAndLogin, resetGame, uniqueUser } = require("../support/game-hel
 async function openWorldClassicGame(page, suffix) {
   await resetGame(page);
   await page.goto("/game.html");
-  const owner = uniqueUser(`mapfit_${suffix}`);
+  const normalizedSuffix = String(suffix).replace(/[^a-z0-9]/gi, "").slice(0, 8).toLowerCase();
+  const owner = uniqueUser(`mf_${normalizedSuffix}`);
   await registerAndLogin(page, owner);
   await page.goto("/new-game.html");
   await expect(page.getByTestId("new-game-shell")).toBeVisible();
@@ -71,5 +72,37 @@ for (const viewport of viewports) {
     expect(metrics.viewportOverflowBottom).toBeFalsy();
     expect(metrics.boardWidth).toBe(metrics.appliedWidth);
     expect(metrics.boardHeight).toBe(metrics.appliedHeight);
+  });
+
+  test(`turn summary panel stays under the map and inside the left column at ${viewport.name}`, async ({ page }) => {
+    test.slow();
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await openWorldClassicGame(page, `${viewport.name}-summary`);
+
+    const metrics = await page.evaluate(() => {
+      const mainColumn = document.querySelector(".game-main-column");
+      const mapStage = document.querySelector(".game-map-stage");
+      const infoPanel = document.querySelector(".game-info-bottom");
+      if (!mainColumn || !mapStage || !infoPanel) {
+        return null;
+      }
+
+      const mainRect = mainColumn.getBoundingClientRect();
+      const mapRect = mapStage.getBoundingClientRect();
+      const infoRect = infoPanel.getBoundingClientRect();
+
+      return {
+        infoStartsBelowMap: infoRect.top >= mapRect.bottom - 1,
+        infoInsideLeftColumnLeft: infoRect.left >= mainRect.left - 1,
+        infoInsideLeftColumnRight: infoRect.right <= mainRect.right + 1,
+        widthMatchesMainColumn: Math.abs(infoRect.width - mainRect.width) <= 2
+      };
+    });
+
+    expect(metrics).not.toBeNull();
+    expect(metrics.infoStartsBelowMap).toBeTruthy();
+    expect(metrics.infoInsideLeftColumnLeft).toBeTruthy();
+    expect(metrics.infoInsideLeftColumnRight).toBeTruthy();
+    expect(metrics.widthMatchesMainColumn).toBeTruthy();
   });
 }

--- a/e2e/layout/game-map-fit.spec.js
+++ b/e2e/layout/game-map-fit.spec.js
@@ -1,0 +1,75 @@
+const { test, expect } = require("@playwright/test");
+const { registerAndLogin, resetGame, uniqueUser } = require("../support/game-helpers.js");
+
+async function openWorldClassicGame(page, suffix) {
+  await resetGame(page);
+  await page.goto("/game.html");
+  const owner = uniqueUser(`mapfit_${suffix}`);
+  await registerAndLogin(page, owner);
+  await page.goto("/new-game.html");
+  await expect(page.getByTestId("new-game-shell")).toBeVisible();
+  await page.locator("#setup-map").selectOption("world-classic");
+  await page.locator("#setup-game-name").fill(`Map Fit ${suffix} ${Date.now().toString(36).slice(-4)}`);
+  await expect(page.locator("#submit-new-game")).toBeEnabled();
+  await page.getByRole("button", { name: "Crea e apri" }).click();
+
+  await expect(page.locator("#game-map-meta")).toContainText("World Classic", { timeout: 15000 });
+  await expect(page.locator(".game-map-stage .map-board")).toBeVisible({ timeout: 15000 });
+}
+
+const viewports = [
+  { name: "desktop", width: 1440, height: 960 },
+  { name: "laptop", width: 1280, height: 800 },
+  { name: "compact", width: 1180, height: 760 }
+];
+
+for (const viewport of viewports) {
+  test(`world classic map board stays inside the requested frame at ${viewport.name}`, async ({ page }) => {
+    test.slow();
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await openWorldClassicGame(page, viewport.name);
+
+    const metrics = await page.locator(".game-map-stage").evaluate((stage) => {
+      const mapRegion = stage.querySelector(".map");
+      const mapBoard = stage.querySelector(".map-board");
+      if (!mapRegion || !mapBoard) {
+        return null;
+      }
+
+      const mapRect = mapRegion.getBoundingClientRect();
+      const boardRect = mapBoard.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      const aspectRatioValue = mapBoard.style.aspectRatio || window.getComputedStyle(mapBoard).aspectRatio || "760 / 500";
+      const match = aspectRatioValue.match(/([\d.]+)\s*\/\s*([\d.]+)/);
+      const aspectRatio = match ? Number.parseFloat(match[1]) / Number.parseFloat(match[2]) : 760 / 500;
+      const expectedHeightBudget = Math.min(mapRect.height, Math.max(0, viewportHeight - mapRect.top));
+      const expectedWidth = Math.min(mapRect.width, expectedHeightBudget * aspectRatio);
+      const expectedHeight = expectedWidth / aspectRatio;
+      const appliedWidth = Math.floor(expectedWidth);
+      const appliedHeight = Math.floor(expectedHeight);
+
+      return {
+        mapWidth: mapRect.width,
+        mapHeight: mapRect.height,
+        boardWidth: boardRect.width,
+        boardHeight: boardRect.height,
+        appliedWidth,
+        appliedHeight,
+        overflowTop: boardRect.top < mapRect.top - 1,
+        overflowRight: boardRect.right > mapRect.right + 1,
+        overflowBottom: boardRect.bottom > mapRect.bottom + 1,
+        overflowLeft: boardRect.left < mapRect.left - 1,
+        viewportOverflowBottom: boardRect.bottom > viewportHeight + 1
+      };
+    });
+
+    expect(metrics).not.toBeNull();
+    expect(metrics.overflowTop).toBeFalsy();
+    expect(metrics.overflowRight).toBeFalsy();
+    expect(metrics.overflowBottom).toBeFalsy();
+    expect(metrics.overflowLeft).toBeFalsy();
+    expect(metrics.viewportOverflowBottom).toBeFalsy();
+    expect(metrics.boardWidth).toBe(metrics.appliedWidth);
+    expect(metrics.boardHeight).toBe(metrics.appliedHeight);
+  });
+}

--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -93,6 +93,8 @@ const elements = {
   identityStatus: document.querySelector("#identity-status"),
   joinButton: document.querySelector("#join-button"),
   startButton: document.querySelector("#start-button"),
+  lobbyControlsSection: document.querySelector("#lobby-controls-section"),
+  lobbyActionButtons: document.querySelector("#lobby-action-buttons"),
   gameName: document.querySelector("#game-name"),
   createGameButton: document.querySelector("#create-game-button"),
   gameList: document.querySelector("#game-list"),
@@ -102,6 +104,9 @@ const elements = {
   gameStatus: document.querySelector("#game-status"),
   gameMapMeta: document.querySelector("#game-map-meta"),
   gameSetupMeta: document.querySelector("#game-setup-meta"),
+  phaseBannerValue: document.querySelector("#phase-banner-value"),
+  reinforcementBanner: document.querySelector("#reinforcement-banner"),
+  reinforcementBannerValue: document.querySelector("#reinforcement-banner-value"),
   gameListState: document.querySelector("#game-list-state"),
   gameSessionList: document.querySelector("#game-session-list"),
   gameSessionDetails: document.querySelector("#game-session-details"),
@@ -159,6 +164,41 @@ function renderNavAvatar(username) {
 
   const label = username ? String(username).trim().charAt(0).toUpperCase() : "C";
   avatar.textContent = label || "C";
+}
+
+function fitMapBoardToViewport() {
+  const mapStage = document.querySelector(".game-map-stage");
+  const mapContainer = document.querySelector(".game-map-stage .map");
+  const mapBoard = document.querySelector(".game-map-stage .map-board");
+  if (!mapStage || !mapContainer || !mapBoard) {
+    return;
+  }
+
+  const stageStyles = window.getComputedStyle(mapStage);
+  const stagePaddingX =
+    Number.parseFloat(stageStyles.paddingLeft || "0") + Number.parseFloat(stageStyles.paddingRight || "0");
+  const stagePaddingY =
+    Number.parseFloat(stageStyles.paddingTop || "0") + Number.parseFloat(stageStyles.paddingBottom || "0");
+  const availableWidth = Math.max(0, mapStage.clientWidth - stagePaddingX);
+  const stageRect = mapStage.getBoundingClientRect();
+  const visibleViewportHeight = Math.max(0, window.innerHeight - stageRect.top - Number.parseFloat(stageStyles.paddingBottom || "0"));
+  const availableHeight = Math.max(0, Math.min(mapStage.clientHeight - stagePaddingY, visibleViewportHeight));
+  if (!availableWidth || !availableHeight) {
+    return;
+  }
+
+  const aspectRatioValue = mapBoard.style.aspectRatio || window.getComputedStyle(mapBoard).aspectRatio || "760 / 500";
+  const aspectRatioMatch = aspectRatioValue.match(/([\d.]+)\s*\/\s*([\d.]+)/);
+  const aspectRatio = aspectRatioMatch
+    ? Number.parseFloat(aspectRatioMatch[1]) / Number.parseFloat(aspectRatioMatch[2])
+    : 760 / 500;
+  const widthFromHeight = availableHeight * aspectRatio;
+  const width = Math.min(availableWidth, widthFromHeight);
+  const height = width / aspectRatio;
+
+  mapBoard.style.width = `${Math.floor(width)}px`;
+  mapBoard.style.height = `${Math.floor(height)}px`;
+  mapContainer.style.height = `${Math.floor(availableHeight)}px`;
 }
 
 function territoryPosition(territory) {
@@ -690,6 +730,7 @@ function render() {
   const currentPlayer = snapshot?.players.find((player) => player.id === snapshot.currentPlayerId) || null;
   ensurePrivateStateFresh(me);
   const winner = snapshot?.players.find((player) => player.id === snapshot.winnerId) || null;
+  const inLobby = snapshot?.phase === "lobby";
   const playerHand = currentPlayerHand();
   state.selectedTradeCardIds = state.selectedTradeCardIds.filter((cardId) => playerHand.some((card) => card.id === cardId));
   if (!playerHand.length) {
@@ -736,8 +777,6 @@ function render() {
 
   elements.statusSummary.innerHTML = snapshot
     ? `
-      <div>Fase: <strong>${snapshot.phase}</strong></div>
-      <div>Rinforzi disponibili: <strong>${snapshot.reinforcementPool}</strong></div>
       <div>Vincitore: <strong>${escapeHtml(winner ? winner.name : "nessuno")}</strong></div>
     `
     : "<div>Caricamento stato...</div>";
@@ -842,6 +881,7 @@ function render() {
   }
 
   elements.map.innerHTML = snapshot ? buildGraphMarkup(snapshot) : "";
+  fitMapBoardToViewport();
   elements.log.innerHTML = (snapshot?.log || []).map((entry) => `<li>${escapeHtml(entry)}</li>`).join("");
   const inReinforcement = snapshot?.turnPhase === "reinforcement";
   const inAttack = snapshot?.turnPhase === "attack";
@@ -867,8 +907,25 @@ function render() {
   }
   elements.logoutButton.hidden = !isAuthenticated;
   elements.logoutButton.disabled = !isAuthenticated;
-  elements.joinButton.disabled = !state.user || Boolean(me) || snapshot?.phase !== "lobby";
-  elements.startButton.disabled = !me || snapshot?.phase !== "lobby" || snapshot.players.length < 2;
+  if (elements.phaseBannerValue) {
+    elements.phaseBannerValue.textContent = snapshot?.phase || "lobby";
+  }
+  if (elements.lobbyControlsSection) {
+    elements.lobbyControlsSection.hidden = !inLobby;
+  }
+  if (elements.reinforcementBanner) {
+    elements.reinforcementBanner.hidden = !canInteract || !inReinforcement;
+  }
+  if (elements.reinforcementBannerValue) {
+    elements.reinforcementBannerValue.textContent = String(snapshot?.reinforcementPool ?? 0);
+  }
+  if (elements.lobbyActionButtons) {
+    elements.lobbyActionButtons.hidden = !inLobby;
+  }
+  elements.joinButton.hidden = !inLobby;
+  elements.startButton.hidden = !inLobby;
+  elements.joinButton.disabled = !state.user || Boolean(me) || !inLobby;
+  elements.startButton.disabled = !me || !inLobby || snapshot.players.length < 2;
   if (elements.createGameButton) {
     elements.createGameButton.disabled = false;
   }
@@ -958,19 +1015,21 @@ function render() {
     elements.surrenderButton.hidden = !canSurrender;
     elements.surrenderButton.disabled = !canSurrender;
   }
-  elements.actionHint.textContent = canInteract
-    ? pendingConquest
-      ? "Conquista"
-      : inReinforcement
-        ? "Rinforzi"
-        : inFortify
-          ? snapshot.fortifyUsed
-            ? "Chiudi turno"
-            : "Fortifica"
-          : "Attacco"
-    : state.user
-      ? "Osservazione"
-      : "Login";
+  if (elements.actionHint) {
+    elements.actionHint.textContent = canInteract
+      ? pendingConquest
+        ? "Conquista"
+        : inReinforcement
+          ? "Rinforzi"
+          : inFortify
+            ? snapshot.fortifyUsed
+              ? "Chiudi turno"
+              : "Fortifica"
+            : "Attacco"
+      : state.user
+        ? "Osservazione"
+        : "Login";
+  }
 }
 
 async function fetchLatestStateSnapshot(options = {}) {
@@ -1566,6 +1625,4 @@ await openRequestedGameIfNeeded();
 await loadState().catch(() => {});
 connectEvents();
 
-
-
-
+window.addEventListener("resize", fitMapBoardToViewport);

--- a/frontend/public/game.html
+++ b/frontend/public/game.html
@@ -37,75 +37,35 @@
           </section>
 
           <section class="battlefield-layout game-battlefield-layout" data-testid="battlefield-layout">
-            <aside class="left-rail panel game-info-rail" data-testid="info-panel">
-              <div class="panel-header tight-header game-compact-heading">
-                <div>
-                  <p class="eyebrow">Command</p>
-                  <h2>Quadro turno</h2>
-                </div>
-                <span id="turn-badge" class="badge" data-testid="phase-indicator">Lobby</span>
+            <section class="game-main-column" data-testid="game-main-column">
+              <section class="center-stage panel map-stage-panel game-map-stage" data-testid="map-panel">
+                <div id="map" class="map tactical-map" data-testid="map-region"></div>
+              </section>
+            </section>
+
+            <aside class="right-rail panel game-actions-rail" data-testid="actions-panel">
+              <div class="rail-section game-phase-banner" id="phase-banner">
+                <span>Fase: <strong id="phase-banner-value">Lobby</strong></span>
               </div>
-              <div class="rail-section game-meta-stack game-session-card">
-                <div class="game-meta-line"><span>Player</span><strong id="identity-status" data-testid="current-player-indicator">Accedi per collegarti alla partita.</strong></div>
-                <div class="game-meta-line"><span>Active game</span><strong id="game-status">Nessuna partita attiva</strong></div>
-                <div class="game-meta-line"><span>Map</span><strong id="game-map-meta">classic-mini</strong></div>
-                <div class="game-meta-line"><span>Setup</span><strong id="game-setup-meta">2 players · 0 AI</strong></div>
-                <div class="game-meta-line"><span>Access</span><span id="auth-status">Registrati o accedi per entrare nella lobby.</span></div>
+
+              <div class="rail-section game-reinforcement-banner" id="reinforcement-banner" hidden>
+                <span>Rinforzi disponibili: <strong id="reinforcement-banner-value">0</strong></span>
               </div>
-              <div class="rail-section game-side-ops">
+
+              <div class="rail-section game-lobby-controls" id="lobby-controls-section">
                 <form id="auth-form" class="auth-form compact-form rail-auth-form">
                   <input id="auth-username" name="username" maxlength="32" placeholder="Username" autocomplete="username" required />
                   <input id="auth-password" name="password" type="password" placeholder="Password" autocomplete="current-password" required />
                   <button type="submit" id="login-button" class="ghost-button">Accedi</button>
                   <a href="/register.html" id="register-link" class="ghost-button full-width">Registrati</a>
                 </form>
-                <div class="identity-actions compact-actions rail-action-group">
+                <div class="identity-actions compact-actions rail-action-group" id="lobby-action-buttons">
                   <button id="join-button">Entra nella lobby</button>
                   <button id="start-button" class="ghost-button">Avvia partita</button>
                 </div>
               </div>
-              <div class="rail-section game-roster-section">
-                <div class="section-title-row">
-                  <h3>Giocatori</h3>
-                  <span class="badge accent">Live</span>
-                </div>
-                <div id="players" class="players rail-players"></div>
-              </div>
-            </aside>
 
-            <section class="center-stage panel map-stage-panel game-map-stage" data-testid="map-panel">
-              <div class="panel-header map-stage-header">
-                <div>
-                  <h2>Teatro di Guerra</h2>
-                  <p class="stage-copy">La mappa resta il focus principale: leggi il turno qui e usa il pannello azioni solo quando serve.</p>
-                </div>
-                <span id="action-hint" class="badge accent">In attesa</span>
-              </div>
-              <div class="map-stage-command-strip">
-                <div id="status-summary" class="status-summary command-summary map-command-summary" data-testid="status-summary"></div>
-                <div id="trade-alert" class="turn-alert turn-alert-danger map-trade-alert" hidden>
-                  <strong>Scambio obbligatorio</strong>
-                  <span id="trade-alert-text">Devi scambiare 3 carte per continuare il turno.</span>
-                </div>
-              </div>
-              <div id="map" class="map tactical-map" data-testid="map-region"></div>
-            </section>
-
-            <aside class="right-rail panel game-actions-rail" data-testid="actions-panel">
               <div class="rail-section actions-section">
-                <div class="section-title-row action-title-row">
-                  <div>
-                    <h3>Azioni</h3>
-                    <p class="stage-copy action-stage-copy">Esegui solo l'azione richiesta dalla fase corrente, poi passa al prossimo passaggio del turno.</p>
-                  </div>
-                  <span class="badge">Turno</span>
-                </div>
-                <div class="phase-ladder" aria-hidden="true">
-                  <span class="phase-step">1. Rinforza</span>
-                  <span class="phase-step">2. Attacca</span>
-                  <span class="phase-step">3. Consolida</span>
-                </div>
-
                 <div class="action-group compact-group" id="reinforce-group">
                   <label for="reinforce-select">Rinforza</label>
                   <div class="action-stack">
@@ -180,6 +140,14 @@
                 </div>
               </div>
 
+              <div class="rail-section game-roster-section">
+                <div class="section-title-row">
+                  <h3>Giocatori</h3>
+                  <span class="badge accent">Live</span>
+                </div>
+                <div id="players" class="players rail-players"></div>
+              </div>
+
               <div class="rail-section log-section">
                 <div class="section-title-row">
                   <h3>Registro</h3>
@@ -192,6 +160,30 @@
                 <button id="surrender-button" class="danger-button full-width" hidden>Arrenditi e abbandona partita</button>
               </div>
             </aside>
+          </section>
+
+          <section class="panel game-info-rail game-info-bottom" data-testid="info-panel">
+            <div class="panel-header tight-header game-compact-heading">
+              <div>
+                <p class="eyebrow">Command</p>
+                <h2>Quadro turno</h2>
+              </div>
+              <span id="turn-badge" class="badge" data-testid="phase-indicator">Lobby</span>
+            </div>
+            <div class="rail-section map-stage-command-strip game-status-bottom-strip">
+              <div id="status-summary" class="status-summary command-summary map-command-summary" data-testid="status-summary"></div>
+              <div id="trade-alert" class="turn-alert turn-alert-danger map-trade-alert" hidden>
+                <strong>Scambio obbligatorio</strong>
+                <span id="trade-alert-text">Devi scambiare 3 carte per continuare il turno.</span>
+              </div>
+            </div>
+            <div class="rail-section game-meta-stack game-session-card">
+              <div class="game-meta-line"><span>Player</span><strong id="identity-status" data-testid="current-player-indicator">Accedi per collegarti alla partita.</strong></div>
+              <div class="game-meta-line"><span>Active game</span><strong id="game-status">Nessuna partita attiva</strong></div>
+              <div class="game-meta-line"><span>Map</span><strong id="game-map-meta">classic-mini</strong></div>
+              <div class="game-meta-line"><span>Setup</span><strong id="game-setup-meta">2 players · 0 AI</strong></div>
+              <div class="game-meta-line"><span>Access</span><span id="auth-status">Registrati o accedi per entrare nella lobby.</span></div>
+            </div>
           </section>
         </section>
       </main>

--- a/frontend/public/game.html
+++ b/frontend/public/game.html
@@ -41,6 +41,30 @@
               <section class="center-stage panel map-stage-panel game-map-stage" data-testid="map-panel">
                 <div id="map" class="map tactical-map" data-testid="map-region"></div>
               </section>
+
+              <section class="panel game-info-rail game-info-bottom" data-testid="info-panel">
+                <div class="panel-header tight-header game-compact-heading">
+                  <div>
+                    <p class="eyebrow">Command</p>
+                    <h2>Quadro turno</h2>
+                  </div>
+                  <span id="turn-badge" class="badge" data-testid="phase-indicator">Lobby</span>
+                </div>
+                <div class="rail-section map-stage-command-strip game-status-bottom-strip">
+                  <div id="status-summary" class="status-summary command-summary map-command-summary" data-testid="status-summary"></div>
+                  <div id="trade-alert" class="turn-alert turn-alert-danger map-trade-alert" hidden>
+                    <strong>Scambio obbligatorio</strong>
+                    <span id="trade-alert-text">Devi scambiare 3 carte per continuare il turno.</span>
+                  </div>
+                </div>
+                <div class="rail-section game-meta-stack game-session-card">
+                  <div class="game-meta-line"><span>Player</span><strong id="identity-status" data-testid="current-player-indicator">Accedi per collegarti alla partita.</strong></div>
+                  <div class="game-meta-line"><span>Active game</span><strong id="game-status">Nessuna partita attiva</strong></div>
+                  <div class="game-meta-line"><span>Map</span><strong id="game-map-meta">classic-mini</strong></div>
+                  <div class="game-meta-line"><span>Setup</span><strong id="game-setup-meta">2 players · 0 AI</strong></div>
+                  <div class="game-meta-line"><span>Access</span><span id="auth-status">Registrati o accedi per entrare nella lobby.</span></div>
+                </div>
+              </section>
             </section>
 
             <aside class="right-rail panel game-actions-rail" data-testid="actions-panel">
@@ -162,29 +186,6 @@
             </aside>
           </section>
 
-          <section class="panel game-info-rail game-info-bottom" data-testid="info-panel">
-            <div class="panel-header tight-header game-compact-heading">
-              <div>
-                <p class="eyebrow">Command</p>
-                <h2>Quadro turno</h2>
-              </div>
-              <span id="turn-badge" class="badge" data-testid="phase-indicator">Lobby</span>
-            </div>
-            <div class="rail-section map-stage-command-strip game-status-bottom-strip">
-              <div id="status-summary" class="status-summary command-summary map-command-summary" data-testid="status-summary"></div>
-              <div id="trade-alert" class="turn-alert turn-alert-danger map-trade-alert" hidden>
-                <strong>Scambio obbligatorio</strong>
-                <span id="trade-alert-text">Devi scambiare 3 carte per continuare il turno.</span>
-              </div>
-            </div>
-            <div class="rail-section game-meta-stack game-session-card">
-              <div class="game-meta-line"><span>Player</span><strong id="identity-status" data-testid="current-player-indicator">Accedi per collegarti alla partita.</strong></div>
-              <div class="game-meta-line"><span>Active game</span><strong id="game-status">Nessuna partita attiva</strong></div>
-              <div class="game-meta-line"><span>Map</span><strong id="game-map-meta">classic-mini</strong></div>
-              <div class="game-meta-line"><span>Setup</span><strong id="game-setup-meta">2 players · 0 AI</strong></div>
-              <div class="game-meta-line"><span>Access</span><span id="auth-status">Registrati o accedi per entrare nella lobby.</span></div>
-            </div>
-          </section>
         </section>
       </main>
     </div>

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -1894,7 +1894,7 @@ body[data-app-section="game"] .board-shell {
   gap: 12px;
   min-width: 0;
   height: 100%;
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
   --game-map-max-height: calc(100vh - 340px);
 }
 
@@ -1931,7 +1931,6 @@ body[data-app-section="game"] .board-shell {
 
 .game-info-bottom {
   min-width: 0;
-  margin-top: 12px;
 }
 
 .game-info-bottom .panel-header {
@@ -2127,7 +2126,6 @@ body[data-app-section="game"] .main-nav-shell {
   }
 
   .game-info-bottom {
-    margin-top: 12px;
   }
 
   .game-main-column {
@@ -2153,7 +2151,6 @@ body[data-app-section="game"] .main-nav-shell {
   }
 
   .game-info-bottom {
-    margin-top: 12px;
   }
 
   .game-info-bottom .game-compact-heading {

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -341,6 +341,7 @@ h1 {
 }
 
 .map-board.has-custom-background .map-board-stage {
+  inset: 0;
   background-image: var(--map-background-image);
   background-position: center;
   background-repeat: no-repeat;
@@ -348,9 +349,9 @@ h1 {
 }
 
 .map-board.map-id-world-classic.has-custom-background .map-board-stage {
-  inset: -3% -5.5% -11% -5.5%;
-  background-size: cover;
-  background-position: 49% 16%;
+  inset: 0;
+  background-size: contain;
+  background-position: center;
 }
 
 .map-board::before,
@@ -1761,6 +1762,7 @@ body[data-app-section="game"] .board-shell {
   width: 100%;
   max-width: none;
   padding-top: 2px;
+  padding-bottom: 8px;
 }
 
 .game-ops-bar,
@@ -1880,9 +1882,20 @@ body[data-app-section="game"] .board-shell {
 }
 
 .game-battlefield-layout {
-  grid-template-columns: 172px minmax(0, 2.2fr) 260px;
+  grid-template-columns: minmax(0, 1fr) 260px;
   gap: 12px;
-  min-height: calc(100vh - 106px);
+  align-items: stretch;
+  min-height: calc(100vh - 92px);
+  height: calc(100vh - 92px);
+}
+
+.game-main-column {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  height: 100%;
+  grid-template-rows: minmax(0, 1fr);
+  --game-map-max-height: calc(100vh - 340px);
 }
 
 .game-info-rail,
@@ -1896,8 +1909,51 @@ body[data-app-section="game"] .board-shell {
   flex-direction: column;
 }
 
+.game-lobby-controls {
+  display: grid;
+  gap: 12px;
+}
+
+.game-phase-banner,
+.game-reinforcement-banner {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  color: rgba(44, 31, 20, 0.82);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
 .game-info-rail {
   gap: 10px;
+}
+
+.game-info-bottom {
+  min-width: 0;
+  margin-top: 12px;
+}
+
+.game-info-bottom .panel-header {
+  margin-bottom: 8px;
+}
+
+.game-info-bottom .game-compact-heading {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.game-info-bottom .game-compact-heading .eyebrow {
+  margin-bottom: 2px;
+}
+
+.game-info-bottom .game-compact-heading h2 {
+  font-size: 1.55rem;
+}
+
+.game-status-bottom-strip {
+  margin-bottom: 0;
+  padding: 10px 14px;
 }
 
 .game-compact-heading {
@@ -1914,8 +1970,7 @@ body[data-app-section="game"] .board-shell {
 
 .game-session-card,
 .game-roster-section,
-.map-stage-command-strip,
-.phase-ladder {
+.map-stage-command-strip {
   border-radius: 18px;
 }
 
@@ -1925,14 +1980,17 @@ body[data-app-section="game"] .board-shell {
   border: 1px solid rgba(96, 65, 41, 0.08);
 }
 
+.game-info-bottom .game-session-card {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px 16px;
+  padding: 10px 14px;
+}
+
 .game-roster-section {
   padding: 12px;
   background: rgba(255, 248, 237, 0.55);
   border: 1px solid rgba(96, 65, 41, 0.08);
-}
-
-.game-actions-rail .log-section {
-  flex: 1 1 auto;
 }
 
 .surrender-section {
@@ -1941,6 +1999,10 @@ body[data-app-section="game"] .board-shell {
 
 .game-map-stage {
   min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 .map-stage-command-strip {
@@ -1954,10 +2016,35 @@ body[data-app-section="game"] .board-shell {
 
 .map-command-summary {
   margin-bottom: 0;
+  grid-template-columns: repeat(2, minmax(0, max-content));
+  align-items: center;
+  column-gap: 18px;
 }
 
 .map-command-summary .status-line:last-child {
   margin-bottom: 0;
+}
+
+.game-info-bottom .command-summary > div {
+  white-space: nowrap;
+  font-size: 0.9rem;
+}
+
+.game-info-bottom .game-meta-line {
+  display: grid;
+  gap: 2px;
+  align-items: start;
+}
+
+.game-info-bottom .game-meta-line span:first-child {
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.game-info-bottom .game-meta-line strong,
+.game-info-bottom .game-meta-line span:last-child {
+  font-size: 0.96rem;
 }
 
 .map-trade-alert {
@@ -1965,42 +2052,31 @@ body[data-app-section="game"] .board-shell {
 }
 
 .game-map-stage .map {
-  min-height: calc(100vh - 258px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 0;
+  height: auto;
+  width: 100%;
+  overflow: hidden;
 }
 
 .game-map-stage .map-board {
-  aspect-ratio: 820 / 520;
+  aspect-ratio: auto;
+  width: auto;
+  height: auto;
+  max-height: none;
+  margin: 0 auto;
 }
 
-.action-title-row {
-  align-items: flex-start;
+.game-map-stage .map-board-stage {
+  inset: 0;
+  background-size: contain;
+  background-position: center;
 }
 
-.action-stage-copy {
-  margin-top: 6px;
-  max-width: 24rem;
-}
-
-.phase-ladder {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  margin: 0 0 14px;
-}
-
-.phase-step {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 34px;
-  padding: 0 10px;
-  border-radius: 999px;
-  background: rgba(44, 31, 20, 0.06);
-  color: rgba(44, 31, 20, 0.78);
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
+.game-map-stage .map-legend {
+  display: none;
 }
 
 body[data-app-section="game"] .main-nav-shell {
@@ -2039,7 +2115,23 @@ body[data-app-section="game"] .main-nav-shell {
   }
 
   .game-battlefield-layout {
-    grid-template-columns: 160px minmax(0, 1fr) 236px;
+    grid-template-columns: minmax(0, 1fr) 236px;
+  }
+
+  .game-info-bottom .game-session-card {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .map-command-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .game-info-bottom {
+    margin-top: 12px;
+  }
+
+  .game-main-column {
+    --game-map-max-height: calc(100vh - 332px);
   }
 }
 
@@ -2047,15 +2139,32 @@ body[data-app-section="game"] .main-nav-shell {
   .game-battlefield-layout {
     grid-template-columns: 1fr;
     min-height: auto;
+    height: auto;
+  }
+
+  .game-actions-rail {
+    max-height: none;
+    overflow: visible;
   }
 
   .game-map-stage .map {
-    min-height: 500px;
+    height: auto;
+    min-height: 420px;
   }
 
-  .phase-ladder {
+  .game-info-bottom {
+    margin-top: 12px;
+  }
+
+  .game-info-bottom .game-compact-heading {
+    align-items: flex-start;
+  }
+
+  .game-info-bottom .game-session-card,
+  .map-command-summary {
     grid-template-columns: 1fr;
   }
+
 }
 
 


### PR DESCRIPTION
## Summary
- move the turn summary panel back under the map inside the left column
- keep the right rail independent so the summary panel no longer spans under it
- extend the layout e2e coverage to verify both map fit and summary panel placement

## Testing
- `node scripts/run-e2e.cjs e2e/layout/game-map-fit.spec.js`