### PR TITLE
Add social auth provider foundation

### DIFF
--- a/backend/leaderboard-store.cjs
+++ b/backend/leaderboard-store.cjs
@@ -1,0 +1,70 @@
+function createLeaderboardStore(options = {}) {
+  const datastore = options.datastore;
+  if (!datastore) {
+    throw new Error("Leaderboard store richiede un datastore.");
+  }
+
+  async function listLeaderboardEntries(communityId, gameModeId = null) {
+    const games = await datastore.listGames();
+    const totals = new Map();
+
+    games.forEach((game) => {
+      const state = game?.state;
+      if (!state || state.phase !== "finished" || !state.communityId || state.communityId !== communityId) {
+        return;
+      }
+
+      const modeId = state.gameModeId || state.gameModeDefinition?.id || null;
+      if (gameModeId && modeId !== gameModeId) {
+        return;
+      }
+
+      const winnerId = state.winnerId || null;
+      const players = Array.isArray(state.players) ? state.players : [];
+      players.forEach((player) => {
+        if (!player || player.isAi) {
+          return;
+        }
+
+        const key = `${communityId}:${modeId || "default"}:${player.id}`;
+        const current = totals.get(key) || {
+          communityId,
+          gameModeId: modeId,
+          playerId: player.id,
+          playerName: player.name,
+          wins: 0,
+          losses: 0,
+          gamesPlayed: 0
+        };
+
+        current.gamesPlayed += 1;
+        if (winnerId && winnerId === player.id) {
+          current.wins += 1;
+        } else {
+          current.losses += 1;
+        }
+
+        totals.set(key, current);
+      });
+    });
+
+    return [...totals.values()]
+      .sort((left, right) => {
+        if (right.wins !== left.wins) {
+          return right.wins - left.wins;
+        }
+        if (left.losses !== right.losses) {
+          return left.losses - right.losses;
+        }
+        return left.playerName.localeCompare(right.playerName);
+      });
+  }
+
+  return {
+    listLeaderboardEntries
+  };
+}
+
+module.exports = {
+  createLeaderboardStore
+};

--- a/backend/server.cjs
+++ b/backend/server.cjs
@@ -31,6 +31,7 @@ const {
 } = require("./engine/game-engine.cjs");
 const { resolveBanzaiAttack } = require("./engine/banzai-attack.cjs");
 const { runAiTurn } = require("./engine/ai-player.cjs");
+const { listAuthProviderIds, listAuthProviders } = require("../shared/auth-providers.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 
 loadLocalEnv();
@@ -787,6 +788,13 @@ function createApp(options = {}) {
       return;
     }
 
+    if (req.method === "GET" && url.pathname === "/api/auth/providers") {
+      sendJson(res, 200, {
+        providers: listAuthProviders()
+      });
+      return;
+    }
+
     if (req.method === "GET" && url.pathname === "/api/profile") {
       const authContext = await requireAuth(req, res, {});
       if (!authContext) {
@@ -854,7 +862,7 @@ function createApp(options = {}) {
       sendJson(res, 201, {
         ok: true,
         user: result.user,
-        nextAuthProviders: ["password", "email", "google", "discord"]
+        nextAuthProviders: listAuthProviderIds()
       });
       return;
     }
@@ -870,7 +878,7 @@ function createApp(options = {}) {
       sendJson(res, 200, {
         ok: true,
         user: result.user,
-        availableAuthProviders: ["password", "email", "google", "discord"]
+        availableAuthProviders: listAuthProviderIds()
       }, {
         "Set-Cookie": buildSessionCookie(req, result.sessionToken)
       });

--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -46,6 +46,7 @@ const classicMiniMap = require("../shared/maps/classic-mini.cjs");
 const middleEarthMap = require("../shared/maps/middle-earth.cjs");
 const worldClassicMap = require("../shared/maps/world-classic.cjs");
 const { listSupportedMaps } = require("../shared/maps/index.cjs");
+const { listAuthProviderIds } = require("../shared/auth-providers.cjs");
 
 const tests = [];
 const TEST_PASSWORD = "Secret123!";
@@ -1952,6 +1953,17 @@ register("API game options espone setup base per nuova partita", async () => {
     assert.equal(payload.diceRuleSets[0].id, "standard");
     assert.equal(payload.playerRange.min, 2);
     assert.equal(payload.playerRange.max, 4);
+  });
+});
+
+register("API auth providers espone password e provider social supportati", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(baseUrl + "/api/auth/providers");
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.deepEqual(payload.providers.map((provider) => provider.id), listAuthProviderIds());
+    assert.equal(payload.providers.some((provider) => provider.id === "google" && provider.type === "social"), true);
+    assert.equal(payload.providers.some((provider) => provider.id === "discord" && provider.type === "social"), true);
   });
 });
 

--- a/shared/auth-providers.cjs
+++ b/shared/auth-providers.cjs
@@ -1,0 +1,49 @@
+const PASSWORD_AUTH_PROVIDER_ID = "password";
+const EMAIL_AUTH_PROVIDER_ID = "email";
+const GOOGLE_AUTH_PROVIDER_ID = "google";
+const DISCORD_AUTH_PROVIDER_ID = "discord";
+
+const authProviders = Object.freeze([
+  Object.freeze({
+    id: PASSWORD_AUTH_PROVIDER_ID,
+    type: "credentials",
+    label: "Password"
+  }),
+  Object.freeze({
+    id: EMAIL_AUTH_PROVIDER_ID,
+    type: "identity",
+    label: "Email"
+  }),
+  Object.freeze({
+    id: GOOGLE_AUTH_PROVIDER_ID,
+    type: "social",
+    label: "Google"
+  }),
+  Object.freeze({
+    id: DISCORD_AUTH_PROVIDER_ID,
+    type: "social",
+    label: "Discord"
+  })
+]);
+
+function listAuthProviders() {
+  return authProviders.map((provider) => ({ ...provider }));
+}
+
+function listAuthProviderIds() {
+  return authProviders.map((provider) => provider.id);
+}
+
+function findAuthProvider(providerId) {
+  return authProviders.find((provider) => provider.id === providerId) || null;
+}
+
+module.exports = {
+  DISCORD_AUTH_PROVIDER_ID,
+  EMAIL_AUTH_PROVIDER_ID,
+  GOOGLE_AUTH_PROVIDER_ID,
+  PASSWORD_AUTH_PROVIDER_ID,
+  findAuthProvider,
+  listAuthProviderIds,
+  listAuthProviders
+};

--- a/shared/models.cjs
+++ b/shared/models.cjs
@@ -45,6 +45,15 @@ const {
   createLeaderboardEntry,
   createPieceThemeDefinition
 } = require("./community-models.cjs");
+const {
+  DISCORD_AUTH_PROVIDER_ID,
+  EMAIL_AUTH_PROVIDER_ID,
+  GOOGLE_AUTH_PROVIDER_ID,
+  PASSWORD_AUTH_PROVIDER_ID,
+  findAuthProvider,
+  listAuthProviderIds,
+  listAuthProviders
+} = require("./auth-providers.cjs");
 const { GameAction } = require("./game-actions.cjs");
 const {
   createActionFailure,
@@ -56,8 +65,15 @@ const {
 
 module.exports = {
   CardType,
+  DISCORD_AUTH_PROVIDER_ID,
   DEFAULT_VICTORY_RULE_ID,
+  EMAIL_AUTH_PROVIDER_ID,
+  findAuthProvider,
   GameAction,
+  GOOGLE_AUTH_PROVIDER_ID,
+  listAuthProviderIds,
+  listAuthProviders,
+  PASSWORD_AUTH_PROVIDER_ID,
   STANDARD_DICE_RULE_SET_ID,
   STANDARD_THREE_DEFENSE_DICE_RULE_SET_ID,
   STANDARD_TWO_DEFENSE_DICE_RULE_SET_ID,


### PR DESCRIPTION
## Summary
- add a shared auth provider catalog for password, email, Google, and Discord
- expose `/api/auth/providers` so frontend and future OAuth flows can read supported providers from the backend
- replace hardcoded auth provider arrays in auth responses with shared registry data

## Testing
- npm test