### PR TITLE
Fix status summary regression for reinforcement count

### DIFF
--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -777,6 +777,8 @@ function render() {
 
   elements.statusSummary.innerHTML = snapshot
     ? `
+      <div>Fase: <strong>${escapeHtml(snapshot.phase)}</strong></div>
+      <div>Rinforzi disponibili: <strong>${snapshot.reinforcementPool}</strong></div>
       <div>Vincitore: <strong>${escapeHtml(winner ? winner.name : "nessuno")}</strong></div>
     `
     : "<div>Caricamento stato...</div>";


### PR DESCRIPTION
### Motivation
- Restore the shared `#status-summary` output to include phase and reinforcement pool so existing gameplay and e2e consumers parsing `data-testid="status-summary"` continue to work.

### Description
- Re-added `Fase` and `Rinforzi disponibili` to `elements.statusSummary.innerHTML` and applied `escapeHtml` to `snapshot.phase` in `frontend/public/app.js` so the summary now contains phase, reinforcement pool, and winner; modified file: `frontend/public/app.js`.

### Testing
- Ran `npm test`, which could not complete in this environment because Node.js v20.19.6 lacks the builtin `node:sqlite` required by `backend/datastore.cjs`, so automated tests did not run to success.