### PR TITLE
[codex] fix fortify map selection

### DIFF
--- a/e2e/gameplay/fortify-map-selection.spec.js
+++ b/e2e/gameplay/fortify-map-selection.spec.js
@@ -1,0 +1,83 @@
+const { test, expect } = require("@playwright/test");
+
+function mockState() {
+  return {
+    phase: "active",
+    turnPhase: "fortify",
+    players: [
+      { id: "p1", name: "alice", color: "#e85d04", connected: true, isAi: false, territoryCount: 3, eliminated: false, cardCount: 0 },
+      { id: "p2", name: "CPU", color: "#0f4c5c", connected: true, isAi: true, territoryCount: 0, eliminated: false, cardCount: 0 }
+    ],
+    map: [
+      { id: "cinder", name: "Cinder", neighbors: ["aurora", "delta", "ember"], continentId: "central", ownerId: "p1", armies: 4 },
+      { id: "delta", name: "Delta", neighbors: ["aurora", "cinder", "grove", "harbor"], continentId: "central", ownerId: "p1", armies: 2 },
+      { id: "harbor", name: "Harbor", neighbors: ["delta", "ember", "forge", "grove", "ion"], continentId: "south", ownerId: "p1", armies: 3 }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool: 0,
+    winnerId: null,
+    gameConfig: { mapId: "classic-mini", mapName: "Classic Mini", totalPlayers: 2, players: [{ type: "human" }, { type: "ai" }] },
+    log: ["Fortify map selection test"],
+    lastAction: null,
+    lastCombat: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: false,
+    diceRuleSet: { id: "standard", attackerMaxDice: 3, defenderMaxDice: 2 },
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 5,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    gameId: "g-1",
+    version: 4,
+    gameName: "Fortify Map Selection",
+    playerId: "p1",
+    playerHand: []
+  };
+}
+
+test("fortify map clicks select origin first and destination second", async ({ page }) => {
+  const currentState = mockState();
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("frontline-player-id", "p1");
+  });
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({ json: { user: { id: "u1", username: "alice", role: "user", authMethods: ["password"] } } });
+  });
+
+  await page.route("**/api/games**", async (route) => {
+    await route.fulfill({ json: { games: [{ id: "g-1", name: "Fortify Map Selection", updatedAt: "2026-04-12T10:00:00.000Z", phase: "active", playerCount: 2 }], activeGameId: "g-1" } });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: currentState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({ status: 200, headers: { "content-type": "text/event-stream" }, body: "" });
+  });
+
+  await page.goto("/game.html");
+
+  await expect(page.locator("#fortify-group")).toBeVisible();
+  await expect(page.locator("#fortify-from")).toHaveValue("cinder");
+  await expect(page.locator("#fortify-to")).toHaveValue("delta");
+
+  await page.locator('[data-territory-id="delta"]').click();
+  await expect(page.locator("#fortify-from")).toHaveValue("delta");
+  await expect(page.locator("#fortify-to")).toHaveValue("cinder");
+  await expect(page.locator('[data-territory-id="delta"]')).toHaveClass(/is-source/);
+
+  await page.locator('[data-territory-id="harbor"]').click();
+  await expect(page.locator("#fortify-from")).toHaveValue("delta");
+  await expect(page.locator("#fortify-to")).toHaveValue("harbor");
+  await expect(page.locator('[data-territory-id="harbor"]')).toHaveClass(/is-target/);
+});

--- a/frontend/public/app.mjs
+++ b/frontend/public/app.mjs
@@ -18,6 +18,7 @@ const state = {
   attackBanzaiInFlight: false,
   selectedFortifyFromId: null,
   selectedFortifyToId: null,
+  fortifySelectionMode: "from",
   tradeError: "",
   tradeSuccess: ""
 };
@@ -649,6 +650,7 @@ function buildGraphMarkup(snapshot) {
     });
   });
 
+  const activeSelection = currentMapSelections();
   const nodes = snapshot.map
     .map((territory) => {
       const owner = ownerById(territory.ownerId);
@@ -659,8 +661,8 @@ function buildGraphMarkup(snapshot) {
       const classes = [
         "territory-node",
         territory.ownerId === state.playerId ? "is-mine" : "",
-        state.selectedAttackFromId === territory.id ? "is-source" : "",
-        state.selectedAttackToId === territory.id ? "is-target" : "",
+        activeSelection.sourceId === territory.id ? "is-source" : "",
+        activeSelection.targetId === territory.id ? "is-target" : "",
         state.selectedReinforceTerritoryId === territory.id ? "is-reinforce" : ""
       ]
         .filter(Boolean)
@@ -737,21 +739,34 @@ function currentRenderedMapSignature(snapshot) {
   ].join("|");
 }
 
+function currentMapSelections() {
+  if (state.snapshot?.turnPhase === "fortify") {
+    return {
+      sourceId: state.selectedFortifyFromId,
+      targetId: state.selectedFortifyToId
+    };
+  }
+
+  return {
+    sourceId: state.selectedAttackFromId,
+    targetId: state.selectedAttackToId
+  };
+}
+
 function updateMapTerritoryHighlights() {
   if (!elements.map) {
     return;
   }
 
-  const selectedAttackFromId = state.selectedAttackFromId;
-  const selectedAttackToId = state.selectedAttackToId;
+  const activeSelection = currentMapSelections();
   const selectedReinforceTerritoryId = state.selectedReinforceTerritoryId;
 
   elements.map.querySelectorAll("[data-territory-id]").forEach((node) => {
     const territoryId = node.getAttribute("data-territory-id");
     const territory = territoryById(territoryId);
     node.classList.toggle("is-mine", territory?.ownerId === state.playerId);
-    node.classList.toggle("is-source", territoryId === selectedAttackFromId);
-    node.classList.toggle("is-target", territoryId === selectedAttackToId);
+    node.classList.toggle("is-source", territoryId === activeSelection.sourceId);
+    node.classList.toggle("is-target", territoryId === activeSelection.targetId);
     node.classList.toggle("is-reinforce", territoryId === selectedReinforceTerritoryId);
   });
 }
@@ -759,6 +774,31 @@ function updateMapTerritoryHighlights() {
 function handleTerritoryClick(territoryId) {
   const territory = territoryById(territoryId);
   if (!territory) {
+    return;
+  }
+
+  if (state.snapshot?.turnPhase === "fortify") {
+    if (territory.ownerId !== state.playerId) {
+      return;
+    }
+
+    const fortifySource = territoryById(state.selectedFortifyFromId);
+    const canSelectFortifyTarget =
+      state.fortifySelectionMode === "to" &&
+      fortifySource &&
+      territory.id !== fortifySource.id &&
+      fortifySource.neighbors.includes(territory.id);
+
+    if (canSelectFortifyTarget) {
+      state.selectedFortifyToId = territory.id;
+      state.fortifySelectionMode = "from";
+    } else {
+      state.selectedFortifyFromId = territory.id;
+      state.selectedFortifyToId = null;
+      state.fortifySelectionMode = "to";
+    }
+
+    render();
     return;
   }
 
@@ -779,6 +819,9 @@ function handleTerritoryClick(territoryId) {
 
 function render() {
   const snapshot = state.snapshot;
+  if (snapshot?.turnPhase !== "fortify") {
+    state.fortifySelectionMode = "from";
+  }
   if (snapshot?.gameId) {
     state.currentGameId = snapshot.gameId;
   }
@@ -1534,10 +1577,12 @@ elements.attackDice.addEventListener("change", () => {
 elements.fortifyFrom.addEventListener("change", () => {
   state.selectedFortifyFromId = elements.fortifyFrom.value || null;
   state.selectedFortifyToId = null;
+  state.fortifySelectionMode = "to";
   render();
 });
 elements.fortifyTo.addEventListener("change", () => {
   state.selectedFortifyToId = elements.fortifyTo.value || null;
+  state.fortifySelectionMode = "from";
   render();
 });
 if (elements.gameList) {


### PR DESCRIPTION
## What changed
- fixed fortify map clicks so the first click selects the origin territory and the next valid click selects the destination territory instead of overwriting the origin
- updated map highlights to reflect fortify source and target selections during the fortify phase
- added a focused Playwright regression test for fortify selection via map clicks

## Why
During the fortify phase, every territory click was reassigning the origin territory. That made it impossible to choose a destination from the map and broke the intended two-step fortify interaction.

## Impact
- players can now complete fortify selection directly from the map
- fortify UI state stays aligned between dropdowns and map highlights
- the new regression test helps prevent this interaction from breaking again

## Validation
- `npx playwright test e2e/gameplay/fortify-map-selection.spec.js --config playwright.config.cjs`
