### PR TITLE
[codex] Fix banzai action response payload

### DIFF
--- a/backend/server.cjs
+++ b/backend/server.cjs
@@ -872,7 +872,10 @@ function createApp(options = {}) {
           throw error;
         }
         broadcastGame(gameContext);
-        sendJson(res, 200, { ok: true, state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user) });
+        sendJson(res, 200, {
+          ok: true,
+          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user)
+        });
         return;
       }
 
@@ -911,7 +914,11 @@ function createApp(options = {}) {
           throw error;
         }
         broadcastGame(gameContext);
-        sendJson(res, 200, { ok: true, state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user) });
+        sendJson(res, 200, {
+          ok: true,
+          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user),
+          rounds: Array.isArray(result.rounds) ? result.rounds : undefined
+        });
         return;
       }
 
@@ -993,8 +1000,7 @@ function createApp(options = {}) {
         broadcastGame(gameContext);
         sendJson(res, 200, {
           ok: true,
-          state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName),
-          rounds: Array.isArray(result.rounds) ? result.rounds : undefined
+          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user)
         });
         return;
       }

--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -2988,6 +2988,57 @@ register("API state espone solo la mano del player autenticato risolto", async (
   });
 });
 
+register("API surrender mantiene lo snapshot per-user anche dopo la resa", async () => {
+  await withServer(async (baseUrl) => {
+    const ownerSession = await createAuthenticatedSession(baseUrl, uniqueName("surrender_owner"));
+    const created = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: authHeaders(ownerSession.sessionToken),
+      body: JSON.stringify({ name: "Surrender snapshot" })
+    });
+    assert.equal(created.status, 201);
+
+    const joinOwner = await fetch(baseUrl + "/api/join", {
+      method: "POST",
+      headers: authHeaders(ownerSession.sessionToken),
+      body: JSON.stringify({ sessionToken: ownerSession.sessionToken })
+    });
+    assert.equal(joinOwner.status, 200);
+    const ownerPayload = await joinOwner.json();
+
+    const otherSession = await createAuthenticatedSession(baseUrl, uniqueName("surrender_other"));
+    const joinOther = await fetch(baseUrl + "/api/join", {
+      method: "POST",
+      headers: authHeaders(otherSession.sessionToken),
+      body: JSON.stringify({ sessionToken: otherSession.sessionToken })
+    });
+    assert.equal(joinOther.status, 201);
+
+    const startResponse = await fetch(baseUrl + "/api/start", {
+      method: "POST",
+      headers: authHeaders(ownerSession.sessionToken),
+      body: JSON.stringify({ sessionToken: ownerSession.sessionToken, playerId: ownerPayload.playerId })
+    });
+    assert.equal(startResponse.status, 200);
+
+    const response = await fetch(baseUrl + "/api/action", {
+      method: "POST",
+      headers: authHeaders(ownerSession.sessionToken),
+      body: JSON.stringify({
+        sessionToken: ownerSession.sessionToken,
+        playerId: ownerPayload.playerId,
+        type: "surrender"
+      })
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.state.playerId, ownerPayload.playerId);
+    assert.equal(payload.state.players.find((player) => player.id === ownerPayload.playerId).surrendered, true);
+    assert.equal(Object.prototype.hasOwnProperty.call(payload, "rounds"), false);
+  });
+});
+
 register("API register + login + join completa il flusso di accesso", async () => {
   await withServer(async (baseUrl) => {
   const unique = `api_${Date.now()}_${uniqueSuffix()}`;


### PR DESCRIPTION
## What changed
- return `rounds` from `/api/action` only for `attack` / `attackBanzai`
- restore `snapshotForUser(...)` on `surrender` responses
- add a regression test covering the authenticated surrender response shape

## Why
Commit `258dd1f` moved the banzai attack flow server-side, but the new response payload was wired to the wrong action handler block. As a result, `attackBanzai` dropped its `rounds` data while `surrender` returned an unrelated dead `rounds` field and a generic snapshot.

## Impact
- banzai attack responses now expose the round-by-round payload generated by the engine
- surrender responses remain consistent with other authenticated actions
- the regression is covered by tests so the response shape is harder to break again

## Validation
- `npm test`