### PR TITLE
Fix low-severity security issues: auth policy, territory validation, game name

### DIFF
--- a/backend/authorization.cjs
+++ b/backend/authorization.cjs
@@ -21,6 +21,12 @@ function canCreateGame(actor) {
   return Boolean(actor && actor.id && (actor.role === Roles.USER || actor.role === Roles.ADMIN));
 }
 
+function isActorPlayer(player, actor) {
+  if (!player) return false;
+  if (player.linkedUserId) return player.linkedUserId === actor.id;
+  return player.name === actor.username;
+}
+
 function canOpenGame(actor, game, state) {
   if (!actor || !actor.id || !game) {
     return false;
@@ -39,7 +45,7 @@ function canOpenGame(actor, game, state) {
   }
 
   const players = Array.isArray(state && state.players) ? state.players : [];
-  if (players.some((player) => player && player.name === actor.username)) {
+  if (players.some((player) => isActorPlayer(player, actor))) {
     return true;
   }
 
@@ -64,7 +70,7 @@ function canReadGame(actor, game, state) {
   }
 
   const players = Array.isArray(state && state.players) ? state.players : [];
-  if (players.some((player) => player && player.name === actor.username)) {
+  if (players.some((player) => isActorPlayer(player, actor))) {
     return true;
   }
 

--- a/backend/game-session-store.cjs
+++ b/backend/game-session-store.cjs
@@ -23,6 +23,10 @@ function normalizeGameName(name, fallbackIndex) {
     throw new Error("Il nome della partita non puo essere vuoto.");
   }
 
+  if (!/^[\p{L}\p{N}\s\-_'.,!?()]+$/u.test(normalized)) {
+    throw new Error("Il nome della partita contiene caratteri non consentiti.");
+  }
+
   return normalized;
 }
 

--- a/backend/server.cjs
+++ b/backend/server.cjs
@@ -892,11 +892,21 @@ function createApp(options = {}) {
         return;
       }
 
+      function isValidTerritoryId(id) {
+        return id && typeof gameContext.state.territories === "object" &&
+          Object.prototype.hasOwnProperty.call(gameContext.state.territories, id);
+      }
+
       if (type === "reinforce") {
+        const territoryId = String(body.territoryId || "");
+        if (!isValidTerritoryId(territoryId)) {
+          sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
+          return;
+        }
         const result = applyReinforcement(
           gameContext.state,
           playerId,
-          String(body.territoryId || ""),
+          territoryId,
           body.amount
         );
         if (!result.ok) {
@@ -938,6 +948,10 @@ function createApp(options = {}) {
         const requestedAttackDice = body.attackDice == null || body.attackDice === "" ? null : Number(body.attackDice);
         const actionFromId = String(body.fromId || "");
         const actionToId = String(body.toId || "");
+        if (!isValidTerritoryId(actionFromId) || !isValidTerritoryId(actionToId)) {
+          sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
+          return;
+        }
         const result = type === "attackBanzai"
           ? resolveBanzaiAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice)
           : resolveAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice);
@@ -984,7 +998,13 @@ function createApp(options = {}) {
       }
 
       if (type === "fortify") {
-        const result = applyFortify(gameContext.state, playerId, String(body.fromId || ""), String(body.toId || ""), body.armies);
+        const fortifyFromId = String(body.fromId || "");
+        const fortifyToId = String(body.toId || "");
+        if (!isValidTerritoryId(fortifyFromId) || !isValidTerritoryId(fortifyToId)) {
+          sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
+          return;
+        }
+        const result = applyFortify(gameContext.state, playerId, fortifyFromId, fortifyToId, body.armies);
         if (!result.ok) {
           sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
           return;


### PR DESCRIPTION
## Riepilogo

Tre fix di sicurezza a bassa gravità, identificati nell'analisi del codebase. Nessun impatto funzionale per gli utenti normali.

## Vulnerabilità corrette

### 1. `authorization.cjs` — Preferenza `linkedUserId` su username match
**Problema:** `canOpenGame` e `canReadGame` usavano solo `player.name === actor.username` per verificare l'appartenenza a una partita. Un attaccante con lo stesso username di un giocatore in una partita privata poteva ottenere accesso.

**Fix:** Aggiunta funzione `isActorPlayer()` condivisa che preferisce `linkedUserId` (check preciso per ID utente) e cade sul confronto username solo per giocatori legacy senza `linkedUserId`.

### 2. `game-session-store.cjs` — Validazione caratteri nel nome partita
**Problema:** Il nome della partita veniva solo troncato a 80 caratteri, senza alcuna validazione dei caratteri. Era possibile salvare nomi con caratteri di controllo, sequenze di escape o altri input anomali.

**Fix:** Aggiunta regex `[\p{L}\p{N}\s\-_'.,!?()]+` (Unicode-aware) che permette lettere, numeri, spazi e punteggiatura comune, rifiutando tutto il resto.

### 3. `server.cjs` — Validazione territory ID prima dell'engine
**Problema:** I territory ID (`territoryId`, `fromId`, `toId`) venivano passati direttamente al game engine senza verificare che esistessero nel game state. L'engine li validava internamente, ma era preferibile un rifiuto esplicito a livello server.

**Fix:** Aggiunta funzione `isValidTerritoryId()` che verifica la presenza dell'ID in `gameContext.state.territories` prima di invocare `applyReinforcement`, `resolveAttack`/`resolveBanzaiAttack` e `applyFortify`.

## Test plan

- [ ] Creare una partita con nome contenente caratteri speciali (es. `<script>`) → deve ritornare errore 500
- [ ] Creare una partita con nome normale (es. `Partita 1!`) → deve funzionare
- [ ] Inviare un'azione `reinforce` con `territoryId` inventato → deve ritornare 400
- [ ] Inviare un'azione `attack` con `fromId`/`toId` inventati → deve ritornare 400
- [ ] Verificare che i test e2e esistenti passino

https://claude.ai/code/session_01PLjLvaKjtD2iAzN5wAmhsx