### PR TITLE
[codex] Show phase and reinforcement count in status summary

### DIFF
--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -777,6 +777,8 @@ function render() {
 
   elements.statusSummary.innerHTML = snapshot
     ? `
+      <div>Fase: <strong>${escapeHtml(snapshot.phase)}</strong></div>
+      <div>Rinforzi disponibili: <strong>${snapshot.reinforcementPool}</strong></div>
       <div>Vincitore: <strong>${escapeHtml(winner ? winner.name : "nessuno")}</strong></div>
     `
     : "<div>Caricamento stato...</div>";


### PR DESCRIPTION
## What changed
- show the current phase in the game status summary
- show the current reinforcement pool in the same summary block

## Why
These values were already useful in the game layout branch and help players understand the current turn state at a glance. Bringing them to `main` through a tiny standalone PR avoids pulling unrelated layout branch history.

## Validation
- inspected diff to confirm only 2 UI lines changed
