### PR TITLE
[codex] Harden TypeScript architecture slices

### DIFF
--- a/backend/auth-repository.cts
+++ b/backend/auth-repository.cts
@@ -1,24 +1,84 @@
-// @ts-nocheck
 const path = require("path");
 const { createDatastore } = require("./datastore.cjs");
 
-function parseJson(value, fallbackValue) {
+interface UserRecord {
+  id: string;
+  username: string;
+  credentials?: Record<string, unknown>;
+  role?: string;
+  profile?: Record<string, unknown>;
+  createdAt?: string;
+}
+
+interface SessionRecord {
+  token: string;
+  user_id: string;
+  created_at: number;
+}
+
+interface UserRow {
+  id: string;
+  username: string;
+  credentials_json?: string | Record<string, unknown> | null;
+  credentials?: string | Record<string, unknown> | null;
+  role?: string | null;
+  profile_json?: string | Record<string, unknown> | null;
+  profile?: string | Record<string, unknown> | null;
+  created_at?: string | null;
+  createdAt?: string | null;
+}
+
+interface SessionRow {
+  token: string;
+  user_id?: string | null;
+  userId?: string | null;
+  created_at?: number | string | null;
+  createdAt?: number | string | null;
+}
+
+interface LocalDatastore {
+  listUsers(): Promise<UserRecord[]> | UserRecord[];
+  findUserByUsername(username: string): Promise<UserRecord | null> | UserRecord | null;
+  findUserById(userId: string): Promise<UserRecord | null> | UserRecord | null;
+  createUser(user: UserRecord): Promise<UserRecord | null> | UserRecord | null;
+  updateUserCredentials(userId: string, credentials: Record<string, unknown>): Promise<UserRecord | null> | UserRecord | null;
+  updateUserProfile(userId: string, profile: Record<string, unknown>): Promise<UserRecord | null> | UserRecord | null;
+  updateUserThemePreference?(userId: string, theme: string): Promise<UserRecord | null> | UserRecord | null;
+  createSession(token: string, userId: string, createdAt: number): Promise<void> | void;
+  findSession(token: string): Promise<SessionRecord | SessionRow | null> | SessionRecord | SessionRow | null;
+  deleteSession(token: string): Promise<void> | void;
+  close?(): void;
+}
+
+interface AuthRepositoryOptions {
+  datastore?: LocalDatastore;
+  driver?: string;
+  dbFile?: string;
+  dataFile?: string;
+  sessionsFile?: string;
+  gamesFile?: string;
+  supabaseUrl?: string;
+  supabaseServiceRoleKey?: string;
+  supabaseSchema?: string;
+}
+
+function parseJson<T>(value: unknown, fallbackValue: T): T {
   if (value == null || value === "") {
     return fallbackValue;
   }
 
   if (typeof value !== "string") {
-    return value;
+    return value as T;
   }
 
   try {
-    return JSON.parse(value);
+    return JSON.parse(value) as T;
   } catch (error) {
     return fallbackValue;
   }
 }
 
-function normalizeUser(row) {
+function normalizeUser(row: UserRow | null | undefined): UserRecord | null {
   if (!row) {
     return null;
   }
@@ -33,56 +93,58 @@ function normalizeUser(row) {
   };
 }
 
-function normalizeSession(row) {
+function normalizeSession(row: SessionRow | SessionRecord | null | undefined): SessionRecord | null {
   if (!row) {
     return null;
   }
 
   return {
     token: row.token,
-    user_id: row.user_id || row.userId,
-    created_at: Number(row.created_at ?? row.createdAt ?? Date.now())
+    user_id: row.user_id || ("userId" in row ? row.userId : null) || "",
+    created_at: Number(row.created_at ?? ("createdAt" in row ? row.createdAt : null) ?? Date.now())
   };
 }
 
-function createLocalAuthRepository(options = {}) {
-  const datastore = options.datastore || createDatastore({
+function createLocalAuthRepository(options: AuthRepositoryOptions = {}) {
+  const datastore = (options.datastore || createDatastore({
     dbFile: options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite"),
     legacyUsersFile: options.dataFile || path.join(__dirname, "..", "data", "users.json"),
     legacySessionsFile: options.sessionsFile || path.join(__dirname, "..", "data", "sessions.json"),
     legacyGamesFile: options.gamesFile || path.join(__dirname, "..", "data", "games.json")
-  });
+  })) as LocalDatastore;
 
   return {
     driver: "local",
     async listUsers() {
       return datastore.listUsers();
     },
-    async findUserByUsername(username) {
+    async findUserByUsername(username: string) {
       return datastore.findUserByUsername(username);
     },
-    async findUserById(userId) {
+    async findUserById(userId: string) {
       return datastore.findUserById(userId);
     },
-    async createUser(user) {
+    async createUser(user: UserRecord) {
       return datastore.createUser(user);
     },
-    async updateUserCredentials(userId, credentials) {
+    async updateUserCredentials(userId: string, credentials: Record<string, unknown>) {
       return datastore.updateUserCredentials(userId, credentials);
     },
-    async updateUserProfile(userId, profile) {
+    async updateUserProfile(userId: string, profile: Record<string, unknown>) {
       return datastore.updateUserProfile(userId, profile);
     },
-    async updateUserThemePreference(userId, theme) {
-      return datastore.updateUserThemePreference(userId, theme);
+    async updateUserThemePreference(userId: string, theme: string) {
+      return typeof datastore.updateUserThemePreference === "function"
+        ? datastore.updateUserThemePreference(userId, theme)
+        : null;
     },
-    async createSession(token, userId, createdAt) {
+    async createSession(token: string, userId: string, createdAt: number) {
       datastore.createSession(token, userId, createdAt);
     },
-    async findSession(token) {
-      return normalizeSession(datastore.findSession(token));
+    async findSession(token: string) {
+      return normalizeSession(await datastore.findSession(token));
     },
-    async deleteSession(token) {
+    async deleteSession(token: string) {
       datastore.deleteSession(token);
     },
     close() {
@@ -93,7 +155,7 @@ function createLocalAuthRepository(options = {}) {
   };
 }
 
-function createSupabaseAuthRepository(options = {}) {
+function createSupabaseAuthRepository(options: AuthRepositoryOptions = {}) {
   const supabaseUrl = String(options.supabaseUrl || process.env.SUPABASE_URL || "").trim().replace(/\/+$/, "");
   const serviceRoleKey = String(options.supabaseServiceRoleKey || process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim();
   const schema = String(options.supabaseSchema || process.env.SUPABASE_DB_SCHEMA || "public").trim() || "public";
@@ -102,11 +164,17 @@ function createSupabaseAuthRepository(options = {}) {
     throw new Error("Configurazione Supabase incompleta per il repository auth.");
   }
 
-  function ilikeValue(value) {
+  function ilikeValue(value: unknown): string {
     return String(value || "").replace(/[%_]/g, (token) => `\\${token}`);
   }
 
-  async function request(table, method = "GET", query = {}, body, preferRepresentation = false) {
+  async function request(
+    table: string,
+    method: string = "GET",
+    query: Record<string, unknown> = {},
+    body?: unknown,
+    preferRepresentation: boolean = false
+  ): Promise<unknown> {
     const params = new URLSearchParams();
     Object.entries(query || {}).forEach(([key, value]) => {
       if (value !== undefined && value !== null && value !== "") {
@@ -133,8 +201,11 @@ function createSupabaseAuthRepository(options = {}) {
     const payload = raw ? JSON.parse(raw) : null;
 
     if (!response.ok) {
-      const message = payload?.message || payload?.error_description || payload?.error || `Supabase auth request fallita (${response.status}).`;
-      throw new Error(message);
+      const message = (payload as Record<string, unknown> | null)?.message
+        || (payload as Record<string, unknown> | null)?.error_description
+        || (payload as Record<string, unknown> | null)?.error
+        || `Supabase auth request fallita (${response.status}).`;
+      throw new Error(String(message));
     }
 
     return payload;
@@ -147,25 +218,25 @@ function createSupabaseAuthRepository(options = {}) {
         select: "*",
         order: "created_at.asc"
       });
-      return Array.isArray(rows) ? rows.map(normalizeUser) : [];
+      return Array.isArray(rows) ? rows.map((row) => normalizeUser(row as UserRow)).filter(Boolean) : [];
     },
-    async findUserByUsername(username) {
+    async findUserByUsername(username: string) {
       const rows = await request("users", "GET", {
         select: "*",
         username: `ilike.${ilikeValue(String(username || "").trim())}`,
         limit: 1
       });
-      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0] as UserRow) : null;
     },
-    async findUserById(userId) {
+    async findUserById(userId: string) {
       const rows = await request("users", "GET", {
         select: "*",
         id: `eq.${String(userId || "").trim()}`,
         limit: 1
       });
-      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0] as UserRow) : null;
     },
-    async createUser(user) {
+    async createUser(user: UserRecord) {
       const rows = await request("users", "POST", {}, [{
         id: user.id,
         username: user.username,
@@ -174,25 +245,25 @@ function createSupabaseAuthRepository(options = {}) {
         credentials_json: JSON.stringify(user.credentials || {}),
         created_at: user.createdAt || new Date().toISOString()
       }], true);
-      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0] as UserRow) : null;
     },
-    async updateUserCredentials(userId, credentials) {
+    async updateUserCredentials(userId: string, credentials: Record<string, unknown>) {
       const rows = await request("users", "PATCH", {
         id: `eq.${String(userId || "").trim()}`
       }, {
         credentials_json: JSON.stringify(credentials || {})
       }, true);
-      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0] as UserRow) : null;
     },
-    async updateUserProfile(userId, profile) {
+    async updateUserProfile(userId: string, profile: Record<string, unknown>) {
       const rows = await request("users", "PATCH", {
         id: `eq.${String(userId || "").trim()}`
       }, {
         profile_json: JSON.stringify(profile || {})
       }, true);
-      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0] as UserRow) : null;
     },
-    async updateUserThemePreference(userId, theme) {
+    async updateUserThemePreference(userId: string, theme: string) {
       const latestUser = await this.findUserById(userId);
       if (!latestUser) {
         return null;
@@ -204,29 +275,29 @@ function createSupabaseAuthRepository(options = {}) {
         profile_json: JSON.stringify({
           ...(latestUser.profile || {}),
           preferences: {
-            ...(latestUser.profile?.preferences || {}),
+            ...(((latestUser.profile as Record<string, unknown> | undefined)?.preferences as Record<string, unknown> | undefined) || {}),
             theme: String(theme || "")
           }
         })
       }, true);
-      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeUser(rows[0] as UserRow) : null;
     },
-    async createSession(token, userId, createdAt) {
+    async createSession(token: string, userId: string, createdAt: number) {
       await request("sessions", "POST", {}, [{
         token,
         user_id: userId,
         created_at: createdAt || Date.now()
       }], false);
     },
-    async findSession(token) {
+    async findSession(token: string) {
       const rows = await request("sessions", "GET", {
         select: "*",
         token: `eq.${String(token || "").trim()}`,
         limit: 1
       });
-      return Array.isArray(rows) && rows.length ? normalizeSession(rows[0]) : null;
+      return Array.isArray(rows) && rows.length ? normalizeSession(rows[0] as SessionRow) : null;
     },
-    async deleteSession(token) {
+    async deleteSession(token: string) {
       await request("sessions", "DELETE", {
         token: `eq.${String(token || "").trim()}`
       });
@@ -236,7 +307,7 @@ function createSupabaseAuthRepository(options = {}) {
   };
 }
 
-function createAuthRepository(options = {}) {
+function createAuthRepository(options: AuthRepositoryOptions = {}) {
   const driver = String(options.driver || process.env.DATASTORE_DRIVER || "local").trim().toLowerCase();
   return driver === "supabase"
     ? createSupabaseAuthRepository(options)

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -1,10 +1,102 @@
-// @ts-nocheck
 const path = require("path");
 const crypto = require("crypto");
 const { createAuthRepository } = require("./auth-repository.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 
-function passwordRecord(secret) {
+interface ThemePreferences {
+  theme?: string;
+}
+
+interface UserProfile {
+  displayName?: string;
+  preferences?: ThemePreferences;
+  contact?: {
+    emailEncrypted?: string;
+    emailHint?: string;
+  };
+  [key: string]: unknown;
+}
+
+interface PasswordHashRecord {
+  algorithm?: string;
+  salt?: string;
+  keylen?: number;
+  hash?: string;
+  digest?: string;
+  iterations?: number;
+  secret?: string;
+}
+
+interface UserCredentials {
+  password?: PasswordHashRecord;
+  [key: string]: unknown;
+}
+
+interface StoredUser {
+  id: string;
+  username: string;
+  role?: string;
+  credentials?: UserCredentials;
+  profile?: UserProfile;
+  createdAt?: string;
+}
+
+interface PublicUser {
+  id: string;
+  username: string;
+  role: string;
+  authMethods: string[];
+  hasEmail: boolean;
+  preferences: ThemePreferences;
+}
+
+interface AuthSession {
+  user_id?: string;
+  userId?: string;
+  created_at?: number;
+  createdAt?: number;
+}
+
+interface AuthRepository {
+  listUsers(): Promise<StoredUser[]> | StoredUser[];
+  findUserByUsername(username: string): Promise<StoredUser | null> | StoredUser | null;
+  findUserById(userId: string): Promise<StoredUser | null> | StoredUser | null;
+  createUser(user: StoredUser): Promise<StoredUser | null> | StoredUser | null;
+  updateUserCredentials(userId: string, credentials: UserCredentials): Promise<StoredUser | null> | StoredUser | null;
+  updateUserProfile(userId: string, profile: UserProfile): Promise<StoredUser | null> | StoredUser | null;
+  updateUserThemePreference?(userId: string, theme: string): Promise<StoredUser | null> | StoredUser | null;
+  createSession(token: string, userId: string, createdAt: number): Promise<void> | void;
+  findSession(token: string): Promise<AuthSession | null> | AuthSession | null;
+  deleteSession(token: string): Promise<void> | void;
+}
+
+interface AuthStoreOptions {
+  datastore?: AuthRepository;
+  driver?: string;
+  dbFile?: string;
+  dataFile?: string;
+  sessionsFile?: string;
+  gamesFile?: string;
+  supabaseUrl?: string;
+  supabaseServiceRoleKey?: string;
+  supabaseSchema?: string;
+  encryptionKey?: string;
+}
+
+interface RegistrationInput {
+  username: string;
+  password: string;
+  email: string;
+}
+
+interface AuthFailure {
+  ok: false;
+  error: string;
+  errorKey: string;
+  errorParams: Record<string, unknown>;
+}
+
+function passwordRecord(secret: unknown): Required<Pick<PasswordHashRecord, "algorithm" | "salt" | "keylen" | "hash">> {
   const salt = crypto.randomBytes(16).toString("hex");
   const keylen = 64;
   const hash = crypto.scryptSync(String(secret || ""), salt, keylen).toString("hex");
@@ -16,24 +108,24 @@ function passwordRecord(secret) {
   };
 }
 
-function normalizeUsername(username) {
+function normalizeUsername(username: unknown): string {
   return String(username || "").trim().toLowerCase();
 }
 
-function normalizeEmail(email) {
+function normalizeEmail(email: unknown): string {
   return String(email || "").trim().toLowerCase();
 }
 
-function userRole(user) {
+function userRole(user: StoredUser | null | undefined): string {
   return user && user.role === "admin" ? "admin" : "user";
 }
 
-function publicUser(user) {
+function publicUser(user: StoredUser | null | undefined): PublicUser | null {
   if (!user) {
     return null;
   }
 
-  const preferences = {};
+  const preferences: ThemePreferences = {};
   if (typeof user.profile?.preferences?.theme === "string" && user.profile.preferences.theme) {
     preferences.theme = user.profile.preferences.theme;
   }
@@ -48,7 +140,7 @@ function publicUser(user) {
   };
 }
 
-function verifyPassword(credentials, password) {
+function verifyPassword(credentials: UserCredentials | undefined, password: unknown): boolean {
   const record = credentials && credentials.password ? credentials.password : null;
   if (!record) {
     return false;
@@ -77,7 +169,7 @@ function verifyPassword(credentials, password) {
   return crypto.timingSafeEqual(expected, received);
 }
 
-function dataProtectionKey(options = {}) {
+function dataProtectionKey(options: AuthStoreOptions = {}): Buffer | null {
   const raw = String(
     options.encryptionKey
     || process.env.AUTH_ENCRYPTION_KEY
@@ -87,14 +179,14 @@ function dataProtectionKey(options = {}) {
   return raw ? crypto.createHash("sha256").update(raw).digest() : null;
 }
 
-function createFieldProtector(options = {}) {
+function createFieldProtector(options: AuthStoreOptions = {}) {
   const key = dataProtectionKey(options);
 
   return {
-    isConfigured() {
+    isConfigured(): boolean {
       return Boolean(key);
     },
-    encrypt(value) {
+    encrypt(value: unknown): string {
       if (!key) {
         throw createLocalizedError("AUTH_ENCRYPTION_KEY mancante.", "auth.internal.missingEncryptionKey");
       }
@@ -113,12 +205,13 @@ function createFieldProtector(options = {}) {
   };
 }
 
-function registrationInput(inputOrUsername, password) {
+function registrationInput(inputOrUsername: unknown, password?: unknown): RegistrationInput {
   if (inputOrUsername && typeof inputOrUsername === "object" && !Array.isArray(inputOrUsername)) {
+    const input = inputOrUsername as Record<string, unknown>;
     return {
-      username: String(inputOrUsername.username || "").trim().slice(0, 32),
-      password: String(inputOrUsername.password || ""),
-      email: normalizeEmail(inputOrUsername.email)
+      username: String(input.username || "").trim().slice(0, 32),
+      password: String(input.password || ""),
+      email: normalizeEmail(input.email)
     };
   }
 
@@ -129,11 +222,11 @@ function registrationInput(inputOrUsername, password) {
   };
 }
 
-function authFailure(error, errorKey, errorParams = {}) {
+function authFailure(error: string, errorKey: string, errorParams: Record<string, unknown> = {}): AuthFailure {
   return { ok: false, error, errorKey, errorParams };
 }
 
-function registrationValidationError(input, protector) {
+function registrationValidationError(input: RegistrationInput, protector: ReturnType<typeof createFieldProtector>): AuthFailure | null {
   if (!input.username || !input.password) {
     return authFailure("Inserisci utente e password.", "auth.register.requiredFields");
   }
@@ -160,7 +253,7 @@ function registrationValidationError(input, protector) {
   return null;
 }
 
-function maskEmail(email) {
+function maskEmail(email: string): string {
   const normalized = normalizeEmail(email);
   const parts = normalized.split("@");
   if (parts.length !== 2) {
@@ -173,8 +266,8 @@ function maskEmail(email) {
   return `${visible}@${domain}`;
 }
 
-function buildProfile(username, email, protector) {
-  const profile = {
+function buildProfile(username: string, email: string, protector: ReturnType<typeof createFieldProtector>): UserProfile {
+  const profile: UserProfile = {
     displayName: username
   };
 
@@ -188,8 +281,8 @@ function buildProfile(username, email, protector) {
   return profile;
 }
 
-function createAuthStore(options = {}) {
-  const datastore = options.datastore || createAuthRepository({
+function createAuthStore(options: AuthStoreOptions = {}) {
+  const datastore = (options.datastore || createAuthRepository({
     driver: options.driver || process.env.DATASTORE_DRIVER || "local",
     dbFile: options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite"),
     dataFile: options.dataFile || path.join(__dirname, "..", "data", "users.json"),
@@ -198,19 +291,19 @@ function createAuthStore(options = {}) {
     supabaseUrl: options.supabaseUrl,
     supabaseServiceRoleKey: options.supabaseServiceRoleKey,
     supabaseSchema: options.supabaseSchema
-  });
+  })) as AuthRepository;
   const protector = createFieldProtector(options);
 
   async function listUsers() {
     return datastore.listUsers();
   }
 
-  async function findByUsername(username) {
+  async function findByUsername(username: string) {
     const normalized = normalizeUsername(username);
     return normalized ? datastore.findUserByUsername(normalized) : null;
   }
 
-  async function registerPasswordUser(inputOrUsername, password) {
+  async function registerPasswordUser(inputOrUsername: unknown, password?: unknown) {
     const input = registrationInput(inputOrUsername, password);
     const validationError = registrationValidationError(input, protector);
     if (validationError) {
@@ -235,7 +328,7 @@ function createAuthStore(options = {}) {
     return { ok: true, user: publicUser(await datastore.createUser(user)) };
   }
 
-  async function loginWithPassword(username, password) {
+  async function loginWithPassword(username: string, password: unknown) {
     const user = await findByUsername(username);
 
     if (typeof user?.credentials?.password?.secret === "string") {
@@ -269,7 +362,7 @@ function createAuthStore(options = {}) {
     };
   }
 
-  async function getUserFromSession(sessionToken) {
+  async function getUserFromSession(sessionToken: string | null | undefined) {
     if (!sessionToken) {
       return null;
     }
@@ -286,10 +379,11 @@ function createAuthStore(options = {}) {
       return null;
     }
 
-    return await datastore.findUserById(session.user_id || session.userId) || null;
+    const sessionUserId = session.user_id || session.userId || "";
+    return sessionUserId ? (await datastore.findUserById(sessionUserId)) || null : null;
   }
 
-  async function logout(sessionToken) {
+  async function logout(sessionToken: string | null | undefined) {
     if (sessionToken) {
       await datastore.deleteSession(sessionToken);
     }
@@ -297,13 +391,13 @@ function createAuthStore(options = {}) {
     return null;
   }
 
-  async function updateUserProfile(userId, profile) {
+  async function updateUserProfile(userId: string, profile: UserProfile) {
     const updatedUser = await datastore.updateUserProfile(userId, profile || {});
     return updatedUser ? publicUser(updatedUser) : null;
   }
 
-  async function updateUserThemePreference(userId, theme) {
-    let updatedUser = null;
+  async function updateUserThemePreference(userId: string, theme: string) {
+    let updatedUser: StoredUser | null = null;
 
     if (typeof datastore.updateUserThemePreference === "function") {
       updatedUser = await datastore.updateUserThemePreference(userId, theme);
@@ -312,7 +406,7 @@ function createAuthStore(options = {}) {
       updatedUser = await datastore.updateUserProfile(userId, {
         ...(currentUser?.profile || {}),
         preferences: {
-          ...(currentUser?.profile?.preferences || {}),
+          ...((currentUser?.profile?.preferences as ThemePreferences | undefined) || {}),
           theme: String(theme || "")
         }
       });

--- a/backend/authorization.cts
+++ b/backend/authorization.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const { userRole } = require("./auth.cjs");
 
 const Roles = {
@@ -6,7 +5,47 @@ const Roles = {
   ADMIN: "admin"
 };
 
-function actorForUser(user) {
+interface Actor {
+  id: string;
+  username: string;
+  role: string;
+}
+
+interface UserLike {
+  id: string;
+  username: string;
+  role?: string;
+}
+
+interface PlayerLike {
+  linkedUserId?: string | null;
+  name?: string | null;
+}
+
+interface GameLike {
+  phase?: string | null;
+  creatorUserId?: string | null;
+}
+
+interface AuthorizationContext {
+  user?: UserLike | null;
+  game?: GameLike | null;
+  state?: { players?: PlayerLike[] | null } | null;
+}
+
+type AuthorizationError = Error & {
+  statusCode: number;
+  code: string;
+};
+
+function createAuthorizationError(message: string, statusCode: number, code: string): AuthorizationError {
+  const error = new Error(message) as AuthorizationError;
+  error.statusCode = statusCode;
+  error.code = code;
+  return error;
+}
+
+function actorForUser(user: UserLike | null | undefined): Actor | null {
   if (!user) {
     return null;
   }
@@ -18,42 +57,17 @@ function actorForUser(user) {
   };
 }
 
-function canCreateGame(actor) {
+function canCreateGame(actor: Actor | null): boolean {
   return Boolean(actor && actor.id && (actor.role === Roles.USER || actor.role === Roles.ADMIN));
 }
 
-function isActorPlayer(player, actor) {
+function isActorPlayer(player: PlayerLike | null | undefined, actor: Actor) {
   if (!player) return false;
   if (player.linkedUserId) return player.linkedUserId === actor.id;
   return player.name === actor.username;
 }
 
-function canOpenGame(actor, game, state) {
-  if (!actor || !actor.id || !game) {
-    return false;
-  }
-
-  if (actor.role === Roles.ADMIN) {
-    return true;
-  }
-
-   if (game.phase === "lobby") {
-    return true;
-  }
-
-  if (game.creatorUserId && game.creatorUserId === actor.id) {
-    return true;
-  }
-
-  const players = Array.isArray(state && state.players) ? state.players : [];
-  if (players.some((player) => isActorPlayer(player, actor))) {
-    return true;
-  }
-
-  return !game.creatorUserId;
-}
-
-function canReadGame(actor, game, state) {
+function canOpenGame(actor: Actor | null, game: GameLike | null | undefined, state: AuthorizationContext["state"]): boolean {
   if (!actor || !actor.id || !game) {
     return false;
   }
@@ -70,7 +84,7 @@ function canReadGame(actor, game, state) {
     return true;
   }
 
-  const players = Array.isArray(state && state.players) ? state.players : [];
+  const players = Array.isArray(state?.players) ? state.players : [];
   if (players.some((player) => isActorPlayer(player, actor))) {
     return true;
   }
@@ -78,7 +92,32 @@ function canReadGame(actor, game, state) {
   return !game.creatorUserId;
 }
 
-function canStartGame(actor, game) {
+function canReadGame(actor: Actor | null, game: GameLike | null | undefined, state: AuthorizationContext["state"]): boolean {
+  if (!actor || !actor.id || !game) {
+    return false;
+  }
+
+  if (actor.role === Roles.ADMIN) {
+    return true;
+  }
+
+  if (game.phase === "lobby") {
+    return true;
+  }
+
+  if (game.creatorUserId && game.creatorUserId === actor.id) {
+    return true;
+  }
+
+  const players = Array.isArray(state?.players) ? state.players : [];
+  if (players.some((player) => isActorPlayer(player, actor))) {
+    return true;
+  }
+
+  return !game.creatorUserId;
+}
+
+function canStartGame(actor: Actor | null, game: GameLike | null | undefined): boolean {
   if (!actor || !actor.id || !game) {
     return false;
   }
@@ -94,22 +133,16 @@ function canStartGame(actor, game) {
   return game.creatorUserId === actor.id;
 }
 
-function authorize(action, context = {}) {
+function authorize(action: string, context: AuthorizationContext = {}) {
   const actor = actorForUser(context.user);
 
   if (action === "game:create") {
     if (!actor) {
-      const error = new Error("Sessione non valida.");
-      error.statusCode = 401;
-      error.code = "AUTH_REQUIRED";
-      throw error;
+      throw createAuthorizationError("Sessione non valida.", 401, "AUTH_REQUIRED");
     }
 
     if (!canCreateGame(actor)) {
-      const error = new Error("Non hai i permessi per creare una partita.");
-      error.statusCode = 403;
-      error.code = "FORBIDDEN";
-      throw error;
+      throw createAuthorizationError("Non hai i permessi per creare una partita.", 403, "FORBIDDEN");
     }
 
     return { ok: true, actor };
@@ -117,10 +150,7 @@ function authorize(action, context = {}) {
 
   if (action === "game:open" || action === "game:read") {
     if (!actor) {
-      const error = new Error("Sessione non valida.");
-      error.statusCode = 401;
-      error.code = "AUTH_REQUIRED";
-      throw error;
+      throw createAuthorizationError("Sessione non valida.", 401, "AUTH_REQUIRED");
     }
 
     const allowed = action === "game:read"
@@ -128,10 +158,7 @@ function authorize(action, context = {}) {
       : canOpenGame(actor, context.game, context.state);
 
     if (!allowed) {
-      const error = new Error("Puoi aprire solo partite di cui fai parte.");
-      error.statusCode = 403;
-      error.code = "MEMBER_ONLY";
-      throw error;
+      throw createAuthorizationError("Puoi aprire solo partite di cui fai parte.", 403, "MEMBER_ONLY");
     }
 
     return { ok: true, actor };
@@ -139,26 +166,17 @@ function authorize(action, context = {}) {
 
   if (action === "game:start") {
     if (!actor) {
-      const error = new Error("Sessione non valida.");
-      error.statusCode = 401;
-      error.code = "AUTH_REQUIRED";
-      throw error;
+      throw createAuthorizationError("Sessione non valida.", 401, "AUTH_REQUIRED");
     }
 
     if (!canStartGame(actor, context.game)) {
-      const error = new Error("Solo il creatore della partita puo avviarla.");
-      error.statusCode = 403;
-      error.code = "HOST_ONLY";
-      throw error;
+      throw createAuthorizationError("Solo il creatore della partita puo avviarla.", 403, "HOST_ONLY");
     }
 
     return { ok: true, actor };
   }
 
-  const error = new Error("Policy non supportata: " + action);
-  error.statusCode = 500;
-  error.code = "POLICY_NOT_IMPLEMENTED";
-  throw error;
+  throw createAuthorizationError("Policy non supportata: " + action, 500, "POLICY_NOT_IMPLEMENTED");
 }
 
 module.exports = {

--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -1,19 +1,136 @@
-// @ts-nocheck
-const { readJsonFile } = require("./json-file-store.cjs");
+const { readJsonFile } = require("./json-file-store.cjs") as {
+  readJsonFile: <T>(filePath: string, fallbackValue: T, isValid?: (value: unknown) => boolean) => T;
+};
 
-function parseJson(value, fallbackValue) {
+type JsonRecord = Record<string, unknown>;
+
+type UserRecord = {
+  id: string;
+  username: string;
+  credentials: JsonRecord;
+  role: string;
+  profile: JsonRecord;
+  createdAt: string;
+};
+
+type GameRecord = {
+  id: string;
+  name: string;
+  version: number;
+  creatorUserId: string | null;
+  state: JsonRecord;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SessionRecord = {
+  token: string;
+  user_id: string;
+  created_at: number;
+};
+
+type UserRow = {
+  id: string;
+  username: string;
+  credentials_json?: string | null;
+  role?: string | null;
+  profile_json?: string | null;
+  created_at?: string | null;
+};
+
+type GameRow = {
+  id: string;
+  name: string;
+  version?: number | string | null;
+  creator_user_id?: string | null;
+  state_json?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+type SessionRow = {
+  token: string;
+  user_id?: string | null;
+  created_at?: number | string | null;
+};
+
+type AppStateRow = {
+  value_json?: string | null;
+};
+
+type SupabaseDatastoreOptions = {
+  driver?: string;
+  schema?: string;
+  supabaseUrl?: string;
+  supabaseServiceRoleKey?: string;
+  legacyUsersFile?: string | null;
+  legacyGamesFile?: string | null;
+  legacySessionsFile?: string | null;
+  dataFile?: string | null;
+  gamesFile?: string | null;
+  sessionsFile?: string | null;
+};
+
+type LegacyUser = {
+  id: string;
+  username: string;
+  role?: string;
+  profile?: JsonRecord;
+  credentials?: JsonRecord;
+  createdAt?: string;
+};
+
+type LegacySession = {
+  token?: string;
+  userId?: string;
+  createdAt?: number | string;
+};
+
+type LegacyGame = {
+  id: string;
+  name: string;
+  version?: number;
+  creatorUserId?: string | null;
+  state?: JsonRecord;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type LegacyGamesDatabase = {
+  games?: LegacyGame[];
+  activeGameId?: string | null;
+};
+
+type VersionConflictError = Error & {
+  code: "VERSION_CONFLICT";
+  currentVersion: number | null;
+  currentState: JsonRecord | null;
+};
+
+type QueryFilters = Record<string, string | number | null | undefined>;
+type SupabaseRequestInit = Omit<RequestInit, "body" | "headers"> & {
+  body?: unknown;
+  headers?: Record<string, string>;
+  prefer?: string;
+};
+
+function parseJson<T>(value: unknown, fallbackValue: T): T {
   if (value == null || value === "") {
     return fallbackValue;
   }
 
+  if (typeof value !== "string") {
+    return value as T;
+  }
+
   try {
-    return JSON.parse(value);
+    return JSON.parse(value) as T;
   } catch (error) {
     return fallbackValue;
   }
 }
 
-function normalizeUser(row) {
+function normalizeUser(row: UserRow | null): UserRecord | null {
   if (!row) {
     return null;
   }
@@ -21,14 +138,14 @@ function normalizeUser(row) {
   return {
     id: row.id,
     username: row.username,
-    credentials: parseJson(row.credentials_json, {}),
+    credentials: parseJson<JsonRecord>(row.credentials_json, {}),
     role: row.role || "user",
-    profile: parseJson(row.profile_json, {}),
-    createdAt: row.created_at
+    profile: parseJson<JsonRecord>(row.profile_json, {}),
+    createdAt: row.created_at || new Date().toISOString()
   };
 }
 
-function normalizeGame(row) {
+function normalizeGame(row: GameRow | null): GameRecord | null {
   if (!row) {
     return null;
   }
@@ -36,27 +153,27 @@ function normalizeGame(row) {
   return {
     id: row.id,
     name: row.name,
-    version: Number.isInteger(row.version) ? row.version : Number(row.version) || 1,
+    version: Number.isInteger(row.version) ? Number(row.version) : Number(row.version) || 1,
     creatorUserId: row.creator_user_id || null,
-    state: parseJson(row.state_json, {}),
-    createdAt: row.created_at,
-    updatedAt: row.updated_at
+    state: parseJson<JsonRecord>(row.state_json, {}),
+    createdAt: row.created_at || new Date().toISOString(),
+    updatedAt: row.updated_at || row.created_at || new Date().toISOString()
   };
 }
 
-function normalizeSession(row) {
+function normalizeSession(row: SessionRow | null): SessionRecord | null {
   if (!row) {
     return null;
   }
 
-  return {
-    token: row.token,
-    user_id: row.user_id,
-    created_at: row.created_at
-  };
+    return {
+      token: row.token,
+      user_id: row.user_id || "",
+      created_at: Number(row.created_at) || Date.now()
+    };
 }
 
-function requiredEnv(name) {
+function requiredEnv(name: string): string {
   const value = String(process.env[name] || "").trim();
   if (!value) {
     throw new Error(`Variabile ambiente mancante: ${name}`);
@@ -64,12 +181,12 @@ function requiredEnv(name) {
   return value;
 }
 
-function encodeFilterValue(value) {
+function encodeFilterValue(value: string | number): string {
   return encodeURIComponent(String(value));
 }
 
-function toQueryString(filters = {}) {
-  const parts = [];
+function toQueryString(filters: QueryFilters = {}): string {
+  const parts: string[] = [];
   Object.entries(filters).forEach(([key, value]) => {
     if (value == null) {
       return;
@@ -80,7 +197,7 @@ function toQueryString(filters = {}) {
   return parts.length ? `?${parts.join("&")}` : "";
 }
 
-function createSupabaseDatastore(options = {}) {
+function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
   const supabaseUrl = String(
     options.supabaseUrl ||
     process.env.SUPABASE_URL ||
@@ -107,7 +224,7 @@ function createSupabaseDatastore(options = {}) {
   const legacySessionsFile = options.legacySessionsFile || options.sessionsFile || null;
   let initialized = false;
 
-  async function request(pathname, init = {}) {
+  async function request(pathname: string, init: SupabaseRequestInit = {}): Promise<unknown> {
     const response = await fetch(restBaseUrl + pathname, {
       method: init.method || "GET",
       headers: {
@@ -135,7 +252,11 @@ function createSupabaseDatastore(options = {}) {
     return text ? JSON.parse(text) : null;
   }
 
-  async function selectOne(tableName, filters = {}, options = {}) {
+  async function selectOne<TRow extends JsonRecord>(
+    tableName: string,
+    filters: QueryFilters = {},
+    options: { select?: string } = {}
+  ): Promise<TRow | null> {
     const query = toQueryString({
       select: options.select || "*",
       limit: 1,
@@ -147,10 +268,14 @@ function createSupabaseDatastore(options = {}) {
         Prefer: "count=exact"
       }
     });
-    return Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+    return Array.isArray(rows) && rows.length > 0 ? (rows[0] as TRow) : null;
   }
 
-  async function selectMany(tableName, filters = {}, options = {}) {
+  async function selectMany<TRow extends JsonRecord>(
+    tableName: string,
+    filters: QueryFilters = {},
+    options: { select?: string; order?: string | null } = {}
+  ): Promise<TRow[]> {
     const query = toQueryString({
       select: options.select || "*",
       order: options.order || null,
@@ -162,10 +287,10 @@ function createSupabaseDatastore(options = {}) {
         Prefer: "count=exact"
       }
     });
-    return Array.isArray(rows) ? rows : [];
+    return Array.isArray(rows) ? (rows as TRow[]) : [];
   }
 
-  async function upsertRows(tableName, rows, onConflict) {
+  async function upsertRows<TRow extends JsonRecord>(tableName: string, rows: TRow[], onConflict: string): Promise<unknown> {
     return request(`/${tableName}?on_conflict=${encodeURIComponent(onConflict)}`, {
       method: "POST",
       body: rows,
@@ -173,24 +298,28 @@ function createSupabaseDatastore(options = {}) {
     });
   }
 
-  async function insertRow(tableName, row) {
+  async function insertRow<TRow extends JsonRecord>(tableName: string, row: TRow): Promise<TRow | null> {
     const rows = await request(`/${tableName}`, {
       method: "POST",
       body: [row]
     });
-    return Array.isArray(rows) ? rows[0] || null : rows;
+    return Array.isArray(rows) ? ((rows[0] as TRow | undefined) || null) : (rows as TRow | null);
   }
 
-  async function patchRows(tableName, filters, patch) {
+  async function patchRows<TRow extends JsonRecord>(
+    tableName: string,
+    filters: QueryFilters,
+    patch: JsonRecord
+  ): Promise<TRow[]> {
     const query = toQueryString(filters);
     const rows = await request(`/${tableName}${query}`, {
       method: "PATCH",
       body: patch
     });
-    return Array.isArray(rows) ? rows : [];
+    return Array.isArray(rows) ? (rows as TRow[]) : [];
   }
 
-  async function deleteRows(tableName, filters) {
+  async function deleteRows(tableName: string, filters: QueryFilters): Promise<unknown> {
     const query = toQueryString(filters);
     return request(`/${tableName}${query}`, {
       method: "DELETE",
@@ -198,8 +327,8 @@ function createSupabaseDatastore(options = {}) {
     });
   }
 
-  async function countRows(tableName, columnName = "id") {
-    const rows = await selectMany(tableName, {}, { select: columnName, order: `${columnName}.asc` });
+  async function countRows(tableName: string, columnName: string = "id"): Promise<number> {
+    const rows = await selectMany<JsonRecord>(tableName, {}, { select: columnName, order: `${columnName}.asc` });
     return rows.length;
   }
 
@@ -213,7 +342,7 @@ function createSupabaseDatastore(options = {}) {
       return;
     }
 
-    const users = readJsonFile(legacyUsersFile, [], Array.isArray);
+    const users = readJsonFile<LegacyUser[]>(legacyUsersFile, [], Array.isArray);
     if (!users.length) {
       return;
     }
@@ -238,12 +367,12 @@ function createSupabaseDatastore(options = {}) {
       return;
     }
 
-    const sessions = readJsonFile(legacySessionsFile, [], Array.isArray);
+    const sessions = readJsonFile<LegacySession[]>(legacySessionsFile, [], Array.isArray);
     if (!sessions.length) {
       return;
     }
 
-    const existingUsers = new Set((await selectMany("users", {}, { select: "id", order: "id.asc" })).map((user) => user.id));
+    const existingUsers = new Set((await selectMany<{ id: string }>("users", {}, { select: "id", order: "id.asc" })).map((user) => user.id));
 
     await upsertRows("sessions", sessions
       .filter((session) => session && session.token && session.userId && existingUsers.has(session.userId))
@@ -264,7 +393,11 @@ function createSupabaseDatastore(options = {}) {
       return;
     }
 
-    const database = readJsonFile(legacyGamesFile, { games: [], activeGameId: null }, (value) => Boolean(value) && typeof value === "object");
+    const database = readJsonFile<LegacyGamesDatabase>(
+      legacyGamesFile,
+      { games: [], activeGameId: null },
+      (value) => Boolean(value) && typeof value === "object"
+    );
     const games = Array.isArray(database.games) ? database.games : [];
     if (!games.length) {
       return;
@@ -273,7 +406,7 @@ function createSupabaseDatastore(options = {}) {
     await upsertRows("games", games.map((game) => ({
       id: game.id,
       name: game.name,
-      version: Number.isInteger(game.version) && game.version > 0 ? game.version : 1,
+      version: typeof game.version === "number" && Number.isInteger(game.version) && game.version > 0 ? game.version : 1,
       creator_user_id: game.creatorUserId || null,
       state_json: JSON.stringify(game.state || {}),
       created_at: game.createdAt || new Date().toISOString(),
@@ -299,7 +432,7 @@ function createSupabaseDatastore(options = {}) {
     initialized = true;
   }
 
-  return {
+  const datastore = {
     driver: "supabase",
     async backupTo() {
       throw new Error("Il backup file-based non e disponibile con Supabase/Postgres.");
@@ -321,22 +454,22 @@ function createSupabaseDatastore(options = {}) {
     close() {
       return undefined;
     },
-    async findUserByUsername(username) {
+    async findUserByUsername(username: string) {
       await ensureInitialized();
-      const row = await selectOne("users", {
+      const row = await selectOne<UserRow>("users", {
         username: `eq.${username}`
       });
       return normalizeUser(row);
     },
-    async findUserById(userId) {
+    async findUserById(userId: string) {
       await ensureInitialized();
-      return normalizeUser(await selectOne("users", { id: `eq.${userId}` }));
+      return normalizeUser(await selectOne<UserRow>("users", { id: `eq.${userId}` }));
     },
     async listUsers() {
       await ensureInitialized();
-      return (await selectMany("users", {}, { order: "created_at.asc" })).map(normalizeUser);
+      return (await selectMany<UserRow>("users", {}, { order: "created_at.asc" })).map((row) => normalizeUser(row));
     },
-    async createUser(user) {
+    async createUser(user: UserRecord) {
       await ensureInitialized();
       await insertRow("users", {
         id: user.id,
@@ -346,29 +479,29 @@ function createSupabaseDatastore(options = {}) {
         credentials_json: JSON.stringify(user.credentials || {}),
         created_at: user.createdAt || new Date().toISOString()
       });
-      return this.findUserById(user.id);
+      return datastore.findUserById(user.id);
     },
-    async updateUserCredentials(userId, credentials) {
+    async updateUserCredentials(userId: string, credentials: JsonRecord) {
       await ensureInitialized();
       await patchRows("users", { id: `eq.${userId}` }, {
         credentials_json: JSON.stringify(credentials || {})
       });
-      return this.findUserById(userId);
+      return datastore.findUserById(userId);
     },
-    async updateUserProfile(userId, profile) {
+    async updateUserProfile(userId: string, profile: JsonRecord) {
       await ensureInitialized();
       await patchRows("users", { id: `eq.${userId}` }, {
         profile_json: JSON.stringify(profile || {})
       });
-      return this.findUserById(userId);
+      return datastore.findUserById(userId);
     },
-    async updateUserRoleByUsername(username, role) {
+    async updateUserRoleByUsername(username: string, role: string) {
       await ensureInitialized();
       await patchRows("users", { username: `eq.${username}` }, {
         role: role === "admin" ? "admin" : "user"
       });
     },
-    async createSession(token, userId, createdAt) {
+    async createSession(token: string, userId: string, createdAt: number) {
       await ensureInitialized();
       await insertRow("sessions", {
         token,
@@ -376,23 +509,23 @@ function createSupabaseDatastore(options = {}) {
         created_at: createdAt || Date.now()
       });
     },
-    async findSession(token) {
+    async findSession(token: string) {
       await ensureInitialized();
-      return normalizeSession(await selectOne("sessions", { token: `eq.${token}` }));
+      return normalizeSession(await selectOne<SessionRow>("sessions", { token: `eq.${token}` }));
     },
-    async deleteSession(token) {
+    async deleteSession(token: string) {
       await ensureInitialized();
       await deleteRows("sessions", { token: `eq.${token}` });
     },
     async listGames() {
       await ensureInitialized();
-      return (await selectMany("games", {}, { order: "updated_at.desc" })).map(normalizeGame);
+      return (await selectMany<GameRow>("games", {}, { order: "updated_at.desc" })).map((row) => normalizeGame(row));
     },
-    async findGameById(gameId) {
+    async findGameById(gameId: string) {
       await ensureInitialized();
-      return normalizeGame(await selectOne("games", { id: `eq.${gameId}` }));
+      return normalizeGame(await selectOne<GameRow>("games", { id: `eq.${gameId}` }));
     },
-    async createGame(entry) {
+    async createGame(entry: GameRecord) {
       await ensureInitialized();
       await insertRow("games", {
         id: entry.id,
@@ -403,11 +536,11 @@ function createSupabaseDatastore(options = {}) {
         created_at: entry.createdAt,
         updated_at: entry.updatedAt
       });
-      return this.findGameById(entry.id);
+      return datastore.findGameById(entry.id);
     },
-    async updateGame(entry) {
+    async updateGame(entry: GameRecord) {
       await ensureInitialized();
-      const updated = await patchRows("games", {
+      const updated = await patchRows<GameRow>("games", {
         id: `eq.${entry.id}`,
         version: `eq.${Number.isInteger(entry.version) && entry.version > 1 ? entry.version - 1 : 1}`
       }, {
@@ -419,29 +552,31 @@ function createSupabaseDatastore(options = {}) {
       });
 
       if (!updated.length) {
-        const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.");
+        const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.") as VersionConflictError;
         conflict.code = "VERSION_CONFLICT";
-        const current = await this.findGameById(entry.id);
+        const current = await datastore.findGameById(entry.id);
         conflict.currentVersion = current ? current.version : null;
         conflict.currentState = current ? current.state : null;
         throw conflict;
       }
 
-      return normalizeGame(updated[0]);
+      return normalizeGame(updated[0] || null);
     },
     async getActiveGameId() {
       await ensureInitialized();
-      const row = await selectOne("app_state", { key: "eq.activeGameId" });
-      return row ? parseJson(row.value_json, null) : null;
+      const row = await selectOne<AppStateRow>("app_state", { key: "eq.activeGameId" });
+      return row ? parseJson<string | null>(row.value_json, null) : null;
     },
-    async setActiveGameId(gameId) {
+    async setActiveGameId(gameId: string | null) {
       await ensureInitialized();
       await upsertRows("app_state", [{
         key: "activeGameId",
         value_json: JSON.stringify(gameId || null)
       }], "key");
     }
-  };
+  } as const;
+
+  return datastore;
 }
 
 module.exports = {

--- a/backend/datastore.cts
+++ b/backend/datastore.cts
@@ -1,27 +1,143 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 const { DatabaseSync, backup } = require("node:sqlite");
-const { readJsonFile } = require("./json-file-store.cjs");
+const { readJsonFile } = require("./json-file-store.cjs") as {
+  readJsonFile: <T>(filePath: string, fallbackValue: T, isValid?: (value: unknown) => boolean) => T;
+};
 const { createSupabaseDatastore } = require("./datastore-supabase.cjs");
 
-function ensureDirectory(filePath) {
+type JsonRecord = Record<string, unknown>;
+
+type UserRecord = {
+  id: string;
+  username: string;
+  credentials: JsonRecord;
+  role: string;
+  profile: JsonRecord;
+  createdAt: string;
+};
+
+type GameRecord = {
+  id: string;
+  name: string;
+  version: number;
+  creatorUserId: string | null;
+  state: JsonRecord;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SessionRecord = {
+  token: string;
+  user_id: string;
+  created_at: number;
+};
+
+type UserRow = {
+  id: string;
+  username: string;
+  credentials_json?: string | null;
+  role?: string | null;
+  profile_json?: string | null;
+  created_at?: string | null;
+};
+
+type GameRow = {
+  id: string;
+  name: string;
+  version?: number | null;
+  creator_user_id?: string | null;
+  state_json?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+type SessionRow = {
+  token: string;
+  user_id?: string | null;
+  created_at?: number | null;
+};
+
+type AppStateRow = {
+  value_json?: string | null;
+};
+
+type CountRow = {
+  count?: number | bigint | string | null;
+};
+
+type ProbeRow = {
+  ok?: number | null;
+};
+
+type Statement<Row> = {
+  get(...args: unknown[]): Row;
+  all(...args: unknown[]): Row[];
+  run(...args: unknown[]): unknown;
+};
+
+type DatastoreOptions = {
+  driver?: string;
+  dbFile?: string;
+  dataFile?: string;
+  gamesFile?: string;
+  sessionsFile?: string;
+  legacyUsersFile?: string;
+  legacyGamesFile?: string;
+  legacySessionsFile?: string;
+};
+
+type LegacyUser = {
+  id: string;
+  username: string;
+  role?: string;
+  profile?: JsonRecord;
+  credentials?: JsonRecord;
+  createdAt?: string;
+};
+
+type LegacySession = {
+  token?: string;
+  userId?: string;
+  createdAt?: number | string;
+};
+
+type LegacyGame = {
+  id: string;
+  name: string;
+  version?: number;
+  creatorUserId?: string | null;
+  state?: JsonRecord;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type LegacyGamesDatabase = {
+  games?: LegacyGame[];
+  activeGameId?: string | null;
+};
+
+function ensureDirectory(filePath: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
-function parseJson(value, fallbackValue) {
+function parseJson<T>(value: unknown, fallbackValue: T): T {
   if (value == null || value === "") {
     return fallbackValue;
   }
 
+  if (typeof value !== "string") {
+    return value as T;
+  }
+
   try {
-    return JSON.parse(value);
+    return JSON.parse(value) as T;
   } catch (error) {
     return fallbackValue;
   }
 }
 
-function normalizeUser(row) {
+function normalizeUser(row: UserRow | null): UserRecord | null {
   if (!row) {
     return null;
   }
@@ -29,14 +145,14 @@ function normalizeUser(row) {
   return {
     id: row.id,
     username: row.username,
-    credentials: parseJson(row.credentials_json, {}),
+    credentials: parseJson<JsonRecord>(row.credentials_json, {}),
     role: row.role || "user",
-    profile: parseJson(row.profile_json, {}),
-    createdAt: row.created_at
+    profile: parseJson<JsonRecord>(row.profile_json, {}),
+    createdAt: row.created_at || new Date().toISOString()
   };
 }
 
-function normalizeGame(row) {
+function normalizeGame(row: GameRow | null): GameRecord | null {
   if (!row) {
     return null;
   }
@@ -44,15 +160,15 @@ function normalizeGame(row) {
   return {
     id: row.id,
     name: row.name,
-    version: Number.isInteger(row.version) ? row.version : 1,
+    version: Number.isInteger(row.version) ? Number(row.version) : 1,
     creatorUserId: row.creator_user_id || null,
-    state: parseJson(row.state_json, {}),
-    createdAt: row.created_at,
-    updatedAt: row.updated_at
+    state: parseJson<JsonRecord>(row.state_json, {}),
+    createdAt: row.created_at || new Date().toISOString(),
+    updatedAt: row.updated_at || row.created_at || new Date().toISOString()
   };
 }
 
-function createDatastore(options = {}) {
+function createDatastore(options: DatastoreOptions = {}) {
   const requestedDriver = String(options.driver || process.env.DATASTORE_DRIVER || "").trim().toLowerCase();
   const shouldUseSupabase = requestedDriver === "supabase" || (requestedDriver !== "sqlite" && Boolean(process.env.SUPABASE_URL));
   if (shouldUseSupabase) {
@@ -98,30 +214,30 @@ function createDatastore(options = {}) {
   `);
 
   const statements = {
-    countUsers: db.prepare("SELECT COUNT(*) AS count FROM users"),
-    countGames: db.prepare("SELECT COUNT(*) AS count FROM games"),
-    countSessions: db.prepare("SELECT COUNT(*) AS count FROM sessions"),
-    probe: db.prepare("SELECT 1 AS ok"),
-    insertUser: db.prepare("INSERT INTO users (id, username, role, profile_json, credentials_json, created_at) VALUES (?, ?, ?, ?, ?, ?)"),
-    updateUserCredentials: db.prepare("UPDATE users SET credentials_json = ? WHERE id = ?"),
-    updateUserProfile: db.prepare("UPDATE users SET profile_json = ? WHERE id = ?"),
-    updateUserThemePreference: db.prepare("UPDATE users SET profile_json = json_patch(COALESCE(NULLIF(profile_json, ''), '{}'), json_object('preferences', json_object('theme', ?))) WHERE id = ?"),
-    updateUserRoleByUsername: db.prepare("UPDATE users SET role = ? WHERE lower(username) = lower(?)"),
-    findUserByUsername: db.prepare("SELECT * FROM users WHERE lower(username) = lower(?)"),
-    findUserById: db.prepare("SELECT * FROM users WHERE id = ?"),
-    listUsers: db.prepare("SELECT * FROM users ORDER BY created_at ASC"),
-    insertSession: db.prepare("INSERT INTO sessions (token, user_id, created_at) VALUES (?, ?, ?)"),
-    findSession: db.prepare("SELECT * FROM sessions WHERE token = ?"),
-    deleteSession: db.prepare("DELETE FROM sessions WHERE token = ?"),
-    listGames: db.prepare("SELECT * FROM games ORDER BY updated_at DESC"),
-    findGameById: db.prepare("SELECT * FROM games WHERE id = ?"),
-    insertGame: db.prepare("INSERT INTO games (id, name, version, creator_user_id, state_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"),
-    updateGame: db.prepare("UPDATE games SET name = ?, version = ?, creator_user_id = ?, state_json = ?, updated_at = ? WHERE id = ?"),
-    getAppState: db.prepare("SELECT value_json FROM app_state WHERE key = ?"),
-    setAppState: db.prepare("INSERT INTO app_state (key, value_json) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json")
+    countUsers: db.prepare("SELECT COUNT(*) AS count FROM users") as Statement<CountRow>,
+    countGames: db.prepare("SELECT COUNT(*) AS count FROM games") as Statement<CountRow>,
+    countSessions: db.prepare("SELECT COUNT(*) AS count FROM sessions") as Statement<CountRow>,
+    probe: db.prepare("SELECT 1 AS ok") as Statement<ProbeRow>,
+    insertUser: db.prepare("INSERT INTO users (id, username, role, profile_json, credentials_json, created_at) VALUES (?, ?, ?, ?, ?, ?)") as Statement<unknown>,
+    updateUserCredentials: db.prepare("UPDATE users SET credentials_json = ? WHERE id = ?") as Statement<unknown>,
+    updateUserProfile: db.prepare("UPDATE users SET profile_json = ? WHERE id = ?") as Statement<unknown>,
+    updateUserThemePreference: db.prepare("UPDATE users SET profile_json = json_patch(COALESCE(NULLIF(profile_json, ''), '{}'), json_object('preferences', json_object('theme', ?))) WHERE id = ?") as Statement<unknown>,
+    updateUserRoleByUsername: db.prepare("UPDATE users SET role = ? WHERE lower(username) = lower(?)") as Statement<unknown>,
+    findUserByUsername: db.prepare("SELECT * FROM users WHERE lower(username) = lower(?)") as Statement<UserRow | null>,
+    findUserById: db.prepare("SELECT * FROM users WHERE id = ?") as Statement<UserRow | null>,
+    listUsers: db.prepare("SELECT * FROM users ORDER BY created_at ASC") as Statement<UserRow>,
+    insertSession: db.prepare("INSERT INTO sessions (token, user_id, created_at) VALUES (?, ?, ?)") as Statement<unknown>,
+    findSession: db.prepare("SELECT * FROM sessions WHERE token = ?") as Statement<SessionRow | null>,
+    deleteSession: db.prepare("DELETE FROM sessions WHERE token = ?") as Statement<unknown>,
+    listGames: db.prepare("SELECT * FROM games ORDER BY updated_at DESC") as Statement<GameRow>,
+    findGameById: db.prepare("SELECT * FROM games WHERE id = ?") as Statement<GameRow | null>,
+    insertGame: db.prepare("INSERT INTO games (id, name, version, creator_user_id, state_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)") as Statement<unknown>,
+    updateGame: db.prepare("UPDATE games SET name = ?, version = ?, creator_user_id = ?, state_json = ?, updated_at = ? WHERE id = ?") as Statement<unknown>,
+    getAppState: db.prepare("SELECT value_json FROM app_state WHERE key = ?") as Statement<AppStateRow | null>,
+    setAppState: db.prepare("INSERT INTO app_state (key, value_json) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json") as Statement<unknown>
   };
 
-  function transaction(run) {
+  function transaction<T>(run: () => T): T {
     db.exec("BEGIN IMMEDIATE");
     try {
       const result = run();
@@ -138,7 +254,7 @@ function createDatastore(options = {}) {
       return;
     }
 
-    const users = readJsonFile(legacyUsersFile, [], Array.isArray);
+    const users = readJsonFile<LegacyUser[]>(legacyUsersFile, [], Array.isArray);
     if (!users.length) {
       return;
     }
@@ -162,7 +278,7 @@ function createDatastore(options = {}) {
       return;
     }
 
-    const sessions = readJsonFile(legacySessionsFile, [], Array.isArray);
+    const sessions = readJsonFile<LegacySession[]>(legacySessionsFile, [], Array.isArray);
     if (!sessions.length) {
       return;
     }
@@ -183,7 +299,11 @@ function createDatastore(options = {}) {
       return;
     }
 
-    const database = readJsonFile(legacyGamesFile, { games: [], activeGameId: null }, (value) => Boolean(value) && typeof value === "object");
+    const database = readJsonFile<LegacyGamesDatabase>(
+      legacyGamesFile,
+      { games: [], activeGameId: null },
+      (value) => Boolean(value) && typeof value === "object"
+    );
     const games = Array.isArray(database.games) ? database.games : [];
     if (!games.length) {
       return;
@@ -194,7 +314,7 @@ function createDatastore(options = {}) {
         statements.insertGame.run(
           game.id,
           game.name,
-          Number.isInteger(game.version) && game.version > 0 ? game.version : 1,
+          typeof game.version === "number" && Number.isInteger(game.version) && game.version > 0 ? game.version : 1,
           game.creatorUserId || null,
           JSON.stringify(game.state || {}),
           game.createdAt || new Date().toISOString(),
@@ -212,7 +332,7 @@ function createDatastore(options = {}) {
   migrateLegacyGames();
   migrateLegacySessions();
 
-  return {
+  const datastore = {
     dbFile,
     resetForTests() {
       transaction(() => {
@@ -224,7 +344,7 @@ function createDatastore(options = {}) {
         `);
       });
     },
-    async backupTo(targetFile) {
+    async backupTo(targetFile: string) {
       if (!targetFile) {
         throw new Error("Il backup richiede un percorso destinazione valido.");
       }
@@ -254,16 +374,16 @@ function createDatastore(options = {}) {
     close() {
       db.close();
     },
-    findUserByUsername(username) {
+    findUserByUsername(username: string) {
       return normalizeUser(statements.findUserByUsername.get(String(username || "")));
     },
-    findUserById(userId) {
+    findUserById(userId: string) {
       return normalizeUser(statements.findUserById.get(userId));
     },
     listUsers() {
-      return statements.listUsers.all().map(normalizeUser);
+      return statements.listUsers.all().map((row) => normalizeUser(row));
     },
-    createUser(user) {
+    createUser(user: UserRecord) {
       transaction(() => {
         statements.insertUser.run(
           user.id,
@@ -274,51 +394,51 @@ function createDatastore(options = {}) {
           user.createdAt || new Date().toISOString()
         );
       });
-      return this.findUserById(user.id);
+      return datastore.findUserById(user.id);
     },
-    updateUserCredentials(userId, credentials) {
+    updateUserCredentials(userId: string, credentials: JsonRecord) {
       transaction(() => {
         statements.updateUserCredentials.run(JSON.stringify(credentials || {}), userId);
       });
-      return this.findUserById(userId);
+      return datastore.findUserById(userId);
     },
-    updateUserProfile(userId, profile) {
+    updateUserProfile(userId: string, profile: JsonRecord) {
       transaction(() => {
         statements.updateUserProfile.run(JSON.stringify(profile || {}), userId);
       });
-      return this.findUserById(userId);
+      return datastore.findUserById(userId);
     },
-    updateUserThemePreference(userId, theme) {
+    updateUserThemePreference(userId: string, theme: string) {
       transaction(() => {
         statements.updateUserThemePreference.run(String(theme || ""), userId);
       });
-      return this.findUserById(userId);
+      return datastore.findUserById(userId);
     },
-    updateUserRoleByUsername(username, role) {
+    updateUserRoleByUsername(username: string, role: string) {
       transaction(() => {
         statements.updateUserRoleByUsername.run(role === "admin" ? "admin" : "user", username);
       });
     },
-    createSession(token, userId, createdAt) {
+    createSession(token: string, userId: string, createdAt: number) {
       transaction(() => {
         statements.insertSession.run(token, userId, createdAt || Date.now());
       });
     },
-    findSession(token) {
+    findSession(token: string) {
       return statements.findSession.get(token) || null;
     },
-    deleteSession(token) {
+    deleteSession(token: string) {
       transaction(() => {
         statements.deleteSession.run(token);
       });
     },
     listGames() {
-      return statements.listGames.all().map(normalizeGame);
+      return statements.listGames.all().map((row) => normalizeGame(row));
     },
-    findGameById(gameId) {
+    findGameById(gameId: string) {
       return normalizeGame(statements.findGameById.get(gameId));
     },
-    createGame(entry) {
+    createGame(entry: GameRecord) {
       transaction(() => {
         statements.insertGame.run(
           entry.id,
@@ -330,9 +450,9 @@ function createDatastore(options = {}) {
           entry.updatedAt
         );
       });
-      return this.findGameById(entry.id);
+      return datastore.findGameById(entry.id);
     },
-    updateGame(entry) {
+    updateGame(entry: GameRecord) {
       transaction(() => {
         statements.updateGame.run(
           entry.name,
@@ -343,18 +463,20 @@ function createDatastore(options = {}) {
           entry.id
         );
       });
-      return this.findGameById(entry.id);
+      return datastore.findGameById(entry.id);
     },
     getActiveGameId() {
       const row = statements.getAppState.get("activeGameId");
-      return row ? parseJson(row.value_json, null) : null;
+      return row ? parseJson<string | null>(row.value_json, null) : null;
     },
-    setActiveGameId(gameId) {
+    setActiveGameId(gameId: string | null) {
       transaction(() => {
         statements.setAppState.run("activeGameId", JSON.stringify(gameId || null));
       });
     }
-  };
+  } as const;
+
+  return datastore;
 }
 
 module.exports = {

--- a/backend/game-session-store.cts
+++ b/backend/game-session-store.cts
@@ -1,20 +1,86 @@
-// @ts-nocheck
 const path = require("path");
 const crypto = require("crypto");
 const { findSupportedMap } = require("../shared/maps/index.cjs");
 const { createDatastore } = require("./datastore.cjs");
 const { chainMaybe, mapMaybe } = require("./maybe-async.cjs");
 
-function safeClone(value) {
-  return JSON.parse(JSON.stringify(value));
+interface GamePlayerConfig {
+  type?: string;
 }
 
-function readableMapName(mapId) {
+interface GameConfig {
+  players?: GamePlayerConfig[];
+  totalPlayers?: number;
+  mapId?: string | null;
+  mapName?: string | null;
+  diceRuleSetId?: string | null;
+}
+
+interface GameStateRecord {
+  phase?: string;
+  players?: Array<Record<string, unknown>>;
+  gameConfig?: GameConfig | null;
+  [key: string]: unknown;
+}
+
+interface GameEntry {
+  id: string;
+  name: string;
+  version?: number;
+  creatorUserId?: string | null;
+  state: GameStateRecord;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GameSummary {
+  id: string;
+  name: string;
+  version: number;
+  creatorUserId: string | null;
+  phase: string;
+  playerCount: number;
+  mapId: string | null;
+  mapName: string | null;
+  diceRuleSetId: string | null;
+  totalPlayers: number | null;
+  aiCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GameSessionStoreOptions {
+  datastore?: {
+    listGames(): GameEntry[] | Promise<GameEntry[]>;
+    createGame(entry: GameEntry): GameEntry | Promise<GameEntry>;
+    setActiveGameId(gameId: string): void | Promise<void>;
+    findGameById(gameId: string): GameEntry | null | Promise<GameEntry | null>;
+    getActiveGameId(): string | null | Promise<string | null>;
+    updateGame(entry: GameEntry): GameEntry | Promise<GameEntry>;
+  };
+  dbFile?: string;
+  dataFile?: string;
+  usersFile?: string;
+  sessionsFile?: string;
+}
+
+type VersionConflictError = Error & {
+  code: string;
+  currentVersion: number;
+  currentState: GameStateRecord;
+  game: GameSummary;
+};
+
+function safeClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function readableMapName(mapId: string | null | undefined): string | null {
   const map = findSupportedMap(mapId);
   return map ? map.name : (mapId || null);
 }
 
-function normalizeGameName(name, fallbackIndex) {
+function normalizeGameName(name: unknown, fallbackIndex: number): string {
   if (name == null) {
     return `Partita ${fallbackIndex}`;
   }
@@ -31,21 +97,22 @@ function normalizeGameName(name, fallbackIndex) {
   return normalized;
 }
 
-function summarizeGame(entry) {
-  const config = entry.state && entry.state.gameConfig ? entry.state.gameConfig : null;
-  const configuredPlayers = Array.isArray(config && config.players) ? config.players : [];
-  const totalPlayers = Number.isInteger(config && config.totalPlayers) ? config.totalPlayers : configuredPlayers.length;
+function summarizeGame(entry: GameEntry): GameSummary {
+  const config = entry.state?.gameConfig || null;
+  const configuredPlayers: GamePlayerConfig[] = Array.isArray(config?.players) ? config.players : [];
+  const totalPlayers = Number.isInteger(config?.totalPlayers) ? Number(config?.totalPlayers) : configuredPlayers.length;
+  const version = Number.isInteger(entry.version) && Number(entry.version) > 0 ? Number(entry.version) : 1;
 
   return {
     id: entry.id,
     name: entry.name,
-    version: Number.isInteger(entry.version) && entry.version > 0 ? entry.version : 1,
+    version,
     creatorUserId: entry.creatorUserId || null,
-    phase: entry.state && entry.state.phase ? entry.state.phase : "lobby",
-    playerCount: Array.isArray(entry.state && entry.state.players) ? entry.state.players.length : 0,
-    mapId: config && config.mapId ? config.mapId : null,
+    phase: entry.state?.phase || "lobby",
+    playerCount: Array.isArray(entry.state?.players) ? entry.state.players.length : 0,
+    mapId: config?.mapId || null,
     mapName: config ? (config.mapName || readableMapName(config.mapId)) : null,
-    diceRuleSetId: config && config.diceRuleSetId ? config.diceRuleSetId : null,
+    diceRuleSetId: config?.diceRuleSetId || null,
     totalPlayers: totalPlayers || null,
     aiCount: configuredPlayers.filter((player) => player.type === "ai").length,
     createdAt: entry.createdAt,
@@ -53,29 +120,29 @@ function summarizeGame(entry) {
   };
 }
 
-function createGameSessionStore(options = {}) {
-  const datastore = options.datastore || createDatastore({
+function createGameSessionStore(options: GameSessionStoreOptions = {}) {
+  const datastore = (options.datastore || createDatastore({
     dbFile: options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite"),
     legacyGamesFile: options.dataFile || path.join(__dirname, "..", "data", "games.json"),
     legacyUsersFile: options.usersFile || options.dataFile || path.join(__dirname, "..", "data", "users.json"),
     legacySessionsFile: options.sessionsFile || path.join(__dirname, "..", "data", "sessions.json")
-  });
+  })) as NonNullable<GameSessionStoreOptions["datastore"]>;
 
   function listGames() {
-    return mapMaybe(datastore.listGames(), (games) => games
+    return mapMaybe(datastore.listGames(), (games: GameEntry[]) => games
       .slice()
-      .sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)))
+      .sort((left: GameEntry, right: GameEntry) => String(right.updatedAt).localeCompare(String(left.updatedAt)))
       .map(summarizeGame));
   }
 
-  function createGame(initialState, input = {}) {
+  function createGame(initialState: GameStateRecord, input: { name?: unknown; creatorUserId?: string | null } = {}) {
     if (!initialState || typeof initialState !== "object") {
       throw new Error("La creazione della partita richiede uno stato iniziale valido.");
     }
 
-    return chainMaybe(datastore.listGames(), (games) => {
+    return chainMaybe(datastore.listGames(), (games: GameEntry[]) => {
       const timestamp = new Date().toISOString();
-      const entry = {
+      const entry: GameEntry = {
         id: crypto.randomBytes(8).toString("hex"),
         name: normalizeGameName(input.name, games.length + 1),
         version: 1,
@@ -85,7 +152,7 @@ function createGameSessionStore(options = {}) {
         updatedAt: timestamp
       };
 
-      return chainMaybe(datastore.createGame(entry), (created) =>
+      return chainMaybe(datastore.createGame(entry), (created: GameEntry) =>
         mapMaybe(datastore.setActiveGameId(created.id), () => ({
           game: summarizeGame(created),
           state: safeClone(created.state)
@@ -93,12 +160,12 @@ function createGameSessionStore(options = {}) {
     });
   }
 
-  function setActiveGame(gameId) {
+  function setActiveGame(gameId: string) {
     if (!gameId) {
       throw new Error("Impostare la partita attiva richiede un game id valido.");
     }
 
-    return chainMaybe(datastore.findGameById(gameId), (entry) => {
+    return chainMaybe(datastore.findGameById(gameId), (entry: GameEntry | null) => {
       if (!entry) {
         throw new Error(`Partita "${gameId}" non trovata.`);
       }
@@ -107,12 +174,12 @@ function createGameSessionStore(options = {}) {
     });
   }
 
-  function getGame(gameId) {
+  function getGame(gameId: string) {
     if (!gameId) {
       throw new Error("Leggere una partita richiede un game id valido.");
     }
 
-    return mapMaybe(datastore.findGameById(gameId), (entry) => {
+    return mapMaybe(datastore.findGameById(gameId), (entry: GameEntry | null) => {
       if (!entry) {
         throw new Error(`Partita "${gameId}" non trovata.`);
       }
@@ -127,12 +194,12 @@ function createGameSessionStore(options = {}) {
     });
   }
 
-  function openGame(gameId) {
+  function openGame(gameId: string) {
     if (!gameId) {
       throw new Error("Aprire una partita richiede un game id valido.");
     }
 
-    return chainMaybe(datastore.findGameById(gameId), (entry) => {
+    return chainMaybe(datastore.findGameById(gameId), (entry: GameEntry | null) => {
       if (!entry) {
         throw new Error(`Partita "${gameId}" non trovata.`);
       }
@@ -144,7 +211,7 @@ function createGameSessionStore(options = {}) {
     });
   }
 
-  function saveGame(gameId, state, expectedVersion) {
+  function saveGame(gameId: string, state: GameStateRecord, expectedVersion?: number | null) {
     if (!gameId) {
       throw new Error("Il salvataggio richiede un game id valido.");
     }
@@ -157,16 +224,16 @@ function createGameSessionStore(options = {}) {
       throw new Error("Il salvataggio richiede una expectedVersion valida.");
     }
 
-    return chainMaybe(datastore.findGameById(gameId), (entry) => {
+    return chainMaybe(datastore.findGameById(gameId), (entry: GameEntry | null) => {
       if (!entry) {
         throw new Error(`Partita "${gameId}" non trovata.`);
       }
 
-      const currentVersion = Number.isInteger(entry.version) && entry.version > 0 ? entry.version : 1;
+      const currentVersion = Number.isInteger(entry.version) && Number(entry.version) > 0 ? Number(entry.version) : 1;
       entry.version = currentVersion;
 
       if (expectedVersion != null && expectedVersion !== currentVersion) {
-        const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.");
+        const conflict = new Error("La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.") as VersionConflictError;
         conflict.code = "VERSION_CONFLICT";
         conflict.currentVersion = currentVersion;
         conflict.currentState = safeClone(entry.state);
@@ -181,9 +248,9 @@ function createGameSessionStore(options = {}) {
     });
   }
 
-  function ensureActiveGame(createInitialState) {
-    return chainMaybe(datastore.listGames(), (games) =>
-      chainMaybe(datastore.getActiveGameId(), (activeGameId) => {
+  function ensureActiveGame(createInitialState: () => GameStateRecord) {
+    return chainMaybe(datastore.listGames(), (games: GameEntry[]) =>
+      chainMaybe(datastore.getActiveGameId(), (activeGameId: string | null) => {
         const preferredId = activeGameId && games.some((game) => game.id === activeGameId)
           ? activeGameId
           : null;
@@ -215,4 +282,3 @@ function createGameSessionStore(options = {}) {
 module.exports = {
   createGameSessionStore
 };
-

--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -1,0 +1,76 @@
+interface LocalizedPayloadInput {
+  message?: string;
+  error?: string;
+  reason?: string;
+  defaultMessage?: string;
+  messageKey?: string | null;
+  errorKey?: string | null;
+  reasonKey?: string | null;
+  messageParams?: Record<string, unknown>;
+  errorParams?: Record<string, unknown>;
+  reasonParams?: Record<string, unknown>;
+  code?: string | null;
+}
+
+export function sendJson(
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  payload: unknown,
+  headers: Record<string, string> = {}
+): void {
+  if (res.headersSent || res.writableEnded) {
+    return;
+  }
+
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    ...headers
+  });
+  res.end(JSON.stringify(payload));
+}
+
+export function localizedPayload(
+  input: LocalizedPayloadInput | null | undefined,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams: Record<string, unknown> = {}
+): {
+  error: string;
+  messageKey: string | null;
+  messageParams: Record<string, unknown>;
+} {
+  const isObject = Boolean(input) && typeof input === "object";
+  const message = isObject
+    ? (input?.message || input?.error || input?.reason || input?.defaultMessage || fallbackMessage)
+    : fallbackMessage;
+  const messageKey = isObject
+    ? (input?.messageKey || input?.errorKey || input?.reasonKey || null)
+    : null;
+  const messageParams = isObject
+    ? (input?.messageParams || input?.errorParams || input?.reasonParams || {})
+    : {};
+
+  return {
+    error: message || fallbackMessage,
+    messageKey: messageKey || fallbackKey || null,
+    messageParams: messageKey ? messageParams : (fallbackKey ? fallbackParams : {})
+  };
+}
+
+export function sendLocalizedError(
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  input: LocalizedPayloadInput | null | undefined,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams: Record<string, unknown> = {},
+  code: string | null = null,
+  extra: Record<string, unknown> = {}
+): void {
+  const payload = localizedPayload(input, fallbackMessage, fallbackKey, fallbackParams);
+  sendJson(res, statusCode, {
+    ...payload,
+    code: code || input?.code || null,
+    ...extra
+  });
+}

--- a/backend/json-file-store.cts
+++ b/backend/json-file-store.cts
@@ -1,16 +1,15 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 
-function ensureDirectory(filePath) {
+function ensureDirectory(filePath: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
-function backupPathFor(filePath) {
+function backupPathFor(filePath: string): string {
   return filePath + ".bak";
 }
 
-function safeReadJson(filePath, fallbackValue) {
+function safeReadJson<T>(filePath: string, fallbackValue: T): T {
   if (!fs.existsSync(filePath)) {
     return fallbackValue;
   }
@@ -23,7 +22,7 @@ function safeReadJson(filePath, fallbackValue) {
   return JSON.parse(raw);
 }
 
-function readJsonFile(filePath, fallbackValue, isValid) {
+function readJsonFile<T>(filePath: string, fallbackValue: T, isValid?: (value: unknown) => boolean): T {
   const validate = typeof isValid === "function"
     ? isValid
     : () => true;
@@ -41,7 +40,7 @@ function readJsonFile(filePath, fallbackValue, isValid) {
   }
 }
 
-function writeJsonFile(filePath, value) {
+function writeJsonFile(filePath: string, value: unknown): void {
   ensureDirectory(filePath);
 
   const tempPath = filePath + `.tmp-${process.pid}-${Date.now()}`;

--- a/backend/load-local-env.cts
+++ b/backend/load-local-env.cts
@@ -1,8 +1,7 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 
-function stripWrappingQuotes(value) {
+function stripWrappingQuotes(value: string): string {
   if (!value || value.length < 2) {
     return value;
   }
@@ -16,8 +15,8 @@ function stripWrappingQuotes(value) {
   return value;
 }
 
-function parseEnvFile(content) {
-  const parsed = {};
+function parseEnvFile(content: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
   const lines = String(content || "").split(/\r?\n/);
 
   lines.forEach((rawLine) => {
@@ -43,7 +42,7 @@ function parseEnvFile(content) {
   return parsed;
 }
 
-function loadEnvFile(filePath) {
+function loadEnvFile(filePath: string): boolean {
   if (!fs.existsSync(filePath)) {
     return false;
   }
@@ -58,14 +57,14 @@ function loadEnvFile(filePath) {
   return true;
 }
 
-function loadLocalEnv() {
+function loadLocalEnv(): void {
   if (String(process.env.E2E || "").toLowerCase() === "true" || String(process.env.TEST || "").toLowerCase() === "true" || String(process.env.NODE_ENV || "").toLowerCase() === "test") {
     return;
   }
 
   const candidates = [process.cwd(), process.env.NETRISK_PROJECT_ROOT, path.join(__dirname, ".."), path.join(__dirname, "../..")];
-  const seen = new Set();
-  const rootDir = candidates.find((candidate) => {
+  const seen = new Set<string>();
+  const rootDir = candidates.find((candidate): boolean => {
     if (!candidate) {
       return false;
     }

--- a/backend/maybe-async.cts
+++ b/backend/maybe-async.cts
@@ -1,9 +1,8 @@
-// @ts-nocheck
-function isPromiseLike(value) {
-  return Boolean(value) && typeof value.then === "function";
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return Boolean(value) && typeof (value as Promise<T>).then === "function";
 }
 
-function mapMaybe(value, mapper) {
+function mapMaybe<T, U>(value: T | Promise<T>, mapper: (value: T) => U): U | Promise<U> {
   if (isPromiseLike(value)) {
     return value.then(mapper);
   }
@@ -11,7 +10,7 @@ function mapMaybe(value, mapper) {
   return mapper(value);
 }
 
-function chainMaybe(value, mapper) {
+function chainMaybe<T, U>(value: T | Promise<T>, mapper: (value: T) => U | Promise<U>): U | Promise<U> {
   if (isPromiseLike(value)) {
     return value.then((resolved) => mapper(resolved));
   }

--- a/backend/player-profile-store.cts
+++ b/backend/player-profile-store.cts
@@ -1,15 +1,38 @@
-// @ts-nocheck
 const path = require("path");
 const { createDatastore } = require("./datastore.cjs");
 const { findSupportedMap } = require("../shared/maps/index.cjs");
 const { mapMaybe } = require("./maybe-async.cjs");
+import type { ParticipatingGameContract, ProfileContract } from "../shared/api-contracts.cjs";
+import type { GameState, Player, TurnPhaseValue } from "../shared/models.cjs";
 
-function readableMapName(mapId) {
+type GameEntry = {
+  id: string;
+  name: string;
+  updatedAt: string;
+  state: GameState & {
+    gameConfig?: {
+      players?: unknown[];
+      totalPlayers?: number;
+      mapId?: string | null;
+      mapName?: string | null;
+    } | null;
+    hands?: Record<string, unknown[]>;
+  };
+};
+
+type PlayerProfileStore = {
+  datastore: {
+    listGames(): GameEntry[] | Promise<GameEntry[]>;
+  };
+  getPlayerProfile(username: string): ProfileContract | Promise<ProfileContract>;
+};
+
+function readableMapName(mapId: string | null | undefined): string | null {
   const map = findSupportedMap(mapId);
   return map ? map.name : (mapId || null);
 }
 
-function territoriesOwnedBy(entry, playerId) {
+function territoriesOwnedBy(entry: GameEntry, playerId: string | null | undefined): number {
   if (!playerId || !entry?.state?.territories) {
     return 0;
   }
@@ -17,7 +40,7 @@ function territoriesOwnedBy(entry, playerId) {
   return Object.values(entry.state.territories).filter((territory) => territory?.ownerId === playerId).length;
 }
 
-function statusLabelForPlayer(entry, player, territoryCount) {
+function statusLabelForPlayer(entry: GameEntry, player: Player | null, territoryCount: number): string {
   if (!player) {
     return "Profilo non collegato";
   }
@@ -33,7 +56,7 @@ function statusLabelForPlayer(entry, player, territoryCount) {
   return territoryCount > 0 && !player.surrendered ? "Operativo" : "Eliminato";
 }
 
-function focusLabelForPlayer(entry, player) {
+function focusLabelForPlayer(entry: GameEntry, player: Player | null): string {
   if (!player) {
     return "Non assegnato";
   }
@@ -45,7 +68,7 @@ function focusLabelForPlayer(entry, player) {
   return entry.state.players[entry.state.currentTurnIndex]?.id === player.id ? "Tocca a te" : "In attesa";
 }
 
-function turnPhaseLabel(turnPhase) {
+function turnPhaseLabel(turnPhase: TurnPhaseValue | string | null | undefined): string {
   if (turnPhase === "reinforcement") {
     return "Rinforzi";
   }
@@ -58,10 +81,11 @@ function turnPhaseLabel(turnPhase) {
   return "Lobby";
 }
 
-function summarizeParticipatingGame(entry, username) {
+function summarizeParticipatingGame(entry: GameEntry, username: string): ParticipatingGameContract {
   const config = entry?.state?.gameConfig || null;
   const configuredPlayers = Array.isArray(config?.players) ? config.players : [];
-  const totalPlayers = Number.isInteger(config?.totalPlayers) ? config.totalPlayers : configuredPlayers.length;
+  const configuredTotalPlayers = config?.totalPlayers;
+  const totalPlayers = Number.isInteger(configuredTotalPlayers) ? configuredTotalPlayers : configuredPlayers.length;
   const player = Array.isArray(entry?.state?.players)
     ? entry.state.players.find((candidate) => candidate?.name === username)
     : null;
@@ -74,12 +98,12 @@ function summarizeParticipatingGame(entry, username) {
     phase: entry?.state?.phase || "lobby",
     playerCount: Array.isArray(entry?.state?.players) ? entry.state.players.length : 0,
     totalPlayers: totalPlayers || null,
-    mapName: config ? (config.mapName || readableMapName(config.mapId)) : null,
+    mapName: config ? (config.mapName || readableMapName(config?.mapId)) : null,
     updatedAt: entry.updatedAt,
     myLobby: {
       playerName: player?.name || username,
-      statusLabel: statusLabelForPlayer(entry, player, territoryCount),
-      focusLabel: focusLabelForPlayer(entry, player),
+      statusLabel: statusLabelForPlayer(entry, player || null, territoryCount),
+      focusLabel: focusLabelForPlayer(entry, player || null),
       turnPhaseLabel: turnPhaseLabel(entry?.state?.turnPhase),
       territoryCount,
       cardCount
@@ -87,7 +111,7 @@ function summarizeParticipatingGame(entry, username) {
   };
 }
 
-function createPlayerProfileStore(options = {}) {
+function createPlayerProfileStore(options: Record<string, unknown> = {}): PlayerProfileStore {
   const datastore = options.datastore || createDatastore({
     dbFile: options.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite"),
     legacyGamesFile: options.gamesFile || path.join(__dirname, "..", "data", "games.json"),
@@ -95,13 +119,13 @@ function createPlayerProfileStore(options = {}) {
     legacySessionsFile: options.sessionsFile || path.join(__dirname, "..", "data", "sessions.json")
   });
 
-  function getPlayerProfile(username) {
+  function getPlayerProfile(username: string): ProfileContract | Promise<ProfileContract> {
     const normalizedUsername = String(username || "").trim();
     if (!normalizedUsername) {
       throw new Error("Il profilo richiede un nome giocatore valido.");
     }
 
-    return mapMaybe(datastore.listGames(), (games) => {
+    return mapMaybe(datastore.listGames(), (games: GameEntry[]) => {
       const relevantGames = games.filter((entry) =>
         Array.isArray(entry?.state?.players) &&
         entry.state.players.some((player) => player.name === normalizedUsername)

--- a/backend/random.cts
+++ b/backend/random.cts
@@ -1,11 +1,10 @@
-// @ts-nocheck
 const crypto = require("crypto");
 
-function secureRandom() {
+function secureRandom(): number {
   return crypto.randomInt(0x100000000) / 0x100000000;
 }
 
-function randomHex(bytes = 4) {
+function randomHex(bytes: number = 4): string {
   return crypto.randomBytes(bytes).toString("hex");
 }
 

--- a/backend/required-runtime-env.cts
+++ b/backend/required-runtime-env.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const REQUIRED_DEPLOY_ENV_KEYS = [
   "AUTH_ENCRYPTION_KEY",
   "SUPABASE_URL",
@@ -6,11 +5,11 @@ const REQUIRED_DEPLOY_ENV_KEYS = [
   "DATASTORE_DRIVER"
 ];
 
-function hasValue(value) {
+function hasValue(value: unknown): boolean {
   return typeof value === "string" ? value.trim() !== "" : Boolean(value);
 }
 
-function shouldValidateDeployEnv(env = process.env) {
+function shouldValidateDeployEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   if (!env || !env.VERCEL) {
     return false;
   }
@@ -19,7 +18,7 @@ function shouldValidateDeployEnv(env = process.env) {
   return targetEnv === "preview" || targetEnv === "production";
 }
 
-function missingRequiredDeployEnv(env = process.env) {
+function missingRequiredDeployEnv(env: NodeJS.ProcessEnv = process.env): string[] {
   return REQUIRED_DEPLOY_ENV_KEYS.filter((key) => !hasValue(env[key]));
 }
 

--- a/backend/routes/account.cts
+++ b/backend/routes/account.cts
@@ -1,0 +1,91 @@
+import type { ProfileResponseContract, AuthSessionResponseContract } from "../../shared/api-contracts.cjs";
+
+type RequireAuthFn = (
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>
+) => Promise<{ user: { id: string; username: string } } | null>;
+
+interface AccountRouteDeps {
+  req: import("node:http").IncomingMessage;
+  res: import("node:http").ServerResponse;
+  requireAuth: RequireAuthFn;
+  auth: {
+    publicUser(user: unknown): unknown;
+    updateUserThemePreference(userId: string, theme: string): Promise<{ preferences?: { theme?: string | null } } | null>;
+  };
+  playerProfiles: {
+    getPlayerProfile(username: string): Promise<Record<string, unknown>> | Record<string, unknown>;
+  };
+  sendJson: (res: import("node:http").ServerResponse, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+  sendLocalizedError: (
+    res: import("node:http").ServerResponse,
+    statusCode: number,
+    input: Record<string, unknown> | null,
+    fallbackMessage: string,
+    fallbackKey: string | null,
+    fallbackParams?: Record<string, unknown>,
+    code?: string | null,
+    extra?: Record<string, unknown>
+  ) => void;
+  extractUserPreferences: (user: unknown) => Record<string, unknown>;
+  supportedSiteThemes: Set<string>;
+  resolveStoredTheme: (theme: string) => string;
+}
+
+export async function handleAuthSessionRoute(deps: AccountRouteDeps): Promise<boolean> {
+  const authContext = await deps.requireAuth(deps.req, deps.res, {});
+  if (!authContext) {
+    return true;
+  }
+
+  const payload: AuthSessionResponseContract = {
+    user: deps.auth.publicUser(authContext.user) as AuthSessionResponseContract["user"]
+  };
+  deps.sendJson(deps.res, 200, payload);
+  return true;
+}
+
+export async function handleProfileRoute(deps: AccountRouteDeps): Promise<boolean> {
+  const authContext = await deps.requireAuth(deps.req, deps.res, {});
+  if (!authContext) {
+    return true;
+  }
+
+  try {
+    const payload: ProfileResponseContract = {
+      profile: ({
+        ...(await deps.playerProfiles.getPlayerProfile(authContext.user.username)),
+        preferences: deps.extractUserPreferences(authContext.user)
+      } as unknown as ProfileResponseContract["profile"])
+    };
+    deps.sendJson(deps.res, 200, payload);
+  } catch (error) {
+    deps.sendLocalizedError(deps.res, 400, error as Record<string, unknown>, "Profilo non disponibile.", "server.profile.unavailable");
+  }
+
+  return true;
+}
+
+export async function handleThemePreferenceRoute(
+  deps: AccountRouteDeps,
+  body: Record<string, unknown>
+): Promise<boolean> {
+  const authContext = await deps.requireAuth(deps.req, deps.res, body);
+  if (!authContext) {
+    return true;
+  }
+
+  if (typeof body.theme !== "string" || !deps.supportedSiteThemes.has(body.theme)) {
+    deps.sendLocalizedError(deps.res, 400, null, "Tema non supportato.", "server.profile.invalidTheme");
+    return true;
+  }
+
+  const user = await deps.auth.updateUserThemePreference(authContext.user.id, body.theme);
+  deps.sendJson(deps.res, 200, {
+    ok: true,
+    user,
+    preferences: user?.preferences || { theme: deps.resolveStoredTheme(body.theme) }
+  });
+  return true;
+}

--- a/backend/routes/game-actions-attack.cts
+++ b/backend/routes/game-actions-attack.cts
@@ -1,0 +1,94 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type SnapshotForUser = (
+  state: any,
+  gameId: string | null,
+  version: number | null,
+  gameName: string | null,
+  user: unknown
+) => unknown;
+type HandleVersionConflict = (error: unknown) => boolean;
+type IsValidTerritoryId = (id: string) => boolean;
+type ResolveAttack = (
+  state: any,
+  playerId: string,
+  fromId: string,
+  toId: string,
+  random?: (() => number) | null,
+  attackDice?: number | null
+) => any;
+type ResolveBanzaiAttack = ResolveAttack;
+type ConsumeQueuedAttackRandom = () => (() => number) | null;
+
+async function handleAttackGameActionRoute(
+  type: string,
+  res: unknown,
+  body: Record<string, any>,
+  gameContext: any,
+  playerId: string,
+  expectedVersion: number | null,
+  user: unknown,
+  resolveAttack: ResolveAttack,
+  resolveBanzaiAttack: ResolveBanzaiAttack,
+  consumeQueuedAttackRandom: ConsumeQueuedAttackRandom,
+  persistGameContext: PersistGameContext,
+  broadcastGame: BroadcastGame,
+  snapshotForUser: SnapshotForUser,
+  handleVersionConflict: HandleVersionConflict,
+  isValidTerritoryId: IsValidTerritoryId,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<boolean> {
+  if (type !== "attack" && type !== "attackBanzai") {
+    return false;
+  }
+
+  const random = consumeQueuedAttackRandom();
+  const requestedAttackDice = body.attackDice == null || body.attackDice === "" ? null : Number(body.attackDice);
+  const actionFromId = String(body.fromId || "");
+  const actionToId = String(body.toId || "");
+  if (!isValidTerritoryId(actionFromId) || !isValidTerritoryId(actionToId)) {
+    sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
+    return true;
+  }
+
+  const result = type === "attackBanzai"
+    ? resolveBanzaiAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice)
+    : resolveAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice);
+  if (!result.ok) {
+    sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+    return true;
+  }
+
+  try {
+    await persistGameContext(gameContext, expectedVersion);
+  } catch (error) {
+    if (handleVersionConflict(error)) {
+      return true;
+    }
+    throw error;
+  }
+  broadcastGame(gameContext);
+  sendJson(res, 200, {
+    ok: true,
+    state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, user),
+    rounds: Array.isArray(result.rounds) ? result.rounds : undefined
+  });
+  return true;
+}
+
+module.exports = {
+  handleAttackGameActionRoute
+};

--- a/backend/routes/game-actions-basic.cts
+++ b/backend/routes/game-actions-basic.cts
@@ -1,0 +1,132 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type SnapshotForUser = (
+  state: any,
+  gameId: string | null,
+  version: number | null,
+  gameName: string | null,
+  user: unknown
+) => unknown;
+type HandleVersionConflict = (error: unknown) => boolean;
+type IsValidTerritoryId = (id: string) => boolean;
+type ApplyReinforcement = (state: any, playerId: string, territoryId: string, amount: unknown) => any;
+type MoveAfterConquest = (state: any, playerId: string, armies: unknown) => any;
+type ApplyFortify = (state: any, playerId: string, fromId: string, toId: string, armies: unknown) => any;
+
+async function handleBasicGameActionRoute(
+  type: string,
+  res: unknown,
+  body: Record<string, any>,
+  gameContext: any,
+  playerId: string,
+  expectedVersion: number | null,
+  user: unknown,
+  applyReinforcement: ApplyReinforcement,
+  moveAfterConquest: MoveAfterConquest,
+  applyFortify: ApplyFortify,
+  persistGameContext: PersistGameContext,
+  broadcastGame: BroadcastGame,
+  snapshotForUser: SnapshotForUser,
+  handleVersionConflict: HandleVersionConflict,
+  isValidTerritoryId: IsValidTerritoryId,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<boolean> {
+  if (type === "reinforce") {
+    const territoryId = String(body.territoryId || "");
+    if (!isValidTerritoryId(territoryId)) {
+      sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
+      return true;
+    }
+    const result = applyReinforcement(gameContext.state, playerId, territoryId, body.amount);
+    if (!result.ok) {
+      sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+      return true;
+    }
+
+    try {
+      await persistGameContext(gameContext, expectedVersion);
+    } catch (error) {
+      if (handleVersionConflict(error)) {
+        return true;
+      }
+      throw error;
+    }
+    broadcastGame(gameContext);
+    sendJson(res, 200, {
+      ok: true,
+      state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, user)
+    });
+    return true;
+  }
+
+  if (type === "moveAfterConquest") {
+    const result = moveAfterConquest(gameContext.state, playerId, body.armies);
+    if (!result.ok) {
+      sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+      return true;
+    }
+
+    try {
+      await persistGameContext(gameContext, expectedVersion);
+    } catch (error) {
+      if (handleVersionConflict(error)) {
+        return true;
+      }
+      throw error;
+    }
+    broadcastGame(gameContext);
+    sendJson(res, 200, {
+      ok: true,
+      state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, user)
+    });
+    return true;
+  }
+
+  if (type === "fortify") {
+    const fortifyFromId = String(body.fromId || "");
+    const fortifyToId = String(body.toId || "");
+    if (!isValidTerritoryId(fortifyFromId) || !isValidTerritoryId(fortifyToId)) {
+      sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
+      return true;
+    }
+    const result = applyFortify(gameContext.state, playerId, fortifyFromId, fortifyToId, body.armies);
+    if (!result.ok) {
+      sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+      return true;
+    }
+
+    try {
+      await persistGameContext(gameContext, expectedVersion);
+    } catch (error) {
+      if (handleVersionConflict(error)) {
+        return true;
+      }
+      throw error;
+    }
+    broadcastGame(gameContext);
+    sendJson(res, 200, {
+      ok: true,
+      state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, user)
+    });
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  handleBasicGameActionRoute
+};

--- a/backend/routes/game-actions-turn.cts
+++ b/backend/routes/game-actions-turn.cts
@@ -1,0 +1,93 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type PersistWithAiTurns = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type SnapshotForUser = (
+  state: any,
+  gameId: string | null,
+  version: number | null,
+  gameName: string | null,
+  user: unknown
+) => unknown;
+type HandleVersionConflict = (error: unknown) => boolean;
+type EndTurn = (state: any, playerId: string) => any;
+type SurrenderPlayer = (state: any, playerId: string) => any;
+
+async function handleTurnGameActionRoute(
+  type: string,
+  res: unknown,
+  gameContext: any,
+  playerId: string,
+  expectedVersion: number | null,
+  user: unknown,
+  endTurn: EndTurn,
+  surrenderPlayer: SurrenderPlayer,
+  persistWithAiTurns: PersistWithAiTurns,
+  broadcastGame: BroadcastGame,
+  snapshotForUser: SnapshotForUser,
+  handleVersionConflict: HandleVersionConflict,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<boolean> {
+  if (type === "endTurn") {
+    const result = endTurn(gameContext.state, playerId);
+    if (!result.ok) {
+      sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+      return true;
+    }
+
+    try {
+      await persistWithAiTurns(gameContext, expectedVersion);
+    } catch (error) {
+      if (handleVersionConflict(error)) {
+        return true;
+      }
+      throw error;
+    }
+    broadcastGame(gameContext);
+    sendJson(res, 200, {
+      ok: true,
+      state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, user)
+    });
+    return true;
+  }
+
+  if (type === "surrender") {
+    const result = surrenderPlayer(gameContext.state, playerId);
+    if (!result.ok) {
+      sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+      return true;
+    }
+
+    try {
+      await persistWithAiTurns(gameContext, expectedVersion);
+    } catch (error) {
+      if (handleVersionConflict(error)) {
+        return true;
+      }
+      throw error;
+    }
+    broadcastGame(gameContext);
+    sendJson(res, 200, {
+      ok: true,
+      state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, user)
+    });
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  handleTurnGameActionRoute
+};

--- a/backend/routes/game-actions.cts
+++ b/backend/routes/game-actions.cts
@@ -1,0 +1,208 @@
+const { handleAttackGameActionRoute } = require("./game-actions-attack.cjs");
+const { handleBasicGameActionRoute } = require("./game-actions-basic.cjs");
+const { handleTurnGameActionRoute } = require("./game-actions-turn.cjs");
+const {
+  applyFortify,
+  applyReinforcement,
+  endTurn,
+  getPlayer,
+  moveAfterConquest,
+  resolveAttack,
+  surrenderPlayer
+} = require("../engine/game-engine.cjs");
+const { resolveBanzaiAttack } = require("../engine/banzai-attack.cjs");
+
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+type LocalizedPayload = (error: any, fallbackMessage: string, fallbackMessageKey?: string) => Record<string, unknown>;
+
+type AuthContext = {
+  user: {
+    id: string;
+    username: string;
+  };
+};
+
+type RequireAuth = (req: unknown, res: unknown, body: Record<string, any>) => Promise<AuthContext | null>;
+type LoadGameContext = (gameId: string | null) => Promise<any>;
+type GetTargetGameId = (body?: Record<string, unknown>, url?: URL | null) => string | null;
+type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
+type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type PersistWithAiTurns = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type SnapshotForUser = (
+  state: any,
+  gameId: string | null,
+  version: number | null,
+  gameName: string | null,
+  user: unknown
+) => unknown;
+type ConsumeQueuedAttackRandom = () => (() => number) | null;
+
+async function handleGameActionRoute({
+  req,
+  res,
+  body,
+  url,
+  requireAuth,
+  loadGameContext,
+  getTargetGameId,
+  playerBelongsToUser,
+  persistGameContext,
+  persistWithAiTurns,
+  broadcastGame,
+  snapshotForUser,
+  consumeQueuedAttackRandom,
+  localizedPayload,
+  sendJson,
+  sendLocalizedError
+}: {
+  req: unknown;
+  res: unknown;
+  body: Record<string, any>;
+  url: URL;
+  requireAuth: RequireAuth;
+  loadGameContext: LoadGameContext;
+  getTargetGameId: GetTargetGameId;
+  playerBelongsToUser: PlayerBelongsToUser;
+  persistGameContext: PersistGameContext;
+  persistWithAiTurns: PersistWithAiTurns;
+  broadcastGame: BroadcastGame;
+  snapshotForUser: SnapshotForUser;
+  consumeQueuedAttackRandom: ConsumeQueuedAttackRandom;
+  localizedPayload: LocalizedPayload;
+  sendJson: SendJson;
+  sendLocalizedError: SendLocalizedError;
+}): Promise<void> {
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  const currentUser = authContext.user;
+  const playerId = body.playerId;
+  const type = body.type;
+  let expectedVersion: number | null = null;
+  if (body.expectedVersion != null) {
+    expectedVersion = Number(body.expectedVersion);
+    if (!Number.isInteger(expectedVersion) || expectedVersion < 1) {
+      sendLocalizedError(res, 400, null, "expectedVersion non valida.", "server.invalidExpectedVersion");
+      return;
+    }
+  }
+
+  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const player = getPlayer(gameContext.state, playerId);
+
+  if (!player || !playerBelongsToUser(player, currentUser)) {
+    sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
+    return;
+  }
+
+  function handleVersionConflict(error: any) {
+    if (!error || error.code !== "VERSION_CONFLICT") {
+      return false;
+    }
+
+    sendJson(res, 409, {
+      ...localizedPayload(error, error.message, error.messageKey || "server.versionConflict"),
+      code: error.code,
+      currentVersion: error.currentVersion,
+      state: snapshotForUser(error.currentState, gameContext.gameId, error.currentVersion, error.game?.name || gameContext.gameName, currentUser)
+    });
+    return true;
+  }
+
+  if (expectedVersion != null && expectedVersion !== gameContext.version) {
+    sendJson(res, 409, {
+      ...localizedPayload(null, "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.", "server.versionConflict"),
+      code: "VERSION_CONFLICT",
+      currentVersion: gameContext.version,
+      state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, currentUser)
+    });
+    return;
+  }
+
+  function isValidTerritoryId(id: string) {
+    return id && typeof gameContext.state.territories === "object" &&
+      Object.prototype.hasOwnProperty.call(gameContext.state.territories, id);
+  }
+
+  if (await handleBasicGameActionRoute(
+    type,
+    res,
+    body,
+    gameContext,
+    playerId,
+    expectedVersion,
+    currentUser,
+    applyReinforcement,
+    moveAfterConquest,
+    applyFortify,
+    persistGameContext,
+    broadcastGame,
+    snapshotForUser,
+    handleVersionConflict,
+    isValidTerritoryId,
+    sendJson,
+    sendLocalizedError
+  )) {
+    return;
+  }
+
+  if (await handleAttackGameActionRoute(
+    type,
+    res,
+    body,
+    gameContext,
+    playerId,
+    expectedVersion,
+    currentUser,
+    resolveAttack,
+    resolveBanzaiAttack,
+    consumeQueuedAttackRandom,
+    persistGameContext,
+    broadcastGame,
+    snapshotForUser,
+    handleVersionConflict,
+    isValidTerritoryId,
+    sendJson,
+    sendLocalizedError
+  )) {
+    return;
+  }
+
+  if (await handleTurnGameActionRoute(
+    type,
+    res,
+    gameContext,
+    playerId,
+    expectedVersion,
+    currentUser,
+    endTurn,
+    surrenderPlayer,
+    persistWithAiTurns,
+    broadcastGame,
+    snapshotForUser,
+    handleVersionConflict,
+    sendJson,
+    sendLocalizedError
+  )) {
+    return;
+  }
+
+  sendLocalizedError(res, 400, null, "Azione non supportata.", "server.action.unsupported");
+}
+
+module.exports = {
+  handleGameActionRoute
+};

--- a/backend/routes/game-cards.cts
+++ b/backend/routes/game-cards.cts
@@ -1,0 +1,103 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type AuthContext = {
+  user: {
+    id: string;
+    username: string;
+  };
+};
+
+type RequireAuth = (req: unknown, res: unknown, body: Record<string, any>) => Promise<AuthContext | null>;
+type LoadGameContext = (gameId: string | null) => Promise<any>;
+type GetTargetGameId = (body?: Record<string, unknown>, url?: URL | null) => string | null;
+type GetPlayer = (state: any, playerId: string) => any;
+type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
+type TradeCardSet = (state: any, playerId: string, cardIds: string[]) => any;
+type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type SnapshotForState = (state: any, gameId: string | null, version: number | null, gameName: string | null) => unknown;
+
+async function handleCardsTradeRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  url: URL,
+  requireAuth: RequireAuth,
+  loadGameContext: LoadGameContext,
+  getTargetGameId: GetTargetGameId,
+  getPlayer: GetPlayer,
+  playerBelongsToUser: PlayerBelongsToUser,
+  tradeCardSet: TradeCardSet,
+  persistGameContext: PersistGameContext,
+  broadcastGame: BroadcastGame,
+  snapshotForState: SnapshotForState,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const player = getPlayer(gameContext.state, body.playerId);
+  if (!player || !playerBelongsToUser(player, authContext.user)) {
+    sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
+    return;
+  }
+
+  const requestedVersion = body.expectedVersion == null ? null : Number(body.expectedVersion);
+  if (body.expectedVersion != null && (!Number.isInteger(requestedVersion ?? NaN) || (requestedVersion ?? 0) < 1)) {
+    sendLocalizedError(res, 400, null, "expectedVersion non valida.", "server.invalidExpectedVersion");
+    return;
+  }
+  if (requestedVersion != null && requestedVersion !== gameContext.version) {
+    sendLocalizedError(res, 409, null, "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.", "server.versionConflict", {}, "VERSION_CONFLICT", {
+      currentVersion: gameContext.version,
+      state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName)
+    });
+    return;
+  }
+
+  const result = tradeCardSet(gameContext.state, body.playerId, body.cardIds);
+  if (!result.ok) {
+    sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
+    return;
+  }
+
+  try {
+    await persistGameContext(gameContext, requestedVersion);
+  } catch (error: any) {
+    if (error && error.code === "VERSION_CONFLICT") {
+      sendLocalizedError(res, 409, error, error.message, error.messageKey || "server.versionConflict", {}, error.code, {
+        currentVersion: error.currentVersion,
+        state: snapshotForState(error.currentState, gameContext.gameId, error.currentVersion, error.game?.name || gameContext.gameName)
+      });
+      return;
+    }
+
+    throw error;
+  }
+
+  broadcastGame(gameContext);
+  sendJson(res, 200, {
+    ok: true,
+    bonus: result.bonus,
+    validation: result.validation,
+    state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName)
+  });
+}
+
+module.exports = {
+  handleCardsTradeRoute
+};

--- a/backend/routes/game-management.cts
+++ b/backend/routes/game-management.cts
@@ -1,0 +1,140 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type AuthContext = {
+  user: {
+    id: string;
+    username: string;
+  };
+};
+
+type RequireAuth = (req: unknown, res: unknown, body: Record<string, any>) => Promise<AuthContext | null>;
+type Authorize = (action: string, context: Record<string, unknown>) => any;
+type CreateConfiguredInitialState = (body: Record<string, any>) => any;
+type AddPlayer = (state: any, name: string, options?: Record<string, unknown>) => any;
+type ListGames = () => Promise<any>;
+type CreateGame = (state: any, options?: Record<string, unknown>) => Promise<any>;
+type GetGame = (gameId: string) => Promise<any>;
+type OpenGame = (gameId: string) => Promise<any>;
+type ReplaceState = (state: any) => void;
+type BroadcastGame = (gameContext: any) => void;
+type Snapshot = () => unknown;
+type SnapshotForState = (state: any, gameId: string | null, version: number | null, gameName: string | null) => unknown;
+type ResumeAiTurnsForRead = (gameContext: any) => Promise<any>;
+type ResolvePlayerForUser = (state: any, user: unknown) => any;
+
+async function handleCreateGameRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  createConfiguredInitialState: CreateConfiguredInitialState,
+  addPlayer: AddPlayer,
+  createGame: CreateGame,
+  listGames: ListGames,
+  replaceState: ReplaceState,
+  broadcastGame: BroadcastGame,
+  snapshot: Snapshot,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  try {
+    const policy = authorize("game:create", { user: authContext.user });
+    const configured = createConfiguredInitialState(body);
+    const creatorJoin = addPlayer(configured.state, authContext.user.username, { linkedUserId: policy.actor.id });
+    if (!creatorJoin.ok) {
+      throw Object.assign(
+        new Error(creatorJoin.error || "Impossibile collegare il creatore alla nuova partita."),
+        {
+          statusCode: 400,
+          messageKey: creatorJoin.errorKey || "server.game.create.creatorJoinFailed",
+          messageParams: creatorJoin.errorParams
+        }
+      );
+    }
+
+    const created = await createGame(configured.state, {
+      ...configured.gameInput,
+      creatorUserId: policy.actor.id
+    });
+    replaceState(created.state);
+    broadcastGame({
+      gameId: created.game.id,
+      gameName: created.game.name,
+      version: created.game.version,
+      state: created.state
+    });
+    sendJson(res, 201, {
+      ok: true,
+      game: created.game,
+      games: await listGames(),
+      activeGameId: created.game.id,
+      state: snapshot(),
+      config: configured.config,
+      playerId: creatorJoin.player.id
+    });
+  } catch (error: any) {
+    const statusCode = error.statusCode || 400;
+    sendLocalizedError(res, statusCode, error, "Creazione partita non riuscita.", "server.game.createFailed");
+  }
+}
+
+async function handleOpenGameRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  getGame: GetGame,
+  openGame: OpenGame,
+  listGames: ListGames,
+  resumeAiTurnsForRead: ResumeAiTurnsForRead,
+  resolvePlayerForUser: ResolvePlayerForUser,
+  snapshotForState: SnapshotForState,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  try {
+    const gameRecord = await getGame(body.gameId);
+    authorize("game:open", { user: authContext.user, game: gameRecord.game, state: gameRecord.state });
+    const opened = await openGame(body.gameId);
+    await resumeAiTurnsForRead(opened);
+    const resolvedPlayer = resolvePlayerForUser(opened.state, authContext.user);
+    sendJson(res, 200, {
+      ok: true,
+      game: opened.game,
+      games: await listGames(),
+      activeGameId: opened.game.id,
+      state: snapshotForState(opened.state, opened.game.id, opened.game.version, opened.game.name),
+      playerId: resolvedPlayer ? resolvedPlayer.id : null
+    });
+  } catch (error: any) {
+    const statusCode = error.statusCode || 400;
+    sendLocalizedError(res, statusCode, error, "Apertura partita non riuscita.", "server.game.openFailed");
+  }
+}
+
+module.exports = {
+  handleCreateGameRoute,
+  handleOpenGameRoute
+};

--- a/backend/routes/game-overview.cts
+++ b/backend/routes/game-overview.cts
@@ -1,0 +1,40 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown) => void;
+
+type ListGames = () => Promise<unknown> | unknown;
+type GetTargetGameId = (body?: Record<string, unknown>, url?: URL | null) => string | null;
+type ListRuleSets = () => unknown;
+type ListMaps = () => unknown;
+type ListDiceRuleSets = () => unknown;
+
+async function handleGamesListRoute(
+  res: unknown,
+  listGames: ListGames,
+  getTargetGameId: GetTargetGameId,
+  sendJson: SendJson,
+  url: URL
+): Promise<void> {
+  sendJson(res, 200, {
+    games: await listGames(),
+    activeGameId: getTargetGameId({}, url)
+  });
+}
+
+function handleGameOptionsRoute(
+  res: unknown,
+  listRuleSets: ListRuleSets,
+  listMaps: ListMaps,
+  listDiceRuleSets: ListDiceRuleSets,
+  sendJson: SendJson
+): void {
+  sendJson(res, 200, {
+    ruleSets: listRuleSets(),
+    maps: listMaps(),
+    diceRuleSets: listDiceRuleSets(),
+    playerRange: { min: 2, max: 4 }
+  });
+}
+
+module.exports = {
+  handleGamesListRoute,
+  handleGameOptionsRoute
+};

--- a/backend/routes/game-read.cts
+++ b/backend/routes/game-read.cts
@@ -1,0 +1,88 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type AuthorizeGameRead = (gameId: string | null, req: unknown, res: unknown, url: URL) => Promise<any>;
+type GetTargetGameId = (body?: Record<string, unknown>, url?: URL | null) => string | null;
+type LoadGameContext = (gameId: string | null) => Promise<any>;
+type ResumeAiTurnsForRead = (gameContext: any) => Promise<any>;
+type SnapshotForUser = (
+  state: any,
+  gameId: string | null,
+  version: number | null,
+  gameName: string | null,
+  user: unknown
+) => unknown;
+type ExtractSessionToken = (req: unknown, body?: Record<string, unknown>, url?: URL | null) => string | null;
+type GetUserFromSession = (sessionToken: string | null) => Promise<unknown>;
+
+async function handleStateRoute(
+  req: unknown,
+  res: unknown,
+  url: URL,
+  authorizeGameRead: AuthorizeGameRead,
+  getTargetGameId: GetTargetGameId,
+  loadGameContext: LoadGameContext,
+  resumeAiTurnsForRead: ResumeAiTurnsForRead,
+  getUserFromSession: GetUserFromSession,
+  extractSessionToken: ExtractSessionToken,
+  snapshotForUser: SnapshotForUser,
+  sendJson: SendJson
+): Promise<void> {
+  const gameId = getTargetGameId({}, url);
+  const access = await authorizeGameRead(gameId, req, res, url);
+  if (access === null) {
+    return;
+  }
+
+  const gameContext = await loadGameContext(gameId);
+  await resumeAiTurnsForRead(gameContext);
+  const sessionUser = access && access.user ? access.user : await getUserFromSession(extractSessionToken(req, {}, url));
+  sendJson(res, 200, snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, sessionUser));
+}
+
+async function handleEventsRoute(
+  req: any,
+  res: any,
+  url: URL,
+  authorizeGameRead: AuthorizeGameRead,
+  getTargetGameId: GetTargetGameId,
+  loadGameContext: LoadGameContext,
+  resumeAiTurnsForRead: ResumeAiTurnsForRead,
+  snapshotForUser: SnapshotForUser,
+  clientsByGameId: Map<string, Set<{ res: any; user: unknown }>>
+): Promise<void> {
+  const gameId = getTargetGameId({}, url);
+  const access = await authorizeGameRead(gameId, req, res, url);
+  if (access === null) {
+    return;
+  }
+
+  const gameContext = await loadGameContext(gameId);
+  await resumeAiTurnsForRead(gameContext);
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*"
+  });
+  res.write("data: " + JSON.stringify(snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, access.user || null)) + "\n\n");
+  const key = gameContext.gameId || "__default__";
+  if (!clientsByGameId.has(key)) {
+    clientsByGameId.set(key, new Set());
+  }
+  const client = { res, user: access.user || null };
+  clientsByGameId.get(key)?.add(client);
+  req.on("close", () => {
+    const group = clientsByGameId.get(key);
+    if (!group) {
+      return;
+    }
+    group.delete(client);
+    if (!group.size) {
+      clientsByGameId.delete(key);
+    }
+  });
+}
+
+module.exports = {
+  handleEventsRoute,
+  handleStateRoute
+};

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -1,0 +1,163 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type AuthContext = {
+  user: {
+    id: string;
+    username: string;
+  };
+};
+
+type RequireAuth = (req: unknown, res: unknown, body: Record<string, any>) => Promise<AuthContext | null>;
+type LoadGameContext = (gameId: string | null) => Promise<any>;
+type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type PersistWithAiTurns = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type GetTargetGameId = (body?: Record<string, unknown>, url?: URL | null) => string | null;
+type AddPlayer = (state: any, name: string, options?: Record<string, unknown>) => any;
+type SnapshotForState = (state: any, gameId: string | null, version: number | null, gameName: string | null) => unknown;
+type Authorize = (action: string, context: Record<string, unknown>) => void;
+type GetGame = (gameId: string | null) => Promise<any>;
+type GetPlayer = (state: any, playerId: string) => any;
+type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
+type StartGame = (state: any) => any;
+
+async function handleAiJoinRoute(
+  res: unknown,
+  body: Record<string, any>,
+  url: URL,
+  loadGameContext: LoadGameContext,
+  getTargetGameId: GetTargetGameId,
+  addPlayer: AddPlayer,
+  persistGameContext: PersistGameContext,
+  broadcastGame: BroadcastGame,
+  snapshotForState: SnapshotForState,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const result = addPlayer(gameContext.state, body.name, { isAi: true });
+  if (!result.ok) {
+    sendLocalizedError(res, 400, result, result.error, result.errorKey || "server.aiJoin.failed", result.errorParams);
+    return;
+  }
+
+  await persistGameContext(gameContext);
+  broadcastGame(gameContext);
+  sendJson(res, result.rejoined ? 200 : 201, {
+    playerId: result.player.id,
+    state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName),
+    player: result.player
+  });
+}
+
+async function handleJoinRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  url: URL,
+  requireAuth: RequireAuth,
+  loadGameContext: LoadGameContext,
+  getTargetGameId: GetTargetGameId,
+  addPlayer: AddPlayer,
+  persistGameContext: PersistGameContext,
+  broadcastGame: BroadcastGame,
+  snapshotForState: SnapshotForState,
+  publicUser: (user: unknown) => unknown,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const result = addPlayer(gameContext.state, authContext.user.username, { linkedUserId: authContext.user.id });
+  if (!result.ok) {
+    sendLocalizedError(res, 400, result, result.error, result.errorKey || "server.join.failed", result.errorParams);
+    return;
+  }
+
+  await persistGameContext(gameContext);
+  broadcastGame(gameContext);
+  sendJson(res, result.rejoined ? 200 : 201, {
+    playerId: result.player.id,
+    state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName),
+    user: publicUser(authContext.user)
+  });
+}
+
+async function handleStartRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  url: URL,
+  requireAuth: RequireAuth,
+  loadGameContext: LoadGameContext,
+  getTargetGameId: GetTargetGameId,
+  getGame: GetGame,
+  authorize: Authorize,
+  getPlayer: GetPlayer,
+  playerBelongsToUser: PlayerBelongsToUser,
+  startGame: StartGame,
+  persistWithAiTurns: PersistWithAiTurns,
+  broadcastGame: BroadcastGame,
+  snapshotForState: SnapshotForState,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  if (gameContext.state.phase !== "lobby") {
+    sendLocalizedError(res, 400, null, "La partita e gia iniziata.", "server.game.alreadyStarted");
+    return;
+  }
+
+  try {
+    const activeGame = await getGame(gameContext.gameId);
+    authorize("game:start", { user: authContext.user, game: activeGame.game });
+  } catch (error: any) {
+    const statusCode = error.statusCode || 400;
+    sendLocalizedError(res, statusCode, error, "Avvio partita non autorizzato.", "server.game.startUnauthorized");
+    return;
+  }
+
+  if (gameContext.state.players.length < 2) {
+    sendLocalizedError(res, 400, null, "Servono almeno 2 giocatori.", "server.game.notEnoughPlayers");
+    return;
+  }
+
+  const player = getPlayer(gameContext.state, body.playerId);
+  if (!player || !playerBelongsToUser(player, authContext.user)) {
+    sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
+    return;
+  }
+
+  startGame(gameContext.state);
+  await persistWithAiTurns(gameContext);
+  broadcastGame(gameContext);
+  sendJson(res, 200, {
+    ok: true,
+    state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName)
+  });
+}
+
+module.exports = {
+  handleAiJoinRoute,
+  handleJoinRoute,
+  handleStartRoute
+};

--- a/backend/routes/health.cts
+++ b/backend/routes/health.cts
@@ -1,0 +1,9 @@
+export async function handleHealthRoute(
+  res: import("node:http").ServerResponse,
+  healthSnapshot: () => Promise<{ ok: boolean } & Record<string, unknown>>,
+  sendJson: (res: import("node:http").ServerResponse, statusCode: number, payload: unknown, headers?: Record<string, string>) => void
+): Promise<boolean> {
+  const health = await healthSnapshot();
+  sendJson(res, health.ok ? 200 : 503, health);
+  return true;
+}

--- a/backend/routes/password-auth.cts
+++ b/backend/routes/password-auth.cts
@@ -1,0 +1,91 @@
+type SendJson = (res: unknown, statusCode: number, payload: unknown, headers?: Record<string, string>) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: unknown,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+
+type AuthStore = {
+  registerPasswordUser(input: { username?: string; password?: string; email?: string }): Promise<any>;
+  loginWithPassword(username?: string, password?: string): Promise<any>;
+  logout(sessionToken: string | null): Promise<void> | void;
+};
+
+type ExtractSessionToken = (req: unknown, body?: Record<string, unknown>) => string | null;
+type BuildSessionCookie = (req: unknown, sessionToken: string) => string;
+type ClearSessionCookie = (req: unknown) => string;
+
+async function handleRegisterRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  auth: AuthStore,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<void> {
+  const result = await auth.registerPasswordUser({
+    username: body.username,
+    password: body.password,
+    email: body.email
+  });
+  if (!result.ok) {
+    sendLocalizedError(res, 400, result, result.error, result.errorKey || "register.errors.submitFailed", result.errorParams);
+    return;
+  }
+
+  sendJson(res, 201, {
+    ok: true,
+    user: result.user,
+    nextAuthProviders: ["password", "email", "google", "discord"]
+  });
+}
+
+async function handleLoginRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  auth: AuthStore,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError,
+  buildSessionCookie: BuildSessionCookie
+): Promise<void> {
+  const result = await auth.loginWithPassword(body.username, body.password);
+  if (!result.ok) {
+    sendLocalizedError(res, 401, result, result.error, result.errorKey || "errors.loginFailed", result.errorParams);
+    return;
+  }
+
+  sendJson(res, 200, {
+    ok: true,
+    user: result.user,
+    availableAuthProviders: ["password", "email", "google", "discord"]
+  }, {
+    "Set-Cookie": buildSessionCookie(req, result.sessionToken)
+  });
+}
+
+async function handleLogoutRoute(
+  req: unknown,
+  res: unknown,
+  body: Record<string, any>,
+  auth: AuthStore,
+  sendJson: SendJson,
+  extractSessionToken: ExtractSessionToken,
+  clearSessionCookie: ClearSessionCookie
+): Promise<void> {
+  await auth.logout(extractSessionToken(req, body));
+  sendJson(res, 200, { ok: true }, {
+    "Set-Cookie": clearSessionCookie(req)
+  });
+}
+
+module.exports = {
+  handleLoginRoute,
+  handleLogoutRoute,
+  handleRegisterRoute
+};

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -37,6 +37,7 @@ const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs");
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
+const { handleTurnGameActionRoute } = require("./routes/game-actions-turn.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
 const { handleLoginRoute, handleLogoutRoute, handleRegisterRoute } = require("./routes/password-auth.cjs");
 
@@ -907,46 +908,22 @@ function createApp(options = {}) {
         return;
       }
 
-      if (type === "endTurn") {
-        const result = endTurn(gameContext.state, playerId);
-        if (!result.ok) {
-          sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-          return;
-        }
-
-        try {
-          await persistWithAiTurns(gameContext, expectedVersion);
-        } catch (error) {
-          if (handleVersionConflict(error)) {
-            return;
-          }
-          throw error;
-        }
-        broadcastGame(gameContext);
-        sendJson(res, 200, { ok: true, state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user) });
-        return;
-      }
-
-      if (type === "surrender") {
-        const result = surrenderPlayer(gameContext.state, playerId);
-        if (!result.ok) {
-          sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-          return;
-        }
-
-        try {
-          await persistWithAiTurns(gameContext, expectedVersion);
-        } catch (error) {
-          if (handleVersionConflict(error)) {
-            return;
-          }
-          throw error;
-        }
-        broadcastGame(gameContext);
-        sendJson(res, 200, {
-          ok: true,
-          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user)
-        });
+      if (await handleTurnGameActionRoute(
+        type,
+        res,
+        gameContext,
+        playerId,
+        expectedVersion,
+        authContext.user,
+        endTurn,
+        surrenderPlayer,
+        persistWithAiTurns,
+        broadcastGame,
+        snapshotForUser,
+        handleVersionConflict,
+        sendJson,
+        sendLocalizedError
+      )) {
         return;
       }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -33,6 +33,7 @@ const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
+const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
 const { handleLoginRoute, handleLogoutRoute, handleRegisterRoute } = require("./routes/password-auth.cjs");
 
@@ -714,44 +715,40 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/ai/join") {
       const body = await parseBody(req);
-      const gameContext = await loadGameContext(getTargetGameId(body, url));
-      const result = addPlayer(gameContext.state, body.name, { isAi: true });
-      if (!result.ok) {
-        sendLocalizedError(res, 400, result, result.error, result.errorKey || "server.aiJoin.failed", result.errorParams);
-        return;
-      }
-
-      await persistGameContext(gameContext);
-      broadcastGame(gameContext);
-      sendJson(res, result.rejoined ? 200 : 201, {
-        playerId: result.player.id,
-        state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName),
-        player: result.player
-      });
+      await handleAiJoinRoute(
+        res,
+        body,
+        url,
+        loadGameContext,
+        getTargetGameId,
+        addPlayer,
+        persistGameContext,
+        broadcastGame,
+        snapshotForState,
+        sendJson,
+        sendLocalizedError
+      );
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/join") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      const gameContext = await loadGameContext(getTargetGameId(body, url));
-      const result = addPlayer(gameContext.state, authContext.user.username, { linkedUserId: authContext.user.id });
-      if (!result.ok) {
-        sendLocalizedError(res, 400, result, result.error, result.errorKey || "server.join.failed", result.errorParams);
-        return;
-      }
-
-      await persistGameContext(gameContext);
-      broadcastGame(gameContext);
-      sendJson(res, result.rejoined ? 200 : 201, {
-        playerId: result.player.id,
-        state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName),
-        user: auth.publicUser(authContext.user)
-      });
+      await handleJoinRoute(
+        req,
+        res,
+        body,
+        url,
+        requireAuth,
+        loadGameContext,
+        getTargetGameId,
+        addPlayer,
+        persistGameContext,
+        broadcastGame,
+        snapshotForState,
+        auth.publicUser,
+        sendJson,
+        sendLocalizedError
+      );
       return;
     }
 
@@ -810,41 +807,25 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/start") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      const gameContext = await loadGameContext(getTargetGameId(body, url));
-      if (gameContext.state.phase !== "lobby") {
-        sendLocalizedError(res, 400, null, "La partita e gia iniziata.", "server.game.alreadyStarted");
-        return;
-      }
-
-      try {
-        const activeGame = await gameSessions.getGame(gameContext.gameId);
-        authorize("game:start", { user: authContext.user, game: activeGame.game });
-      } catch (error) {
-        const statusCode = error.statusCode || 400;
-        sendLocalizedError(res, statusCode, error, "Avvio partita non autorizzato.", "server.game.startUnauthorized");
-        return;
-      }
-
-      if (gameContext.state.players.length < 2) {
-        sendLocalizedError(res, 400, null, "Servono almeno 2 giocatori.", "server.game.notEnoughPlayers");
-        return;
-      }
-
-      const player = getPlayer(gameContext.state, body.playerId);
-      if (!player || !playerBelongsToUser(player, authContext.user)) {
-        sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
-        return;
-      }
-
-      startGame(gameContext.state);
-      await persistWithAiTurns(gameContext);
-      broadcastGame(gameContext);
-      sendJson(res, 200, { ok: true, state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName) });
+      await handleStartRoute(
+        req,
+        res,
+        body,
+        url,
+        requireAuth,
+        loadGameContext,
+        getTargetGameId,
+        gameSessions.getGame,
+        authorize,
+        getPlayer,
+        playerBelongsToUser,
+        startGame,
+        persistWithAiTurns,
+        broadcastGame,
+        snapshotForState,
+        sendJson,
+        sendLocalizedError
+      );
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -35,6 +35,7 @@ const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute }
 const { handleAttackGameActionRoute } = require("./routes/game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("./routes/game-actions-basic.cjs");
 const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
+const { handleCreateGameRoute, handleOpenGameRoute } = require("./routes/game-management.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs");
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
@@ -564,60 +565,48 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/games") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      try {
-        const policy = authorize("game:create", { user: authContext.user });
-        const configured = createConfiguredInitialState(body);
-        const creatorJoin = addPlayer(configured.state, authContext.user.username, { linkedUserId: policy.actor.id });
-        if (!creatorJoin.ok) {
-          throw createLocalizedError(creatorJoin.error || "Impossibile collegare il creatore alla nuova partita.", creatorJoin.errorKey || "server.game.create.creatorJoinFailed", creatorJoin.errorParams);
-        }
-        const created = await gameSessions.createGame(configured.state, {
-          ...configured.gameInput,
-          creatorUserId: policy.actor.id
-        });
-        activeGameId = created.game.id;
-        activeGameVersion = created.game.version;
-        activeGameName = created.game.name;
-        replaceState(created.state);
-        broadcastGame({ gameId: created.game.id, gameName: created.game.name, version: created.game.version, state: created.state });
-        sendJson(res, 201, { ok: true, game: created.game, games: await gameSessions.listGames(), activeGameId, state: snapshot(), config: configured.config, playerId: creatorJoin.player.id });
-      } catch (error) {
-        const statusCode = error.statusCode || 400;
-        sendLocalizedError(res, statusCode, error, "Creazione partita non riuscita.", "server.game.createFailed");
-      }
+      await handleCreateGameRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        createConfiguredInitialState,
+        addPlayer,
+        async (state, options) => {
+          const created = await gameSessions.createGame(state, options);
+          activeGameId = created.game.id;
+          activeGameVersion = created.game.version;
+          activeGameName = created.game.name;
+          return created;
+        },
+        () => gameSessions.listGames(),
+        replaceState,
+        broadcastGame,
+        snapshot,
+        sendJson,
+        sendLocalizedError
+      );
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/games/open") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      try {
-        const gameRecord = await gameSessions.getGame(body.gameId);
-        authorize("game:open", { user: authContext.user, game: gameRecord.game, state: gameRecord.state });
-        const opened = await gameSessions.openGame(body.gameId);
-        await resumeAiTurnsForRead(opened);
-        const resolvedPlayer = resolvePlayerForUser(opened.state, authContext.user);
-        sendJson(res, 200, {
-          ok: true,
-          game: opened.game,
-          games: await gameSessions.listGames(),
-          activeGameId: opened.game.id,
-          state: snapshotForState(opened.state, opened.game.id, opened.game.version, opened.game.name),
-          playerId: resolvedPlayer ? resolvedPlayer.id : null
-        });
-      } catch (error) {
-        const statusCode = error.statusCode || 400;
-        sendLocalizedError(res, statusCode, error, "Apertura partita non riuscita.", "server.game.openFailed");
-      }
+      await handleOpenGameRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        (gameId) => gameSessions.getGame(gameId),
+        (gameId) => gameSessions.openGame(gameId),
+        () => gameSessions.listGames(),
+        resumeAiTurnsForRead,
+        resolvePlayerForUser,
+        snapshotForState,
+        sendJson,
+        sendLocalizedError
+      );
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -34,6 +34,7 @@ const { sendJson, sendLocalizedError, localizedPayload } = require("./http-respo
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
 const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
+const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs");
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
 const { handleLoginRoute, handleLogoutRoute, handleRegisterRoute } = require("./routes/password-auth.cjs");
@@ -532,15 +533,19 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/state") {
-      const gameId = getTargetGameId({}, url);
-      const access = await authorizeGameRead(gameId, req, res, url);
-      if (access === null) {
-        return;
-      }
-      const gameContext = await loadGameContext(gameId);
-      await resumeAiTurnsForRead(gameContext);
-      const sessionUser = access && access.user ? access.user : await auth.getUserFromSession(extractSessionToken(req, {}, url));
-      sendJson(res, 200, snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, sessionUser));
+      await handleStateRoute(
+        req,
+        res,
+        url,
+        authorizeGameRead,
+        getTargetGameId,
+        loadGameContext,
+        resumeAiTurnsForRead,
+        auth.getUserFromSession,
+        extractSessionToken,
+        snapshotForUser,
+        sendJson
+      );
       return;
     }
 
@@ -663,36 +668,17 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/events") {
-      const gameId = getTargetGameId({}, url);
-      const access = await authorizeGameRead(gameId, req, res, url);
-      if (access === null) {
-        return;
-      }
-      const gameContext = await loadGameContext(gameId);
-      await resumeAiTurnsForRead(gameContext);
-      res.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Access-Control-Allow-Origin": "*"
-      });
-      res.write("data: " + JSON.stringify(snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, access.user || null)) + "\n\n");
-      const key = gameContext.gameId || "__default__";
-      if (!clientsByGameId.has(key)) {
-        clientsByGameId.set(key, new Set());
-      }
-      const client = { res, user: access.user || null };
-      clientsByGameId.get(key).add(client);
-      req.on("close", () => {
-        const group = clientsByGameId.get(key);
-        if (!group) {
-          return;
-        }
-        group.delete(client);
-        if (!group.size) {
-          clientsByGameId.delete(key);
-        }
-      });
+      await handleEventsRoute(
+        req,
+        res,
+        url,
+        authorizeGameRead,
+        getTargetGameId,
+        loadGameContext,
+        resumeAiTurnsForRead,
+        snapshotForUser,
+        clientsByGameId
+      );
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const http = require("http");
 const fs = require("fs");
 const path = require("path");
@@ -33,6 +32,38 @@ const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs"
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
 const { handleLoginRoute, handleLogoutRoute, handleRegisterRoute } = require("./routes/password-auth.cjs");
+
+type Request = import("http").IncomingMessage;
+type Response = import("http").ServerResponse;
+type CookieMap = Record<string, string>;
+type AppUser = {
+  id: string;
+  username: string;
+  profile?: {
+    preferences?: {
+      theme?: string;
+    };
+  };
+  preferences?: {
+    theme?: string;
+  };
+};
+type CreateAppOptions = {
+  dbFile?: string;
+  dataFile?: string;
+  gamesFile?: string;
+  sessionsFile?: string;
+};
+type GameContext = {
+  gameId: string | null;
+  gameName: string | null;
+  version: number | null;
+  state: any;
+};
+type EventClient = {
+  res: Response;
+  user: unknown;
+};
 
 loadLocalEnv();
 
@@ -72,11 +103,11 @@ const port = process.env.PORT || 3000;
 const sessionCookieName = "netrisk_session";
 const supportedSiteThemes = new Set(["command", "midnight", "ember"]);
 
-function resolveStoredTheme(theme) {
-  return supportedSiteThemes.has(theme) ? theme : "command";
+function resolveStoredTheme(theme: unknown): string {
+  return typeof theme === "string" && supportedSiteThemes.has(theme) ? theme : "command";
 }
 
-function extractUserPreferences(user) {
+function extractUserPreferences(user: AppUser | null | undefined) {
   return {
     theme: resolveStoredTheme(user?.profile?.preferences?.theme)
   };
@@ -90,10 +121,10 @@ function defaultDbFile() {
   return path.join(projectRoot, "data", "netrisk.sqlite");
 }
 
-function parseBody(req) {
+function parseBody(req: Request): Promise<Record<string, any>> {
   return new Promise((resolve, reject) => {
     let raw = "";
-    req.on("data", (chunk) => {
+    req.on("data", (chunk: Buffer | string) => {
       raw += chunk;
       if (raw.length > 1000000) {
         reject(createLocalizedError("Payload troppo grande", "server.payloadTooLarge"));
@@ -107,7 +138,7 @@ function parseBody(req) {
       }
 
       try {
-        resolve(JSON.parse(raw));
+        resolve(JSON.parse(raw) as Record<string, any>);
       } catch (error) {
         reject(createLocalizedError("JSON non valido", "server.invalidJson"));
       }
@@ -115,7 +146,7 @@ function parseBody(req) {
   });
 }
 
-function parseCookies(req) {
+function parseCookies(req: Request): CookieMap {
   const rawCookies = String(req.headers.cookie || "");
   if (!rawCookies) {
     return {};
@@ -135,14 +166,14 @@ function parseCookies(req) {
 
     cookies[key] = decodeURIComponent(value);
     return cookies;
-  }, {});
+  }, {} as CookieMap);
 }
 
-function secureCookieFlag(req) {
-  return req.socket?.encrypted || req.headers["x-forwarded-proto"] === "https";
+function secureCookieFlag(req: Request): boolean {
+  return Boolean((req.socket as any)?.encrypted) || req.headers["x-forwarded-proto"] === "https";
 }
 
-function buildSessionCookie(req, sessionToken) {
+function buildSessionCookie(req: Request, sessionToken: string): string {
   const parts = [
     `${sessionCookieName}=${encodeURIComponent(sessionToken)}`,
     "HttpOnly",
@@ -155,7 +186,7 @@ function buildSessionCookie(req, sessionToken) {
   return parts.join("; ");
 }
 
-function clearSessionCookie(req) {
+function clearSessionCookie(req: Request): string {
   const parts = [
     `${sessionCookieName}=`,
     "HttpOnly",
@@ -169,7 +200,7 @@ function clearSessionCookie(req) {
   return parts.join("; ");
 }
 
-function createApp(options = {}) {
+function createApp(options: CreateAppOptions = {}) {
   if (shouldValidateDeployEnv(process.env)) {
     const missingEnvKeys = missingRequiredDeployEnv(process.env);
     if (missingEnvKeys.length) {
@@ -183,10 +214,10 @@ function createApp(options = {}) {
   }
 
   const state = createInitialState();
-  let activeGameId = null;
-  let activeGameVersion = null;
-  let activeGameName = null;
-  let nextAttackRolls = null;
+  let activeGameId: string | null = null;
+  let activeGameVersion: number | null = null;
+  let activeGameName: string | null = null;
+  let nextAttackRolls: number[] | null = null;
   const datastore = createDatastore({
     dbFile: options.dbFile || defaultDbFile(),
     legacyUsersFile: options.dataFile || path.join(projectRoot, "data", "users.json"),
@@ -207,13 +238,13 @@ function createApp(options = {}) {
     dataFile: options.dataFile || path.join(projectRoot, "data", "users.json"),
     sessionsFile: options.sessionsFile || path.join(projectRoot, "data", "sessions.json")
   });
-  const clientsByGameId = new Map();
-  let initPromise = null;
+  const clientsByGameId = new Map<string, Set<EventClient>>();
+  let initPromise: Promise<void> | null = null;
 
   const eagerInitialGame = gameSessions.ensureActiveGame(createInitialState);
   if (isPromiseLike(eagerInitialGame)) {
     initPromise = eagerInitialGame
-      .then((initialGame) => {
+      .then((initialGame: any) => {
         activeGameId = initialGame.game.id;
         activeGameVersion = initialGame.game.version;
         activeGameName = initialGame.game.name;
@@ -229,7 +260,7 @@ function createApp(options = {}) {
     replaceState(eagerInitialGame.state);
   }
 
-  function replaceState(nextState) {
+  function replaceState(nextState: Record<string, any>) {
     Object.keys(state).forEach((key) => delete state[key]);
     Object.assign(state, nextState);
   }
@@ -241,7 +272,7 @@ function createApp(options = {}) {
 
     if (!initPromise) {
       initPromise = Promise.resolve(gameSessions.ensureActiveGame(createInitialState))
-        .then((initialGame) => {
+        .then((initialGame: any) => {
           activeGameId = initialGame.game.id;
           activeGameVersion = initialGame.game.version;
           activeGameName = initialGame.game.name;
@@ -255,7 +286,7 @@ function createApp(options = {}) {
     await initPromise;
   }
 
-  async function persistActiveGame(expectedVersion) {
+  async function persistActiveGame(expectedVersion?: number | null) {
     if (!activeGameId) {
       return null;
     }
@@ -266,7 +297,7 @@ function createApp(options = {}) {
     return savedGame;
   }
 
-  function snapshotForState(nextState, gameId, version, gameName) {
+  function snapshotForState(nextState: any, gameId: string | null, version: number | null, gameName: string | null) {
     return { ...publicState(nextState), gameId, version, gameName };
   }
 
@@ -274,11 +305,11 @@ function createApp(options = {}) {
     return snapshotForState(state, activeGameId, activeGameVersion, activeGameName);
   }
 
-  function getTargetGameId(body = {}, url = null) {
+  function getTargetGameId(body: Record<string, any> = {}, url: URL | null = null): string | null {
     return body.gameId || (url ? url.searchParams.get("gameId") : null) || activeGameId || null;
   }
 
-  async function loadGameContext(gameId) {
+  async function loadGameContext(gameId: string | null): Promise<GameContext> {
     await initializeActiveGame();
 
     if (!gameId || gameId === activeGameId) {
@@ -299,7 +330,7 @@ function createApp(options = {}) {
     };
   }
 
-  async function persistGameContext(gameContext, expectedVersion) {
+  async function persistGameContext(gameContext: GameContext, expectedVersion?: number | null) {
     if (!gameContext?.gameId) {
       return null;
     }
@@ -319,7 +350,7 @@ function createApp(options = {}) {
     return savedGame;
   }
 
-  function broadcastGame(gameContext) {
+  function broadcastGame(gameContext: GameContext) {
     if (!gameContext?.gameId) {
       return;
     }
@@ -329,7 +360,7 @@ function createApp(options = {}) {
       return;
     }
 
-    clients.forEach((client) => {
+    clients.forEach((client: EventClient) => {
       const payload = "data: " + JSON.stringify(
         snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, client.user)
       ) + "\n\n";
@@ -337,7 +368,7 @@ function createApp(options = {}) {
     });
   }
 
-  function runAiTurnsIfNeeded(targetState) {
+  function runAiTurnsIfNeeded(targetState: any): any[] {
     const reports = [];
     const maxTurns = Math.max(4, targetState.players.length * 4);
 
@@ -358,7 +389,7 @@ function createApp(options = {}) {
     return reports;
   }
 
-  async function persistWithAiTurns(gameContext, expectedVersion) {
+  async function persistWithAiTurns(gameContext: GameContext, expectedVersion?: number | null) {
     await persistGameContext(gameContext, expectedVersion);
     const aiReports = runAiTurnsIfNeeded(gameContext.state);
     if (aiReports.length > 0) {
@@ -367,7 +398,7 @@ function createApp(options = {}) {
     return aiReports;
   }
 
-  async function resumeAiTurnsForRead(gameContext) {
+  async function resumeAiTurnsForRead(gameContext: GameContext) {
     if (!gameContext?.state || gameContext.state.phase !== "active" || gameContext.state.winnerId) {
       return [];
     }
@@ -380,12 +411,12 @@ function createApp(options = {}) {
     return persistWithAiTurns(gameContext, gameContext.version);
   }
 
-  function extractSessionToken(req, body = {}, url = null) {
+  function extractSessionToken(req: Request, body: Record<string, any> = {}, url: URL | null = null): string | null {
     const cookies = parseCookies(req);
     return cookies[sessionCookieName] || null;
   }
 
-  async function requireAuth(req, res, body, url = null) {
+  async function requireAuth(req: Request, res: Response, body: Record<string, any>, url: URL | null = null) {
     const sessionToken = extractSessionToken(req, body, url);
     const user = await auth.getUserFromSession(sessionToken);
     if (!user) {
@@ -396,7 +427,7 @@ function createApp(options = {}) {
     return { sessionToken, user };
   }
 
-  async function authorizeGameRead(gameId, req, res, url) {
+  async function authorizeGameRead(gameId: string | null, req: Request, res: Response, url: URL) {
     if (!gameId) {
       return { ok: true, user: null, gameRecord: null };
     }
@@ -419,7 +450,7 @@ function createApp(options = {}) {
 
     try {
       authorize("game:read", { user: authContext.user, game: gameRecord.game, state: gameRecord.state });
-    } catch (error) {
+    } catch (error: any) {
       const statusCode = error.statusCode || 400;
       sendLocalizedError(res, statusCode, error, "Accesso partita non autorizzato.", "server.game.readUnauthorized");
       return null;
@@ -428,12 +459,12 @@ function createApp(options = {}) {
     return { ...authContext, gameRecord };
   }
 
-  function resolvePlayerForUser(nextState, user) {
+  function resolvePlayerForUser(nextState: any, user: any) {
     if (!user || !nextState || !Array.isArray(nextState.players)) {
       return null;
     }
 
-    return nextState.players.find((player) => {
+    return nextState.players.find((player: any) => {
       if (player.isAi) {
         return false;
       }
@@ -446,7 +477,7 @@ function createApp(options = {}) {
     }) || null;
   }
 
-  function playerBelongsToUser(player, user) {
+  function playerBelongsToUser(player: any, user: any): boolean {
     if (!player || !user || player.isAi) {
       return false;
     }
@@ -458,15 +489,15 @@ function createApp(options = {}) {
     return player.linkedUserId === user.id;
   }
 
-  function visibleHandForPlayer(nextState, player) {
+  function visibleHandForPlayer(nextState: any, player: any): any[] {
     if (!player || !Array.isArray(nextState?.hands?.[player.id])) {
       return [];
     }
 
-    return nextState.hands[player.id].map((card) => ({ ...card }));
+    return nextState.hands[player.id].map((card: any) => ({ ...card }));
   }
 
-  function snapshotForUser(nextState, gameId, version, gameName, user) {
+  function snapshotForUser(nextState: any, gameId: string | null, version: number | null, gameName: string | null, user: any) {
     const baseSnapshot = snapshotForState(nextState, gameId, version, gameName);
     const resolvedPlayer = resolvePlayerForUser(nextState, user);
 
@@ -489,7 +520,7 @@ function createApp(options = {}) {
     };
   }
 
-  async function handleApi(req, res, url) {
+  async function handleApi(req: Request, res: Response, url: URL) {
     await initializeActiveGame();
 
     if (req.method === "GET" && url.pathname === "/api/health") {
@@ -564,7 +595,7 @@ function createApp(options = {}) {
         authorize,
         createConfiguredInitialState,
         addPlayer,
-        async (state, options) => {
+        async (state: any, options: Record<string, any>) => {
           const created = await gameSessions.createGame(state, options);
           activeGameId = created.game.id;
           activeGameVersion = created.game.version;
@@ -589,8 +620,8 @@ function createApp(options = {}) {
         body,
         requireAuth,
         authorize,
-        (gameId) => gameSessions.getGame(gameId),
-        (gameId) => gameSessions.openGame(gameId),
+        (gameId: string) => gameSessions.getGame(gameId),
+        (gameId: string) => gameSessions.openGame(gameId),
         () => gameSessions.listGames(),
         resumeAiTurnsForRead,
         resolvePlayerForUser,
@@ -811,7 +842,7 @@ function createApp(options = {}) {
     sendLocalizedError(res, 404, null, "Endpoint non trovato.", "server.endpoint.notFound");
   }
 
-  function serveStatic(res, url) {
+  function serveStatic(res: Response, url: URL) {
     const relativePath = url.pathname === "/"
       ? "/index.html"
       : url.pathname.indexOf("/game/") === 0
@@ -824,7 +855,7 @@ function createApp(options = {}) {
       return;
     }
 
-    fs.readFile(filePath, (error, data) => {
+    fs.readFile(filePath, (error: NodeJS.ErrnoException | null, data: Buffer) => {
       if (error) {
         sendLocalizedError(res, 404, null, "File non trovato.", "server.static.fileNotFound");
         return;
@@ -843,14 +874,15 @@ function createApp(options = {}) {
         ".webp": "image/webp"
       };
 
+      const contentType = contentTypes[extension as keyof typeof contentTypes] || "text/plain; charset=utf-8";
       res.writeHead(200, {
-        "Content-Type": contentTypes[extension] || "text/plain; charset=utf-8"
+        "Content-Type": contentType
       });
       res.end(data);
     });
   }
 
-  function addSecurityHeaders(res) {
+  function addSecurityHeaders(res: Response) {
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("X-Frame-Options", "DENY");
     res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
@@ -858,8 +890,8 @@ function createApp(options = {}) {
       "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'");
   }
 
-  function handleRequest(req, res) {
-    const url = new URL(req.url, "http://" + req.headers.host);
+  function handleRequest(req: Request, res: Response) {
+    const url = new URL(req.url || "/", "http://" + req.headers.host);
 
     addSecurityHeaders(res);
 
@@ -872,7 +904,7 @@ function createApp(options = {}) {
         serveStatic(res, url);
         return null;
       })
-      .catch((error) => {
+      .catch((error: any) => {
         sendLocalizedError(res, 500, error, "Errore interno.", "server.internalError");
       });
   }

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -32,6 +32,7 @@ const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
+const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
 
 loadLocalEnv();
@@ -541,17 +542,12 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/games") {
-      sendJson(res, 200, { games: await gameSessions.listGames(), activeGameId: getTargetGameId({}, url) });
+      await handleGamesListRoute(res, () => gameSessions.listGames(), getTargetGameId, sendJson, url);
       return;
     }
 
     if (req.method === "GET" && url.pathname === "/api/game-options") {
-      sendJson(res, 200, {
-        ruleSets: listNewGameRuleSets(),
-        maps: listSupportedMaps(),
-        diceRuleSets: listDiceRuleSets(),
-        playerRange: { min: 2, max: 4 }
-      });
+      handleGameOptionsRoute(res, listNewGameRuleSets, listSupportedMaps, listDiceRuleSets, sendJson);
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -32,6 +32,7 @@ const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
+const { handleAttackGameActionRoute } = require("./routes/game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("./routes/game-actions-basic.cjs");
 const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
@@ -861,50 +862,42 @@ function createApp(options = {}) {
         return;
       }
 
-      if (type === "attack" || type === "attackBanzai") {
-        let random;
-        if (process.env.E2E === "true" && Array.isArray(nextAttackRolls) && nextAttackRolls.length === 2) {
-          const queuedRolls = nextAttackRolls.slice();
-          nextAttackRolls = null;
-          random = () => {
-            const roll = queuedRolls.shift();
-            if (!roll) {
-              return secureRandom();
-            }
-
-            return (roll - 0.01) / 6;
-          };
+      function consumeQueuedAttackRandom() {
+        if (process.env.E2E !== "true" || !Array.isArray(nextAttackRolls) || nextAttackRolls.length !== 2) {
+          return null;
         }
 
-        const requestedAttackDice = body.attackDice == null || body.attackDice === "" ? null : Number(body.attackDice);
-        const actionFromId = String(body.fromId || "");
-        const actionToId = String(body.toId || "");
-        if (!isValidTerritoryId(actionFromId) || !isValidTerritoryId(actionToId)) {
-          sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
-          return;
-        }
-        const result = type === "attackBanzai"
-          ? resolveBanzaiAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice)
-          : resolveAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice);
-        if (!result.ok) {
-          sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-          return;
-        }
-
-        try {
-          await persistGameContext(gameContext, expectedVersion);
-        } catch (error) {
-          if (handleVersionConflict(error)) {
-            return;
+        const queuedRolls = nextAttackRolls.slice();
+        nextAttackRolls = null;
+        return () => {
+          const roll = queuedRolls.shift();
+          if (!roll) {
+            return secureRandom();
           }
-          throw error;
-        }
-        broadcastGame(gameContext);
-        sendJson(res, 200, {
-          ok: true,
-          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user),
-          rounds: Array.isArray(result.rounds) ? result.rounds : undefined
-        });
+
+          return (roll - 0.01) / 6;
+        };
+      }
+
+      if (await handleAttackGameActionRoute(
+        type,
+        res,
+        body,
+        gameContext,
+        playerId,
+        expectedVersion,
+        authContext.user,
+        resolveAttack,
+        resolveBanzaiAttack,
+        consumeQueuedAttackRandom,
+        persistGameContext,
+        broadcastGame,
+        snapshotForUser,
+        handleVersionConflict,
+        isValidTerritoryId,
+        sendJson,
+        sendLocalizedError
+      )) {
         return;
       }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -32,6 +32,7 @@ const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
+const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
@@ -754,54 +755,23 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/cards/trade") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      const gameContext = await loadGameContext(getTargetGameId(body, url));
-      const player = getPlayer(gameContext.state, body.playerId);
-      if (!player || !playerBelongsToUser(player, authContext.user)) {
-        sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
-        return;
-      }
-
-      const expectedVersion = body.expectedVersion == null ? null : Number(body.expectedVersion);
-      if (body.expectedVersion != null && (!Number.isInteger(expectedVersion) || expectedVersion < 1)) {
-        sendLocalizedError(res, 400, null, "expectedVersion non valida.", "server.invalidExpectedVersion");
-        return;
-      }
-
-      if (expectedVersion != null && expectedVersion !== gameContext.version) {
-        sendLocalizedError(res, 409, null, "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.", "server.versionConflict", {}, "VERSION_CONFLICT", {
-          currentVersion: gameContext.version,
-          state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName)
-        });
-        return;
-      }
-
-      const result = tradeCardSet(gameContext.state, body.playerId, body.cardIds);
-      if (!result.ok) {
-        sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-        return;
-      }
-
-      try {
-        await persistGameContext(gameContext, expectedVersion);
-      } catch (error) {
-        if (error && error.code === "VERSION_CONFLICT") {
-          sendLocalizedError(res, 409, error, error.message, error.messageKey || "server.versionConflict", {}, error.code, {
-            currentVersion: error.currentVersion,
-            state: snapshotForState(error.currentState, gameContext.gameId, error.currentVersion, error.game?.name || gameContext.gameName)
-          });
-          return;
-        }
-
-        throw error;
-      }
-
-      broadcastGame(gameContext);
-      sendJson(res, 200, { ok: true, bonus: result.bonus, validation: result.validation, state: snapshotForState(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName) });
+      await handleCardsTradeRoute(
+        req,
+        res,
+        body,
+        url,
+        requireAuth,
+        loadGameContext,
+        getTargetGameId,
+        getPlayer,
+        playerBelongsToUser,
+        tradeCardSet,
+        persistGameContext,
+        broadcastGame,
+        snapshotForState,
+        sendJson,
+        sendLocalizedError
+      );
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -34,6 +34,7 @@ const { sendJson, sendLocalizedError, localizedPayload } = require("./http-respo
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
+const { handleLoginRoute, handleLogoutRoute, handleRegisterRoute } = require("./routes/password-auth.cjs");
 
 loadLocalEnv();
 
@@ -695,48 +696,19 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/auth/register") {
       const body = await parseBody(req);
-      const result = await auth.registerPasswordUser({
-        username: body.username,
-        password: body.password,
-        email: body.email
-      });
-      if (!result.ok) {
-        sendLocalizedError(res, 400, result, result.error, result.errorKey || "register.errors.submitFailed", result.errorParams);
-        return;
-      }
-
-      sendJson(res, 201, {
-        ok: true,
-        user: result.user,
-        nextAuthProviders: ["password", "email", "google", "discord"]
-      });
+      await handleRegisterRoute(req, res, body, auth, sendJson, sendLocalizedError);
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/auth/login") {
       const body = await parseBody(req);
-      const result = await auth.loginWithPassword(body.username, body.password);
-      if (!result.ok) {
-        sendLocalizedError(res, 401, result, result.error, result.errorKey || "errors.loginFailed", result.errorParams);
-        return;
-      }
-
-      sendJson(res, 200, {
-        ok: true,
-        user: result.user,
-        availableAuthProviders: ["password", "email", "google", "discord"]
-      }, {
-        "Set-Cookie": buildSessionCookie(req, result.sessionToken)
-      });
+      await handleLoginRoute(req, res, body, auth, sendJson, sendLocalizedError, buildSessionCookie);
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/auth/logout") {
       const body = await parseBody(req);
-      await auth.logout(extractSessionToken(req, body));
-      sendJson(res, 200, { ok: true }, {
-        "Set-Cookie": clearSessionCookie(req)
-      });
+      await handleLogoutRoute(req, res, body, auth, sendJson, extractSessionToken, clearSessionCookie);
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -30,6 +30,9 @@ const {
 const { resolveBanzaiAttack } = require("./engine/banzai-attack.cjs");
 const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
+const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
+const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
+const { handleHealthRoute } = require("./routes/health.cjs");
 
 loadLocalEnv();
 
@@ -87,18 +90,6 @@ function defaultDbFile() {
   return path.join(projectRoot, "data", "netrisk.sqlite");
 }
 
-function sendJson(res, statusCode, payload, headers = {}) {
-  if (res.headersSent || res.writableEnded) {
-    return;
-  }
-
-  res.writeHead(statusCode, {
-    "Content-Type": "application/json; charset=utf-8",
-    ...headers
-  });
-  res.end(JSON.stringify(payload));
-}
-
 function parseBody(req) {
   return new Promise((resolve, reject) => {
     let raw = "";
@@ -121,34 +112,6 @@ function parseBody(req) {
         reject(createLocalizedError("JSON non valido", "server.invalidJson"));
       }
     });
-  });
-}
-
-function localizedPayload(input, fallbackMessage, fallbackKey, fallbackParams = {}, code = null) {
-  const isObject = input && typeof input === "object";
-  const message = isObject
-    ? (input.message || input.error || input.reason || input.defaultMessage || fallbackMessage)
-    : fallbackMessage;
-  const messageKey = isObject
-    ? (input.messageKey || input.errorKey || input.reasonKey || null)
-    : null;
-  const messageParams = isObject
-    ? (input.messageParams || input.errorParams || input.reasonParams || {})
-    : {};
-
-  return {
-    error: message || fallbackMessage,
-    messageKey: messageKey || fallbackKey || null,
-    messageParams: messageKey ? messageParams : (fallbackKey ? fallbackParams : {})
-  };
-}
-
-function sendLocalizedError(res, statusCode, input, fallbackMessage, fallbackKey, fallbackParams = {}, code = null, extra = {}) {
-  const payload = localizedPayload(input, fallbackMessage, fallbackKey, fallbackParams, code);
-  sendJson(res, statusCode, {
-    ...payload,
-    code: code || (input && input.code) || null,
-    ...extra
   });
 }
 
@@ -530,8 +493,7 @@ function createApp(options = {}) {
     await initializeActiveGame();
 
     if (req.method === "GET" && url.pathname === "/api/health") {
-      const health = await healthSnapshot();
-      sendJson(res, health.ok ? 200 : 503, health);
+      await handleHealthRoute(res, healthSnapshot, sendJson);
       return;
     }
 
@@ -653,53 +615,51 @@ function createApp(options = {}) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/auth/session") {
-      const authContext = await requireAuth(req, res, {});
-      if (!authContext) {
-        return;
-      }
-
-      sendJson(res, 200, { user: auth.publicUser(authContext.user) });
+      await handleAuthSessionRoute({
+        req,
+        res,
+        requireAuth,
+        auth,
+        playerProfiles,
+        sendJson,
+        sendLocalizedError,
+        extractUserPreferences,
+        supportedSiteThemes,
+        resolveStoredTheme
+      });
       return;
     }
 
     if (req.method === "GET" && url.pathname === "/api/profile") {
-      const authContext = await requireAuth(req, res, {});
-      if (!authContext) {
-        return;
-      }
-
-      try {
-        sendJson(res, 200, {
-          profile: {
-            ...(await playerProfiles.getPlayerProfile(authContext.user.username)),
-            preferences: extractUserPreferences(authContext.user)
-          }
-        });
-      } catch (error) {
-        sendLocalizedError(res, 400, error, "Profilo non disponibile.", "server.profile.unavailable");
-      }
+      await handleProfileRoute({
+        req,
+        res,
+        requireAuth,
+        auth,
+        playerProfiles,
+        sendJson,
+        sendLocalizedError,
+        extractUserPreferences,
+        supportedSiteThemes,
+        resolveStoredTheme
+      });
       return;
     }
 
     if (req.method === "PUT" && url.pathname === "/api/profile/preferences/theme") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      if (!supportedSiteThemes.has(body.theme)) {
-        sendLocalizedError(res, 400, null, "Tema non supportato.", "server.profile.invalidTheme");
-        return;
-      }
-
-      const user = await auth.updateUserThemePreference(authContext.user.id, body.theme);
-
-      sendJson(res, 200, {
-        ok: true,
-        user,
-        preferences: user?.preferences || { theme: resolveStoredTheme(body.theme) }
-      });
+      await handleThemePreferenceRoute({
+        req,
+        res,
+        requireAuth,
+        auth,
+        playerProfiles,
+        sendJson,
+        sendLocalizedError,
+        extractUserPreferences,
+        supportedSiteThemes,
+        resolveStoredTheme
+      }, body);
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -14,32 +14,23 @@ const { isPromiseLike } = require("./maybe-async.cjs");
 const { missingRequiredDeployEnv, shouldValidateDeployEnv } = require("./required-runtime-env.cjs");
 const {
   addPlayer,
-  applyFortify,
-  applyReinforcement,
   createInitialState,
-  endTurn,
   getCurrentPlayer,
   getPlayer,
-  moveAfterConquest,
   publicState,
-  resolveAttack,
   startGame,
-  surrenderPlayer,
   tradeCardSet
 } = require("./engine/game-engine.cjs");
-const { resolveBanzaiAttack } = require("./engine/banzai-attack.cjs");
 const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
-const { handleAttackGameActionRoute } = require("./routes/game-actions-attack.cjs");
-const { handleBasicGameActionRoute } = require("./routes/game-actions-basic.cjs");
+const { handleGameActionRoute } = require("./routes/game-actions.cjs");
 const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
 const { handleCreateGameRoute, handleOpenGameRoute } = require("./routes/game-management.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs");
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
-const { handleTurnGameActionRoute } = require("./routes/game-actions-turn.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
 const { handleLoginRoute, handleLogoutRoute, handleRegisterRoute } = require("./routes/password-auth.cjs");
 
@@ -779,78 +770,6 @@ function createApp(options = {}) {
 
     if (req.method === "POST" && url.pathname === "/api/action") {
       const body = await parseBody(req);
-      const authContext = await requireAuth(req, res, body);
-      if (!authContext) {
-        return;
-      }
-
-      const playerId = body.playerId;
-      const type = body.type;
-      const expectedVersion = body.expectedVersion == null ? null : Number(body.expectedVersion);
-      if (body.expectedVersion != null && (!Number.isInteger(expectedVersion) || expectedVersion < 1)) {
-        sendLocalizedError(res, 400, null, "expectedVersion non valida.", "server.invalidExpectedVersion");
-        return;
-      }
-
-      const gameContext = await loadGameContext(getTargetGameId(body, url));
-      const player = getPlayer(gameContext.state, playerId);
-
-      if (!player || !playerBelongsToUser(player, authContext.user)) {
-        sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
-        return;
-      }
-
-      function handleVersionConflict(error) {
-        if (!error || error.code !== "VERSION_CONFLICT") {
-          return false;
-        }
-
-        sendJson(res, 409, {
-          ...localizedPayload(error, error.message, error.messageKey || "server.versionConflict"),
-          code: error.code,
-          currentVersion: error.currentVersion,
-          state: snapshotForUser(error.currentState, gameContext.gameId, error.currentVersion, error.game?.name || gameContext.gameName, authContext.user)
-        });
-        return true;
-      }
-
-      if (expectedVersion != null && expectedVersion !== gameContext.version) {
-        sendJson(res, 409, {
-          ...localizedPayload(null, "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.", "server.versionConflict"),
-          code: "VERSION_CONFLICT",
-          currentVersion: gameContext.version,
-          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user)
-        });
-        return;
-      }
-
-      function isValidTerritoryId(id) {
-        return id && typeof gameContext.state.territories === "object" &&
-          Object.prototype.hasOwnProperty.call(gameContext.state.territories, id);
-      }
-
-      if (await handleBasicGameActionRoute(
-        type,
-        res,
-        body,
-        gameContext,
-        playerId,
-        expectedVersion,
-        authContext.user,
-        applyReinforcement,
-        moveAfterConquest,
-        applyFortify,
-        persistGameContext,
-        broadcastGame,
-        snapshotForUser,
-        handleVersionConflict,
-        isValidTerritoryId,
-        sendJson,
-        sendLocalizedError
-      )) {
-        return;
-      }
-
       function consumeQueuedAttackRandom() {
         if (process.env.E2E !== "true" || !Array.isArray(nextAttackRolls) || nextAttackRolls.length !== 2) {
           return null;
@@ -868,48 +787,24 @@ function createApp(options = {}) {
         };
       }
 
-      if (await handleAttackGameActionRoute(
-        type,
+      await handleGameActionRoute({
+        req,
         res,
         body,
-        gameContext,
-        playerId,
-        expectedVersion,
-        authContext.user,
-        resolveAttack,
-        resolveBanzaiAttack,
-        consumeQueuedAttackRandom,
+        url,
+        requireAuth,
+        loadGameContext,
+        getTargetGameId,
+        playerBelongsToUser,
         persistGameContext,
-        broadcastGame,
-        snapshotForUser,
-        handleVersionConflict,
-        isValidTerritoryId,
-        sendJson,
-        sendLocalizedError
-      )) {
-        return;
-      }
-
-      if (await handleTurnGameActionRoute(
-        type,
-        res,
-        gameContext,
-        playerId,
-        expectedVersion,
-        authContext.user,
-        endTurn,
-        surrenderPlayer,
         persistWithAiTurns,
         broadcastGame,
         snapshotForUser,
-        handleVersionConflict,
+        consumeQueuedAttackRandom,
+        localizedPayload,
         sendJson,
         sendLocalizedError
-      )) {
-        return;
-      }
-
-      sendLocalizedError(res, 400, null, "Azione non supportata.", "server.action.unsupported");
+      });
       return;
     }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -32,6 +32,7 @@ const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
+const { handleBasicGameActionRoute } = require("./routes/game-actions-basic.cjs");
 const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
 const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-overview.cjs");
 const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs");
@@ -837,36 +838,25 @@ function createApp(options = {}) {
           Object.prototype.hasOwnProperty.call(gameContext.state.territories, id);
       }
 
-      if (type === "reinforce") {
-        const territoryId = String(body.territoryId || "");
-        if (!isValidTerritoryId(territoryId)) {
-          sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
-          return;
-        }
-        const result = applyReinforcement(
-          gameContext.state,
-          playerId,
-          territoryId,
-          body.amount
-        );
-        if (!result.ok) {
-          sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-          return;
-        }
-
-        try {
-          await persistGameContext(gameContext, expectedVersion);
-        } catch (error) {
-          if (handleVersionConflict(error)) {
-            return;
-          }
-          throw error;
-        }
-        broadcastGame(gameContext);
-        sendJson(res, 200, {
-          ok: true,
-          state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user)
-        });
+      if (await handleBasicGameActionRoute(
+        type,
+        res,
+        body,
+        gameContext,
+        playerId,
+        expectedVersion,
+        authContext.user,
+        applyReinforcement,
+        moveAfterConquest,
+        applyFortify,
+        persistGameContext,
+        broadcastGame,
+        snapshotForUser,
+        handleVersionConflict,
+        isValidTerritoryId,
+        sendJson,
+        sendLocalizedError
+      )) {
         return;
       }
 
@@ -914,52 +904,6 @@ function createApp(options = {}) {
           state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user),
           rounds: Array.isArray(result.rounds) ? result.rounds : undefined
         });
-        return;
-      }
-
-      if (type === "moveAfterConquest") {
-        const result = moveAfterConquest(gameContext.state, playerId, body.armies);
-        if (!result.ok) {
-          sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-          return;
-        }
-
-        try {
-          await persistGameContext(gameContext, expectedVersion);
-        } catch (error) {
-          if (handleVersionConflict(error)) {
-            return;
-          }
-          throw error;
-        }
-        broadcastGame(gameContext);
-        sendJson(res, 200, { ok: true, state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user) });
-        return;
-      }
-
-      if (type === "fortify") {
-        const fortifyFromId = String(body.fromId || "");
-        const fortifyToId = String(body.toId || "");
-        if (!isValidTerritoryId(fortifyFromId) || !isValidTerritoryId(fortifyToId)) {
-          sendLocalizedError(res, 400, null, "Territorio non valido.", "game.invalidTerritory");
-          return;
-        }
-        const result = applyFortify(gameContext.state, playerId, fortifyFromId, fortifyToId, body.armies);
-        if (!result.ok) {
-          sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
-          return;
-        }
-
-        try {
-          await persistGameContext(gameContext, expectedVersion);
-        } catch (error) {
-          if (handleVersionConflict(error)) {
-            return;
-          }
-          throw error;
-        }
-        broadcastGame(gameContext);
-        sendJson(res, 200, { ok: true, state: snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, authContext.user) });
         return;
       }
 

--- a/frontend/public/app.mjs
+++ b/frontend/public/app.mjs
@@ -1,3 +1,4 @@
+import { closest as closestElement, maybeQuery, setMarkup } from "./core/dom.mjs";
 import { formatDate, t, translateGameLogEntries, translateServerMessage } from "./i18n.mjs";
 const state = {
     playerId: localStorage.getItem("frontline-player-id") || null,
@@ -149,7 +150,7 @@ const elements = {
     log: document.querySelector("#log")
 };
 function renderNavAvatar(username) {
-    const avatar = document.querySelector("#nav-avatar");
+    const avatar = maybeQuery("#nav-avatar");
     if (!avatar) {
         return;
     }
@@ -486,9 +487,9 @@ function renderGameSessionBrowser() {
     if (!elements.gameList) {
         return;
     }
-    elements.gameList.innerHTML = state.gameList
+    setMarkup(elements.gameList, state.gameList
         .map((game) => `<option value="${escapeHtml(game.id)}">${escapeHtml(game.name)}</option>`)
-        .join("") || '<option value="">' + t("game.runtime.noGamesOption") + '</option>';
+        .join("") || '<option value="">' + t("game.runtime.noGamesOption") + '</option>');
     if (selectedId && state.gameList.some((game) => game.id === selectedId)) {
         elements.gameList.value = selectedId;
     }
@@ -506,7 +507,7 @@ function renderGameSessionBrowser() {
     else {
         elements.gameListState.textContent = t("lobby.empty");
     }
-    elements.gameSessionList.innerHTML = state.gameList
+    setMarkup(elements.gameSessionList, state.gameList
         .map((game) => `
       <button type="button" class="session-row session-row-button${game.id === selectedId ? " is-selected" : ""}" data-game-id="${game.id}">
         <span class="session-primary">
@@ -519,9 +520,9 @@ function renderGameSessionBrowser() {
         <span class="session-cell-muted">${formatUpdatedTime(game.updatedAt)}</span>
       </button>
     `)
-        .join("");
+        .join(""));
     elements.selectedGameStatus.textContent = selected ? phaseLabel(selected.phase) : t("lobby.details.emptyBadge");
-    elements.gameSessionDetails.innerHTML = selected
+    setMarkup(elements.gameSessionDetails, selected
         ? `
       <div class="session-detail-grid">
         <div class="session-detail-item"><span>${t("lobby.details.name")}</span><strong>${escapeHtml(selected.name)}</strong></div>
@@ -535,7 +536,7 @@ function renderGameSessionBrowser() {
         <button type="button" id="open-selected-inline">${t("game.runtime.openGame")}</button>
       </div>
     `
-        : '<div class="session-empty-copy">' + t("game.runtime.selectGameFromList") + '</div>';
+        : '<div class="session-empty-copy">' + t("game.runtime.selectGameFromList") + '</div>');
     const hasSelection = Boolean(selected);
     if (elements.openGameButton) {
         elements.openGameButton.disabled = !hasSelection;
@@ -767,14 +768,14 @@ function render() {
                     : currentPlayer
                         ? t("game.runtime.turnOf", { name: currentPlayer.name })
                         : t("game.runtime.waiting");
-    elements.statusSummary.innerHTML = snapshot
+    setMarkup(elements.statusSummary, snapshot
         ? `
       <div>Fase: <strong>${escapeHtml(snapshot.phase)}</strong></div>
       <div>${t("game.reinforcementBanner")} <strong>${snapshot.reinforcementPool}</strong></div>
       <div>${t("game.runtime.winner")}: <strong>${escapeHtml(winner ? winner.name : t("game.runtime.noneLower"))}</strong></div>
     `
-        : "<div>" + t("game.runtime.loadingState") + "</div>";
-    elements.players.innerHTML = (snapshot?.players || [])
+        : "<div>" + t("game.runtime.loadingState") + "</div>");
+    setMarkup(elements.players, (snapshot?.players || [])
         .map((player) => `
         <article class="player-card">
           <strong>${escapeHtml(player.name)}</strong>
@@ -783,14 +784,14 @@ function render() {
           <div style="margin-top: 8px; height: 10px; border-radius: 99px; --player-color:${player.color}; background: var(--player-color);"></div>
         </article>
       `)
-        .join("");
+        .join(""));
     const territories = myTerritories();
     const reinforceOptions = territories
         .map((territory) => `<option value="${territory.id}">${territoryOptionLabel(territory)}</option>`)
         .join("");
     const selectedReinforceId = selectOrFallback(state.selectedReinforceTerritoryId, territories);
     state.selectedReinforceTerritoryId = selectedReinforceId || null;
-    elements.reinforceSelect.innerHTML = reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>';
+    setMarkup(elements.reinforceSelect, reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>');
     if (selectedReinforceId) {
         elements.reinforceSelect.value = selectedReinforceId;
     }
@@ -802,7 +803,7 @@ function render() {
     }
     const selectedFromId = selectOrFallback(state.selectedAttackFromId, territories, selectedReinforceId);
     state.selectedAttackFromId = selectedFromId || null;
-    elements.attackFrom.innerHTML = reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>';
+    setMarkup(elements.attackFrom, reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>');
     if (selectedFromId) {
         elements.attackFrom.value = selectedFromId;
     }
@@ -812,20 +813,19 @@ function render() {
         territory.ownerId !== state.playerId);
     const selectedAttackToId = selectOrFallback(state.selectedAttackToId, attackTargets);
     state.selectedAttackToId = selectedAttackToId || null;
-    elements.attackTo.innerHTML =
-        attackTargets
-            .map((territory) => {
-            const owner = ownerById(territory.ownerId);
-            return `<option value="${territory.id}">${escapeHtml(territory.name)} vs ${escapeHtml(owner?.name || "?")} (${territory.armies})</option>`;
-        })
-            .join("") || '<option value="">' + t("game.runtime.noTarget") + '</option>';
+    setMarkup(elements.attackTo, attackTargets
+        .map((territory) => {
+        const owner = ownerById(territory.ownerId);
+        return `<option value="${territory.id}">${escapeHtml(territory.name)} vs ${escapeHtml(owner?.name || "?")} (${territory.armies})</option>`;
+    })
+        .join("") || '<option value="">' + t("game.runtime.noTarget") + '</option>');
     if (selectedAttackToId) {
         elements.attackTo.value = selectedAttackToId;
     }
     const maxAttackDice = source
         ? Math.max(0, Math.min(currentDiceRuleSet().attackerMaxDice || 3, source.armies - 1))
         : 0;
-    elements.attackDice.innerHTML = attackDiceOptions(maxAttackDice);
+    setMarkup(elements.attackDice, attackDiceOptions(maxAttackDice));
     if (maxAttackDice > 0) {
         const selectedAttackDiceCount = String(Math.min(Number(state.selectedAttackDiceCount || maxAttackDice), maxAttackDice));
         state.selectedAttackDiceCount = selectedAttackDiceCount;
@@ -837,7 +837,7 @@ function render() {
     }
     const selectedFortifyFromId = selectOrFallback(state.selectedFortifyFromId, territories, selectedReinforceId);
     state.selectedFortifyFromId = selectedFortifyFromId || null;
-    elements.fortifyFrom.innerHTML = reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>';
+    setMarkup(elements.fortifyFrom, reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>');
     if (selectedFortifyFromId) {
         elements.fortifyFrom.value = selectedFortifyFromId;
     }
@@ -845,10 +845,9 @@ function render() {
     const fortifyTargets = territories.filter((territory) => territory.id !== selectedFortifyFromId && fortifySource?.neighbors.includes(territory.id));
     const selectedFortifyToId = selectOrFallback(state.selectedFortifyToId, fortifyTargets);
     state.selectedFortifyToId = selectedFortifyToId || null;
-    elements.fortifyTo.innerHTML =
-        fortifyTargets
-            .map((territory) => `<option value="${territory.id}">${territoryOptionLabel(territory)}</option>`)
-            .join("") || '<option value="">' + t("game.runtime.noAdjacentTerritory") + '</option>';
+    setMarkup(elements.fortifyTo, fortifyTargets
+        .map((territory) => `<option value="${territory.id}">${territoryOptionLabel(territory)}</option>`)
+        .join("") || '<option value="">' + t("game.runtime.noAdjacentTerritory") + '</option>');
     if (selectedFortifyToId) {
         elements.fortifyTo.value = selectedFortifyToId;
     }
@@ -857,7 +856,7 @@ function render() {
     }
     const nextMapSignature = currentRenderedMapSignature(snapshot);
     if (nextMapSignature !== renderedMapSignature) {
-        elements.map.innerHTML = snapshot ? buildGraphMarkup(snapshot) : "";
+        setMarkup(elements.map, snapshot ? buildGraphMarkup(snapshot) : "");
         renderedMapSignature = nextMapSignature;
         queueMapBoardFit();
     }
@@ -865,7 +864,7 @@ function render() {
         updateMapTerritoryHighlights();
     }
     const logEntries = translateGameLogEntries(snapshot);
-    elements.log.innerHTML = logEntries.map((entry) => `<li>${escapeHtml(entry)}</li>`).join("");
+    setMarkup(elements.log, logEntries.map((entry) => `<li>${escapeHtml(entry)}</li>`).join(""));
     const inReinforcement = snapshot?.turnPhase === "reinforcement";
     const inAttack = snapshot?.turnPhase === "attack";
     const inFortify = snapshot?.turnPhase === "fortify";
@@ -963,9 +962,9 @@ function render() {
         }
         elements.cardTradeSummary.textContent = t("game.runtime.cardsInHand", { count: playerHand.length });
         elements.cardTradeBonus.textContent = t("game.runtime.nextTradeBonus", { bonus: snapshot?.cardState?.nextTradeBonus || 4 });
-        elements.cardTradeList.innerHTML = playerHand.length
+        setMarkup(elements.cardTradeList, playerHand.length
             ? playerHand.map((card) => `<button type="button" class="card-chip${state.selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}" data-card-id="${card.id}" aria-pressed="${state.selectedTradeCardIds.includes(card.id) ? "true" : "false"}"><span>${cardDisplayLabel(card)}</span></button>`).join("")
-            : '<p class="card-trade-empty">' + t("game.runtime.noCardsAvailable") + '</p>';
+            : '<p class="card-trade-empty">' + t("game.runtime.noCardsAvailable") + '</p>');
         elements.cardTradeHelp.textContent = mustTradeCards
             ? t("game.runtime.tradeHelp.mustTrade", { limit: snapshot?.cardState?.maxHandBeforeForcedTrade || 5 })
             : playerHand.length
@@ -1431,7 +1430,7 @@ if (elements.gameList) {
 }
 if (elements.gameSessionList) {
     elements.gameSessionList.addEventListener("click", (event) => {
-        const trigger = event.target.closest("[data-game-id]");
+        const trigger = closestElement(event.target, "[data-game-id]");
         if (!trigger) {
             return;
         }
@@ -1441,7 +1440,7 @@ if (elements.gameSessionList) {
 }
 if (elements.gameSessionDetails) {
     elements.gameSessionDetails.addEventListener("click", (event) => {
-        const trigger = event.target.closest("#open-selected-inline");
+        const trigger = closestElement(event.target, "#open-selected-inline");
         if (!trigger) {
             return;
         }
@@ -1450,7 +1449,7 @@ if (elements.gameSessionDetails) {
 }
 if (elements.cardTradeList) {
     elements.cardTradeList.addEventListener("click", (event) => {
-        const trigger = event.target.closest("[data-card-id]");
+        const trigger = closestElement(event.target, "[data-card-id]");
         if (!trigger) {
             return;
         }
@@ -1467,7 +1466,7 @@ if (elements.cardTradeList) {
     });
 }
 elements.map.addEventListener("click", (event) => {
-    const button = event.target.closest("[data-territory-id]");
+    const button = closestElement(event.target, "[data-territory-id]");
     if (!button) {
         return;
     }

--- a/frontend/public/core/contracts.mjs
+++ b/frontend/public/core/contracts.mjs
@@ -1,0 +1,5 @@
+export const DEFAULT_THEME = "command";
+export const SUPPORTED_THEMES = Object.freeze(["command", "midnight", "ember"]);
+export function normalizeTheme(theme) {
+    return SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME;
+}

--- a/frontend/public/core/dom.mjs
+++ b/frontend/public/core/dom.mjs
@@ -1,0 +1,32 @@
+export function byId(id, scope = document) {
+    const element = scope.getElementById(id);
+    if (!element) {
+        throw new Error(`Missing required element: #${id}`);
+    }
+    return element;
+}
+export function query(selector, scope = document) {
+    const element = scope.querySelector(selector);
+    if (!element) {
+        throw new Error(`Missing required element: ${selector}`);
+    }
+    return element;
+}
+export function maybeQuery(selector, scope = document) {
+    return scope.querySelector(selector);
+}
+export function closest(target, selector) {
+    return target instanceof Element ? target.closest(selector) : null;
+}
+export function setMarkup(element, markup) {
+    element.innerHTML = markup;
+}
+export function clearMarkup(element) {
+    setMarkup(element, "");
+}
+export function setHidden(element, hidden) {
+    element.hidden = Boolean(hidden);
+}
+export function setDisabled(element, disabled) {
+    element.disabled = Boolean(disabled);
+}

--- a/frontend/public/core/errors.mjs
+++ b/frontend/public/core/errors.mjs
@@ -1,0 +1,9 @@
+export function messageFromError(error, fallback = "") {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+    if (typeof error === "string" && error) {
+        return error;
+    }
+    return fallback;
+}

--- a/frontend/public/i18n.mjs
+++ b/frontend/public/i18n.mjs
@@ -1,3 +1,4 @@
+import { setMarkup } from "./core/dom.mjs";
 import { it } from "./locales/it.mjs";
 import { en } from "./locales/en.mjs";
 export const SUPPORTED_LOCALES = Object.freeze(["it", "en"]);
@@ -159,24 +160,31 @@ export function applyTranslations(root = document, locale = getLocale()) {
         return;
     }
     root.querySelectorAll("[data-i18n]").forEach((element) => {
-        element.textContent = t(element.dataset.i18n, {}, { locale });
+        const translatedElement = element;
+        translatedElement.textContent = t(translatedElement.dataset.i18n, {}, { locale });
     });
     root.querySelectorAll("[data-i18n-html]").forEach((element) => {
-        element.innerHTML = t(element.dataset.i18nHtml, {}, { locale });
+        const translatedElement = element;
+        setMarkup(translatedElement, t(translatedElement.dataset.i18nHtml, {}, { locale }));
     });
     root.querySelectorAll("[data-i18n-content]").forEach((element) => {
-        element.setAttribute("content", t(element.dataset.i18nContent, {}, { locale }));
+        const translatedElement = element;
+        translatedElement.setAttribute("content", t(translatedElement.dataset.i18nContent, {}, { locale }));
     });
     root.querySelectorAll("[data-i18n-placeholder]").forEach((element) => {
-        element.setAttribute("placeholder", t(element.dataset.i18nPlaceholder, {}, { locale }));
+        const translatedElement = element;
+        translatedElement.setAttribute("placeholder", t(translatedElement.dataset.i18nPlaceholder, {}, { locale }));
     });
     root.querySelectorAll("[data-i18n-aria-label]").forEach((element) => {
-        element.setAttribute("aria-label", t(element.dataset.i18nAriaLabel, {}, { locale }));
+        const translatedElement = element;
+        translatedElement.setAttribute("aria-label", t(translatedElement.dataset.i18nAriaLabel, {}, { locale }));
     });
     root.querySelectorAll("[data-i18n-title]").forEach((element) => {
-        element.setAttribute("title", t(element.dataset.i18nTitle, {}, { locale }));
+        const translatedElement = element;
+        translatedElement.setAttribute("title", t(translatedElement.dataset.i18nTitle, {}, { locale }));
     });
     root.querySelectorAll("[data-i18n-alt]").forEach((element) => {
-        element.setAttribute("alt", t(element.dataset.i18nAlt, {}, { locale }));
+        const translatedElement = element;
+        translatedElement.setAttribute("alt", t(translatedElement.dataset.i18nAlt, {}, { locale }));
     });
 }

--- a/frontend/public/lobby.mjs
+++ b/frontend/public/lobby.mjs
@@ -1,7 +1,9 @@
+import { closest as closestElement, maybeQuery, setMarkup } from "./core/dom.mjs";
 import { formatDate, t, translateServerMessage } from "./i18n.mjs";
 const VISIBLE_GAMES_BATCH_SIZE = 15;
 const state = {
     currentGameId: null,
+    currentGameName: null,
     selectedGameId: null,
     gameList: [],
     visibleGameCount: VISIBLE_GAMES_BATCH_SIZE,
@@ -39,7 +41,7 @@ function escapeHtml(value) {
         .replace(/'/g, "&#39;");
 }
 function renderNavAvatar(username) {
-    const avatar = document.querySelector("#nav-avatar");
+    const avatar = maybeQuery("#nav-avatar");
     if (!avatar) {
         return;
     }
@@ -151,7 +153,7 @@ function render() {
     else {
         elements.gameListState.textContent = t("lobby.empty");
     }
-    elements.gameSessionList.innerHTML = renderedGames
+    setMarkup(elements.gameSessionList, renderedGames
         .map((game) => '<button type="button" class="session-row session-row-button' + (game.id === selectedId ? ' is-selected' : '') + '" data-game-id="' + game.id + '">' +
         '<span class="session-primary" data-cell-label="' + t("lobby.table.game") + '">' +
         '<span class="session-name" data-open-game-id="' + game.id + '" role="link" tabindex="0">' + escapeHtml(game.name) + '</span>' +
@@ -161,7 +163,7 @@ function render() {
         '<span class="session-cell-muted" data-cell-label="' + t("lobby.table.players") + '">' + gameCapacityLabel(game) + '</span>' +
         '<span class="session-cell-muted" data-cell-label="' + t("lobby.table.updated") + '">' + formatUpdatedTime(game.updatedAt) + '</span>' +
         '</button>')
-        .join("");
+        .join(""));
     elements.authStatus.textContent = state.user
         ? t("lobby.auth.loggedIn", { username: state.user.username })
         : t("lobby.auth.loggedOut");
@@ -197,7 +199,7 @@ function render() {
     else {
         elements.gameListLoadMoreState.textContent = t("lobby.loadMore.complete", { total: state.gameList.length });
     }
-    elements.gameSessionDetails.innerHTML = selected
+    setMarkup(elements.gameSessionDetails, selected
         ? '<div class="session-detail-hero">' +
             '<p class="session-detail-kicker">' + t("lobby.details.selectedKicker") + '</p>' +
             '<h4 class="session-detail-title">' + escapeHtml(selected.name) + '</h4>' +
@@ -219,7 +221,7 @@ function render() {
             '<button type="button" id="open-selected-inline">' + t("lobby.details.open") + '</button>' +
             (canJoinGame(selected) ? '<button type="button" id="join-selected-inline" class="ghost-button">' + t("lobby.details.joinOpen") + '</button>' : '') +
             '</div>'
-        : '<div class="session-empty-copy">' + t("lobby.details.emptyExtended") + '</div>';
+        : '<div class="session-empty-copy">' + t("lobby.details.emptyExtended") + '</div>');
     elements.openGameButton.disabled = !selected;
 }
 function resetVisibleGameCount() {
@@ -354,7 +356,7 @@ async function handleJoinSelectedGame() {
 }
 elements.openGameButton.addEventListener("click", handleOpenSelectedGame);
 elements.gameSessionList.addEventListener("click", async (event) => {
-    const gameNameTrigger = event.target.closest("[data-open-game-id]");
+    const gameNameTrigger = closestElement(event.target, "[data-open-game-id]");
     if (gameNameTrigger) {
         event.stopPropagation();
         try {
@@ -368,7 +370,7 @@ elements.gameSessionList.addEventListener("click", async (event) => {
         }
         return;
     }
-    const trigger = event.target.closest("[data-game-id]");
+    const trigger = closestElement(event.target, "[data-game-id]");
     if (!trigger) {
         return;
     }
@@ -376,12 +378,12 @@ elements.gameSessionList.addEventListener("click", async (event) => {
     render();
 });
 elements.gameSessionDetails.addEventListener("click", (event) => {
-    const joinTrigger = event.target.closest("#join-selected-inline");
+    const joinTrigger = closestElement(event.target, "#join-selected-inline");
     if (joinTrigger) {
         handleJoinSelectedGame();
         return;
     }
-    const trigger = event.target.closest("#open-selected-inline");
+    const trigger = closestElement(event.target, "#open-selected-inline");
     if (!trigger) {
         return;
     }
@@ -438,14 +440,15 @@ elements.logoutButton.addEventListener("click", async () => {
     render();
 });
 elements.gameSessionList.addEventListener("keydown", (event) => {
-    const gameNameTrigger = event.target.closest("[data-open-game-id]");
+    const gameNameTrigger = closestElement(event.target, "[data-open-game-id]");
     if (!gameNameTrigger) {
         return;
     }
-    if (event.key !== "Enter" && event.key !== " ") {
+    const keyboardEvent = event;
+    if (keyboardEvent.key !== "Enter" && keyboardEvent.key !== " ") {
         return;
     }
-    event.preventDefault();
+    keyboardEvent.preventDefault();
     event.stopPropagation();
     window.location.href = "/game/" + encodeURIComponent(gameNameTrigger.dataset.openGameId);
 });

--- a/frontend/public/new-game.mjs
+++ b/frontend/public/new-game.mjs
@@ -1,3 +1,5 @@
+import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
+import { messageFromError } from "./core/errors.mjs";
 import { t, translateServerMessage } from "./i18n.mjs";
 const state = {
     ruleSets: [],
@@ -8,28 +10,28 @@ const state = {
     sessionReady: false
 };
 const elements = {
-    authStatus: document.querySelector("#setup-auth-status"),
-    feedback: document.querySelector("#new-game-feedback"),
-    form: document.querySelector("#new-game-form"),
-    gameName: document.querySelector("#setup-game-name"),
-    headerLoginForm: document.querySelector("#header-login-form"),
-    headerAuthUsername: document.querySelector("#header-auth-username"),
-    headerAuthPassword: document.querySelector("#header-auth-password"),
-    headerLoginButton: document.querySelector("#header-login-button"),
-    logoutButton: document.querySelector("#logout-button"),
-    ruleSet: document.querySelector("#setup-ruleset"),
-    ruleSetSummary: document.querySelector("#setup-ruleset-summary"),
-    map: document.querySelector("#setup-map"),
-    mapDetails: document.querySelector("#setup-map-details"),
-    customizeOptions: document.querySelector("#setup-customize-options"),
-    advancedOptions: document.querySelector("#setup-advanced-options"),
-    diceRuleSet: document.querySelector("#setup-dice-ruleset"),
-    playerSlots: document.querySelector("#setup-player-slots"),
-    submit: document.querySelector("#submit-new-game"),
-    totalPlayers: document.querySelector("#setup-total-players")
+    authStatus: byId("setup-auth-status"),
+    feedback: byId("new-game-feedback"),
+    form: byId("new-game-form"),
+    gameName: byId("setup-game-name"),
+    headerLoginForm: maybeQuery("#header-login-form"),
+    headerAuthUsername: maybeQuery("#header-auth-username"),
+    headerAuthPassword: maybeQuery("#header-auth-password"),
+    headerLoginButton: maybeQuery("#header-login-button"),
+    logoutButton: byId("logout-button"),
+    ruleSet: byId("setup-ruleset"),
+    ruleSetSummary: byId("setup-ruleset-summary"),
+    map: byId("setup-map"),
+    mapDetails: byId("setup-map-details"),
+    customizeOptions: byId("setup-customize-options"),
+    advancedOptions: byId("setup-advanced-options"),
+    diceRuleSet: byId("setup-dice-ruleset"),
+    playerSlots: byId("setup-player-slots"),
+    submit: byId("submit-new-game"),
+    totalPlayers: byId("setup-total-players")
 };
-function renderNavAvatar(username) {
-    const avatar = document.querySelector("#nav-avatar");
+function renderNavAvatar(username = "") {
+    const avatar = maybeQuery("#nav-avatar");
     if (!avatar) {
         return;
     }
@@ -62,12 +64,15 @@ function updateSlotNotes() {
     Array.from(elements.playerSlots.querySelectorAll("[data-slot-index]")).forEach((slot, index) => {
         const typeControl = slot.querySelector('[data-role="type"]');
         const type = typeControl ? typeControl.value : "human";
-        slot.querySelector('[data-role="note"]').textContent = slotDescription(type, index);
+        const note = slot.querySelector('[data-role="note"]');
+        if (note) {
+            note.textContent = slotDescription(type, index);
+        }
     });
 }
 function renderSlots() {
     const total = Number(elements.totalPlayers.value || 2);
-    elements.playerSlots.innerHTML = Array.from({ length: total }, (_, index) => slotMarkup(index)).join("");
+    setMarkup(elements.playerSlots, Array.from({ length: total }, (_, index) => slotMarkup(index)).join(""));
     updateSlotNotes();
 }
 function setFeedback(message, type = "") {
@@ -75,7 +80,7 @@ function setFeedback(message, type = "") {
     elements.feedback.textContent = message || "";
 }
 function updateSubmitState() {
-    elements.submit.disabled = state.creating || !state.sessionReady || !state.user;
+    setDisabled(elements.submit, state.creating || !state.sessionReady || !state.user);
 }
 function selectedMapSummary() {
     return state.maps.find((map) => map.id === elements.map.value) || null;
@@ -102,47 +107,45 @@ function syncRuleSetDefaults() {
 function renderRuleSetSummary() {
     const ruleSet = selectedRuleSet();
     if (!ruleSet) {
-        elements.ruleSetSummary.innerHTML = "";
+        setMarkup(elements.ruleSetSummary, "");
         return;
     }
     const activeDiceRuleSet = elements.customizeOptions.checked
         ? selectedDiceRuleSet()
         : state.diceRuleSets.find((entry) => entry.id === ruleSet.defaultDiceRuleSetId) || null;
-    elements.ruleSetSummary.innerHTML =
-        '<div class="map-setup-card-head">' +
-            '<strong>' + ruleSet.name + '</strong>' +
-            '<span class="badge">' + diceRuleSetLabel(activeDiceRuleSet) + '</span>' +
-            '</div>' +
-            '<p class="map-setup-copy">' +
-            t(elements.customizeOptions.checked
-                ? "newGame.ruleset.summary.custom"
-                : "newGame.ruleset.summary.default", {
-                ruleset: ruleSet.name,
-                dice: diceRuleSetLabel(activeDiceRuleSet)
-            }) +
-            '</p>';
+    setMarkup(elements.ruleSetSummary, '<div class="map-setup-card-head">' +
+        '<strong>' + ruleSet.name + '</strong>' +
+        '<span class="badge">' + diceRuleSetLabel(activeDiceRuleSet) + '</span>' +
+        '</div>' +
+        '<p class="map-setup-copy">' +
+        t(elements.customizeOptions.checked
+            ? "newGame.ruleset.summary.custom"
+            : "newGame.ruleset.summary.default", {
+            ruleset: ruleSet.name,
+            dice: diceRuleSetLabel(activeDiceRuleSet)
+        }) +
+        '</p>');
 }
 function renderAdvancedOptions() {
-    elements.advancedOptions.hidden = !elements.customizeOptions.checked;
+    setHidden(elements.advancedOptions, !elements.customizeOptions.checked);
     renderRuleSetSummary();
 }
 function renderMapDetails() {
     const map = selectedMapSummary();
     if (!map) {
-        elements.mapDetails.innerHTML = "";
+        setMarkup(elements.mapDetails, "");
         return;
     }
     const bonuses = Array.isArray(map.continentBonuses) ? map.continentBonuses : [];
     const bonusMarkup = bonuses.map((continent) => '<li><span>' + continent.name + '</span><strong>' + t("newGame.map.bonusLine", { bonus: continent.bonus, territoryCount: continent.territoryCount }) + '</strong></li>').join("");
-    elements.mapDetails.innerHTML =
-        '<div class="map-setup-card-head">' +
-            '<strong>' + map.name + '</strong>' +
-            '<span class="badge">'
-            + t("newGame.map.summary", { territoryCount: map.territoryCount, continentCount: map.continentCount }) +
-            '</span>' +
-            '</div>' +
-            '<p class="map-setup-copy">' + t("newGame.map.copy") + '</p>' +
-            '<ul class="map-setup-bonus-list">' + bonusMarkup + '</ul>';
+    setMarkup(elements.mapDetails, '<div class="map-setup-card-head">' +
+        '<strong>' + map.name + '</strong>' +
+        '<span class="badge">'
+        + t("newGame.map.summary", { territoryCount: map.territoryCount, continentCount: map.continentCount }) +
+        '</span>' +
+        '</div>' +
+        '<p class="map-setup-copy">' + t("newGame.map.copy") + '</p>' +
+        '<ul class="map-setup-bonus-list">' + bonusMarkup + '</ul>');
 }
 function readConfig() {
     const totalPlayers = Number(elements.totalPlayers.value || 2);
@@ -181,9 +184,9 @@ async function loadOptions() {
     state.maps = data.maps || [];
     state.ruleSets = data.ruleSets || [];
     state.diceRuleSets = data.diceRuleSets || [];
-    elements.ruleSet.innerHTML = state.ruleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + ruleSet.name + '</option>').join("");
-    elements.map.innerHTML = state.maps.map((map) => '<option value="' + map.id + '">' + map.name + '</option>').join("");
-    elements.diceRuleSet.innerHTML = state.diceRuleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + diceRuleSetLabel(ruleSet) + '</option>').join("");
+    setMarkup(elements.ruleSet, state.ruleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + ruleSet.name + '</option>').join(""));
+    setMarkup(elements.map, state.maps.map((map) => '<option value="' + map.id + '">' + map.name + '</option>').join(""));
+    setMarkup(elements.diceRuleSet, state.diceRuleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + diceRuleSetLabel(ruleSet) + '</option>').join(""));
     syncRuleSetDefaults();
     renderRuleSetSummary();
     renderMapDetails();
@@ -201,13 +204,19 @@ async function restoreSession() {
     catch (error) {
         state.user = null;
     }
-    elements.logoutButton.hidden = !state.user;
+    setHidden(elements.logoutButton, !state.user);
     if (elements.headerLoginForm) {
         const isAuthenticated = Boolean(state.user);
-        elements.headerLoginForm.hidden = isAuthenticated;
-        elements.headerAuthUsername.disabled = isAuthenticated;
-        elements.headerAuthPassword.disabled = isAuthenticated;
-        elements.headerLoginButton.disabled = isAuthenticated;
+        setHidden(elements.headerLoginForm, isAuthenticated);
+        if (elements.headerAuthUsername) {
+            setDisabled(elements.headerAuthUsername, isAuthenticated);
+        }
+        if (elements.headerAuthPassword) {
+            setDisabled(elements.headerAuthPassword, isAuthenticated);
+        }
+        if (elements.headerLoginButton) {
+            setDisabled(elements.headerLoginButton, isAuthenticated);
+        }
     }
     elements.authStatus.textContent = state.user
         ? t("newGame.auth.commander", { username: state.user.username })
@@ -240,7 +249,8 @@ elements.map.addEventListener("change", renderMapDetails);
 elements.customizeOptions.addEventListener("change", renderAdvancedOptions);
 elements.diceRuleSet.addEventListener("change", renderRuleSetSummary);
 elements.playerSlots.addEventListener("change", (event) => {
-    if (!event.target.matches('[data-role="type"]')) {
+    const trigger = closest(event.target, '[data-role="type"]');
+    if (!trigger) {
         return;
     }
     updateSlotNotes();
@@ -268,7 +278,7 @@ elements.form.addEventListener("submit", async (event) => {
         window.location.href = "/game.html?gameId=" + encodeURIComponent(data.game.id);
     }
     catch (error) {
-        setFeedback(error.message, "error");
+        setFeedback(messageFromError(error, t("newGame.errors.submitFailed")), "error");
     }
     finally {
         state.creating = false;
@@ -283,7 +293,7 @@ elements.logoutButton.addEventListener("click", async () => {
     }
     state.user = null;
     state.sessionReady = true;
-    elements.logoutButton.hidden = true;
+    setHidden(elements.logoutButton, true);
     elements.authStatus.textContent = t("newGame.authStatus");
     renderNavAvatar();
     updateSubmitState();
@@ -301,7 +311,7 @@ if (elements.headerLoginForm) {
             await loginWithCredentials(username, password);
         }
         catch (error) {
-            setFeedback(error.message, "error");
+            setFeedback(messageFromError(error, t("errors.loginFailed")), "error");
         }
     });
 }

--- a/frontend/public/profile.mjs
+++ b/frontend/public/profile.mjs
@@ -1,40 +1,42 @@
+import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
+import { messageFromError } from "./core/errors.mjs";
 import { formatDate, t, translateServerMessage } from "./i18n.mjs";
 const elements = {
-    profileName: document.querySelector("#profile-name"),
-    profileSubtitle: document.querySelector("#profile-subtitle"),
-    headerLoginForm: document.querySelector("#header-login-form"),
-    headerAuthUsername: document.querySelector("#header-auth-username"),
-    headerAuthPassword: document.querySelector("#header-auth-password"),
-    headerLoginButton: document.querySelector("#header-login-button"),
-    authStatus: document.querySelector("#auth-status"),
-    logoutButton: document.querySelector("#logout-button"),
-    profileFeedback: document.querySelector("#profile-feedback"),
-    profilePreferences: document.querySelector("#profile-preferences"),
-    themeSelect: document.querySelector("#profile-theme-select"),
-    themeStatus: document.querySelector("#profile-theme-status"),
-    profileContent: document.querySelector("#profile-content"),
-    profileHeading: document.querySelector("#profile-heading"),
-    profileCopy: document.querySelector("#profile-copy"),
-    gamesPlayed: document.querySelector("#metric-games-played"),
-    wins: document.querySelector("#metric-wins"),
-    losses: document.querySelector("#metric-losses"),
-    inProgress: document.querySelector("#metric-in-progress"),
-    winRate: document.querySelector("#metric-win-rate"),
-    gamesCount: document.querySelector("#profile-games-count"),
-    gamesEmpty: document.querySelector("#profile-games-empty"),
-    gamesList: document.querySelector("#profile-games-list"),
-    profileRankingTitle: document.querySelector("#profile-ranking-title"),
-    profileRankingCopy: document.querySelector("#profile-ranking-copy"),
-    profileMapTitle: document.querySelector("#profile-map-title"),
-    profileMapCopy: document.querySelector("#profile-map-copy"),
-    profileAdvancedTitle: document.querySelector("#profile-advanced-title"),
-    profileAdvancedCopy: document.querySelector("#profile-advanced-copy"),
-    profileCommandName: document.querySelector("#profile-command-name"),
-    profileCommandStatus: document.querySelector("#profile-command-status"),
-    profileCommandFocus: document.querySelector("#profile-command-focus"),
-    profileCommandFocusNote: document.querySelector("#profile-command-focus-note"),
-    profileCommandDirective: document.querySelector("#profile-command-directive"),
-    profileCommandDirectiveNote: document.querySelector("#profile-command-directive-note")
+    profileName: byId("profile-name"),
+    profileSubtitle: maybeQuery("#profile-subtitle"),
+    headerLoginForm: maybeQuery("#header-login-form"),
+    headerAuthUsername: maybeQuery("#header-auth-username"),
+    headerAuthPassword: maybeQuery("#header-auth-password"),
+    headerLoginButton: maybeQuery("#header-login-button"),
+    authStatus: byId("auth-status"),
+    logoutButton: byId("logout-button"),
+    profileFeedback: byId("profile-feedback"),
+    profilePreferences: byId("profile-preferences"),
+    themeSelect: byId("profile-theme-select"),
+    themeStatus: byId("profile-theme-status"),
+    profileContent: byId("profile-content"),
+    profileHeading: byId("profile-heading"),
+    profileCopy: byId("profile-copy"),
+    gamesPlayed: byId("metric-games-played"),
+    wins: byId("metric-wins"),
+    losses: byId("metric-losses"),
+    inProgress: byId("metric-in-progress"),
+    winRate: byId("metric-win-rate"),
+    gamesCount: byId("profile-games-count"),
+    gamesEmpty: byId("profile-games-empty"),
+    gamesList: byId("profile-games-list"),
+    profileRankingTitle: byId("profile-ranking-title"),
+    profileRankingCopy: byId("profile-ranking-copy"),
+    profileMapTitle: byId("profile-map-title"),
+    profileMapCopy: byId("profile-map-copy"),
+    profileAdvancedTitle: byId("profile-advanced-title"),
+    profileAdvancedCopy: byId("profile-advanced-copy"),
+    profileCommandName: byId("profile-command-name"),
+    profileCommandStatus: byId("profile-command-status"),
+    profileCommandFocus: byId("profile-command-focus"),
+    profileCommandFocusNote: byId("profile-command-focus-note"),
+    profileCommandDirective: byId("profile-command-directive"),
+    profileCommandDirectiveNote: byId("profile-command-directive-note")
 };
 const themeManager = window.netriskTheme || {
     defaultTheme: "command",
@@ -61,12 +63,10 @@ function themeLabel(theme) {
     return t(`profile.preferences.theme.${theme}`, {}, { fallback: theme });
 }
 function setThemeStatus(message) {
-    if (elements.themeStatus) {
-        elements.themeStatus.textContent = message;
-    }
+    elements.themeStatus.textContent = message;
 }
 function renderThemeOptions() {
-    if (!elements.themeSelect || elements.themeSelect.options.length) {
+    if (elements.themeSelect.options.length) {
         return;
     }
     themeManager.getThemes().forEach((theme) => {
@@ -77,16 +77,10 @@ function renderThemeOptions() {
     });
 }
 function showThemePreferences(isVisible) {
-    if (!elements.profilePreferences) {
-        return;
-    }
-    elements.profilePreferences.hidden = !isVisible;
+    setHidden(elements.profilePreferences, !isVisible);
 }
 function syncThemePreference({ announce = false, preferredTheme = null } = {}) {
     renderThemeOptions();
-    if (!elements.themeSelect) {
-        return;
-    }
     const currentTheme = preferredTheme || themeManager.getCurrentTheme();
     elements.themeSelect.value = currentTheme;
     setThemeStatus(announce
@@ -119,16 +113,22 @@ async function persistThemePreference(theme) {
 function renderAuthArea(user) {
     const isAuthenticated = Boolean(user);
     if (elements.headerLoginForm) {
-        elements.headerLoginForm.hidden = isAuthenticated;
-        elements.headerAuthUsername.disabled = isAuthenticated;
-        elements.headerAuthPassword.disabled = isAuthenticated;
-        elements.headerLoginButton.disabled = isAuthenticated;
+        setHidden(elements.headerLoginForm, isAuthenticated);
+        if (elements.headerAuthUsername) {
+            setDisabled(elements.headerAuthUsername, isAuthenticated);
+        }
+        if (elements.headerAuthPassword) {
+            setDisabled(elements.headerAuthPassword, isAuthenticated);
+        }
+        if (elements.headerLoginButton) {
+            setDisabled(elements.headerLoginButton, isAuthenticated);
+        }
     }
-    elements.logoutButton.hidden = !isAuthenticated;
-    elements.logoutButton.disabled = !isAuthenticated;
+    setHidden(elements.logoutButton, !isAuthenticated);
+    setDisabled(elements.logoutButton, !isAuthenticated);
 }
-function renderNavAvatar(username) {
-    const avatar = document.querySelector("#nav-avatar");
+function renderNavAvatar(username = "") {
+    const avatar = maybeQuery("#nav-avatar");
     if (!avatar) {
         return;
     }
@@ -136,10 +136,10 @@ function renderNavAvatar(username) {
     avatar.textContent = label || "C";
 }
 function showFeedback(message, tone = "neutral") {
-    elements.profileFeedback.hidden = false;
+    setHidden(elements.profileFeedback, false);
     elements.profileFeedback.textContent = message;
     elements.profileFeedback.className = `profile-feedback${tone === "error" ? " is-error" : ""}`;
-    elements.profileContent.hidden = true;
+    setHidden(elements.profileContent, true);
 }
 function escapeHtml(value) {
     return String(value ?? "")
@@ -179,14 +179,14 @@ function renderParticipatingGames(profile) {
     const label = t(count === 1 ? "profile.games.activeCount.one" : "profile.games.activeCount.other", { count });
     elements.gamesCount.textContent = label;
     if (!participatingGames.length) {
-        elements.gamesEmpty.hidden = false;
-        elements.gamesList.hidden = true;
-        elements.gamesList.innerHTML = "";
+        setHidden(elements.gamesEmpty, false);
+        setHidden(elements.gamesList, true);
+        setMarkup(elements.gamesList, "");
         return;
     }
-    elements.gamesEmpty.hidden = true;
-    elements.gamesList.hidden = false;
-    elements.gamesList.innerHTML = participatingGames
+    setHidden(elements.gamesEmpty, true);
+    setHidden(elements.gamesList, false);
+    setMarkup(elements.gamesList, participatingGames
         .map((game) => {
         const lobby = game.myLobby || {};
         return (`<button type="button" class="profile-game-row" data-open-game-id="${escapeHtml(game.id)}">` +
@@ -213,7 +213,7 @@ function renderParticipatingGames(profile) {
             `</span>` +
             `</button>`);
     })
-        .join("");
+        .join(""));
 }
 function showProfile(profile) {
     const participatingGames = Array.isArray(profile.participatingGames) ? profile.participatingGames : [];
@@ -277,8 +277,8 @@ function showProfile(profile) {
         showFeedback(t("profile.runtime.noStats"));
         return;
     }
-    elements.profileFeedback.hidden = true;
-    elements.profileContent.hidden = false;
+    setHidden(elements.profileFeedback, true);
+    setHidden(elements.profileContent, false);
 }
 async function loadProfile() {
     const requestId = ++profileRequestId;
@@ -316,7 +316,7 @@ async function loadProfile() {
         if (requestId !== profileRequestId) {
             return;
         }
-        showFeedback(error.message || t("profile.errors.loadFailed"), "error");
+        showFeedback(messageFromError(error, t("profile.errors.loadFailed")), "error");
         if (sessionUser) {
             elements.authStatus.textContent = t("profile.auth.loggedIn", { username: sessionUser.username });
             renderAuthArea(sessionUser);
@@ -345,8 +345,8 @@ if (elements.headerLoginForm) {
     elements.headerLoginForm.dataset.headerLoginManaged = "true";
     elements.headerLoginForm.addEventListener("submit", async (event) => {
         event.preventDefault();
-        const username = elements.headerAuthUsername.value.trim();
-        const password = elements.headerAuthPassword.value;
+        const username = elements.headerAuthUsername?.value.trim() || "";
+        const password = elements.headerAuthPassword?.value || "";
         if (!username || !password) {
             return;
         }
@@ -360,11 +360,13 @@ if (elements.headerLoginForm) {
             if (!response.ok) {
                 throw new Error(translateServerMessage(data, t("errors.loginFailed")));
             }
-            elements.headerAuthPassword.value = "";
+            if (elements.headerAuthPassword) {
+                elements.headerAuthPassword.value = "";
+            }
             await loadProfile();
         }
         catch (error) {
-            showFeedback(error.message || t("errors.loginFailed"), "error");
+            showFeedback(messageFromError(error, t("errors.loginFailed")), "error");
             renderAuthArea(null);
             renderNavAvatar();
         }
@@ -392,46 +394,42 @@ elements.logoutButton.addEventListener("click", async () => {
     catch (error) {
     }
 });
-if (elements.themeSelect) {
-    renderThemeOptions();
-    syncThemePreference();
-    elements.themeSelect.addEventListener("change", async () => {
-        const previousTheme = themeManager.getCurrentTheme();
-        const selectedTheme = elements.themeSelect.value;
-        const nextTheme = themeManager.applyTheme(selectedTheme);
-        elements.themeSelect.value = nextTheme;
-        elements.themeSelect.disabled = true;
-        setThemeStatus(t("profile.preferences.status.saving", { theme: themeLabel(nextTheme) }));
-        try {
-            const data = await persistThemePreference(nextTheme);
-            const storedTheme = themeManager.getThemeFromUser(data.user) || nextTheme;
-            themeManager.applyUserTheme(data.user);
-            syncThemePreference({ announce: true, preferredTheme: storedTheme });
-        }
-        catch (error) {
-            if (isNavigationAbort(error) || document.visibilityState === "hidden") {
-                setThemeStatus(t("profile.preferences.status.current", { theme: themeLabel(nextTheme) }));
-                return;
-            }
-            themeManager.applyTheme(previousTheme);
-            elements.themeSelect.value = previousTheme;
-            setThemeStatus(t("profile.preferences.status.saveFailed", { theme: themeLabel(previousTheme) }));
-        }
-        finally {
-            elements.themeSelect.disabled = false;
-        }
-    });
-}
-if (elements.gamesList) {
-    elements.gamesList.addEventListener("click", async (event) => {
-        const trigger = event.target.closest("[data-open-game-id]");
-        if (!trigger) {
+renderThemeOptions();
+syncThemePreference();
+elements.themeSelect.addEventListener("change", async () => {
+    const previousTheme = themeManager.getCurrentTheme();
+    const selectedTheme = elements.themeSelect.value;
+    const nextTheme = themeManager.applyTheme(selectedTheme);
+    elements.themeSelect.value = nextTheme;
+    setDisabled(elements.themeSelect, true);
+    setThemeStatus(t("profile.preferences.status.saving", { theme: themeLabel(nextTheme) }));
+    try {
+        const data = await persistThemePreference(nextTheme);
+        const storedTheme = themeManager.getThemeFromUser(data.user) || nextTheme;
+        themeManager.applyUserTheme(data.user);
+        syncThemePreference({ announce: true, preferredTheme: storedTheme });
+    }
+    catch (error) {
+        if (isNavigationAbort(error) || document.visibilityState === "hidden") {
+            setThemeStatus(t("profile.preferences.status.current", { theme: themeLabel(nextTheme) }));
             return;
         }
-        const gameId = trigger.dataset.openGameId;
-        if (!gameId) {
-            return;
-        }
-        window.location.href = "/game/" + encodeURIComponent(gameId);
-    });
-}
+        themeManager.applyTheme(previousTheme);
+        elements.themeSelect.value = previousTheme;
+        setThemeStatus(t("profile.preferences.status.saveFailed", { theme: themeLabel(previousTheme) }));
+    }
+    finally {
+        setDisabled(elements.themeSelect, false);
+    }
+});
+elements.gamesList.addEventListener("click", async (event) => {
+    const trigger = closest(event.target, "[data-open-game-id]");
+    if (!trigger) {
+        return;
+    }
+    const gameId = trigger.dataset.openGameId;
+    if (!gameId) {
+        return;
+    }
+    window.location.href = "/game/" + encodeURIComponent(gameId);
+});

--- a/frontend/public/register.mjs
+++ b/frontend/public/register.mjs
@@ -1,25 +1,27 @@
+import { byId, maybeQuery, setDisabled, setHidden } from "./core/dom.mjs";
+import { messageFromError } from "./core/errors.mjs";
 import { t, translateServerMessage } from "./i18n.mjs";
 const state = {
     user: null,
     submitting: false
 };
 const elements = {
-    headerLoginForm: document.querySelector("#header-login-form"),
-    headerAuthUsername: document.querySelector("#header-auth-username"),
-    headerAuthPassword: document.querySelector("#header-auth-password"),
-    headerLoginButton: document.querySelector("#header-login-button"),
-    authStatus: document.querySelector("#register-auth-status"),
-    logoutButton: document.querySelector("#logout-button"),
-    form: document.querySelector("#register-form"),
-    username: document.querySelector("#register-username"),
-    email: document.querySelector("#register-email"),
-    password: document.querySelector("#register-password"),
-    passwordConfirm: document.querySelector("#register-password-confirm"),
-    feedback: document.querySelector("#register-feedback"),
-    submit: document.querySelector("#register-submit-button")
+    headerLoginForm: maybeQuery("#header-login-form"),
+    headerAuthUsername: maybeQuery("#header-auth-username"),
+    headerAuthPassword: maybeQuery("#header-auth-password"),
+    headerLoginButton: maybeQuery("#header-login-button"),
+    authStatus: byId("register-auth-status"),
+    logoutButton: byId("logout-button"),
+    form: byId("register-form"),
+    username: byId("register-username"),
+    email: byId("register-email"),
+    password: byId("register-password"),
+    passwordConfirm: byId("register-password-confirm"),
+    feedback: byId("register-feedback"),
+    submit: byId("register-submit-button")
 };
-function renderNavAvatar(username) {
-    const avatar = document.querySelector("#nav-avatar");
+function renderNavAvatar(username = "") {
+    const avatar = maybeQuery("#nav-avatar");
     if (!avatar) {
         return;
     }
@@ -28,12 +30,12 @@ function renderNavAvatar(username) {
 }
 function setFeedback(message = "", tone = "") {
     if (!message) {
-        elements.feedback.hidden = true;
+        setHidden(elements.feedback, true);
         elements.feedback.textContent = "";
         elements.feedback.className = "auth-feedback";
         return;
     }
-    elements.feedback.hidden = false;
+    setHidden(elements.feedback, false);
     elements.feedback.textContent = message;
     elements.feedback.className = `auth-feedback${tone === "error" ? " is-error" : " is-success"}`;
 }
@@ -87,14 +89,20 @@ async function restoreSession() {
 function render() {
     const isAuthenticated = Boolean(state.user);
     if (elements.headerLoginForm) {
-        elements.headerLoginForm.hidden = isAuthenticated;
-        elements.headerAuthUsername.disabled = isAuthenticated;
-        elements.headerAuthPassword.disabled = isAuthenticated;
-        elements.headerLoginButton.disabled = isAuthenticated;
+        setHidden(elements.headerLoginForm, isAuthenticated);
+        if (elements.headerAuthUsername) {
+            setDisabled(elements.headerAuthUsername, isAuthenticated);
+        }
+        if (elements.headerAuthPassword) {
+            setDisabled(elements.headerAuthPassword, isAuthenticated);
+        }
+        if (elements.headerLoginButton) {
+            setDisabled(elements.headerLoginButton, isAuthenticated);
+        }
     }
-    elements.logoutButton.hidden = !isAuthenticated;
-    elements.logoutButton.disabled = !isAuthenticated;
-    elements.submit.disabled = state.submitting || isAuthenticated;
+    setHidden(elements.logoutButton, !isAuthenticated);
+    setDisabled(elements.logoutButton, !isAuthenticated);
+    setDisabled(elements.submit, state.submitting || isAuthenticated);
     elements.authStatus.textContent = isAuthenticated
         ? t("register.auth.loggedIn", { username: state.user.username })
         : t("register.authStatus");
@@ -113,7 +121,7 @@ if (elements.headerLoginForm) {
             await loginWithCredentials(username, password);
         }
         catch (error) {
-            setFeedback(error.message, "error");
+            setFeedback(messageFromError(error, t("errors.loginFailed")), "error");
             render();
         }
     });
@@ -161,7 +169,7 @@ elements.form.addEventListener("submit", async (event) => {
         await loginWithCredentials(username, password);
     }
     catch (error) {
-        setFeedback(error.message, "error");
+        setFeedback(messageFromError(error, t("register.errors.submitFailed")), "error");
     }
     finally {
         state.submitting = false;

--- a/frontend/public/shell.mjs
+++ b/frontend/public/shell.mjs
@@ -1,22 +1,20 @@
+import { setMarkup } from "./core/dom.mjs";
+import { DEFAULT_THEME, SUPPORTED_THEMES, normalizeTheme } from "./core/contracts.mjs";
+import { messageFromError } from "./core/errors.mjs";
 import { applyTranslations, listSupportedLocales, resolveLocale, setLocale, t, translateServerMessage } from "./i18n.mjs";
-const DEFAULT_THEME = "command";
-const SUPPORTED_THEMES = Object.freeze(["command", "midnight", "ember"]);
 const THEME_STORAGE_KEY = "netrisk.theme";
-const query = new URLSearchParams(window.location.search);
+const routeQuery = new URLSearchParams(window.location.search);
 const shellKind = document.body.dataset.shellKind || (document.body.dataset.appSection ? "app" : "marketing");
 const section = document.body.dataset.appSection || "";
 const pathGameMatch = window.location.pathname.match(/^\/game\/([^/]+)$/);
-const currentGameId = pathGameMatch ? decodeURIComponent(pathGameMatch[1]) : query.get("gameId");
+const currentGameId = pathGameMatch ? decodeURIComponent(pathGameMatch[1]) : routeQuery.get("gameId");
 const activeLocale = setLocale(resolveLocale());
-function normalizeTheme(theme) {
-    return SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME;
-}
 function resolveThemeFromUser(user) {
     const requestedTheme = user?.preferences?.theme;
     return SUPPORTED_THEMES.includes(requestedTheme) ? requestedTheme : null;
 }
 function resolveTheme() {
-    const requested = query.get("theme");
+    const requested = routeQuery.get("theme");
     if (requested) {
         return normalizeTheme(requested);
     }
@@ -167,15 +165,17 @@ function sharedFooterMarkup() {
 }
 function mountAppChrome() {
     document.querySelectorAll("[data-shared-top-nav]").forEach((container) => {
-        if (!container.dataset.sharedChromeMounted) {
-            container.innerHTML = sharedNavMarkup();
-            container.dataset.sharedChromeMounted = "true";
+        const topNavContainer = container;
+        if (!topNavContainer.dataset.sharedChromeMounted) {
+            setMarkup(topNavContainer, sharedNavMarkup());
+            topNavContainer.dataset.sharedChromeMounted = "true";
         }
     });
     document.querySelectorAll("[data-shared-footer]").forEach((container) => {
-        if (!container.dataset.sharedChromeMounted) {
-            container.innerHTML = sharedFooterMarkup();
-            container.dataset.sharedChromeMounted = "true";
+        const footerContainer = container;
+        if (!footerContainer.dataset.sharedChromeMounted) {
+            setMarkup(footerContainer, sharedFooterMarkup());
+            footerContainer.dataset.sharedChromeMounted = "true";
         }
     });
 }
@@ -186,14 +186,15 @@ function syncAppNav() {
         profile: t("nav.profile")
     };
     document.querySelectorAll("[data-nav-section]").forEach((link) => {
-        const isActive = link.dataset.navSection === section;
-        link.classList.toggle("is-active", isActive);
-        link.setAttribute("aria-current", isActive ? "page" : "false");
-        if (navLabels[link.dataset.navSection]) {
-            link.textContent = navLabels[link.dataset.navSection];
+        const navLink = link;
+        const isActive = navLink.dataset.navSection === section;
+        navLink.classList.toggle("is-active", isActive);
+        navLink.setAttribute("aria-current", isActive ? "page" : "false");
+        if (navLabels[navLink.dataset.navSection]) {
+            navLink.textContent = navLabels[navLink.dataset.navSection];
         }
-        if (link.dataset.navSection === "game" && currentGameId) {
-            link.href = gameHref();
+        if (navLink.dataset.navSection === "game" && currentGameId) {
+            navLink.href = gameHref();
         }
     });
     document.querySelectorAll(".top-nav-links").forEach((nav) => {
@@ -260,7 +261,7 @@ function initAppShell() {
             window.location.href = nextUrl.toString();
         }
         catch (error) {
-            window.alert(error.message || t("errors.loginFailed"));
+            window.alert(messageFromError(error, t("errors.loginFailed")));
         }
     }, true);
 }

--- a/frontend/src/app.mts
+++ b/frontend/src/app.mts
@@ -1,4 +1,5 @@
-import { formatDate, t, translateGameLogEntries, translateMessagePayload, translateServerMessage } from "./i18n.mts";
+import { closest as closestElement, maybeQuery, setMarkup } from "./core/dom.mjs";
+import { formatDate, t, translateGameLogEntries, translateMessagePayload, translateServerMessage } from "./i18n.mjs";
 
 const state = {
   playerId: localStorage.getItem("frontline-player-id") || null,
@@ -82,7 +83,7 @@ const classicMapLayout = {
   ion: { x: 86.2, y: 50 }
 };
 
-const elements = {
+const elements: Record<string, any> = {
   authForm: document.querySelector("#auth-form"),
   authUsername: document.querySelector("#auth-username"),
   authPassword: document.querySelector("#auth-password"),
@@ -161,7 +162,7 @@ const elements = {
 };
 
 function renderNavAvatar(username) {
-  const avatar = document.querySelector("#nav-avatar");
+  const avatar = maybeQuery("#nav-avatar");
   if (!avatar) {
     return;
   }
@@ -173,9 +174,9 @@ function renderNavAvatar(username) {
 let pendingMapFitFrame = null;
 
 function fitMapBoardToViewport() {
-  const mapStage = document.querySelector(".game-map-stage");
-  const mapContainer = document.querySelector(".game-map-stage .map");
-  const mapBoard = document.querySelector(".game-map-stage .map-board");
+  const mapStage = document.querySelector(".game-map-stage") as HTMLElement | null;
+  const mapContainer = document.querySelector(".game-map-stage .map") as HTMLElement | null;
+  const mapBoard = document.querySelector(".game-map-stage .map-board") as HTMLElement | null;
   if (!mapStage || !mapContainer || !mapBoard) {
     return;
   }
@@ -563,9 +564,9 @@ function renderGameSessionBrowser() {
     return;
   }
 
-  elements.gameList.innerHTML = state.gameList
+  setMarkup(elements.gameList, state.gameList
     .map((game) => `<option value="${escapeHtml(game.id)}">${escapeHtml(game.name)}</option>`)
-    .join("") || '<option value="">' + t("game.runtime.noGamesOption") + '</option>';
+    .join("") || '<option value="">' + t("game.runtime.noGamesOption") + '</option>');
 
   if (selectedId && state.gameList.some((game) => game.id === selectedId)) {
     elements.gameList.value = selectedId;
@@ -585,7 +586,7 @@ function renderGameSessionBrowser() {
     elements.gameListState.textContent = t("lobby.empty");
   }
 
-  elements.gameSessionList.innerHTML = state.gameList
+  setMarkup(elements.gameSessionList, state.gameList
     .map((game) => `
       <button type="button" class="session-row session-row-button${game.id === selectedId ? " is-selected" : ""}" data-game-id="${game.id}">
         <span class="session-primary">
@@ -598,10 +599,10 @@ function renderGameSessionBrowser() {
         <span class="session-cell-muted">${formatUpdatedTime(game.updatedAt)}</span>
       </button>
     `)
-    .join("");
+    .join(""));
 
   elements.selectedGameStatus.textContent = selected ? phaseLabel(selected.phase) : t("lobby.details.emptyBadge");
-  elements.gameSessionDetails.innerHTML = selected
+  setMarkup(elements.gameSessionDetails, selected
     ? `
       <div class="session-detail-grid">
         <div class="session-detail-item"><span>${t("lobby.details.name")}</span><strong>${escapeHtml(selected.name)}</strong></div>
@@ -615,7 +616,7 @@ function renderGameSessionBrowser() {
         <button type="button" id="open-selected-inline">${t("game.runtime.openGame")}</button>
       </div>
     `
-    : '<div class="session-empty-copy">' + t("game.runtime.selectGameFromList") + '</div>';
+    : '<div class="session-empty-copy">' + t("game.runtime.selectGameFromList") + '</div>');
 
   const hasSelection = Boolean(selected);
   if (elements.openGameButton) {
@@ -877,15 +878,15 @@ function render() {
             ? t("game.runtime.turnOf", { name: currentPlayer.name })
             : t("game.runtime.waiting");
 
-  elements.statusSummary.innerHTML = snapshot
+  setMarkup(elements.statusSummary, snapshot
     ? `
       <div>Fase: <strong>${escapeHtml(snapshot.phase)}</strong></div>
       <div>${t("game.reinforcementBanner")} <strong>${snapshot.reinforcementPool}</strong></div>
       <div>${t("game.runtime.winner")}: <strong>${escapeHtml(winner ? winner.name : t("game.runtime.noneLower"))}</strong></div>
     `
-    : "<div>" + t("game.runtime.loadingState") + "</div>";
+    : "<div>" + t("game.runtime.loadingState") + "</div>");
 
-  elements.players.innerHTML = (snapshot?.players || [])
+  setMarkup(elements.players, (snapshot?.players || [])
     .map(
       (player) => `
         <article class="player-card">
@@ -896,7 +897,7 @@ function render() {
         </article>
       `
     )
-    .join("");
+    .join(""));
 
   const territories = myTerritories();
   const reinforceOptions = territories
@@ -904,7 +905,7 @@ function render() {
     .join("");
   const selectedReinforceId = selectOrFallback(state.selectedReinforceTerritoryId, territories);
   state.selectedReinforceTerritoryId = selectedReinforceId || null;
-  elements.reinforceSelect.innerHTML = reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>';
+  setMarkup(elements.reinforceSelect, reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>');
   if (selectedReinforceId) {
     elements.reinforceSelect.value = selectedReinforceId;
   }
@@ -917,7 +918,7 @@ function render() {
 
   const selectedFromId = selectOrFallback(state.selectedAttackFromId, territories, selectedReinforceId);
   state.selectedAttackFromId = selectedFromId || null;
-  elements.attackFrom.innerHTML = reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>';
+  setMarkup(elements.attackFrom, reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>');
   if (selectedFromId) {
     elements.attackFrom.value = selectedFromId;
   }
@@ -932,13 +933,13 @@ function render() {
   const selectedAttackToId = selectOrFallback(state.selectedAttackToId, attackTargets);
   state.selectedAttackToId = selectedAttackToId || null;
 
-  elements.attackTo.innerHTML =
+  setMarkup(elements.attackTo,
     attackTargets
       .map((territory) => {
         const owner = ownerById(territory.ownerId);
         return `<option value="${territory.id}">${escapeHtml(territory.name)} vs ${escapeHtml(owner?.name || "?")} (${territory.armies})</option>`;
       })
-      .join("") || '<option value="">' + t("game.runtime.noTarget") + '</option>';
+      .join("") || '<option value="">' + t("game.runtime.noTarget") + '</option>');
 
   if (selectedAttackToId) {
     elements.attackTo.value = selectedAttackToId;
@@ -947,7 +948,7 @@ function render() {
   const maxAttackDice = source
     ? Math.max(0, Math.min(currentDiceRuleSet().attackerMaxDice || 3, source.armies - 1))
     : 0;
-  elements.attackDice.innerHTML = attackDiceOptions(maxAttackDice);
+  setMarkup(elements.attackDice, attackDiceOptions(maxAttackDice));
   if (maxAttackDice > 0) {
     const selectedAttackDiceCount = String(Math.min(Number(state.selectedAttackDiceCount || maxAttackDice), maxAttackDice));
     state.selectedAttackDiceCount = selectedAttackDiceCount;
@@ -959,7 +960,7 @@ function render() {
 
   const selectedFortifyFromId = selectOrFallback(state.selectedFortifyFromId, territories, selectedReinforceId);
   state.selectedFortifyFromId = selectedFortifyFromId || null;
-  elements.fortifyFrom.innerHTML = reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>';
+  setMarkup(elements.fortifyFrom, reinforceOptions || '<option value="">' + t("game.runtime.noTerritory") + '</option>');
   if (selectedFortifyFromId) {
     elements.fortifyFrom.value = selectedFortifyFromId;
   }
@@ -971,10 +972,10 @@ function render() {
   const selectedFortifyToId = selectOrFallback(state.selectedFortifyToId, fortifyTargets);
   state.selectedFortifyToId = selectedFortifyToId || null;
 
-  elements.fortifyTo.innerHTML =
+  setMarkup(elements.fortifyTo,
     fortifyTargets
       .map((territory) => `<option value="${territory.id}">${territoryOptionLabel(territory)}</option>`)
-      .join("") || '<option value="">' + t("game.runtime.noAdjacentTerritory") + '</option>';
+      .join("") || '<option value="">' + t("game.runtime.noAdjacentTerritory") + '</option>');
 
   if (selectedFortifyToId) {
     elements.fortifyTo.value = selectedFortifyToId;
@@ -986,14 +987,14 @@ function render() {
 
   const nextMapSignature = currentRenderedMapSignature(snapshot);
   if (nextMapSignature !== renderedMapSignature) {
-    elements.map.innerHTML = snapshot ? buildGraphMarkup(snapshot) : "";
+    setMarkup(elements.map, snapshot ? buildGraphMarkup(snapshot) : "");
     renderedMapSignature = nextMapSignature;
     queueMapBoardFit();
   } else {
     updateMapTerritoryHighlights();
   }
   const logEntries = translateGameLogEntries(snapshot);
-  elements.log.innerHTML = logEntries.map((entry) => `<li>${escapeHtml(entry)}</li>`).join("");
+  setMarkup(elements.log, logEntries.map((entry) => `<li>${escapeHtml(entry)}</li>`).join(""));
   const inReinforcement = snapshot?.turnPhase === "reinforcement";
   const inAttack = snapshot?.turnPhase === "attack";
   const inFortify = snapshot?.turnPhase === "fortify";
@@ -1092,9 +1093,9 @@ function render() {
     }
     elements.cardTradeSummary.textContent = t("game.runtime.cardsInHand", { count: playerHand.length });
     elements.cardTradeBonus.textContent = t("game.runtime.nextTradeBonus", { bonus: snapshot?.cardState?.nextTradeBonus || 4 });
-    elements.cardTradeList.innerHTML = playerHand.length
+    setMarkup(elements.cardTradeList, playerHand.length
       ? playerHand.map((card) => `<button type="button" class="card-chip${state.selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}" data-card-id="${card.id}" aria-pressed="${state.selectedTradeCardIds.includes(card.id) ? "true" : "false"}"><span>${cardDisplayLabel(card)}</span></button>`).join("")
-      : '<p class="card-trade-empty">' + t("game.runtime.noCardsAvailable") + '</p>';
+      : '<p class="card-trade-empty">' + t("game.runtime.noCardsAvailable") + '</p>');
     elements.cardTradeHelp.textContent = mustTradeCards
       ? t("game.runtime.tradeHelp.mustTrade", { limit: snapshot?.cardState?.maxHandBeforeForcedTrade || 5 })
       : playerHand.length
@@ -1143,7 +1144,7 @@ function render() {
   }
 }
 
-async function fetchLatestStateSnapshot(options = {}) {
+async function fetchLatestStateSnapshot(options: Record<string, any> = {}) {
   const includeGameId = options.includeGameId !== false;
   const query = includeGameId && state.currentGameId ? "?gameId=" + encodeURIComponent(state.currentGameId) : "";
   const response = await fetch("/api/state" + query);
@@ -1154,7 +1155,7 @@ async function fetchLatestStateSnapshot(options = {}) {
   return data;
 }
 
-function shouldAcceptSnapshot(nextSnapshot, options = {}) {
+function shouldAcceptSnapshot(nextSnapshot, options: Record<string, any> = {}) {
   if (!nextSnapshot || typeof nextSnapshot !== "object") {
     return false;
   }
@@ -1179,7 +1180,7 @@ function shouldAcceptSnapshot(nextSnapshot, options = {}) {
   return true;
 }
 
-function applySnapshot(nextSnapshot, options = {}) {
+function applySnapshot(nextSnapshot, options: Record<string, any> = {}) {
   if (!shouldAcceptSnapshot(nextSnapshot, options)) {
     return false;
   }
@@ -1197,7 +1198,7 @@ function applySnapshot(nextSnapshot, options = {}) {
   return true;
 }
 
-async function send(path, payload = {}, options = {}) {
+async function send(path, payload = {}, options: Record<string, any> = {}) {
   const response = await fetch(path, {
     method: options.method || "POST",
     headers: { "Content-Type": "application/json" },
@@ -1469,7 +1470,7 @@ elements.authForm.addEventListener("submit", async (event) => {
 });
 
 if (elements.headerLoginForm) {
-  elements.headerLoginForm.dataset.headerLoginManaged = "true";
+  (elements.headerLoginForm as HTMLElement).dataset.headerLoginManaged = "true";
   elements.headerLoginForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     const username = elements.headerAuthUsername.value.trim();
@@ -1593,7 +1594,7 @@ if (elements.gameList) {
 }
 if (elements.gameSessionList) {
   elements.gameSessionList.addEventListener("click", (event) => {
-    const trigger = event.target.closest("[data-game-id]");
+    const trigger = closestElement<HTMLElement>(event.target, "[data-game-id]");
     if (!trigger) {
       return;
     }
@@ -1604,7 +1605,7 @@ if (elements.gameSessionList) {
 }
 if (elements.gameSessionDetails) {
   elements.gameSessionDetails.addEventListener("click", (event) => {
-    const trigger = event.target.closest("#open-selected-inline");
+    const trigger = closestElement<HTMLElement>(event.target, "#open-selected-inline");
     if (!trigger) {
       return;
     }
@@ -1614,7 +1615,7 @@ if (elements.gameSessionDetails) {
 }
 if (elements.cardTradeList) {
   elements.cardTradeList.addEventListener("click", (event) => {
-    const trigger = event.target.closest("[data-card-id]");
+    const trigger = closestElement<HTMLElement>(event.target, "[data-card-id]");
     if (!trigger) {
       return;
     }
@@ -1632,7 +1633,7 @@ if (elements.cardTradeList) {
   });
 }
 elements.map.addEventListener("click", (event) => {
-  const button = event.target.closest("[data-territory-id]");
+  const button = closestElement<HTMLElement>(event.target, "[data-territory-id]");
   if (!button) {
     return;
   }

--- a/frontend/src/core/contracts.mts
+++ b/frontend/src/core/contracts.mts
@@ -1,0 +1,6 @@
+export const DEFAULT_THEME = "command";
+export const SUPPORTED_THEMES = Object.freeze(["command", "midnight", "ember"]);
+
+export function normalizeTheme(theme) {
+  return SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME;
+}

--- a/frontend/src/core/dom.mts
+++ b/frontend/src/core/dom.mts
@@ -1,0 +1,41 @@
+export function byId(id: string, scope: Document | DocumentFragment = document): HTMLElement {
+  const element = scope.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing required element: #${id}`);
+  }
+
+  return element;
+}
+
+export function query<T extends Element>(selector: string, scope: ParentNode = document): T {
+  const element = scope.querySelector(selector);
+  if (!element) {
+    throw new Error(`Missing required element: ${selector}`);
+  }
+
+  return element as T;
+}
+
+export function maybeQuery<T extends Element>(selector: string, scope: ParentNode = document): T | null {
+  return scope.querySelector(selector) as T | null;
+}
+
+export function closest<T extends Element>(target: EventTarget | null, selector: string): T | null {
+  return target instanceof Element ? (target.closest(selector) as T | null) : null;
+}
+
+export function setMarkup(element: Element, markup: string): void {
+  element.innerHTML = markup;
+}
+
+export function clearMarkup(element: Element): void {
+  setMarkup(element, "");
+}
+
+export function setHidden(element: HTMLElement, hidden: boolean): void {
+  element.hidden = Boolean(hidden);
+}
+
+export function setDisabled(element: HTMLButtonElement | HTMLInputElement | HTMLSelectElement, disabled: boolean): void {
+  element.disabled = Boolean(disabled);
+}

--- a/frontend/src/core/errors.mts
+++ b/frontend/src/core/errors.mts
@@ -1,0 +1,11 @@
+export function messageFromError(error, fallback = "") {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === "string" && error) {
+    return error;
+  }
+
+  return fallback;
+}

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,15 @@
+interface NetRiskThemeManager {
+  defaultTheme: string;
+  storageKey?: string;
+  getThemes(): string[];
+  getCurrentTheme(): string;
+  getThemeFromUser(user?: { preferences?: { theme?: string | null } | null } | null): string | null;
+  applyUserTheme(user?: { preferences?: { theme?: string | null } | null } | null): string;
+  applyTheme(theme: string): string;
+  normalizeTheme(theme: string): string;
+}
+
+interface Window {
+  __netriskLocale?: string;
+  netriskTheme?: NetRiskThemeManager;
+}

--- a/frontend/src/i18n.mts
+++ b/frontend/src/i18n.mts
@@ -1,5 +1,6 @@
-import { it } from "./locales/it.mts";
-import { en } from "./locales/en.mts";
+import { setMarkup } from "./core/dom.mjs";
+import { it } from "./locales/it.mjs";
+import { en } from "./locales/en.mjs";
 
 export const SUPPORTED_LOCALES = Object.freeze(["it", "en"]);
 export const DEFAULT_LOCALE = "it";
@@ -67,7 +68,7 @@ export function getLocale() {
   return normalizeLocale(window.__netriskLocale) || DEFAULT_LOCALE;
 }
 
-export function resolveLocale(options = {}) {
+export function resolveLocale(options: Record<string, any> = {}) {
   const searchParams = options.searchParams
     || (typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null);
   const requested = searchParams && typeof searchParams.get === "function"
@@ -90,7 +91,7 @@ export function resolveLocale(options = {}) {
   return browserLocale() || DEFAULT_LOCALE;
 }
 
-export function setLocale(locale, options = {}) {
+export function setLocale(locale, options: Record<string, any> = {}) {
   const normalized = normalizeLocale(locale);
   const nextLocale = normalized || DEFAULT_LOCALE;
 
@@ -117,7 +118,7 @@ function interpolate(template, params = {}) {
   ));
 }
 
-export function t(key, params = {}, options = {}) {
+export function t(key, params = {}, options: Record<string, any> = {}) {
   const requestedLocale = options.locale || getLocale();
   const dictionary = getLocaleDictionary(requestedLocale);
   const fallbackDictionary = getLocaleDictionary(DEFAULT_LOCALE);
@@ -203,30 +204,37 @@ export function applyTranslations(root = document, locale = getLocale()) {
   }
 
   root.querySelectorAll("[data-i18n]").forEach((element) => {
-    element.textContent = t(element.dataset.i18n, {}, { locale });
+    const translatedElement = element as HTMLElement;
+    translatedElement.textContent = t(translatedElement.dataset.i18n, {}, { locale });
   });
 
   root.querySelectorAll("[data-i18n-html]").forEach((element) => {
-    element.innerHTML = t(element.dataset.i18nHtml, {}, { locale });
+    const translatedElement = element as HTMLElement;
+    setMarkup(translatedElement, t(translatedElement.dataset.i18nHtml, {}, { locale }));
   });
 
   root.querySelectorAll("[data-i18n-content]").forEach((element) => {
-    element.setAttribute("content", t(element.dataset.i18nContent, {}, { locale }));
+    const translatedElement = element as HTMLElement;
+    translatedElement.setAttribute("content", t(translatedElement.dataset.i18nContent, {}, { locale }));
   });
 
   root.querySelectorAll("[data-i18n-placeholder]").forEach((element) => {
-    element.setAttribute("placeholder", t(element.dataset.i18nPlaceholder, {}, { locale }));
+    const translatedElement = element as HTMLElement;
+    translatedElement.setAttribute("placeholder", t(translatedElement.dataset.i18nPlaceholder, {}, { locale }));
   });
 
   root.querySelectorAll("[data-i18n-aria-label]").forEach((element) => {
-    element.setAttribute("aria-label", t(element.dataset.i18nAriaLabel, {}, { locale }));
+    const translatedElement = element as HTMLElement;
+    translatedElement.setAttribute("aria-label", t(translatedElement.dataset.i18nAriaLabel, {}, { locale }));
   });
 
   root.querySelectorAll("[data-i18n-title]").forEach((element) => {
-    element.setAttribute("title", t(element.dataset.i18nTitle, {}, { locale }));
+    const translatedElement = element as HTMLElement;
+    translatedElement.setAttribute("title", t(translatedElement.dataset.i18nTitle, {}, { locale }));
   });
 
   root.querySelectorAll("[data-i18n-alt]").forEach((element) => {
-    element.setAttribute("alt", t(element.dataset.i18nAlt, {}, { locale }));
+    const translatedElement = element as HTMLElement;
+    translatedElement.setAttribute("alt", t(translatedElement.dataset.i18nAlt, {}, { locale }));
   });
 }

--- a/frontend/src/landing.mts
+++ b/frontend/src/landing.mts
@@ -1,2 +1,2 @@
 // Legacy marketing-shell entrypoint kept for backward compatibility.
-import "./shell.mts";
+import "./shell.mjs";

--- a/frontend/src/layout.mts
+++ b/frontend/src/layout.mts
@@ -1,2 +1,2 @@
 // Legacy app-shell entrypoint kept for backward compatibility.
-import "./shell.mts";
+import "./shell.mjs";

--- a/frontend/src/lobby.mts
+++ b/frontend/src/lobby.mts
@@ -1,9 +1,11 @@
-import { formatDate, t, translateServerMessage } from "./i18n.mts";
+import { closest as closestElement, maybeQuery, setMarkup } from "./core/dom.mjs";
+import { formatDate, t, translateServerMessage } from "./i18n.mjs";
 
 const VISIBLE_GAMES_BATCH_SIZE = 15;
 
 const state = {
   currentGameId: null,
+  currentGameName: null,
   selectedGameId: null,
   gameList: [],
   visibleGameCount: VISIBLE_GAMES_BATCH_SIZE,
@@ -12,7 +14,7 @@ const state = {
   user: null
 };
 
-const elements = {
+const elements: Record<string, any> = {
   createGameButton: document.querySelector("#create-game-button"),
   openGameButton: document.querySelector("#open-game-button"),
   gameStatus: document.querySelector("#game-status"),
@@ -45,7 +47,7 @@ function escapeHtml(value) {
 }
 
 function renderNavAvatar(username) {
-  const avatar = document.querySelector("#nav-avatar");
+  const avatar = maybeQuery("#nav-avatar");
   if (!avatar) {
     return;
   }
@@ -178,7 +180,7 @@ function render() {
     elements.gameListState.textContent = t("lobby.empty");
   }
 
-  elements.gameSessionList.innerHTML = renderedGames
+  setMarkup(elements.gameSessionList, renderedGames
     .map((game) => 
       '<button type="button" class="session-row session-row-button' + (game.id === selectedId ? ' is-selected' : '') + '" data-game-id="' + game.id + '">' +
         '<span class="session-primary" data-cell-label="' + t("lobby.table.game") + '">' +
@@ -190,7 +192,7 @@ function render() {
         '<span class="session-cell-muted" data-cell-label="' + t("lobby.table.updated") + '">' + formatUpdatedTime(game.updatedAt) + '</span>' +
       '</button>'
     )
-    .join("");
+    .join(""));
 
   elements.authStatus.textContent = state.user
     ? t("lobby.auth.loggedIn", { username: state.user.username })
@@ -228,7 +230,7 @@ function render() {
     elements.gameListLoadMoreState.textContent = t("lobby.loadMore.complete", { total: state.gameList.length });
   }
 
-  elements.gameSessionDetails.innerHTML = selected
+  setMarkup(elements.gameSessionDetails, selected
     ? '<div class="session-detail-hero">' +
         '<p class="session-detail-kicker">' + t("lobby.details.selectedKicker") + '</p>' +
         '<h4 class="session-detail-title">' + escapeHtml(selected.name) + '</h4>' +
@@ -250,7 +252,7 @@ function render() {
         '<button type="button" id="open-selected-inline">' + t("lobby.details.open") + '</button>' +
         (canJoinGame(selected) ? '<button type="button" id="join-selected-inline" class="ghost-button">' + t("lobby.details.joinOpen") + '</button>' : '') +
       '</div>'
-    : '<div class="session-empty-copy">' + t("lobby.details.emptyExtended") + '</div>';
+    : '<div class="session-empty-copy">' + t("lobby.details.emptyExtended") + '</div>');
 
   elements.openGameButton.disabled = !selected;
 }
@@ -311,7 +313,7 @@ async function send(path, body) {
 
   const data = await response.json();
   if (!response.ok) {
-    const error = new Error(translateServerMessage(data, t("errors.requestFailed")));
+    const error = new Error(translateServerMessage(data, t("errors.requestFailed"))) as Error & { code?: string | null };
     error.code = data.code || null;
     throw error;
   }
@@ -319,7 +321,7 @@ async function send(path, body) {
   return data;
 }
 
-async function loadGameList(options = {}) {
+async function loadGameList(options: Record<string, any> = {}) {
   const renderOnChange = options.renderOnChange !== false;
   state.gameListState = "loading";
   state.gameListError = "";
@@ -406,7 +408,7 @@ async function handleJoinSelectedGame() {
 
 elements.openGameButton.addEventListener("click", handleOpenSelectedGame);
 elements.gameSessionList.addEventListener("click", async (event) => {
-  const gameNameTrigger = event.target.closest("[data-open-game-id]");
+  const gameNameTrigger = closestElement<HTMLElement>(event.target, "[data-open-game-id]");
   if (gameNameTrigger) {
     event.stopPropagation();
     try {
@@ -420,7 +422,7 @@ elements.gameSessionList.addEventListener("click", async (event) => {
     return;
   }
 
-  const trigger = event.target.closest("[data-game-id]");
+  const trigger = closestElement<HTMLElement>(event.target, "[data-game-id]");
   if (!trigger) {
     return;
   }
@@ -429,13 +431,13 @@ elements.gameSessionList.addEventListener("click", async (event) => {
   render();
 });
 elements.gameSessionDetails.addEventListener("click", (event) => {
-  const joinTrigger = event.target.closest("#join-selected-inline");
+  const joinTrigger = closestElement<HTMLElement>(event.target, "#join-selected-inline");
   if (joinTrigger) {
     handleJoinSelectedGame();
     return;
   }
 
-  const trigger = event.target.closest("#open-selected-inline");
+  const trigger = closestElement<HTMLElement>(event.target, "#open-selected-inline");
   if (!trigger) {
     return;
   }
@@ -443,7 +445,7 @@ elements.gameSessionDetails.addEventListener("click", (event) => {
   handleOpenSelectedGame();
 });
 
-async function restoreSession(options = {}) {
+async function restoreSession(options: Record<string, any> = {}) {
   const renderOnChange = options.renderOnChange !== false;
   try {
     const response = await fetch("/api/auth/session");
@@ -471,7 +473,7 @@ render();
 setupInfiniteScroll();
 
 if (elements.headerLoginForm) {
-  elements.headerLoginForm.dataset.headerLoginManaged = "true";
+  (elements.headerLoginForm as HTMLElement).dataset.headerLoginManaged = "true";
   elements.headerLoginForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     const username = elements.headerAuthUsername.value.trim();
@@ -501,16 +503,17 @@ elements.logoutButton.addEventListener("click", async () => {
 
 
 elements.gameSessionList.addEventListener("keydown", (event) => {
-  const gameNameTrigger = event.target.closest("[data-open-game-id]");
+  const gameNameTrigger = closestElement<HTMLElement>(event.target, "[data-open-game-id]");
   if (!gameNameTrigger) {
     return;
   }
 
-  if (event.key !== "Enter" && event.key !== " ") {
+  const keyboardEvent = event as KeyboardEvent;
+  if (keyboardEvent.key !== "Enter" && keyboardEvent.key !== " ") {
     return;
   }
 
-  event.preventDefault();
+  keyboardEvent.preventDefault();
   event.stopPropagation();
   window.location.href = "/game/" + encodeURIComponent(gameNameTrigger.dataset.openGameId);
 });

--- a/frontend/src/new-game.mts
+++ b/frontend/src/new-game.mts
@@ -1,4 +1,6 @@
-import { t, translateServerMessage } from "./i18n.mts";
+import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
+import { messageFromError } from "./core/errors.mjs";
+import { t, translateServerMessage } from "./i18n.mjs";
 
 const state = {
   ruleSets: [],
@@ -10,29 +12,29 @@ const state = {
 };
 
 const elements = {
-  authStatus: document.querySelector("#setup-auth-status"),
-  feedback: document.querySelector("#new-game-feedback"),
-  form: document.querySelector("#new-game-form"),
-  gameName: document.querySelector("#setup-game-name"),
-  headerLoginForm: document.querySelector("#header-login-form"),
-  headerAuthUsername: document.querySelector("#header-auth-username"),
-  headerAuthPassword: document.querySelector("#header-auth-password"),
-  headerLoginButton: document.querySelector("#header-login-button"),
-  logoutButton: document.querySelector("#logout-button"),
-  ruleSet: document.querySelector("#setup-ruleset"),
-  ruleSetSummary: document.querySelector("#setup-ruleset-summary"),
-  map: document.querySelector("#setup-map"),
-  mapDetails: document.querySelector("#setup-map-details"),
-  customizeOptions: document.querySelector("#setup-customize-options"),
-  advancedOptions: document.querySelector("#setup-advanced-options"),
-  diceRuleSet: document.querySelector("#setup-dice-ruleset"),
-  playerSlots: document.querySelector("#setup-player-slots"),
-  submit: document.querySelector("#submit-new-game"),
-  totalPlayers: document.querySelector("#setup-total-players")
+  authStatus: byId("setup-auth-status"),
+  feedback: byId("new-game-feedback"),
+  form: byId("new-game-form") as HTMLFormElement,
+  gameName: byId("setup-game-name") as HTMLInputElement,
+  headerLoginForm: maybeQuery("#header-login-form"),
+  headerAuthUsername: maybeQuery<HTMLInputElement>("#header-auth-username"),
+  headerAuthPassword: maybeQuery<HTMLInputElement>("#header-auth-password"),
+  headerLoginButton: maybeQuery<HTMLButtonElement>("#header-login-button"),
+  logoutButton: byId("logout-button") as HTMLButtonElement,
+  ruleSet: byId("setup-ruleset") as HTMLSelectElement,
+  ruleSetSummary: byId("setup-ruleset-summary"),
+  map: byId("setup-map") as HTMLSelectElement,
+  mapDetails: byId("setup-map-details"),
+  customizeOptions: byId("setup-customize-options") as HTMLInputElement,
+  advancedOptions: byId("setup-advanced-options"),
+  diceRuleSet: byId("setup-dice-ruleset") as HTMLSelectElement,
+  playerSlots: byId("setup-player-slots"),
+  submit: byId("submit-new-game") as HTMLButtonElement,
+  totalPlayers: byId("setup-total-players") as HTMLSelectElement
 };
 
-function renderNavAvatar(username) {
-  const avatar = document.querySelector("#nav-avatar");
+function renderNavAvatar(username = "") {
+  const avatar = maybeQuery("#nav-avatar");
   if (!avatar) {
     return;
   }
@@ -69,15 +71,18 @@ function slotMarkup(index) {
 
 function updateSlotNotes() {
   Array.from(elements.playerSlots.querySelectorAll("[data-slot-index]")).forEach((slot, index) => {
-    const typeControl = slot.querySelector('[data-role="type"]');
+    const typeControl = slot.querySelector('[data-role="type"]') as HTMLSelectElement | null;
     const type = typeControl ? typeControl.value : "human";
-    slot.querySelector('[data-role="note"]').textContent = slotDescription(type, index);
+    const note = slot.querySelector('[data-role="note"]');
+    if (note) {
+      note.textContent = slotDescription(type, index);
+    }
   });
 }
 
 function renderSlots() {
   const total = Number(elements.totalPlayers.value || 2);
-  elements.playerSlots.innerHTML = Array.from({ length: total }, (_, index) => slotMarkup(index)).join("");
+  setMarkup(elements.playerSlots, Array.from({ length: total }, (_, index) => slotMarkup(index)).join(""));
   updateSlotNotes();
 }
 
@@ -87,7 +92,7 @@ function setFeedback(message, type = "") {
 }
 
 function updateSubmitState() {
-  elements.submit.disabled = state.creating || !state.sessionReady || !state.user;
+  setDisabled(elements.submit, state.creating || !state.sessionReady || !state.user);
 }
 
 function selectedMapSummary() {
@@ -122,7 +127,7 @@ function syncRuleSetDefaults() {
 function renderRuleSetSummary() {
   const ruleSet = selectedRuleSet();
   if (!ruleSet) {
-    elements.ruleSetSummary.innerHTML = "";
+    setMarkup(elements.ruleSetSummary, "");
     return;
   }
 
@@ -130,7 +135,7 @@ function renderRuleSetSummary() {
     ? selectedDiceRuleSet()
     : state.diceRuleSets.find((entry) => entry.id === ruleSet.defaultDiceRuleSetId) || null;
 
-  elements.ruleSetSummary.innerHTML =
+  setMarkup(elements.ruleSetSummary,
     '<div class="map-setup-card-head">' +
       '<strong>' + ruleSet.name + '</strong>' +
       '<span class="badge">' + diceRuleSetLabel(activeDiceRuleSet) + '</span>' +
@@ -145,18 +150,18 @@ function renderRuleSetSummary() {
           dice: diceRuleSetLabel(activeDiceRuleSet)
         }
       ) +
-    '</p>';
+    '</p>');
 }
 
 function renderAdvancedOptions() {
-  elements.advancedOptions.hidden = !elements.customizeOptions.checked;
+  setHidden(elements.advancedOptions, !elements.customizeOptions.checked);
   renderRuleSetSummary();
 }
 
 function renderMapDetails() {
   const map = selectedMapSummary();
   if (!map) {
-    elements.mapDetails.innerHTML = "";
+    setMarkup(elements.mapDetails, "");
     return;
   }
 
@@ -165,7 +170,7 @@ function renderMapDetails() {
     '<li><span>' + continent.name + '</span><strong>' + t("newGame.map.bonusLine", { bonus: continent.bonus, territoryCount: continent.territoryCount }) + '</strong></li>'
   ).join("");
 
-  elements.mapDetails.innerHTML =
+  setMarkup(elements.mapDetails,
     '<div class="map-setup-card-head">' +
       '<strong>' + map.name + '</strong>' +
       '<span class="badge">'
@@ -173,14 +178,14 @@ function renderMapDetails() {
       '</span>' +
     '</div>' +
     '<p class="map-setup-copy">' + t("newGame.map.copy") + '</p>' +
-    '<ul class="map-setup-bonus-list">' + bonusMarkup + '</ul>';
+    '<ul class="map-setup-bonus-list">' + bonusMarkup + '</ul>');
 }
 
 function readConfig() {
   const totalPlayers = Number(elements.totalPlayers.value || 2);
   const players = Array.from(elements.playerSlots.querySelectorAll("[data-slot-index]"))
     .map((slot, index) => ({
-      type: index === 0 ? "human" : slot.querySelector('[data-role="type"]').value,
+      type: index === 0 ? "human" : (slot.querySelector('[data-role="type"]') as HTMLSelectElement).value,
       slot: index + 1
     }));
 
@@ -217,9 +222,9 @@ async function loadOptions() {
   state.maps = data.maps || [];
   state.ruleSets = data.ruleSets || [];
   state.diceRuleSets = data.diceRuleSets || [];
-  elements.ruleSet.innerHTML = state.ruleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + ruleSet.name + '</option>').join("");
-  elements.map.innerHTML = state.maps.map((map) => '<option value="' + map.id + '">' + map.name + '</option>').join("");
-  elements.diceRuleSet.innerHTML = state.diceRuleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + diceRuleSetLabel(ruleSet) + '</option>').join("");
+  setMarkup(elements.ruleSet, state.ruleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + ruleSet.name + '</option>').join(""));
+  setMarkup(elements.map, state.maps.map((map) => '<option value="' + map.id + '">' + map.name + '</option>').join(""));
+  setMarkup(elements.diceRuleSet, state.diceRuleSets.map((ruleSet) => '<option value="' + ruleSet.id + '">' + diceRuleSetLabel(ruleSet) + '</option>').join(""));
   syncRuleSetDefaults();
   renderRuleSetSummary();
   renderMapDetails();
@@ -240,13 +245,19 @@ async function restoreSession() {
     state.user = null;
   }
 
-  elements.logoutButton.hidden = !state.user;
+  setHidden(elements.logoutButton, !state.user);
   if (elements.headerLoginForm) {
     const isAuthenticated = Boolean(state.user);
-    elements.headerLoginForm.hidden = isAuthenticated;
-    elements.headerAuthUsername.disabled = isAuthenticated;
-    elements.headerAuthPassword.disabled = isAuthenticated;
-    elements.headerLoginButton.disabled = isAuthenticated;
+    setHidden(elements.headerLoginForm as HTMLElement, isAuthenticated);
+    if (elements.headerAuthUsername) {
+      setDisabled(elements.headerAuthUsername, isAuthenticated);
+    }
+    if (elements.headerAuthPassword) {
+      setDisabled(elements.headerAuthPassword, isAuthenticated);
+    }
+    if (elements.headerLoginButton) {
+      setDisabled(elements.headerLoginButton, isAuthenticated);
+    }
   }
   elements.authStatus.textContent = state.user
     ? t("newGame.auth.commander", { username: state.user.username })
@@ -282,7 +293,8 @@ elements.map.addEventListener("change", renderMapDetails);
 elements.customizeOptions.addEventListener("change", renderAdvancedOptions);
 elements.diceRuleSet.addEventListener("change", renderRuleSetSummary);
 elements.playerSlots.addEventListener("change", (event) => {
-  if (!event.target.matches('[data-role="type"]')) {
+  const trigger = closest(event.target, '[data-role="type"]');
+  if (!trigger) {
     return;
   }
   updateSlotNotes();
@@ -311,7 +323,7 @@ elements.form.addEventListener("submit", async (event) => {
     }
     window.location.href = "/game.html?gameId=" + encodeURIComponent(data.game.id);
   } catch (error) {
-    setFeedback(error.message, "error");
+    setFeedback(messageFromError(error, t("newGame.errors.submitFailed")), "error");
   } finally {
     state.creating = false;
     updateSubmitState();
@@ -326,14 +338,14 @@ elements.logoutButton.addEventListener("click", async () => {
 
   state.user = null;
   state.sessionReady = true;
-  elements.logoutButton.hidden = true;
+  setHidden(elements.logoutButton, true);
   elements.authStatus.textContent = t("newGame.authStatus");
   renderNavAvatar();
   updateSubmitState();
 });
 
 if (elements.headerLoginForm) {
-  elements.headerLoginForm.dataset.headerLoginManaged = "true";
+  (elements.headerLoginForm as HTMLElement).dataset.headerLoginManaged = "true";
   elements.headerLoginForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     const username = elements.headerAuthUsername.value.trim();
@@ -345,7 +357,7 @@ if (elements.headerLoginForm) {
     try {
       await loginWithCredentials(username, password);
     } catch (error) {
-      setFeedback(error.message, "error");
+      setFeedback(messageFromError(error, t("errors.loginFailed")), "error");
     }
   });
 }

--- a/frontend/src/profile.mts
+++ b/frontend/src/profile.mts
@@ -1,41 +1,43 @@
-import { formatDate, t, translateServerMessage } from "./i18n.mts";
+import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
+import { messageFromError } from "./core/errors.mjs";
+import { formatDate, t, translateServerMessage } from "./i18n.mjs";
 
 const elements = {
-  profileName: document.querySelector("#profile-name"),
-  profileSubtitle: document.querySelector("#profile-subtitle"),
-  headerLoginForm: document.querySelector("#header-login-form"),
-  headerAuthUsername: document.querySelector("#header-auth-username"),
-  headerAuthPassword: document.querySelector("#header-auth-password"),
-  headerLoginButton: document.querySelector("#header-login-button"),
-  authStatus: document.querySelector("#auth-status"),
-  logoutButton: document.querySelector("#logout-button"),
-  profileFeedback: document.querySelector("#profile-feedback"),
-  profilePreferences: document.querySelector("#profile-preferences"),
-  themeSelect: document.querySelector("#profile-theme-select"),
-  themeStatus: document.querySelector("#profile-theme-status"),
-  profileContent: document.querySelector("#profile-content"),
-  profileHeading: document.querySelector("#profile-heading"),
-  profileCopy: document.querySelector("#profile-copy"),
-  gamesPlayed: document.querySelector("#metric-games-played"),
-  wins: document.querySelector("#metric-wins"),
-  losses: document.querySelector("#metric-losses"),
-  inProgress: document.querySelector("#metric-in-progress"),
-  winRate: document.querySelector("#metric-win-rate"),
-  gamesCount: document.querySelector("#profile-games-count"),
-  gamesEmpty: document.querySelector("#profile-games-empty"),
-  gamesList: document.querySelector("#profile-games-list"),
-  profileRankingTitle: document.querySelector("#profile-ranking-title"),
-  profileRankingCopy: document.querySelector("#profile-ranking-copy"),
-  profileMapTitle: document.querySelector("#profile-map-title"),
-  profileMapCopy: document.querySelector("#profile-map-copy"),
-  profileAdvancedTitle: document.querySelector("#profile-advanced-title"),
-  profileAdvancedCopy: document.querySelector("#profile-advanced-copy"),
-  profileCommandName: document.querySelector("#profile-command-name"),
-  profileCommandStatus: document.querySelector("#profile-command-status"),
-  profileCommandFocus: document.querySelector("#profile-command-focus"),
-  profileCommandFocusNote: document.querySelector("#profile-command-focus-note"),
-  profileCommandDirective: document.querySelector("#profile-command-directive"),
-  profileCommandDirectiveNote: document.querySelector("#profile-command-directive-note")
+  profileName: byId("profile-name"),
+  profileSubtitle: maybeQuery("#profile-subtitle"),
+  headerLoginForm: maybeQuery("#header-login-form"),
+  headerAuthUsername: maybeQuery<HTMLInputElement>("#header-auth-username"),
+  headerAuthPassword: maybeQuery<HTMLInputElement>("#header-auth-password"),
+  headerLoginButton: maybeQuery<HTMLButtonElement>("#header-login-button"),
+  authStatus: byId("auth-status"),
+  logoutButton: byId("logout-button") as HTMLButtonElement,
+  profileFeedback: byId("profile-feedback"),
+  profilePreferences: byId("profile-preferences"),
+  themeSelect: byId("profile-theme-select") as HTMLSelectElement,
+  themeStatus: byId("profile-theme-status"),
+  profileContent: byId("profile-content"),
+  profileHeading: byId("profile-heading"),
+  profileCopy: byId("profile-copy"),
+  gamesPlayed: byId("metric-games-played"),
+  wins: byId("metric-wins"),
+  losses: byId("metric-losses"),
+  inProgress: byId("metric-in-progress"),
+  winRate: byId("metric-win-rate"),
+  gamesCount: byId("profile-games-count"),
+  gamesEmpty: byId("profile-games-empty"),
+  gamesList: byId("profile-games-list"),
+  profileRankingTitle: byId("profile-ranking-title"),
+  profileRankingCopy: byId("profile-ranking-copy"),
+  profileMapTitle: byId("profile-map-title"),
+  profileMapCopy: byId("profile-map-copy"),
+  profileAdvancedTitle: byId("profile-advanced-title"),
+  profileAdvancedCopy: byId("profile-advanced-copy"),
+  profileCommandName: byId("profile-command-name"),
+  profileCommandStatus: byId("profile-command-status"),
+  profileCommandFocus: byId("profile-command-focus"),
+  profileCommandFocusNote: byId("profile-command-focus-note"),
+  profileCommandDirective: byId("profile-command-directive"),
+  profileCommandDirectiveNote: byId("profile-command-directive-note")
 };
 
 const themeManager = window.netriskTheme || {
@@ -66,13 +68,11 @@ function themeLabel(theme) {
 }
 
 function setThemeStatus(message) {
-  if (elements.themeStatus) {
-    elements.themeStatus.textContent = message;
-  }
+  elements.themeStatus.textContent = message;
 }
 
 function renderThemeOptions() {
-  if (!elements.themeSelect || elements.themeSelect.options.length) {
+  if (elements.themeSelect.options.length) {
     return;
   }
 
@@ -85,19 +85,11 @@ function renderThemeOptions() {
 }
 
 function showThemePreferences(isVisible) {
-  if (!elements.profilePreferences) {
-    return;
-  }
-
-  elements.profilePreferences.hidden = !isVisible;
+  setHidden(elements.profilePreferences, !isVisible);
 }
 
 function syncThemePreference({ announce = false, preferredTheme = null } = {}) {
   renderThemeOptions();
-
-  if (!elements.themeSelect) {
-    return;
-  }
 
   const currentTheme = preferredTheme || themeManager.getCurrentTheme();
   elements.themeSelect.value = currentTheme;
@@ -139,17 +131,23 @@ async function persistThemePreference(theme) {
 function renderAuthArea(user) {
   const isAuthenticated = Boolean(user);
   if (elements.headerLoginForm) {
-    elements.headerLoginForm.hidden = isAuthenticated;
-    elements.headerAuthUsername.disabled = isAuthenticated;
-    elements.headerAuthPassword.disabled = isAuthenticated;
-    elements.headerLoginButton.disabled = isAuthenticated;
+    setHidden(elements.headerLoginForm as HTMLElement, isAuthenticated);
+    if (elements.headerAuthUsername) {
+      setDisabled(elements.headerAuthUsername, isAuthenticated);
+    }
+    if (elements.headerAuthPassword) {
+      setDisabled(elements.headerAuthPassword, isAuthenticated);
+    }
+    if (elements.headerLoginButton) {
+      setDisabled(elements.headerLoginButton, isAuthenticated);
+    }
   }
-  elements.logoutButton.hidden = !isAuthenticated;
-  elements.logoutButton.disabled = !isAuthenticated;
+  setHidden(elements.logoutButton, !isAuthenticated);
+  setDisabled(elements.logoutButton, !isAuthenticated);
 }
 
-function renderNavAvatar(username) {
-  const avatar = document.querySelector("#nav-avatar");
+function renderNavAvatar(username = "") {
+  const avatar = maybeQuery("#nav-avatar");
   if (!avatar) {
     return;
   }
@@ -159,10 +157,10 @@ function renderNavAvatar(username) {
 }
 
 function showFeedback(message, tone = "neutral") {
-  elements.profileFeedback.hidden = false;
+  setHidden(elements.profileFeedback, false);
   elements.profileFeedback.textContent = message;
   elements.profileFeedback.className = `profile-feedback${tone === "error" ? " is-error" : ""}`;
-  elements.profileContent.hidden = true;
+  setHidden(elements.profileContent, true);
 }
 
 function escapeHtml(value) {
@@ -209,15 +207,15 @@ function renderParticipatingGames(profile) {
   elements.gamesCount.textContent = label;
 
   if (!participatingGames.length) {
-    elements.gamesEmpty.hidden = false;
-    elements.gamesList.hidden = true;
-    elements.gamesList.innerHTML = "";
+    setHidden(elements.gamesEmpty, false);
+    setHidden(elements.gamesList, true);
+    setMarkup(elements.gamesList, "");
     return;
   }
 
-  elements.gamesEmpty.hidden = true;
-  elements.gamesList.hidden = false;
-  elements.gamesList.innerHTML = participatingGames
+  setHidden(elements.gamesEmpty, true);
+  setHidden(elements.gamesList, false);
+  setMarkup(elements.gamesList, participatingGames
     .map((game) => {
       const lobby = game.myLobby || {};
       return (
@@ -246,7 +244,7 @@ function renderParticipatingGames(profile) {
       `</button>`
       );
     })
-    .join("");
+    .join(""));
 }
 
 function showProfile(profile) {
@@ -313,8 +311,8 @@ function showProfile(profile) {
     return;
   }
 
-  elements.profileFeedback.hidden = true;
-  elements.profileContent.hidden = false;
+  setHidden(elements.profileFeedback, true);
+  setHidden(elements.profileContent, false);
 }
 
 async function loadProfile() {
@@ -358,7 +356,7 @@ async function loadProfile() {
     if (requestId !== profileRequestId) {
       return;
     }
-    showFeedback(error.message || t("profile.errors.loadFailed"), "error");
+    showFeedback(messageFromError(error, t("profile.errors.loadFailed")), "error");
     if (sessionUser) {
       elements.authStatus.textContent = t("profile.auth.loggedIn", { username: sessionUser.username });
       renderAuthArea(sessionUser);
@@ -388,11 +386,11 @@ await loadProfile();
 
 
 if (elements.headerLoginForm) {
-  elements.headerLoginForm.dataset.headerLoginManaged = "true";
+  (elements.headerLoginForm as HTMLElement).dataset.headerLoginManaged = "true";
   elements.headerLoginForm.addEventListener("submit", async (event) => {
     event.preventDefault();
-    const username = elements.headerAuthUsername.value.trim();
-    const password = elements.headerAuthPassword.value;
+      const username = elements.headerAuthUsername?.value.trim() || "";
+      const password = elements.headerAuthPassword?.value || "";
     if (!username || !password) {
       return;
     }
@@ -408,10 +406,12 @@ if (elements.headerLoginForm) {
         throw new Error(translateServerMessage(data, t("errors.loginFailed")));
       }
 
-      elements.headerAuthPassword.value = "";
+      if (elements.headerAuthPassword) {
+        elements.headerAuthPassword.value = "";
+      }
       await loadProfile();
     } catch (error) {
-      showFeedback(error.message || t("errors.loginFailed"), "error");
+      showFeedback(messageFromError(error, t("errors.loginFailed")), "error");
       renderAuthArea(null);
       renderNavAvatar();
     }
@@ -441,49 +441,45 @@ elements.logoutButton.addEventListener("click", async () => {
   }
 });
 
-if (elements.themeSelect) {
-  renderThemeOptions();
-  syncThemePreference();
-  elements.themeSelect.addEventListener("change", async () => {
-    const previousTheme = themeManager.getCurrentTheme();
-    const selectedTheme = elements.themeSelect.value;
-    const nextTheme = themeManager.applyTheme(selectedTheme);
-    elements.themeSelect.value = nextTheme;
-    elements.themeSelect.disabled = true;
-    setThemeStatus(t("profile.preferences.status.saving", { theme: themeLabel(nextTheme) }));
+renderThemeOptions();
+syncThemePreference();
+elements.themeSelect.addEventListener("change", async () => {
+  const previousTheme = themeManager.getCurrentTheme();
+  const selectedTheme = elements.themeSelect.value;
+  const nextTheme = themeManager.applyTheme(selectedTheme);
+  elements.themeSelect.value = nextTheme;
+  setDisabled(elements.themeSelect, true);
+  setThemeStatus(t("profile.preferences.status.saving", { theme: themeLabel(nextTheme) }));
 
-    try {
-      const data = await persistThemePreference(nextTheme);
-      const storedTheme = themeManager.getThemeFromUser(data.user) || nextTheme;
-      themeManager.applyUserTheme(data.user);
-      syncThemePreference({ announce: true, preferredTheme: storedTheme });
-    } catch (error) {
-      if (isNavigationAbort(error) || document.visibilityState === "hidden") {
-        setThemeStatus(t("profile.preferences.status.current", { theme: themeLabel(nextTheme) }));
-        return;
-      }
-
-      themeManager.applyTheme(previousTheme);
-      elements.themeSelect.value = previousTheme;
-      setThemeStatus(t("profile.preferences.status.saveFailed", { theme: themeLabel(previousTheme) }));
-    } finally {
-      elements.themeSelect.disabled = false;
-    }
-  });
-}
-
-if (elements.gamesList) {
-  elements.gamesList.addEventListener("click", async (event) => {
-    const trigger = event.target.closest("[data-open-game-id]");
-    if (!trigger) {
+  try {
+    const data = await persistThemePreference(nextTheme);
+    const storedTheme = themeManager.getThemeFromUser(data.user) || nextTheme;
+    themeManager.applyUserTheme(data.user);
+    syncThemePreference({ announce: true, preferredTheme: storedTheme });
+  } catch (error) {
+    if (isNavigationAbort(error) || document.visibilityState === "hidden") {
+      setThemeStatus(t("profile.preferences.status.current", { theme: themeLabel(nextTheme) }));
       return;
     }
 
-    const gameId = trigger.dataset.openGameId;
-    if (!gameId) {
-      return;
-    }
+    themeManager.applyTheme(previousTheme);
+    elements.themeSelect.value = previousTheme;
+    setThemeStatus(t("profile.preferences.status.saveFailed", { theme: themeLabel(previousTheme) }));
+  } finally {
+    setDisabled(elements.themeSelect, false);
+  }
+});
 
-    window.location.href = "/game/" + encodeURIComponent(gameId);
-  });
-}
+elements.gamesList.addEventListener("click", async (event) => {
+  const trigger = closest<HTMLElement>(event.target, "[data-open-game-id]");
+  if (!trigger) {
+    return;
+  }
+
+  const gameId = trigger.dataset.openGameId;
+  if (!gameId) {
+    return;
+  }
+
+  window.location.href = "/game/" + encodeURIComponent(gameId);
+});

--- a/frontend/src/register.mts
+++ b/frontend/src/register.mts
@@ -1,4 +1,6 @@
-import { t, translateServerMessage } from "./i18n.mts";
+import { byId, maybeQuery, setDisabled, setHidden } from "./core/dom.mjs";
+import { messageFromError } from "./core/errors.mjs";
+import { t, translateServerMessage } from "./i18n.mjs";
 
 const state = {
   user: null,
@@ -6,23 +8,23 @@ const state = {
 };
 
 const elements = {
-  headerLoginForm: document.querySelector("#header-login-form"),
-  headerAuthUsername: document.querySelector("#header-auth-username"),
-  headerAuthPassword: document.querySelector("#header-auth-password"),
-  headerLoginButton: document.querySelector("#header-login-button"),
-  authStatus: document.querySelector("#register-auth-status"),
-  logoutButton: document.querySelector("#logout-button"),
-  form: document.querySelector("#register-form"),
-  username: document.querySelector("#register-username"),
-  email: document.querySelector("#register-email"),
-  password: document.querySelector("#register-password"),
-  passwordConfirm: document.querySelector("#register-password-confirm"),
-  feedback: document.querySelector("#register-feedback"),
-  submit: document.querySelector("#register-submit-button")
+  headerLoginForm: maybeQuery("#header-login-form"),
+  headerAuthUsername: maybeQuery<HTMLInputElement>("#header-auth-username"),
+  headerAuthPassword: maybeQuery<HTMLInputElement>("#header-auth-password"),
+  headerLoginButton: maybeQuery<HTMLButtonElement>("#header-login-button"),
+  authStatus: byId("register-auth-status"),
+  logoutButton: byId("logout-button") as HTMLButtonElement,
+  form: byId("register-form") as HTMLFormElement,
+  username: byId("register-username") as HTMLInputElement,
+  email: byId("register-email") as HTMLInputElement,
+  password: byId("register-password") as HTMLInputElement,
+  passwordConfirm: byId("register-password-confirm") as HTMLInputElement,
+  feedback: byId("register-feedback"),
+  submit: byId("register-submit-button") as HTMLButtonElement
 };
 
-function renderNavAvatar(username) {
-  const avatar = document.querySelector("#nav-avatar");
+function renderNavAvatar(username = "") {
+  const avatar = maybeQuery("#nav-avatar");
   if (!avatar) {
     return;
   }
@@ -33,13 +35,13 @@ function renderNavAvatar(username) {
 
 function setFeedback(message = "", tone = "") {
   if (!message) {
-    elements.feedback.hidden = true;
+    setHidden(elements.feedback, true);
     elements.feedback.textContent = "";
     elements.feedback.className = "auth-feedback";
     return;
   }
 
-  elements.feedback.hidden = false;
+  setHidden(elements.feedback, false);
   elements.feedback.textContent = message;
   elements.feedback.className = `auth-feedback${tone === "error" ? " is-error" : " is-success"}`;
 }
@@ -103,15 +105,21 @@ async function restoreSession() {
 function render() {
   const isAuthenticated = Boolean(state.user);
   if (elements.headerLoginForm) {
-    elements.headerLoginForm.hidden = isAuthenticated;
-    elements.headerAuthUsername.disabled = isAuthenticated;
-    elements.headerAuthPassword.disabled = isAuthenticated;
-    elements.headerLoginButton.disabled = isAuthenticated;
+    setHidden(elements.headerLoginForm as HTMLElement, isAuthenticated);
+    if (elements.headerAuthUsername) {
+      setDisabled(elements.headerAuthUsername, isAuthenticated);
+    }
+    if (elements.headerAuthPassword) {
+      setDisabled(elements.headerAuthPassword, isAuthenticated);
+    }
+    if (elements.headerLoginButton) {
+      setDisabled(elements.headerLoginButton, isAuthenticated);
+    }
   }
 
-  elements.logoutButton.hidden = !isAuthenticated;
-  elements.logoutButton.disabled = !isAuthenticated;
-  elements.submit.disabled = state.submitting || isAuthenticated;
+  setHidden(elements.logoutButton, !isAuthenticated);
+  setDisabled(elements.logoutButton, !isAuthenticated);
+  setDisabled(elements.submit, state.submitting || isAuthenticated);
   elements.authStatus.textContent = isAuthenticated
     ? t("register.auth.loggedIn", { username: state.user.username })
     : t("register.authStatus");
@@ -119,7 +127,7 @@ function render() {
 }
 
 if (elements.headerLoginForm) {
-  elements.headerLoginForm.dataset.headerLoginManaged = "true";
+  (elements.headerLoginForm as HTMLElement).dataset.headerLoginManaged = "true";
   elements.headerLoginForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     const username = elements.headerAuthUsername.value.trim();
@@ -131,7 +139,7 @@ if (elements.headerLoginForm) {
     try {
       await loginWithCredentials(username, password);
     } catch (error) {
-      setFeedback(error.message, "error");
+      setFeedback(messageFromError(error, t("errors.loginFailed")), "error");
       render();
     }
   });
@@ -184,7 +192,7 @@ elements.form.addEventListener("submit", async (event) => {
 
     await loginWithCredentials(username, password);
   } catch (error) {
-    setFeedback(error.message, "error");
+      setFeedback(messageFromError(error, t("register.errors.submitFailed")), "error");
   } finally {
     state.submitting = false;
     render();

--- a/frontend/src/shell.mts
+++ b/frontend/src/shell.mts
@@ -1,18 +1,15 @@
-import { applyTranslations, listSupportedLocales, resolveLocale, setLocale, t, translateServerMessage } from "./i18n.mts";
+import { setMarkup } from "./core/dom.mjs";
+import { DEFAULT_THEME, SUPPORTED_THEMES, normalizeTheme } from "./core/contracts.mjs";
+import { messageFromError } from "./core/errors.mjs";
+import { applyTranslations, listSupportedLocales, resolveLocale, setLocale, t, translateServerMessage } from "./i18n.mjs";
 
-const DEFAULT_THEME = "command";
-const SUPPORTED_THEMES = Object.freeze(["command", "midnight", "ember"]);
 const THEME_STORAGE_KEY = "netrisk.theme";
-const query = new URLSearchParams(window.location.search);
+const routeQuery = new URLSearchParams(window.location.search);
 const shellKind = document.body.dataset.shellKind || (document.body.dataset.appSection ? "app" : "marketing");
 const section = document.body.dataset.appSection || "";
 const pathGameMatch = window.location.pathname.match(/^\/game\/([^/]+)$/);
-const currentGameId = pathGameMatch ? decodeURIComponent(pathGameMatch[1]) : query.get("gameId");
+const currentGameId = pathGameMatch ? decodeURIComponent(pathGameMatch[1]) : routeQuery.get("gameId");
 const activeLocale = setLocale(resolveLocale());
-
-function normalizeTheme(theme) {
-  return SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME;
-}
 
 function resolveThemeFromUser(user) {
   const requestedTheme = user?.preferences?.theme;
@@ -20,7 +17,7 @@ function resolveThemeFromUser(user) {
 }
 
 function resolveTheme() {
-  const requested = query.get("theme");
+  const requested = routeQuery.get("theme");
   if (requested) {
     return normalizeTheme(requested);
   }
@@ -200,16 +197,18 @@ function sharedFooterMarkup() {
 
 function mountAppChrome() {
   document.querySelectorAll("[data-shared-top-nav]").forEach((container) => {
-    if (!container.dataset.sharedChromeMounted) {
-      container.innerHTML = sharedNavMarkup();
-      container.dataset.sharedChromeMounted = "true";
+    const topNavContainer = container as HTMLElement;
+    if (!topNavContainer.dataset.sharedChromeMounted) {
+      setMarkup(topNavContainer, sharedNavMarkup());
+      topNavContainer.dataset.sharedChromeMounted = "true";
     }
   });
 
   document.querySelectorAll("[data-shared-footer]").forEach((container) => {
-    if (!container.dataset.sharedChromeMounted) {
-      container.innerHTML = sharedFooterMarkup();
-      container.dataset.sharedChromeMounted = "true";
+    const footerContainer = container as HTMLElement;
+    if (!footerContainer.dataset.sharedChromeMounted) {
+      setMarkup(footerContainer, sharedFooterMarkup());
+      footerContainer.dataset.sharedChromeMounted = "true";
     }
   });
 }
@@ -222,16 +221,17 @@ function syncAppNav() {
   };
 
   document.querySelectorAll("[data-nav-section]").forEach((link) => {
-    const isActive = link.dataset.navSection === section;
-    link.classList.toggle("is-active", isActive);
-    link.setAttribute("aria-current", isActive ? "page" : "false");
+    const navLink = link as HTMLAnchorElement;
+    const isActive = navLink.dataset.navSection === section;
+    navLink.classList.toggle("is-active", isActive);
+    navLink.setAttribute("aria-current", isActive ? "page" : "false");
 
-    if (navLabels[link.dataset.navSection]) {
-      link.textContent = navLabels[link.dataset.navSection];
+    if (navLabels[navLink.dataset.navSection]) {
+      navLink.textContent = navLabels[navLink.dataset.navSection];
     }
 
-    if (link.dataset.navSection === "game" && currentGameId) {
-      link.href = gameHref();
+    if (navLink.dataset.navSection === "game" && currentGameId) {
+      navLink.href = gameHref();
     }
   });
 
@@ -291,8 +291,8 @@ function initAppShell() {
     event.preventDefault();
     event.stopImmediatePropagation();
 
-    const usernameInput = form.querySelector("#header-auth-username");
-    const passwordInput = form.querySelector("#header-auth-password");
+    const usernameInput = form.querySelector("#header-auth-username") as HTMLInputElement | null;
+    const passwordInput = form.querySelector("#header-auth-password") as HTMLInputElement | null;
     const username = usernameInput?.value?.trim() || "";
     const password = passwordInput?.value || "";
     if (!username || !password) {
@@ -309,7 +309,7 @@ function initAppShell() {
 
       window.location.href = nextUrl.toString();
     } catch (error) {
-      window.alert(error.message || t("errors.loginFailed"));
+      window.alert(messageFromError(error, t("errors.loginFailed")));
     }
   }, true);
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "backup:check": "node scripts/check-backup.cjs",
     "build:ts": "tsc -p tsconfig.json && npm run build:frontend",
     "build:frontend": "tsc -p tsconfig.frontend.json && node scripts/sync-frontend-imports.cjs",
+    "typecheck:frontend": "tsc -p tsconfig.frontend.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:theme-tokens": "node scripts/check-theme-tokenization.cjs",
     "vercel:env:check": "node scripts/check-vercel-env-parity.cjs",

--- a/scripts/backup-datastore.cts
+++ b/scripts/backup-datastore.cts
@@ -1,13 +1,18 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 const { createDatastore } = require("../backend/datastore.cjs");
 
-function pad(value) {
+interface BackupArgs {
+  dbFile?: string;
+  outputFile?: string;
+  keep?: number;
+}
+
+function pad(value: number): string {
   return String(value).padStart(2, "0");
 }
 
-function timestampLabel(date = new Date()) {
+function timestampLabel(date: Date = new Date()): string {
   return [
     date.getFullYear(),
     pad(date.getMonth() + 1),
@@ -19,8 +24,8 @@ function timestampLabel(date = new Date()) {
   ].join("");
 }
 
-function parseArgs(argv) {
-  const args = {};
+function parseArgs(argv: string[]): BackupArgs {
+  const args: BackupArgs = {};
 
   for (let index = 0; index < argv.length; index += 1) {
     const current = argv[index];
@@ -48,18 +53,19 @@ function parseArgs(argv) {
   return args;
 }
 
-function backupDirectoryFor(outputFile) {
+function backupDirectoryFor(outputFile: string): string {
   return path.dirname(outputFile);
 }
 
-function baseNameFor(outputFile) {
+function baseNameFor(outputFile: string): string {
   return path.basename(outputFile).replace(/-\d{8}-\d{6}\.sqlite$/, "");
 }
 
-function pruneBackups(outputFile, keepCount) {
-  if (!Number.isInteger(keepCount) || keepCount < 1) {
+function pruneBackups(outputFile: string, keepCount?: number): string[] {
+  if (typeof keepCount !== "number" || !Number.isInteger(keepCount) || keepCount < 1) {
     return [];
   }
+  const normalizedKeepCount = keepCount;
 
   const directory = backupDirectoryFor(outputFile);
   const baseName = baseNameFor(outputFile);
@@ -68,12 +74,12 @@ function pruneBackups(outputFile, keepCount) {
   }
 
   const backups = fs.readdirSync(directory)
-    .filter((name) => name.startsWith(baseName + "-") && name.endsWith(".sqlite"))
+    .filter((name: string) => name.startsWith(baseName + "-") && name.endsWith(".sqlite"))
     .sort()
     .reverse();
 
-  const removed = backups.slice(keepCount).map((name) => path.join(directory, name));
-  removed.forEach((filePath) => {
+  const removed = backups.slice(normalizedKeepCount).map((name: string) => path.join(directory, name));
+  removed.forEach((filePath: string) => {
     if (fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);
     }
@@ -81,7 +87,7 @@ function pruneBackups(outputFile, keepCount) {
   return removed;
 }
 
-async function main() {
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const dbFile = args.dbFile || path.join(__dirname, "..", "data", "netrisk.sqlite");
   const outputFile = args.outputFile || path.join(__dirname, "..", "data", "backups", `netrisk-${timestampLabel()}.sqlite`);
@@ -107,9 +113,9 @@ module.exports = {
   timestampLabel
 };
 
-if (require.main === module) {
+  if (require.main === module) {
   main().catch((error) => {
-    console.error(error && error.message ? error.message : error);
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }

--- a/scripts/check-backup.cts
+++ b/scripts/check-backup.cts
@@ -1,12 +1,27 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 const { DatabaseSync } = require("node:sqlite");
 
 const requiredTables = ["users", "sessions", "games", "app_state"];
 
-function parseArgs(argv) {
-  const args = {};
+interface CheckBackupArgs {
+  file?: string;
+}
+
+interface SqliteCountRow {
+  count?: number;
+}
+
+interface SqliteTableRow {
+  name: string;
+}
+
+interface SqliteAppStateRow {
+  value_json?: string;
+}
+
+function parseArgs(argv: string[]): CheckBackupArgs {
+  const args: CheckBackupArgs = {};
 
   for (let index = 0; index < argv.length; index += 1) {
     const current = argv[index];
@@ -21,7 +36,7 @@ function parseArgs(argv) {
   return args;
 }
 
-function inspectBackup(filePath) {
+function inspectBackup(filePath: string | undefined) {
   if (!filePath) {
     throw new Error("La verifica richiede il percorso di un backup SQLite.");
   }
@@ -34,30 +49,33 @@ function inspectBackup(filePath) {
   const db = new DatabaseSync(resolvedFile, { readOnly: true });
 
   try {
-    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map((row) => row.name);
+    const tables = (db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as SqliteTableRow[]).map((row) => row.name);
     const missingTables = requiredTables.filter((tableName) => !tables.includes(tableName));
     if (missingTables.length > 0) {
       throw new Error(`Backup incompleto: tabelle mancanti ${missingTables.join(", ")}`);
     }
 
-    const activeGameRow = db.prepare("SELECT value_json FROM app_state WHERE key = ?").get("activeGameId");
+    const activeGameRow = db.prepare("SELECT value_json FROM app_state WHERE key = ?").get("activeGameId") as SqliteAppStateRow | undefined;
+    const usersCount = db.prepare("SELECT COUNT(*) AS count FROM users").get() as SqliteCountRow;
+    const gamesCount = db.prepare("SELECT COUNT(*) AS count FROM games").get() as SqliteCountRow;
+    const sessionsCount = db.prepare("SELECT COUNT(*) AS count FROM sessions").get() as SqliteCountRow;
     return {
       ok: true,
       file: resolvedFile,
       storage: "sqlite",
       counts: {
-        users: Number(db.prepare("SELECT COUNT(*) AS count FROM users").get().count) || 0,
-        games: Number(db.prepare("SELECT COUNT(*) AS count FROM games").get().count) || 0,
-        sessions: Number(db.prepare("SELECT COUNT(*) AS count FROM sessions").get().count) || 0
+        users: Number(usersCount.count) || 0,
+        games: Number(gamesCount.count) || 0,
+        sessions: Number(sessionsCount.count) || 0
       },
-      activeGameId: activeGameRow ? JSON.parse(activeGameRow.value_json) : null
+      activeGameId: activeGameRow?.value_json ? JSON.parse(activeGameRow.value_json) : null
     };
   } finally {
     db.close();
   }
 }
 
-function main() {
+function main(): void {
   const args = parseArgs(process.argv.slice(2));
   const summary = inspectBackup(args.file);
   console.log(JSON.stringify(summary, null, 2));
@@ -73,7 +91,7 @@ if (require.main === module) {
   try {
     main();
   } catch (error) {
-    console.error(error && error.message ? error.message : error);
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/scripts/check-theme-tokenization.cts
+++ b/scripts/check-theme-tokenization.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const fs = require("node:fs");
 const path = require("node:path");
 const projectRoot = path.resolve(__dirname, "..", "..");
@@ -7,17 +6,21 @@ const TOKEN_LITERAL_PATTERN = /#[0-9A-Fa-f]{3,8}\b|rgba?\(/;
 const TOKEN_SECTION_START = "/* Theme token definitions start */";
 const TOKEN_SECTION_END = "/* Theme token definitions end */";
 
-function checkThemeTokenization() {
-  const publicDir = path.join(projectRoot, "frontend", "public");
-  const cssFiles = fs.readdirSync(publicDir).filter((fileName) => fileName.endsWith(".css"));
-  const violations = [];
+type ThemeTokenizationError = Error & {
+  violations: string[];
+};
 
-  cssFiles.forEach((fileName) => {
+function checkThemeTokenization(): void {
+  const publicDir = path.join(projectRoot, "frontend", "public");
+  const cssFiles = fs.readdirSync(publicDir).filter((fileName: string) => fileName.endsWith(".css"));
+  const violations: string[] = [];
+
+  cssFiles.forEach((fileName: string) => {
     const absolutePath = path.join(publicDir, fileName);
     const lines = fs.readFileSync(absolutePath, "utf8").split(/\r?\n/);
     let inTokenSection = false;
 
-    lines.forEach((line, index) => {
+    lines.forEach((line: string, index: number) => {
       if (line.includes(TOKEN_SECTION_START)) {
         inTokenSection = true;
       }
@@ -35,7 +38,7 @@ function checkThemeTokenization() {
   if (violations.length > 0) {
     const error = new Error(
       "Trovati colori hardcoded fuori dalla sezione token temi:\n" + violations.join("\n")
-    );
+    ) as ThemeTokenizationError;
     error.violations = violations;
     throw error;
   }
@@ -46,7 +49,7 @@ if (require.main === module) {
     checkThemeTokenization();
     console.log("Theme tokenization check passed.");
   } catch (error) {
-    console.error(error.message);
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/scripts/check-vercel-env-parity.cts
+++ b/scripts/check-vercel-env-parity.cts
@@ -1,10 +1,18 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const { REQUIRED_DEPLOY_ENV_KEYS } = require("../backend/required-runtime-env.cjs");
 
-function run(command, args, options = {}) {
+interface RunOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+type SpawnError = Error & {
+  status?: number | null;
+};
+
+function run(command: string, args: string[], options: RunOptions = {}): string {
   const result = spawnSync(command, args, {
     encoding: "utf8",
     stdio: "pipe",
@@ -14,7 +22,7 @@ function run(command, args, options = {}) {
   });
 
   if (result.status !== 0) {
-    const error = new Error((result.stderr || result.stdout || "").trim() || `${command} ${args.join(" ")} failed`);
+    const error = new Error((result.stderr || result.stdout || "").trim() || `${command} ${args.join(" ")} failed`) as SpawnError;
     error.status = result.status;
     throw error;
   }
@@ -22,11 +30,11 @@ function run(command, args, options = {}) {
   return result.stdout || "";
 }
 
-function parseEnvFile(filePath) {
-  const parsed = {};
+function parseEnvFile(filePath: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
   const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
 
-  lines.forEach((line) => {
+  lines.forEach((line: string) => {
     const match = line.match(/^([A-Z0-9_]+)=\"([\s\S]*)\"$/);
     if (!match) {
       return;
@@ -38,15 +46,15 @@ function parseEnvFile(filePath) {
   return parsed;
 }
 
-function tempFile(name) {
+function tempFile(name: string): string {
   return path.join(process.cwd(), name);
 }
 
-function currentBranch() {
+function currentBranch(): string {
   return run("git", ["branch", "--show-current"]).trim();
 }
 
-function pullEnv(outputFile, environment, branch = null) {
+function pullEnv(outputFile: string, environment: string, branch: string | null = null): Record<string, string> {
   const args = ["env", "pull", outputFile, `--environment=${environment}`, "--yes"];
   if (branch) {
     args.push(`--git-branch=${branch}`);
@@ -55,11 +63,11 @@ function pullEnv(outputFile, environment, branch = null) {
   return parseEnvFile(outputFile);
 }
 
-function summarizeMissing(keys, source, target) {
+function summarizeMissing(keys: string[], source: Record<string, string>, target: Record<string, string>): string[] {
   return keys.filter((key) => source[key] && !target[key]);
 }
 
-function main() {
+function main(): void {
   const branch = process.env.VERCEL_ENV_CHECK_BRANCH || currentBranch();
   const productionFile = tempFile(`.vercel.env-check-production-${process.pid}.env`);
   const previewFile = tempFile(`.vercel.env-check-preview-${process.pid}.env`);
@@ -68,8 +76,8 @@ function main() {
     const production = pullEnv(productionFile, "production");
     const preview = pullEnv(previewFile, "preview", branch);
 
-    const missingInProduction = REQUIRED_DEPLOY_ENV_KEYS.filter((key) => !production[key]);
-    const missingInPreview = REQUIRED_DEPLOY_ENV_KEYS.filter((key) => !preview[key]);
+    const missingInProduction = REQUIRED_DEPLOY_ENV_KEYS.filter((key: string) => !production[key]);
+    const missingInPreview = REQUIRED_DEPLOY_ENV_KEYS.filter((key: string) => !preview[key]);
     const missingFromPreviewComparedToProduction = summarizeMissing(REQUIRED_DEPLOY_ENV_KEYS, production, preview);
 
     if (!missingInProduction.length && !missingInPreview.length && !missingFromPreviewComparedToProduction.length) {
@@ -89,7 +97,7 @@ function main() {
 
     process.exitCode = 1;
   } finally {
-    [productionFile, previewFile].forEach((filePath) => {
+    [productionFile, previewFile].forEach((filePath: string) => {
       try {
         fs.rmSync(filePath, { force: true });
       } catch (error) {

--- a/scripts/run-e2e.cts
+++ b/scripts/run-e2e.cts
@@ -1,12 +1,20 @@
-// @ts-nocheck
 const fs = require("fs");
 const net = require("net");
 const { spawn } = require("child_process");
 const path = require("path");
 const http = require("http");
 
-function canBind(port) {
-  return new Promise((resolve) => {
+interface CleanupOptions {
+  strict?: boolean;
+}
+
+interface ExitResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+function canBind(port: number): Promise<boolean> {
+  return new Promise((resolve: (value: boolean) => void) => {
     const server = net.createServer();
     server.unref();
     server.on("error", () => resolve(false));
@@ -16,7 +24,7 @@ function canBind(port) {
   });
 }
 
-async function findAvailablePort(startPort, attempts = 20) {
+async function findAvailablePort(startPort: number, attempts: number = 20): Promise<number> {
   for (let offset = 0; offset < attempts; offset += 1) {
     const candidate = startPort + offset;
     if (await canBind(candidate)) {
@@ -27,7 +35,7 @@ async function findAvailablePort(startPort, attempts = 20) {
   throw new Error(`Nessuna porta libera trovata a partire da ${startPort}.`);
 }
 
-async function removeIfExists(filePath, attempts = 10, options = {}) {
+async function removeIfExists(filePath: string, attempts: number = 10, options: CleanupOptions = {}): Promise<void> {
   const strict = options.strict !== false;
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
@@ -35,16 +43,17 @@ async function removeIfExists(filePath, attempts = 10, options = {}) {
       await fs.promises.rm(filePath, { force: true });
       return;
     } catch (error) {
-      if (!error || error.code === "ENOENT") {
+      const fsError = error as NodeJS.ErrnoException | null;
+      if (!fsError || fsError.code === "ENOENT") {
         return;
       }
 
-      if (!strict && (error.code === "EBUSY" || error.code === "EPERM")) {
+      if (!strict && (fsError.code === "EBUSY" || fsError.code === "EPERM")) {
         return;
       }
 
       if (attempt === attempts - 1) {
-        throw error;
+        throw fsError;
       }
 
       await new Promise((resolve) => setTimeout(resolve, 200));
@@ -52,30 +61,30 @@ async function removeIfExists(filePath, attempts = 10, options = {}) {
   }
 }
 
-async function cleanupSqliteFiles(dbFile) {
+async function cleanupSqliteFiles(dbFile: string): Promise<void> {
   await removeIfExists(`${dbFile}-shm`);
   await removeIfExists(`${dbFile}-wal`);
   await removeIfExists(dbFile);
 }
 
-async function cleanupStaleE2eDatabases(dataDir) {
+async function cleanupStaleE2eDatabases(dataDir: string): Promise<void> {
   const entries = await fs.promises.readdir(dataDir, { withFileTypes: true });
   const targets = entries
-    .filter((entry) => entry.isFile() && /^e2e-\d+\.sqlite(?:-shm|-wal)?$/.test(entry.name))
-    .map((entry) => path.join(dataDir, entry.name));
+    .filter((entry: import("node:fs").Dirent) => entry.isFile() && /^e2e-\d+\.sqlite(?:-shm|-wal)?$/.test(entry.name))
+    .map((entry: import("node:fs").Dirent) => path.join(dataDir, entry.name));
 
   for (const target of targets) {
     await removeIfExists(target, 3, { strict: false });
   }
 }
 
-function wait(ms) {
+function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function isServerHealthy(baseURL) {
-  return new Promise((resolve) => {
-    const request = http.get(`${baseURL}/api/health`, (response) => {
+function isServerHealthy(baseURL: string): Promise<boolean> {
+  return new Promise((resolve: (value: boolean) => void) => {
+    const request = http.get(`${baseURL}/api/health`, (response: import("node:http").IncomingMessage) => {
       response.resume();
       resolve(response.statusCode === 200);
     });
@@ -88,7 +97,7 @@ function isServerHealthy(baseURL) {
   });
 }
 
-async function waitForServer(baseURL, timeoutMs = 120000) {
+async function waitForServer(baseURL: string, timeoutMs: number = 120000): Promise<void> {
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < timeoutMs) {
@@ -102,7 +111,7 @@ async function waitForServer(baseURL, timeoutMs = 120000) {
   throw new Error(`Timeout avvio server E2E su ${baseURL}.`);
 }
 
-function createNoWebserverPlaywrightConfig(repoRoot, tempConfigPath = null) {
+function createNoWebserverPlaywrightConfig(repoRoot: string, tempConfigPath: string | null = null): Promise<string> {
   const sourceConfig = path.join(repoRoot, "playwright.config.cjs");
   const tempConfig = tempConfigPath || path.join(repoRoot, ".tsbuild", "playwright.tmp.no-webserver.cjs");
   const configPath = JSON.stringify(sourceConfig);
@@ -121,11 +130,11 @@ module.exports = baseConfig;
   return fs.promises.writeFile(tempConfig, content, "utf8").then(() => tempConfig);
 }
 
-function removeNoWebserverPlaywrightConfig(repoRoot) {
+function removeNoWebserverPlaywrightConfig(repoRoot: string): Promise<void> {
   return removeIfExists(path.join(repoRoot, ".tsbuild", "playwright.tmp.no-webserver.cjs"), 3, { strict: false });
 }
 
-async function main() {
+async function main(): Promise<void> {
   const requestedPort = Number(process.env.E2E_PORT || process.env.PORT || 3100);
   const port = await findAvailablePort(requestedPort);
   const baseURL = `http://127.0.0.1:${port}`;
@@ -167,8 +176,8 @@ async function main() {
     env: runnerEnv
   });
 
-  const result = await new Promise((resolve) => {
-    child.on("exit", (code, signal) => {
+  const result = await new Promise<ExitResult>((resolve) => {
+    child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
       resolve({ code, signal });
     });
   });
@@ -186,6 +195,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(error.message || error);
+  console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 });

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -57,6 +57,7 @@ const { missingRequiredDeployEnv, shouldValidateDeployEnv } = require("../backen
 const { createApp } = require("../backend/server.cjs");
 const { sendJson, localizedPayload, sendLocalizedError } = require("../backend/http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("../backend/routes/account.cjs");
+const { handleAttackGameActionRoute } = require("../backend/routes/game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("../backend/routes/game-actions-basic.cjs");
 const { handleTurnGameActionRoute } = require("../backend/routes/game-actions-turn.cjs");
 const { handleHealthRoute } = require("../backend/routes/health.cjs");
@@ -986,6 +987,127 @@ register("basic game action route valida i territori nel fortify", async () => {
     () => {
       throw new Error("applyFortify should not be called");
     },
+    async () => {
+      throw new Error("persistGameContext should not be called");
+    },
+    () => {
+      throw new Error("broadcastGame should not be called");
+    },
+    () => {
+      throw new Error("snapshotForUser should not be called");
+    },
+    () => false,
+    (territoryId) => territoryId === "alpha" || territoryId === "beta",
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(handled, true);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "Territorio non valido.",
+    messageKey: "game.invalidTerritory",
+    messageParams: {},
+    code: null
+  });
+});
+
+register("attack game action route gestisce un attacco con random consumato dalla queue", async () => {
+  const res = makeMockResponse();
+  const gameContext = {
+    state: { territories: { alpha: {}, beta: {} } },
+    gameId: "game-attack",
+    version: 5,
+    gameName: "Attack Route"
+  };
+  const persisted = [];
+  const broadcasts = [];
+  let consumeCount = 0;
+
+  const handled = await handleAttackGameActionRoute(
+    "attack",
+    res,
+    { fromId: "alpha", toId: "beta", attackDice: "3" },
+    gameContext,
+    "p1",
+    5,
+    { id: "user-1" },
+    (state, playerId, fromId, toId, random, attackDice) => {
+      assert.equal(playerId, "p1");
+      assert.equal(fromId, "alpha");
+      assert.equal(toId, "beta");
+      assert.equal(attackDice, 3);
+      assert.equal(typeof random, "function");
+      assert.equal(random(), 0.25);
+      state.lastAttack = { fromId, toId };
+      return { ok: true, rounds: [{ attack: 6, defend: 2 }] };
+    },
+    () => {
+      throw new Error("resolveBanzaiAttack should not be called");
+    },
+    () => {
+      consumeCount += 1;
+      return () => 0.25;
+    },
+    async (context, expectedVersion) => {
+      persisted.push(expectedVersion);
+      context.version = 6;
+    },
+    (context) => {
+      broadcasts.push(context.version);
+    },
+    (state, gameId, version, gameName, user) => ({
+      gameId,
+      version,
+      gameName,
+      lastAttack: state.lastAttack,
+      playerId: user.id
+    }),
+    () => false,
+    (territoryId) => territoryId === "alpha" || territoryId === "beta",
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(handled, true);
+  assert.equal(consumeCount, 1);
+  assert.deepEqual(persisted, [5]);
+  assert.deepEqual(broadcasts, [6]);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    state: {
+      gameId: "game-attack",
+      version: 6,
+      gameName: "Attack Route",
+      lastAttack: { fromId: "alpha", toId: "beta" },
+      playerId: "user-1"
+    },
+    rounds: [{ attack: 6, defend: 2 }]
+  });
+});
+
+register("attack game action route valida i territori prima del banzai", async () => {
+  const res = makeMockResponse();
+  const handled = await handleAttackGameActionRoute(
+    "attackBanzai",
+    res,
+    { fromId: "alpha", toId: "missing" },
+    {
+      state: { territories: { alpha: {}, beta: {} } },
+      gameId: "game-attack",
+      version: 5,
+      gameName: "Attack Route"
+    },
+    "p1",
+    5,
+    { id: "user-1" },
+    () => {
+      throw new Error("resolveAttack should not be called");
+    },
+    () => {
+      throw new Error("resolveBanzaiAttack should not be called");
+    },
+    () => null,
     async () => {
       throw new Error("persistGameContext should not be called");
     },

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -55,6 +55,9 @@ const { readJsonFile, writeJsonFile } = require("../backend/json-file-store.cjs"
 const { createPlayerProfileStore } = require("../backend/player-profile-store.cjs");
 const { missingRequiredDeployEnv, shouldValidateDeployEnv } = require("../backend/required-runtime-env.cjs");
 const { createApp } = require("../backend/server.cjs");
+const { sendJson, localizedPayload, sendLocalizedError } = require("../backend/http-response.cjs");
+const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("../backend/routes/account.cjs");
+const { handleHealthRoute } = require("../backend/routes/health.cjs");
 const { randomHex, secureRandom } = require("../backend/random.cjs");
 const { pruneBackups } = require("./backup-datastore.cjs");
 const { inspectBackup } = require("./check-backup.cjs");
@@ -696,6 +699,195 @@ register("player profile store riassume vittorie, sconfitte e partite in corso",
   assert.equal(profile.participatingGames[0].myLobby.cardCount, 2);
   assert.equal(profile.participatingGames[1].myLobby.focusLabel, "Lobby");
   assert.equal(profile.participatingGames[1].mapName, "Custom Lobby");
+});
+
+register("http response helpers normalizzano payload localizzati e codici extra", () => {
+  assert.deepEqual(
+    localizedPayload(
+      {
+        message: "Messaggio dal server",
+        messageKey: "server.message",
+        messageParams: { scope: "test" }
+      },
+      "Fallback",
+      "server.fallback"
+    ),
+    {
+      error: "Messaggio dal server",
+      messageKey: "server.message",
+      messageParams: { scope: "test" }
+    }
+  );
+
+  const res = makeMockResponse();
+  sendLocalizedError(
+    res,
+    409,
+    null,
+    "Conflict",
+    "server.versionConflict",
+    { currentVersion: 3 },
+    "VERSION_CONFLICT",
+    { retryable: true }
+  );
+
+  assert.equal(res.statusCode, 409);
+  assert.equal(res.headers["Content-Type"], "application/json; charset=utf-8");
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "Conflict",
+    messageKey: "server.versionConflict",
+    messageParams: { currentVersion: 3 },
+    code: "VERSION_CONFLICT",
+    retryable: true
+  });
+});
+
+register("health route usa 503 quando lo snapshot segnala errore", async () => {
+  const res = makeMockResponse();
+  const handled = await handleHealthRoute(
+    res,
+    async () => ({ ok: false, storage: { storage: "sqlite" } }),
+    sendJson
+  );
+
+  assert.equal(handled, true);
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    storage: { storage: "sqlite" }
+  });
+});
+
+register("account routes rispondono con sessione, profilo e validazione tema", async () => {
+  const authContext = {
+    user: {
+      id: "user-1",
+      username: "Alice",
+      preferences: { theme: "ember" }
+    }
+  };
+
+  const sessionRes = makeMockResponse();
+  const sessionHandled = await handleAuthSessionRoute({
+    req: { method: "GET", headers: {} },
+    res: sessionRes,
+    requireAuth: async () => authContext,
+    auth: {
+      publicUser(user) {
+        return {
+          id: user.id,
+          username: user.username,
+          preferences: user.preferences
+        };
+      },
+      async updateUserThemePreference() {
+        return null;
+      }
+    },
+    playerProfiles: {
+      async getPlayerProfile() {
+        return {};
+      }
+    },
+    sendJson,
+    sendLocalizedError,
+    extractUserPreferences(user) {
+      return { theme: user?.preferences?.theme || "command" };
+    },
+    supportedSiteThemes: new Set(["command", "midnight", "ember"]),
+    resolveStoredTheme(theme) {
+      return theme;
+    }
+  });
+
+  assert.equal(sessionHandled, true);
+  assert.equal(sessionRes.statusCode, 200);
+  assert.deepEqual(JSON.parse(sessionRes.body), {
+    user: {
+      id: "user-1",
+      username: "Alice",
+      preferences: { theme: "ember" }
+    }
+  });
+
+  const profileRes = makeMockResponse();
+  const profileHandled = await handleProfileRoute({
+    req: { method: "GET", headers: {} },
+    res: profileRes,
+    requireAuth: async () => authContext,
+    auth: {
+      publicUser() {
+        return null;
+      },
+      async updateUserThemePreference() {
+        return null;
+      }
+    },
+    playerProfiles: {
+      async getPlayerProfile() {
+        return {
+          playerName: "Alice",
+          gamesPlayed: 3,
+          wins: 2,
+          losses: 1,
+          gamesInProgress: 1,
+          participatingGames: [],
+          winRate: 67,
+          hasHistory: true,
+          placeholders: {
+            recentGames: false,
+            ranking: false
+          }
+        };
+      }
+    },
+    sendJson,
+    sendLocalizedError,
+    extractUserPreferences(user) {
+      return { theme: user?.preferences?.theme || "command" };
+    },
+    supportedSiteThemes: new Set(["command", "midnight", "ember"]),
+    resolveStoredTheme(theme) {
+      return theme;
+    }
+  });
+
+  assert.equal(profileHandled, true);
+  assert.equal(profileRes.statusCode, 200);
+  assert.equal(JSON.parse(profileRes.body).profile.preferences.theme, "ember");
+
+  const invalidThemeRes = makeMockResponse();
+  const invalidThemeHandled = await handleThemePreferenceRoute({
+    req: { method: "PUT", headers: {} },
+    res: invalidThemeRes,
+    requireAuth: async () => authContext,
+    auth: {
+      publicUser() {
+        return null;
+      },
+      async updateUserThemePreference() {
+        return null;
+      }
+    },
+    playerProfiles: {
+      async getPlayerProfile() {
+        return {};
+      }
+    },
+    sendJson,
+    sendLocalizedError,
+    extractUserPreferences() {
+      return { theme: "command" };
+    },
+    supportedSiteThemes: new Set(["command", "midnight", "ember"]),
+    resolveStoredTheme(theme) {
+      return theme;
+    }
+  }, { theme: "ultraviolet" });
+
+  assert.equal(invalidThemeHandled, true);
+  assert.equal(invalidThemeRes.statusCode, 400);
+  assert.equal(JSON.parse(invalidThemeRes.body).messageKey, "server.profile.invalidTheme");
 });
 
 async function createAuthenticatedAppSession(app, username) {
@@ -3498,4 +3690,3 @@ async function run() {
 }
 
 run();
-

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -60,6 +60,7 @@ const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute }
 const { handleAttackGameActionRoute } = require("../backend/routes/game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("../backend/routes/game-actions-basic.cjs");
 const { handleTurnGameActionRoute } = require("../backend/routes/game-actions-turn.cjs");
+const { handleCreateGameRoute, handleOpenGameRoute } = require("../backend/routes/game-management.cjs");
 const { handleHealthRoute } = require("../backend/routes/health.cjs");
 const { randomHex, secureRandom } = require("../backend/random.cjs");
 const { pruneBackups } = require("./backup-datastore.cjs");
@@ -1234,6 +1235,104 @@ register("turn game action route gestisce surrender con version conflict", async
   assert.deepEqual(JSON.parse(res.body), {
     ok: false,
     code: "VERSION_CONFLICT"
+  });
+});
+
+register("game management route crea una partita e collega il creatore", async () => {
+  const res = makeMockResponse();
+  const broadcasts = [];
+  let replacedState = null;
+
+  await handleCreateGameRoute(
+    { method: "POST", headers: {} },
+    res,
+    { name: "Nuova partita" },
+    async () => ({ user: { id: "user-1", username: "Alice" } }),
+    () => ({ actor: { id: "user-1" } }),
+    () => ({
+      state: { phase: "lobby", players: [] },
+      gameInput: { name: "Nuova partita" },
+      config: { mapId: "classic-mini" }
+    }),
+    (state, username, options) => {
+      assert.equal(username, "Alice");
+      assert.equal(options.linkedUserId, "user-1");
+      state.players.push({ id: "player-1", name: username });
+      return { ok: true, player: { id: "player-1" } };
+    },
+    async (state, options) => ({
+      game: { id: "game-1", name: options.name, version: 1 },
+      state
+    }),
+    async () => [{ id: "game-1", name: "Nuova partita" }],
+    (state) => {
+      replacedState = state;
+    },
+    (context) => {
+      broadcasts.push(context.gameId);
+    },
+    () => ({ snapshot: true }),
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(replacedState.phase, "lobby");
+  assert.deepEqual(broadcasts, ["game-1"]);
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    game: { id: "game-1", name: "Nuova partita", version: 1 },
+    games: [{ id: "game-1", name: "Nuova partita" }],
+    activeGameId: "game-1",
+    state: { snapshot: true },
+    config: { mapId: "classic-mini" },
+    playerId: "player-1"
+  });
+});
+
+register("game management route apre una partita e risolve il player autenticato", async () => {
+  const res = makeMockResponse();
+
+  await handleOpenGameRoute(
+    { method: "POST", headers: {} },
+    res,
+    { gameId: "game-1" },
+    async () => ({ user: { id: "user-1", username: "Alice" } }),
+    () => undefined,
+    async (gameId) => ({
+      game: { id: gameId, name: "Nuova partita", version: 3 },
+      state: { players: [] }
+    }),
+    async (gameId) => ({
+      game: { id: gameId, name: "Nuova partita", version: 3 },
+      state: { players: [{ id: "player-1", linkedUserId: "user-1" }] }
+    }),
+    async () => [{ id: "game-1", name: "Nuova partita" }],
+    async () => [],
+    (state, user) => state.players.find((player) => player.linkedUserId === user.id) || null,
+    (state, gameId, version, gameName) => ({
+      gameId,
+      version,
+      gameName,
+      players: state.players.length
+    }),
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    game: { id: "game-1", name: "Nuova partita", version: 3 },
+    games: [{ id: "game-1", name: "Nuova partita" }],
+    activeGameId: "game-1",
+    state: {
+      gameId: "game-1",
+      version: 3,
+      gameName: "Nuova partita",
+      players: 1
+    },
+    playerId: "player-1"
   });
 });
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -58,6 +58,7 @@ const { createApp } = require("../backend/server.cjs");
 const { sendJson, localizedPayload, sendLocalizedError } = require("../backend/http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("../backend/routes/account.cjs");
 const { handleBasicGameActionRoute } = require("../backend/routes/game-actions-basic.cjs");
+const { handleTurnGameActionRoute } = require("../backend/routes/game-actions-turn.cjs");
 const { handleHealthRoute } = require("../backend/routes/health.cjs");
 const { randomHex, secureRandom } = require("../backend/random.cjs");
 const { pruneBackups } = require("./backup-datastore.cjs");
@@ -1007,6 +1008,110 @@ register("basic game action route valida i territori nel fortify", async () => {
     messageKey: "game.invalidTerritory",
     messageParams: {},
     code: null
+  });
+});
+
+register("turn game action route gestisce endTurn con persistenza AI-aware", async () => {
+  const res = makeMockResponse();
+  const gameContext = {
+    state: { phase: "active", turnPhase: "attack" },
+    gameId: "game-turn",
+    version: 7,
+    gameName: "Turn Route"
+  };
+  const persisted = [];
+  const broadcasts = [];
+
+  const handled = await handleTurnGameActionRoute(
+    "endTurn",
+    res,
+    gameContext,
+    "p1",
+    7,
+    { id: "user-1" },
+    (state, playerId) => {
+      assert.equal(playerId, "p1");
+      state.turnPhase = "reinforcement";
+      return { ok: true };
+    },
+    () => {
+      throw new Error("surrenderPlayer should not be called");
+    },
+    async (context, expectedVersion) => {
+      persisted.push({ context, expectedVersion });
+      context.version = 8;
+    },
+    (context) => {
+      broadcasts.push(context.version);
+    },
+    (state, gameId, version, gameName, user) => ({
+      gameId,
+      version,
+      gameName,
+      phase: state.turnPhase,
+      playerId: user.id
+    }),
+    () => false,
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(handled, true);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0].expectedVersion, 7);
+  assert.deepEqual(broadcasts, [8]);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    state: {
+      gameId: "game-turn",
+      version: 8,
+      gameName: "Turn Route",
+      phase: "reinforcement",
+      playerId: "user-1"
+    }
+  });
+});
+
+register("turn game action route gestisce surrender con version conflict", async () => {
+  const res = makeMockResponse();
+  const handled = await handleTurnGameActionRoute(
+    "surrender",
+    res,
+    {
+      state: { players: [] },
+      gameId: "game-turn",
+      version: 4,
+      gameName: "Turn Route"
+    },
+    "p1",
+    4,
+    { id: "user-1" },
+    () => {
+      throw new Error("endTurn should not be called");
+    },
+    () => ({ ok: true }),
+    async () => {
+      throw { code: "VERSION_CONFLICT" };
+    },
+    () => {
+      throw new Error("broadcastGame should not be called");
+    },
+    () => {
+      throw new Error("snapshotForUser should not be called");
+    },
+    (error) => {
+      sendJson(res, 409, { ok: false, code: error.code });
+      return true;
+    },
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(handled, true);
+  assert.equal(res.statusCode, 409);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    code: "VERSION_CONFLICT"
   });
 });
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -57,6 +57,7 @@ const { missingRequiredDeployEnv, shouldValidateDeployEnv } = require("../backen
 const { createApp } = require("../backend/server.cjs");
 const { sendJson, localizedPayload, sendLocalizedError } = require("../backend/http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("../backend/routes/account.cjs");
+const { handleBasicGameActionRoute } = require("../backend/routes/game-actions-basic.cjs");
 const { handleHealthRoute } = require("../backend/routes/health.cjs");
 const { randomHex, secureRandom } = require("../backend/random.cjs");
 const { pruneBackups } = require("./backup-datastore.cjs");
@@ -888,6 +889,125 @@ register("account routes rispondono con sessione, profilo e validazione tema", a
   assert.equal(invalidThemeHandled, true);
   assert.equal(invalidThemeRes.statusCode, 400);
   assert.equal(JSON.parse(invalidThemeRes.body).messageKey, "server.profile.invalidTheme");
+});
+
+register("basic game action route gestisce reinforce e persiste lo snapshot per-user", async () => {
+  const res = makeMockResponse();
+  const gameContext = {
+    state: { territories: { alpha: { ownerId: "p1", armies: 3 } } },
+    gameId: "game-basic",
+    version: 2,
+    gameName: "Basic Route"
+  };
+  const user = { id: "user-1", username: "Alice" };
+  const persisted = [];
+  const broadcasts = [];
+
+  const handled = await handleBasicGameActionRoute(
+    "reinforce",
+    res,
+    { territoryId: "alpha", amount: 2 },
+    gameContext,
+    "p1",
+    2,
+    user,
+    (state, playerId, territoryId, amount) => {
+      assert.equal(playerId, "p1");
+      assert.equal(territoryId, "alpha");
+      assert.equal(amount, 2);
+      state.territories.alpha.armies += amount;
+      return { ok: true };
+    },
+    () => {
+      throw new Error("moveAfterConquest should not be called");
+    },
+    () => {
+      throw new Error("applyFortify should not be called");
+    },
+    async (context, expectedVersion) => {
+      persisted.push({ context, expectedVersion });
+      context.version = 3;
+    },
+    (context) => {
+      broadcasts.push(context.version);
+    },
+    (state, gameId, version, gameName, currentUser) => ({
+      gameId,
+      version,
+      gameName,
+      armies: state.territories.alpha.armies,
+      playerId: currentUser.id
+    }),
+    () => false,
+    (territoryId) => territoryId === "alpha",
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(handled, true);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0].expectedVersion, 2);
+  assert.deepEqual(broadcasts, [3]);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    state: {
+      gameId: "game-basic",
+      version: 3,
+      gameName: "Basic Route",
+      armies: 5,
+      playerId: "user-1"
+    }
+  });
+});
+
+register("basic game action route valida i territori nel fortify", async () => {
+  const res = makeMockResponse();
+  const handled = await handleBasicGameActionRoute(
+    "fortify",
+    res,
+    { fromId: "invalid", toId: "beta", armies: 1 },
+    {
+      state: { territories: { alpha: {}, beta: {} } },
+      gameId: "game-basic",
+      version: 1,
+      gameName: "Basic Route"
+    },
+    "p1",
+    1,
+    { id: "user-1" },
+    () => {
+      throw new Error("applyReinforcement should not be called");
+    },
+    () => {
+      throw new Error("moveAfterConquest should not be called");
+    },
+    () => {
+      throw new Error("applyFortify should not be called");
+    },
+    async () => {
+      throw new Error("persistGameContext should not be called");
+    },
+    () => {
+      throw new Error("broadcastGame should not be called");
+    },
+    () => {
+      throw new Error("snapshotForUser should not be called");
+    },
+    () => false,
+    (territoryId) => territoryId === "alpha" || territoryId === "beta",
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(handled, true);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "Territorio non valido.",
+    messageKey: "game.invalidTerritory",
+    messageParams: {},
+    code: null
+  });
 });
 
 async function createAuthenticatedAppSession(app, username) {

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
@@ -72,11 +71,50 @@ const middleEarthMap = require("../shared/maps/middle-earth.cjs");
 const worldClassicMap = require("../shared/maps/world-classic.cjs");
 const { listSupportedMaps } = require("../shared/maps/index.cjs");
 
-const tests = [];
+type TestFn = () => void | Promise<void>;
+type TestCase = {
+  name: string;
+  fn: TestFn;
+};
+type HeaderMap = Record<string, string>;
+type MockResponse = {
+  statusCode: number;
+  headers: HeaderMap;
+  body: string;
+  writeHead(statusCode: number, nextHeaders?: HeaderMap): void;
+  end(chunk?: string): void;
+};
+type CallAppResult = {
+  statusCode: number;
+  payload: any;
+};
+type FetchGameOptions = {
+  method?: string;
+  body?: any;
+  headers?: HeaderMap;
+};
+type ServerTestContext = {
+  app: any;
+  tempFile: string;
+  tempGamesFile: string;
+  tempSessionsFile: string;
+  tempDbFile: string;
+};
+type MockSupabaseData = {
+  users?: any[];
+  games?: any[];
+  sessions?: any[];
+  app_state?: any[];
+};
+interface Body {
+  json(): Promise<any>;
+}
+
+const tests: TestCase[] = [];
 const TEST_PASSWORD = "Secret123!";
 const frontendI18nModulePromise = import(pathToFileURL(path.join(projectRoot, "frontend", "public", "i18n.mjs")).href);
 
-function register(name, fn) {
+function register(name: string, fn: TestFn) {
   tests.push({ name, fn });
 }
 
@@ -84,7 +122,7 @@ function uniqueSuffix() {
   return randomHex(4);
 }
 
-function uniqueName(prefix) {
+function uniqueName(prefix: string) {
   return `${prefix}_${uniqueSuffix()}`;
 }
 
@@ -97,23 +135,23 @@ function setupLobby() {
   return { state, first: first.player, second: second.player };
 }
 
-function makeMockResponse() {
-  const headers = {};
+function makeMockResponse(): MockResponse {
+  const headers: HeaderMap = {};
   return {
     statusCode: 200,
     headers,
     body: "",
-    writeHead(statusCode, nextHeaders) {
+    writeHead(statusCode: number, nextHeaders: HeaderMap = {}) {
       this.statusCode = statusCode;
-      Object.assign(headers, nextHeaders || {});
+      Object.assign(headers, nextHeaders);
     },
-    end(chunk) {
+    end(chunk = "") {
       this.body += chunk || "";
     }
   };
 }
 
-async function callApp(app, method, pathname, body, headers = {}) {
+async function callApp(app: any, method: string, pathname: string, body?: any, headers: HeaderMap = {}): Promise<CallAppResult> {
   const req = new (require("events").EventEmitter)();
   req.method = method;
   req.headers = { "content-type": "application/json", ...headers };
@@ -135,18 +173,22 @@ async function callApp(app, method, pathname, body, headers = {}) {
   };
 }
 
-async function fetchGame(app, pathname, options = {}) {
+async function fetchGame(app: any, pathname: string, options: FetchGameOptions = {}): Promise<any> {
   return (await callApp(app, options.method || "GET", pathname, options.body, options.headers)).payload;
 }
 
-function sessionTokenFromSetCookie(rawSetCookie) {
+async function readJson(response: any): Promise<any> {
+  return response.json();
+}
+
+function sessionTokenFromSetCookie(rawSetCookie: string | string[] | null | undefined): string {
   const value = Array.isArray(rawSetCookie) ? rawSetCookie.join("; ") : String(rawSetCookie || "");
   const match = value.match(/netrisk_session=([^;]+)/);
   return match ? decodeURIComponent(match[1]) : "";
 }
 
 
-async function createAuthenticatedSession(baseUrl, username) {
+async function createAuthenticatedSession(baseUrl: string, username: string): Promise<any> {
   const password = TEST_PASSWORD;
   const registerResponse = await fetch(baseUrl + "/api/auth/register", {
     method: "POST",
@@ -161,25 +203,25 @@ async function createAuthenticatedSession(baseUrl, username) {
     body: JSON.stringify({ username, password })
   });
   assert.equal(loginResponse.status, 200);
-  const payload = await loginResponse.json();
+  const payload: any = await loginResponse.json();
   return {
     ...payload,
     sessionToken: sessionTokenFromSetCookie(loginResponse.headers.get("set-cookie"))
   };
 }
 
-function authHeaders(sessionToken) {
+function authHeaders(sessionToken: string): HeaderMap {
   return {
     "Content-Type": "application/json",
     cookie: `netrisk_session=${encodeURIComponent(sessionToken)}`
   };
 }
 
-function readPublicHtml(fileName) {
+function readPublicHtml(fileName: string): string {
   return fs.readFileSync(path.join(projectRoot, "frontend", "public", fileName), "utf8");
 }
 
-function readProjectJson(fileName) {
+function readProjectJson(fileName: string): any {
   return JSON.parse(fs.readFileSync(path.join(projectRoot, fileName), "utf8"));
 }
 
@@ -223,7 +265,7 @@ register("game log merge mantiene la cronologia legacy quando arrivano entry loc
   ]);
 });
 
-function createMockSupabaseResponse(status, payload) {
+function createMockSupabaseResponse(status: number, payload: any) {
   const text = payload == null ? "" : JSON.stringify(payload);
   return {
     ok: status >= 200 && status < 300,
@@ -234,17 +276,17 @@ function createMockSupabaseResponse(status, payload) {
   };
 }
 
-function createMockSupabaseFetch(initialData = {}) {
-  const tables = {
-    users: Array.isArray(initialData.users) ? initialData.users.map((row) => ({ ...row })) : [],
-    games: Array.isArray(initialData.games) ? initialData.games.map((row) => ({ ...row })) : [],
-    sessions: Array.isArray(initialData.sessions) ? initialData.sessions.map((row) => ({ ...row })) : [],
-    app_state: Array.isArray(initialData.app_state) ? initialData.app_state.map((row) => ({ ...row })) : []
+function createMockSupabaseFetch(initialData: MockSupabaseData = {}) {
+  const tables: Record<string, any[]> = {
+    users: Array.isArray(initialData.users) ? initialData.users.map((row: any) => ({ ...row })) : [],
+    games: Array.isArray(initialData.games) ? initialData.games.map((row: any) => ({ ...row })) : [],
+    sessions: Array.isArray(initialData.sessions) ? initialData.sessions.map((row: any) => ({ ...row })) : [],
+    app_state: Array.isArray(initialData.app_state) ? initialData.app_state.map((row: any) => ({ ...row })) : []
   };
 
-  function parseFilter(rawValue) {
+  function parseFilter(rawValue: any) {
     const value = String(rawValue || "");
-    const decodeLiteral = (input) => decodeURIComponent(input).replace(/\\([%_])/g, "$1");
+    const decodeLiteral = (input: string) => decodeURIComponent(input).replace(/\\([%_])/g, "$1");
     if (value.startsWith("eq.")) {
       return { operator: "eq", value: decodeLiteral(value.slice(3)) };
     }
@@ -256,12 +298,12 @@ function createMockSupabaseFetch(initialData = {}) {
     return { operator: "eq", value: decodeLiteral(value) };
   }
 
-  function cloneRows(rows) {
-    return rows.map((row) => ({ ...row }));
+  function cloneRows(rows: any[]) {
+    return rows.map((row: any) => ({ ...row }));
   }
 
-  function applyFilters(rows, searchParams) {
-    return rows.filter((row) => {
+  function applyFilters(rows: any[], searchParams: URLSearchParams) {
+    return rows.filter((row: any) => {
       for (const [key, value] of searchParams.entries()) {
         if (key === "select" || key === "limit" || key === "order" || key === "on_conflict") {
           continue;
@@ -285,7 +327,7 @@ function createMockSupabaseFetch(initialData = {}) {
     });
   }
 
-  function applyOrdering(rows, order) {
+  function applyOrdering(rows: any[], order: any) {
     if (!order) {
       return rows;
     }
@@ -299,7 +341,7 @@ function createMockSupabaseFetch(initialData = {}) {
     });
   }
 
-  function applySelection(rows, select) {
+  function applySelection(rows: any[], select: any) {
     if (!select || select === "*") {
       return cloneRows(rows);
     }
@@ -309,18 +351,18 @@ function createMockSupabaseFetch(initialData = {}) {
       .map((field) => field.trim())
       .filter(Boolean);
 
-    return rows.map((row) => {
-      const projected = {};
-      fields.forEach((field) => {
+    return rows.map((row: any) => {
+      const projected: Record<string, any> = {};
+      fields.forEach((field: string) => {
         projected[field] = row[field];
       });
       return projected;
     });
   }
 
-  async function fetchMock(url, init = {}) {
+  async function fetchMock(url: string, init: any = {}) {
     const requestUrl = new URL(url);
-    const tableName = requestUrl.pathname.split("/").pop();
+    const tableName = requestUrl.pathname.split("/").pop() || "";
     const table = tables[tableName];
     if (!table) {
       return createMockSupabaseResponse(404, { error: "unknown_table" });
@@ -343,12 +385,12 @@ function createMockSupabaseFetch(initialData = {}) {
       const payload = JSON.parse(init.body || "[]");
       const rows = Array.isArray(payload) ? payload : [payload];
       const onConflict = searchParams.get("on_conflict");
-      const inserted = [];
+      const inserted: any[] = [];
 
-      rows.forEach((row) => {
+      rows.forEach((row: any) => {
         const nextRow = { ...row };
         if (onConflict) {
-          const existingIndex = table.findIndex((candidate) => String(candidate[onConflict] ?? "") === String(nextRow[onConflict] ?? ""));
+          const existingIndex = table.findIndex((candidate: any) => String(candidate[onConflict] ?? "") === String(nextRow[onConflict] ?? ""));
           if (existingIndex >= 0) {
             table[existingIndex] = { ...table[existingIndex], ...nextRow };
             inserted.push({ ...table[existingIndex] });
@@ -365,8 +407,8 @@ function createMockSupabaseFetch(initialData = {}) {
 
     if (method === "PATCH") {
       const patch = JSON.parse(init.body || "{}");
-      const updated = [];
-      table.forEach((row, index) => {
+      const updated: any[] = [];
+      table.forEach((row: any, index: number) => {
         const matches = applyFilters([row], searchParams).length === 1;
         if (!matches) {
           return;
@@ -380,8 +422,8 @@ function createMockSupabaseFetch(initialData = {}) {
     }
 
     if (method === "DELETE") {
-      const remaining = [];
-      table.forEach((row) => {
+      const remaining: any[] = [];
+      table.forEach((row: any) => {
         const matches = applyFilters([row], searchParams).length === 1;
         if (!matches) {
           remaining.push(row);
@@ -400,8 +442,8 @@ function createMockSupabaseFetch(initialData = {}) {
   };
 }
 
-async function withMockSupabase(run, initialData = {}) {
-  const originalFetch = global.fetch;
+async function withMockSupabase(run: (mock: any) => Promise<void>, initialData: MockSupabaseData = {}) {
+  const originalFetch: any = global.fetch;
   const envKeys = [
     "DATASTORE_DRIVER",
     "SUPABASE_URL",
@@ -421,7 +463,7 @@ async function withMockSupabase(run, initialData = {}) {
   process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY = "publishable-test-key";
   process.env.SUPABASE_DB_SCHEMA = "public";
   delete process.env.VERCEL;
-  global.fetch = mock.fetch;
+  global.fetch = mock.fetch as any;
 
   try {
     return await run(mock);
@@ -499,7 +541,7 @@ register("auth repository supabase normalizza utenti, preferenze e sessioni", as
 });
 
 register("auth repository locale delega aggiornamenti profilo, tema e sessioni", async () => {
-  const calls = [];
+  const calls: any[] = [];
   const localRepository = createAuthRepository({
     driver: "local",
     datastore: {
@@ -507,38 +549,38 @@ register("auth repository locale delega aggiornamenti profilo, tema e sessioni",
         calls.push("listUsers");
         return [{ id: "u1" }];
       },
-      async findUserByUsername(username) {
+      async findUserByUsername(username: any) {
         calls.push(["findUserByUsername", username]);
         return { id: "u1", username };
       },
-      async findUserById(userId) {
+      async findUserById(userId: any) {
         calls.push(["findUserById", userId]);
         return { id: userId };
       },
-      async createUser(user) {
+      async createUser(user: any) {
         calls.push(["createUser", user.id]);
         return user;
       },
-      async updateUserCredentials(userId, credentials) {
+      async updateUserCredentials(userId: any, credentials: any) {
         calls.push(["updateUserCredentials", userId, credentials.password.hash]);
         return { id: userId, credentials };
       },
-      async updateUserProfile(userId, profile) {
+      async updateUserProfile(userId: any, profile: any) {
         calls.push(["updateUserProfile", userId, profile.displayName]);
         return { id: userId, profile };
       },
-      async updateUserThemePreference(userId, theme) {
+      async updateUserThemePreference(userId: any, theme: any) {
         calls.push(["updateUserThemePreference", userId, theme]);
         return { id: userId, profile: { preferences: { theme } } };
       },
-      createSession(token, userId, createdAt) {
+      createSession(token: any, userId: any, createdAt: any) {
         calls.push(["createSession", token, userId, createdAt]);
       },
-      findSession(token) {
+      findSession(token: any) {
         calls.push(["findSession", token]);
         return { token, userId: "u1", createdAt: 1234 };
       },
-      deleteSession(token) {
+      deleteSession(token: any) {
         calls.push(["deleteSession", token]);
       },
       close() {
@@ -563,8 +605,8 @@ register("auth repository locale delega aggiornamenti profilo, tema e sessioni",
   await localRepository.deleteSession("token-local");
   localRepository.close();
 
-  assert.equal(calls.some((entry) => Array.isArray(entry) && entry[0] === "updateUserProfile"), true);
-  assert.equal(calls.some((entry) => Array.isArray(entry) && entry[0] === "updateUserThemePreference"), true);
+  assert.equal(calls.some((entry: any) => Array.isArray(entry) && entry[0] === "updateUserProfile"), true);
+  assert.equal(calls.some((entry: any) => Array.isArray(entry) && entry[0] === "updateUserThemePreference"), true);
   assert.equal(calls.includes("close"), true);
 });
 
@@ -578,11 +620,11 @@ register("json file store usa backup e valida il payload letto", () => {
   fs.writeFileSync(filePath, "{ invalid json", "utf8");
   fs.writeFileSync(backupPath, JSON.stringify({ ok: true, source: "backup" }), "utf8");
 
-  const recovered = readJsonFile(filePath, { ok: false }, (value) => value && value.ok === true);
+  const recovered = readJsonFile(filePath, { ok: false }, (value: any) => value && value.ok === true);
   assert.deepEqual(recovered, { ok: true, source: "backup" });
 
   fs.writeFileSync(filePath, JSON.stringify({ ok: false }), "utf8");
-  const fallback = readJsonFile(filePath, { ok: "fallback" }, (value) => value && value.ok === true);
+  const fallback = readJsonFile(filePath, { ok: "fallback" }, (value: any) => value && value.ok === true);
   assert.deepEqual(fallback, { ok: "fallback" });
 
   fs.rmSync(tempDir, { recursive: true, force: true });
@@ -698,7 +740,7 @@ register("player profile store riassume vittorie, sconfitte e partite in corso",
   assert.equal(profile.losses, 1);
   assert.equal(profile.gamesInProgress, 2);
   assert.equal(profile.winRate, 50);
-  assert.deepEqual(profile.participatingGames.map((game) => game.id), ["active-2", "active-1"]);
+  assert.deepEqual(profile.participatingGames.map((game: any) => game.id), ["active-2", "active-1"]);
   assert.equal(profile.participatingGames[0].myLobby.focusLabel, "Tocca a te");
   assert.equal(profile.participatingGames[0].myLobby.statusLabel, "Operativo");
   assert.equal(profile.participatingGames[0].myLobby.cardCount, 2);
@@ -778,7 +820,7 @@ register("account routes rispondono con sessione, profilo e validazione tema", a
     res: sessionRes,
     requireAuth: async () => authContext,
     auth: {
-      publicUser(user) {
+      publicUser(user: any) {
         return {
           id: user.id,
           username: user.username,
@@ -796,11 +838,11 @@ register("account routes rispondono con sessione, profilo e validazione tema", a
     },
     sendJson,
     sendLocalizedError,
-    extractUserPreferences(user) {
+      extractUserPreferences(user: any) {
       return { theme: user?.preferences?.theme || "command" };
     },
     supportedSiteThemes: new Set(["command", "midnight", "ember"]),
-    resolveStoredTheme(theme) {
+      resolveStoredTheme(theme: any) {
       return theme;
     }
   });
@@ -848,11 +890,11 @@ register("account routes rispondono con sessione, profilo e validazione tema", a
     },
     sendJson,
     sendLocalizedError,
-    extractUserPreferences(user) {
+      extractUserPreferences(user: any) {
       return { theme: user?.preferences?.theme || "command" };
     },
     supportedSiteThemes: new Set(["command", "midnight", "ember"]),
-    resolveStoredTheme(theme) {
+      resolveStoredTheme(theme: any) {
       return theme;
     }
   });
@@ -885,7 +927,7 @@ register("account routes rispondono con sessione, profilo e validazione tema", a
       return { theme: "command" };
     },
     supportedSiteThemes: new Set(["command", "midnight", "ember"]),
-    resolveStoredTheme(theme) {
+      resolveStoredTheme(theme: any) {
       return theme;
     }
   }, { theme: "ultraviolet" });
@@ -904,8 +946,8 @@ register("basic game action route gestisce reinforce e persiste lo snapshot per-
     gameName: "Basic Route"
   };
   const user = { id: "user-1", username: "Alice" };
-  const persisted = [];
-  const broadcasts = [];
+  const persisted: any[] = [];
+  const broadcasts: any[] = [];
 
   const handled = await handleBasicGameActionRoute(
     "reinforce",
@@ -915,7 +957,7 @@ register("basic game action route gestisce reinforce e persiste lo snapshot per-
     "p1",
     2,
     user,
-    (state, playerId, territoryId, amount) => {
+    (state: any, playerId: any, territoryId: any, amount: any) => {
       assert.equal(playerId, "p1");
       assert.equal(territoryId, "alpha");
       assert.equal(amount, 2);
@@ -928,14 +970,14 @@ register("basic game action route gestisce reinforce e persiste lo snapshot per-
     () => {
       throw new Error("applyFortify should not be called");
     },
-    async (context, expectedVersion) => {
+    async (context: any, expectedVersion: any) => {
       persisted.push({ context, expectedVersion });
       context.version = 3;
     },
-    (context) => {
+    (context: any) => {
       broadcasts.push(context.version);
     },
-    (state, gameId, version, gameName, currentUser) => ({
+    (state: any, gameId: any, version: any, gameName: any, currentUser: any) => ({
       gameId,
       version,
       gameName,
@@ -943,7 +985,7 @@ register("basic game action route gestisce reinforce e persiste lo snapshot per-
       playerId: currentUser.id
     }),
     () => false,
-    (territoryId) => territoryId === "alpha",
+    (territoryId: any) => territoryId === "alpha",
     sendJson,
     sendLocalizedError
   );
@@ -999,7 +1041,7 @@ register("basic game action route valida i territori nel fortify", async () => {
       throw new Error("snapshotForUser should not be called");
     },
     () => false,
-    (territoryId) => territoryId === "alpha" || territoryId === "beta",
+    (territoryId: any) => territoryId === "alpha" || territoryId === "beta",
     sendJson,
     sendLocalizedError
   );
@@ -1022,8 +1064,8 @@ register("attack game action route gestisce un attacco con random consumato dall
     version: 5,
     gameName: "Attack Route"
   };
-  const persisted = [];
-  const broadcasts = [];
+  const persisted: any[] = [];
+  const broadcasts: any[] = [];
   let consumeCount = 0;
 
   const handled = await handleAttackGameActionRoute(
@@ -1034,7 +1076,7 @@ register("attack game action route gestisce un attacco con random consumato dall
     "p1",
     5,
     { id: "user-1" },
-    (state, playerId, fromId, toId, random, attackDice) => {
+    (state: any, playerId: any, fromId: any, toId: any, random: any, attackDice: any) => {
       assert.equal(playerId, "p1");
       assert.equal(fromId, "alpha");
       assert.equal(toId, "beta");
@@ -1051,14 +1093,14 @@ register("attack game action route gestisce un attacco con random consumato dall
       consumeCount += 1;
       return () => 0.25;
     },
-    async (context, expectedVersion) => {
+    async (context: any, expectedVersion: any) => {
       persisted.push(expectedVersion);
       context.version = 6;
     },
-    (context) => {
+    (context: any) => {
       broadcasts.push(context.version);
     },
-    (state, gameId, version, gameName, user) => ({
+    (state: any, gameId: any, version: any, gameName: any, user: any) => ({
       gameId,
       version,
       gameName,
@@ -1066,7 +1108,7 @@ register("attack game action route gestisce un attacco con random consumato dall
       playerId: user.id
     }),
     () => false,
-    (territoryId) => territoryId === "alpha" || territoryId === "beta",
+    (territoryId: any) => territoryId === "alpha" || territoryId === "beta",
     sendJson,
     sendLocalizedError
   );
@@ -1120,7 +1162,7 @@ register("attack game action route valida i territori prima del banzai", async (
       throw new Error("snapshotForUser should not be called");
     },
     () => false,
-    (territoryId) => territoryId === "alpha" || territoryId === "beta",
+    (territoryId: any) => territoryId === "alpha" || territoryId === "beta",
     sendJson,
     sendLocalizedError
   );
@@ -1143,8 +1185,8 @@ register("turn game action route gestisce endTurn con persistenza AI-aware", asy
     version: 7,
     gameName: "Turn Route"
   };
-  const persisted = [];
-  const broadcasts = [];
+  const persisted: any[] = [];
+  const broadcasts: any[] = [];
 
   const handled = await handleTurnGameActionRoute(
     "endTurn",
@@ -1153,7 +1195,7 @@ register("turn game action route gestisce endTurn con persistenza AI-aware", asy
     "p1",
     7,
     { id: "user-1" },
-    (state, playerId) => {
+    (state: any, playerId: any) => {
       assert.equal(playerId, "p1");
       state.turnPhase = "reinforcement";
       return { ok: true };
@@ -1161,14 +1203,14 @@ register("turn game action route gestisce endTurn con persistenza AI-aware", asy
     () => {
       throw new Error("surrenderPlayer should not be called");
     },
-    async (context, expectedVersion) => {
+    async (context: any, expectedVersion: any) => {
       persisted.push({ context, expectedVersion });
       context.version = 8;
     },
-    (context) => {
+    (context: any) => {
       broadcasts.push(context.version);
     },
-    (state, gameId, version, gameName, user) => ({
+    (state: any, gameId: any, version: any, gameName: any, user: any) => ({
       gameId,
       version,
       gameName,
@@ -1223,7 +1265,7 @@ register("turn game action route gestisce surrender con version conflict", async
     () => {
       throw new Error("snapshotForUser should not be called");
     },
-    (error) => {
+    (error: any) => {
       sendJson(res, 409, { ok: false, code: error.code });
       return true;
     },
@@ -1241,8 +1283,8 @@ register("turn game action route gestisce surrender con version conflict", async
 
 register("game management route crea una partita e collega il creatore", async () => {
   const res = makeMockResponse();
-  const broadcasts = [];
-  let replacedState = null;
+  const broadcasts: any[] = [];
+  let replacedState: any = null;
 
   await handleCreateGameRoute(
     { method: "POST", headers: {} },
@@ -1255,21 +1297,21 @@ register("game management route crea una partita e collega il creatore", async (
       gameInput: { name: "Nuova partita" },
       config: { mapId: "classic-mini" }
     }),
-    (state, username, options) => {
+    (state: any, username: any, options: any) => {
       assert.equal(username, "Alice");
       assert.equal(options.linkedUserId, "user-1");
       state.players.push({ id: "player-1", name: username });
       return { ok: true, player: { id: "player-1" } };
     },
-    async (state, options) => ({
+    async (state: any, options: any) => ({
       game: { id: "game-1", name: options.name, version: 1 },
       state
     }),
     async () => [{ id: "game-1", name: "Nuova partita" }],
-    (state) => {
+    (state: any) => {
       replacedState = state;
     },
-    (context) => {
+    (context: any) => {
       broadcasts.push(context.gameId);
     },
     () => ({ snapshot: true }),
@@ -1300,18 +1342,18 @@ register("game management route apre una partita e risolve il player autenticato
     { gameId: "game-1" },
     async () => ({ user: { id: "user-1", username: "Alice" } }),
     () => undefined,
-    async (gameId) => ({
+    async (gameId: any) => ({
       game: { id: gameId, name: "Nuova partita", version: 3 },
       state: { players: [] }
     }),
-    async (gameId) => ({
+    async (gameId: any) => ({
       game: { id: gameId, name: "Nuova partita", version: 3 },
       state: { players: [{ id: "player-1", linkedUserId: "user-1" }] }
     }),
     async () => [{ id: "game-1", name: "Nuova partita" }],
     async () => [],
-    (state, user) => state.players.find((player) => player.linkedUserId === user.id) || null,
-    (state, gameId, version, gameName) => ({
+    (state: any, user: any) => state.players.find((player: any) => player.linkedUserId === user.id) || null,
+    (state: any, gameId: any, version: any, gameName: any) => ({
       gameId,
       version,
       gameName,
@@ -1363,7 +1405,7 @@ register("game action route segnala il version conflict prima di eseguire mutazi
     broadcastGame: () => {
       throw new Error("broadcastGame should not be called");
     },
-    snapshotForUser: (state, gameId, version, gameName, user) => ({
+    snapshotForUser: (state: any, gameId: any, version: any, gameName: any, user: any) => ({
       gameId,
       version,
       gameName,
@@ -1437,7 +1479,7 @@ register("game action route rifiuta player non associato all'utente", async () =
   });
 });
 
-async function createAuthenticatedAppSession(app, username) {
+async function createAuthenticatedAppSession(app: any, username: string): Promise<any> {
   const registered = await app.auth.registerPasswordUser(username, TEST_PASSWORD);
   assert.equal(registered.ok, true);
   const login = await app.auth.loginWithPassword(username, TEST_PASSWORD);
@@ -1445,14 +1487,14 @@ async function createAuthenticatedAppSession(app, username) {
   return login;
 }
 
-function setStoredUserRole(datastore, username, role) {
+function setStoredUserRole(datastore: any, username: string, role: string) {
   datastore.updateUserRoleByUsername(username, role);
   const target = datastore.findUserByUsername(username);
   assert.equal(Boolean(target), true);
   assert.equal(target.role, role);
 }
 
-function cleanupSqliteFiles(filePath) {
+function cleanupSqliteFiles(filePath: string) {
   [filePath, `${filePath}-wal`, `${filePath}-shm`].forEach((target) => {
     if (fs.existsSync(target)) {
       fs.unlinkSync(target);
@@ -1460,7 +1502,7 @@ function cleanupSqliteFiles(filePath) {
   });
 }
 
-async function withServer(run) {
+async function withServer(run: (baseUrl: string, context: ServerTestContext) => Promise<void>): Promise<void> {
   const unique = `${Date.now()}-${uniqueSuffix()}`;
   const tempFile = path.join(__dirname, `tmp-users-${Date.now()}-${uniqueSuffix()}.json`);
   const tempGamesFile = path.join(__dirname, `tmp-games-${Date.now()}-${uniqueSuffix()}.json`);
@@ -1469,16 +1511,16 @@ async function withServer(run) {
   const app = createApp({ dataFile: tempFile, gamesFile: tempGamesFile, sessionsFile: tempSessionsFile, dbFile: tempDbFile });
   const listener = app.server.listen(0);
 
-  await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     listener.once("listening", resolve);
     listener.once("error", reject);
   });
 
   try {
-    const address = listener.address();
+    const address = listener.address() as { port: number };
     return await run(`http://127.0.0.1:${address.port}`, { app, tempFile, tempGamesFile, tempSessionsFile, tempDbFile });
   } finally {
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       if (!listener.listening) {
         resolve();
         return;
@@ -1946,21 +1988,21 @@ register("resolveAttack usa i dadi richiesti dall'attaccante entro il limite dis
 
 register("listSupportedMaps espone riepiloghi con bonus continente per il setup", () => {
   const maps = listSupportedMaps();
-  const classicMini = maps.find((map) => map.id === classicMiniMap.id);
-  const middleEarth = maps.find((map) => map.id === middleEarthMap.id);
-  const worldClassic = maps.find((map) => map.id === worldClassicMap.id);
+  const classicMini = maps.find((map: any) => map.id === classicMiniMap.id);
+  const middleEarth = maps.find((map: any) => map.id === middleEarthMap.id);
+  const worldClassic = maps.find((map: any) => map.id === worldClassicMap.id);
 
   assert.equal(classicMini.territoryCount, classicMiniMap.territories.length);
   assert.equal(classicMini.continentCount, classicMiniMap.continents.length);
-  assert.deepEqual(classicMini.continentBonuses.map((continent) => continent.bonus), [1, 2, 1, 1]);
+  assert.deepEqual(classicMini.continentBonuses.map((continent: any) => continent.bonus), [1, 2, 1, 1]);
 
   assert.equal(middleEarth.territoryCount, middleEarthMap.territories.length);
   assert.equal(middleEarth.continentCount, middleEarthMap.continents.length);
-  assert.deepEqual(middleEarth.continentBonuses.map((continent) => continent.bonus), [2, 3, 4, 3, 2, 2, 3, 2]);
+  assert.deepEqual(middleEarth.continentBonuses.map((continent: any) => continent.bonus), [2, 3, 4, 3, 2, 2, 3, 2]);
 
   assert.equal(worldClassic.territoryCount, worldClassicMap.territories.length);
   assert.equal(worldClassic.continentCount, worldClassicMap.continents.length);
-  assert.deepEqual(worldClassic.continentBonuses.map((continent) => continent.bonus), [5, 2, 5, 3, 7, 2]);
+  assert.deepEqual(worldClassic.continentBonuses.map((continent: any) => continent.bonus), [5, 2, 5, 3, 7, 2]);
 });
 
 register("resolveAttack rifiuta un numero di dadi oltre il massimo disponibile", () => {
@@ -2251,8 +2293,8 @@ register("combat resolution applica i limiti dadi dal rule set centralizzato", (
     }
   };
   const graph = {
-    hasTerritory(id) { return id === "a" || id === "b"; },
-    areAdjacent(fromId, toId) {
+    hasTerritory(id: any) { return id === "a" || id === "b"; },
+    areAdjacent(fromId: any, toId: any) {
       return (fromId === "a" && toId === "b") || (fromId === "b" && toId === "a");
     }
   };
@@ -2279,7 +2321,7 @@ register("combat dice helpers separano tiro e confronto", () => {
   const compared = compareCombatDice([2, 6, 4], [4, 1], { defenderWinsTies: true });
   assert.deepEqual(compared.attackerRolls, [6, 4, 2]);
   assert.deepEqual(compared.defenderRolls, [4, 1]);
-  assert.deepEqual(compared.comparisons.map((entry) => entry.winner), ["attacker", "attacker"]);
+  assert.deepEqual(compared.comparisons.map((entry: any) => entry.winner), ["attacker", "attacker"]);
 });
 
 register("standard card rules rifiutano set invalidi e centralizzano la progressione bonus", () => {
@@ -2319,7 +2361,7 @@ register("tradeCardSet converte un set valido in rinforzi e incrementa la progre
   assert.equal(state.reinforcementPool, 7);
   assert.equal(state.tradeCount, 1);
   assert.deepEqual(state.hands[first.id], []);
-  assert.deepEqual(state.discardPile.map((card) => card.id), ["t1", "t2", "t3"]);
+  assert.deepEqual(state.discardPile.map((card: any) => card.id), ["t1", "t2", "t3"]);
 });
 
 register("tradeCardSet rifiuta set invalidi o trade fuori fase senza mutare lo stato", () => {
@@ -2501,12 +2543,12 @@ register("awardTurnCardIfEligible continua ad assegnare carte su molti turni di 
   }
 
   assert.equal(state.hands[first.id].length, 4);
-  assert.deepEqual(state.hands[first.id].map((card) => card.id).sort(), ["deck-1", "discard-1", "discard-2", "discard-3"]);
+  assert.deepEqual(state.hands[first.id].map((card: any) => card.id).sort(), ["deck-1", "discard-1", "discard-2", "discard-3"]);
 });
 
 register("getMapTerritories legge la mappa runtime con fallback legacy", () => {
   const defaultState = createInitialState();
-  assert.deepEqual(getMapTerritories(defaultState).map((territory) => territory.id), classicMiniMap.territories.map((territory) => territory.id));
+  assert.deepEqual(getMapTerritories(defaultState).map((territory: any) => territory.id), classicMiniMap.territories.map((territory: any) => territory.id));
 
   const customState = createInitialState();
   customState.mapTerritories = [
@@ -2519,16 +2561,16 @@ register("createInitialState inizializza deck, discard pile, hands e progression
   const state = createInitialState();
   assert.equal(state.mapId, "classic-mini");
   assert.equal(state.mapName, "Classic Mini");
-  assert.deepEqual(state.mapTerritories.map((territory) => territory.id), classicMiniMap.territories.map((territory) => territory.id));
-  assert.deepEqual(state.continents.map((continent) => continent.id), classicMiniMap.continents.map((continent) => continent.id));
+  assert.deepEqual(state.mapTerritories.map((territory: any) => territory.id), classicMiniMap.territories.map((territory: any) => territory.id));
+  assert.deepEqual(state.continents.map((continent: any) => continent.id), classicMiniMap.continents.map((continent: any) => continent.id));
   assert.equal(state.cardRuleSetId, "standard");
   assert.equal(Array.isArray(state.deck), true);
   assert.equal(state.deck.length, 11);
   assert.deepEqual(state.discardPile, []);
   assert.deepEqual(state.hands, {});
   assert.equal(state.tradeCount, 0);
-  assert.equal(state.deck.filter((card) => card.type === CardType.WILD).length, 2);
-  assert.equal(state.deck.filter((card) => card.territoryId).length, 9);
+  assert.equal(state.deck.filter((card: any) => card.type === CardType.WILD).length, 2);
+  assert.equal(state.deck.filter((card: any) => card.territoryId).length, 9);
 
   const rebuiltDeck = createStandardDeck(Object.keys(state.territories));
   assert.equal(rebuiltDeck.length, state.deck.length);
@@ -2551,8 +2593,8 @@ register("publicState espone i metadati carte senza rivelare deck e discard pile
   assert.equal(snapshot.cardState.discardCount, 1);
   assert.equal(snapshot.cardState.maxHandBeforeForcedTrade, STANDARD_MAX_HAND_BEFORE_FORCED_TRADE);
   assert.equal(snapshot.cardState.currentPlayerMustTrade, false);
-  assert.equal(snapshot.players.find((player) => player.id === first.id).cardCount, 1);
-  assert.equal(snapshot.players.find((player) => player.id === second.id).cardCount, 2);
+  assert.equal(snapshot.players.find((player: any) => player.id === first.id).cardCount, 1);
+  assert.equal(snapshot.players.find((player: any) => player.id === second.id).cardCount, 2);
   assert.equal(Object.prototype.hasOwnProperty.call(snapshot.cardState, "deck"), false);
   assert.equal(Object.prototype.hasOwnProperty.call(snapshot.cardState, "discardPile"), false);
 });
@@ -2626,8 +2668,8 @@ register("createInitialState supporta Middle-earth con coordinate e immagine", (
   assert.equal(state.mapTerritories.length, middleEarthMap.territories.length);
   assert.equal(snapshot.mapVisual.imageUrl, "/assets/maps/middle-earth.jpg");
   assert.equal(snapshot.mapVisual.aspectRatio.width, 463);
-  assert.equal(snapshot.map.find((territory) => territory.id === "gondor").x, middleEarthMap.positions.gondor.x);
-  assert.equal(snapshot.map.find((territory) => territory.id === "the_shire").name, "The Shire");
+  assert.equal(snapshot.map.find((territory: any) => territory.id === "gondor").x, middleEarthMap.positions.gondor.x);
+  assert.equal(snapshot.map.find((territory: any) => territory.id === "the_shire").name, "The Shire");
 });
 
 register("createInitialState supporta World Classic con i territori standard Risk", () => {
@@ -2654,8 +2696,8 @@ register("createInitialState supporta World Classic con i territori standard Ris
   assert.equal(worldClassicMap.positions.japan.x, 0.93);
   assert.equal(worldClassicMap.positions.western_australia.x, 0.85);
   assert.equal(worldClassicMap.positions.western_australia.y, 0.87);
-  assert.equal(snapshot.map.find((territory) => territory.id === "ukraine").name, "Ukraine");
-  assert.equal(snapshot.map.find((territory) => territory.id === "eastern_australia").y, worldClassicMap.positions.eastern_australia.y);
+  assert.equal(snapshot.map.find((territory: any) => territory.id === "ukraine").name, "Ukraine");
+  assert.equal(snapshot.map.find((territory: any) => territory.id === "eastern_australia").y, worldClassicMap.positions.eastern_australia.y);
 });
 
 register("createConfiguredInitialState usa la mappa shared selezionata", () => {
@@ -2668,7 +2710,7 @@ register("createConfiguredInitialState usa la mappa shared selezionata", () => {
   assert.equal(config.selectedMap.id, "classic-mini");
   assert.equal(state.mapId, "classic-mini");
   assert.equal(state.mapName, "Classic Mini");
-  assert.deepEqual(state.mapTerritories.map((territory) => territory.id), classicMiniMap.territories.map((territory) => territory.id));
+  assert.deepEqual(state.mapTerritories.map((territory: any) => territory.id), classicMiniMap.territories.map((territory: any) => territory.id));
   assert.equal(state.gameConfig.mapId, "classic-mini");
 });
 
@@ -2753,7 +2795,7 @@ register("API games richiede autenticazione per creare una partita", async () =>
       body: JSON.stringify({ name: "Anonima" })
     });
     assert.equal(response.status, 401);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(payload.code, "AUTH_REQUIRED");
   });
 });
@@ -2826,7 +2868,7 @@ register("API state consente lettura spettatore sulla lobby protetta senza auto-
       headers: authHeaders(outsider.sessionToken)
     });
     assert.equal(outsiderState.status, 200);
-    const outsiderPayload = await outsiderState.json();
+    const outsiderPayload: any = await readJson(outsiderState);
     assert.equal(outsiderPayload.gameName, "Stato protetto");
     assert.equal(outsiderPayload.playerId, null);
     assert.equal(Array.isArray(outsiderPayload.playerHand), false);
@@ -2847,7 +2889,7 @@ register("API games open richiede autenticazione", async () => {
       body: JSON.stringify({ name: "Apri protetta" })
     });
     assert.equal(created.status, 201);
-    const createdPayload = await created.json();
+    const createdPayload: any = await readJson(created);
 
     const opened = await fetch(baseUrl + "/api/games/open", {
       method: "POST",
@@ -2855,7 +2897,7 @@ register("API games open richiede autenticazione", async () => {
       body: JSON.stringify({ gameId: createdPayload.game.id })
     });
     assert.equal(opened.status, 401);
-    const payload = await opened.json();
+    const payload: any = await readJson(opened);
     assert.equal(payload.code, "AUTH_REQUIRED");
   });
 });
@@ -2867,7 +2909,7 @@ register("API state restituisce GAME_NOT_FOUND per un gameId inesistente senza c
       headers: authHeaders(owner.sessionToken)
     });
     assert.equal(response.status, 404);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(payload.code, "GAME_NOT_FOUND");
 
     const health = await fetch(baseUrl + "/api/health");
@@ -2884,7 +2926,7 @@ register("API games open consente al creatore di riaprire la propria partita", a
       body: JSON.stringify({ name: "Apri membro" })
     });
     assert.equal(created.status, 201);
-    const createdPayload = await created.json();
+    const createdPayload: any = await readJson(created);
 
     const opened = await fetch(baseUrl + "/api/games/open", {
       method: "POST",
@@ -2906,7 +2948,7 @@ register("API state e mutazioni restano isolate tra partite diverse tramite game
       body: JSON.stringify({ name: "Isolation A" })
     });
     assert.equal(createdA.status, 201);
-    const payloadA = await createdA.json();
+    const payloadA: any = await readJson(createdA);
 
     const createdB = await fetch(baseUrl + "/api/games", {
       method: "POST",
@@ -2914,7 +2956,7 @@ register("API state e mutazioni restano isolate tra partite diverse tramite game
       body: JSON.stringify({ name: "Isolation B" })
     });
     assert.equal(createdB.status, 201);
-    const payloadB = await createdB.json();
+    const payloadB: any = await readJson(createdB);
 
     const aiJoinA = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
@@ -2934,7 +2976,7 @@ register("API state e mutazioni restano isolate tra partite diverse tramite game
       headers: authHeaders(ownerA.sessionToken)
     });
     assert.equal(stateA.status, 200);
-    const stateAPayload = await stateA.json();
+    const stateAPayload: any = await readJson(stateA);
     assert.equal(stateAPayload.gameId, payloadA.game.id);
     assert.equal(stateAPayload.players.length, 2);
 
@@ -2942,7 +2984,7 @@ register("API state e mutazioni restano isolate tra partite diverse tramite game
       headers: authHeaders(ownerB.sessionToken)
     });
     assert.equal(stateB.status, 200);
-    const stateBPayload = await stateB.json();
+    const stateBPayload: any = await readJson(stateB);
     assert.equal(stateBPayload.gameId, payloadB.game.id);
     assert.equal(stateBPayload.players.length, 1);
   });
@@ -2965,14 +3007,14 @@ register("API start consente solo al creatore di avviare la partita", async () =
       headers: authHeaders(owner.sessionToken),
       body: JSON.stringify({ sessionToken: owner.sessionToken })
     });
-    const joinOwnerPayload = await joinOwner.json();
+    const joinOwnerPayload: any = await readJson(joinOwner);
 
     const joinGuest = await fetch(baseUrl + "/api/join", {
       method: "POST",
       headers: authHeaders(guest.sessionToken),
       body: JSON.stringify({ sessionToken: guest.sessionToken })
     });
-    const joinGuestPayload = await joinGuest.json();
+    const joinGuestPayload: any = await readJson(joinGuest);
 
     const forbiddenStart = await fetch(baseUrl + "/api/start", {
       method: "POST",
@@ -2980,7 +3022,7 @@ register("API start consente solo al creatore di avviare la partita", async () =
       body: JSON.stringify({ sessionToken: guest.sessionToken, playerId: joinGuestPayload.playerId })
     });
     assert.equal(forbiddenStart.status, 403);
-    const forbiddenPayload = await forbiddenStart.json();
+    const forbiddenPayload: any = await readJson(forbiddenStart);
     assert.equal(forbiddenPayload.code, "HOST_ONLY");
 
     const ownerStart = await fetch(baseUrl + "/api/start", {
@@ -2995,13 +3037,13 @@ register("API game options espone setup base per nuova partita", async () => {
   await withServer(async (baseUrl) => {
     const response = await fetch(baseUrl + "/api/game-options");
     assert.equal(response.status, 200);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.deepEqual(payload.maps, listSupportedMaps());
     assert.equal(Array.isArray(payload.ruleSets), true);
-    assert.equal(payload.ruleSets.some((ruleSet) => ruleSet.id === DEFENSE_THREE_NEW_GAME_RULE_SET_ID), true);
+    assert.equal(payload.ruleSets.some((ruleSet: any) => ruleSet.id === DEFENSE_THREE_NEW_GAME_RULE_SET_ID), true);
     assert.equal(Array.isArray(payload.diceRuleSets), true);
     assert.equal(payload.diceRuleSets[0].id, "standard");
-    assert.equal(payload.diceRuleSets.some((ruleSet) => ruleSet.id === DEFENSE_THREE_DICE_RULE_SET_ID), true);
+    assert.equal(payload.diceRuleSets.some((ruleSet: any) => ruleSet.id === DEFENSE_THREE_DICE_RULE_SET_ID), true);
     assert.equal(payload.playerRange.min, 2);
     assert.equal(payload.playerRange.max, 4);
   });
@@ -3027,7 +3069,7 @@ register("API games crea una sessione da configurazione strutturata", async () =
       })
     });
     assert.equal(response.status, 201);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(payload.game.name, "Scenario AI");
     assert.equal(payload.config.diceRuleSetId, "standard");
     assert.equal(payload.state.gameConfig.diceRuleSetId, "standard");
@@ -3037,8 +3079,8 @@ register("API games crea una sessione da configurazione strutturata", async () =
     assert.equal(Boolean(payload.config.players[1].name), true);
     assert.equal(payload.state.players.length, 3);
     assert.equal(payload.playerId != null, true);
-    assert.equal(payload.state.players.some((player) => player.id === payload.playerId && player.name === session.user.username && player.isAi === false), true);
-    assert.equal(payload.state.players.filter((player) => player.isAi).length, 2);
+    assert.equal(payload.state.players.some((player: any) => player.id === payload.playerId && player.name === session.user.username && player.isAi === false), true);
+    assert.equal(payload.state.players.filter((player: any) => player.isAi).length, 2);
   });
 });
 
@@ -3066,8 +3108,8 @@ register("API games summary espone metadati configurazione", async () => {
 
     const listResponse = await fetch(baseUrl + "/api/games");
     assert.equal(listResponse.status, 200);
-    const listPayload = await listResponse.json();
-    const game = listPayload.games.find((entry) => entry.name === "Scenario Meta");
+    const listPayload: any = await readJson(listResponse);
+    const game = listPayload.games.find((entry: any) => entry.name === "Scenario Meta");
 
     assert.equal(game.mapId, "classic-mini");
     assert.equal(game.mapName, "Classic Mini");
@@ -3092,7 +3134,7 @@ register("API games rifiuta configurazioni incomplete", async () => {
       })
     });
     assert.equal(response.status, 400);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(payload.error, "Configura tutti gli slot giocatore prima di creare la partita.");
   });
 });
@@ -3102,7 +3144,7 @@ register("API games create + list + open persiste e riapre una sessione", async 
     const session = await createAuthenticatedSession(baseUrl, uniqueName("list"));
     const initialList = await fetch(baseUrl + "/api/games");
     assert.equal(initialList.status, 200);
-    const initialPayload = await initialList.json();
+    const initialPayload: any = await readJson(initialList);
     assert.equal(Array.isArray(initialPayload.games), true);
 
     const created = await fetch(baseUrl + "/api/games", {
@@ -3111,15 +3153,15 @@ register("API games create + list + open persiste e riapre una sessione", async 
       body: JSON.stringify({ name: "Campagna test" })
     });
     assert.equal(created.status, 201);
-    const createdPayload = await created.json();
+    const createdPayload: any = await readJson(created);
     assert.equal(createdPayload.game.name, "Campagna test");
     assert.equal(Boolean(createdPayload.game.id), true);
     assert.equal(createdPayload.state.phase, "lobby");
     assert.equal(createdPayload.activeGameId, createdPayload.game.id);
 
     const listed = await fetch(baseUrl + "/api/games");
-    const listedPayload = await listed.json();
-    assert.equal(listedPayload.games.some((game) => game.id === createdPayload.game.id), true);
+    const listedPayload: any = await readJson(listed);
+    assert.equal(listedPayload.games.some((game: any) => game.id === createdPayload.game.id), true);
 
     const opened = await fetch(baseUrl + "/api/games/open", {
       method: "POST",
@@ -3127,7 +3169,7 @@ register("API games create + list + open persiste e riapre una sessione", async 
       body: JSON.stringify({ gameId: createdPayload.game.id })
     });
     assert.equal(opened.status, 200);
-    const openedPayload = await opened.json();
+    const openedPayload: any = await readJson(opened);
     assert.equal(openedPayload.activeGameId, createdPayload.game.id);
     assert.equal(openedPayload.state.gameId, createdPayload.game.id);
   });
@@ -3143,7 +3185,7 @@ register("API game session persists mutations across reopen", async () => {
       body: JSON.stringify({ name: "Persistenza campagna" })
     });
     assert.equal(createdResponse.status, 201);
-    const createdPayload = await createdResponse.json();
+    const createdPayload: any = await readJson(createdResponse);
     const gameId = createdPayload.game.id;
 
     const secondUser = `persist_b_${Date.now()}`;
@@ -3163,14 +3205,14 @@ register("API game session persists mutations across reopen", async () => {
       body: JSON.stringify({ sessionToken: firstAuth.sessionToken })
     });
     assert.equal(joinFirst.status, 200);
-    const firstJoinPayload = await joinFirst.json();
+    const firstJoinPayload: any = await readJson(joinFirst);
 
     const loginSecond = await fetch(baseUrl + "/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: secondUser, password: TEST_PASSWORD })
     });
-    const secondAuthPayload = await loginSecond.json();
+    const secondAuthPayload: any = await readJson(loginSecond);
     const secondAuth = {
       ...secondAuthPayload,
       sessionToken: sessionTokenFromSetCookie(loginSecond.headers.get("set-cookie"))
@@ -3189,9 +3231,9 @@ register("API game session persists mutations across reopen", async () => {
       body: JSON.stringify({ sessionToken: firstAuth.sessionToken, playerId: firstJoinPayload.playerId })
     });
     assert.equal(startResponse.status, 200);
-    const startedPayload = await startResponse.json();
+    const startedPayload: any = await readJson(startResponse);
 
-    const ownedTerritoryId = startedPayload.state.map.find((territory) => territory.ownerId === firstJoinPayload.playerId).id;
+    const ownedTerritoryId = startedPayload.state.map.find((territory: any) => territory.ownerId === firstJoinPayload.playerId).id;
 
     const reinforceResponse = await fetch(baseUrl + "/api/action", {
       method: "POST",
@@ -3211,9 +3253,9 @@ register("API game session persists mutations across reopen", async () => {
       body: JSON.stringify({ gameId })
     });
     assert.equal(reopenedResponse.status, 200);
-    const reopenedPayload = await reopenedResponse.json();
+    const reopenedPayload: any = await readJson(reopenedResponse);
 
-    const reopenedTerritory = reopenedPayload.state.map.find((territory) => territory.id === ownedTerritoryId);
+    const reopenedTerritory = reopenedPayload.state.map.find((territory: any) => territory.id === ownedTerritoryId);
     assert.equal(reopenedPayload.state.gameId, gameId);
     assert.equal(reopenedPayload.state.phase, "active");
     assert.equal(reopenedTerritory.ownerId, firstJoinPayload.playerId);
@@ -3225,10 +3267,11 @@ register("API game session restores active game across app recreation", async ()
   const tempUsers = path.join(__dirname, `tmp-users-${Date.now()}-restore.json`);
   const tempGames = path.join(__dirname, `tmp-games-${Date.now()}-restore.json`);
   const tempSessions = path.join(__dirname, `tmp-sessions-${Date.now()}-restore.json`);
-  let app = createApp({ dataFile: tempUsers, gamesFile: tempGames, sessionsFile: tempSessions });
+  const tempDbFile = path.join(__dirname, `tmp-games-${Date.now()}-restore.sqlite`);
+  let app = createApp({ dataFile: tempUsers, gamesFile: tempGames, sessionsFile: tempSessions, dbFile: tempDbFile });
 
   try {
-  const firstSession = await createAuthenticatedAppSession(app, uniqueName("restore"));
+    const firstSession = await createAuthenticatedAppSession(app, uniqueName("restore"));
     const created = await fetchGame(app, "/api/games", { method: "POST", headers: authHeaders(firstSession.sessionToken), body: { name: "Sessione persistita" } });
     const createdGameId = created.game.id;
 
@@ -3237,8 +3280,9 @@ register("API game session restores active game across app recreation", async ()
 
     await fetchGame(app, "/api/games/open", { method: "POST", headers: authHeaders(firstSession.sessionToken), body: { gameId: createdGameId } });
 
-    app.server.close();
-    app = createApp({ dataFile: tempUsers, gamesFile: tempGames, sessionsFile: tempSessions });
+    app.datastore.close();
+    await new Promise<void>((resolve) => app.server.close(resolve));
+    app = createApp({ dataFile: tempUsers, gamesFile: tempGames, sessionsFile: tempSessions, dbFile: tempDbFile });
 
     const relogin = await app.auth.loginWithPassword(firstSession.user.username, TEST_PASSWORD);
     assert.equal(relogin.ok, true);
@@ -3250,14 +3294,16 @@ register("API game session restores active game across app recreation", async ()
     const listResponse = await callApp(app, "GET", "/api/games");
     assert.equal(listResponse.statusCode, 200);
     assert.equal(listResponse.payload.activeGameId, createdGameId);
-    assert.equal(listResponse.payload.games.some((game) => game.id === secondGameId), true);
+    assert.equal(listResponse.payload.games.some((game: any) => game.id === secondGameId), true);
   } finally {
+    app.datastore.close();
     if (app.server.listening) {
-      await new Promise((resolve) => app.server.close(resolve));
+      await new Promise<void>((resolve) => app.server.close(resolve));
     }
     if (fs.existsSync(tempUsers)) fs.unlinkSync(tempUsers);
     if (fs.existsSync(tempGames)) fs.unlinkSync(tempGames);
     if (fs.existsSync(tempSessions)) fs.unlinkSync(tempSessions);
+    cleanupSqliteFiles(tempDbFile);
   }
 });
 
@@ -3277,7 +3323,7 @@ register("game session store versiona i salvataggi e rifiuta versioni stale", ()
 
     assert.throws(() => {
       store.saveGame(created.game.id, nextState, 1);
-    }, (error) => error && error.code === "VERSION_CONFLICT" && error.currentVersion === 2);
+    }, (error: any) => error && error.code === "VERSION_CONFLICT" && error.currentVersion === 2);
   } finally {
     store.datastore.close();
     if (fs.existsSync(tempGames)) fs.unlinkSync(tempGames);
@@ -3317,7 +3363,7 @@ register("API action incrementa la version e rifiuta expectedVersion stale", asy
       body: JSON.stringify({ name: "Concorrenza" })
     });
     assert.equal(createdResponse.status, 201);
-    const createdPayload = await createdResponse.json();
+    const createdPayload: any = await readJson(createdResponse);
     assert.equal(createdPayload.state.version, 1);
 
     const uniqueVersionSuffix = uniqueSuffix();
@@ -3346,14 +3392,14 @@ register("API action incrementa la version e rifiuta expectedVersion stale", asy
       body: JSON.stringify({ sessionToken: firstLoginPayload.sessionToken })
     });
     assert.equal(joinFirst.status, 200);
-    const firstJoinPayload = await joinFirst.json();
+    const firstJoinPayload: any = await readJson(joinFirst);
 
     const loginSecond = await fetch(baseUrl + "/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: secondUsername, password: TEST_PASSWORD })
     });
-    const secondLoginBody = await loginSecond.json();
+    const secondLoginBody: any = await readJson(loginSecond);
     const secondLoginPayload = {
       ...secondLoginBody,
       sessionToken: sessionTokenFromSetCookie(loginSecond.headers.get("set-cookie"))
@@ -3374,8 +3420,8 @@ register("API action incrementa la version e rifiuta expectedVersion stale", asy
     assert.equal(startResponse.status, 200);
 
     const stateResponse = await fetch(baseUrl + "/api/state", { headers: authHeaders(firstLoginPayload.sessionToken) });
-    const statePayload = await stateResponse.json();
-    const ownedTerritory = statePayload.map.find((territory) => territory.ownerId === firstJoinPayload.playerId);
+    const statePayload: any = await readJson(stateResponse);
+    const ownedTerritory = statePayload.map.find((territory: any) => territory.ownerId === firstJoinPayload.playerId);
 
     const actionResponse = await fetch(baseUrl + "/api/action", {
       method: "POST",
@@ -3389,7 +3435,7 @@ register("API action incrementa la version e rifiuta expectedVersion stale", asy
       })
     });
     assert.equal(actionResponse.status, 200);
-    const actionPayload = await actionResponse.json();
+    const actionPayload: any = await readJson(actionResponse);
     assert.equal(actionPayload.state.version, statePayload.version + 1);
 
     const staleResponse = await fetch(baseUrl + "/api/action", {
@@ -3404,7 +3450,7 @@ register("API action incrementa la version e rifiuta expectedVersion stale", asy
       })
     });
     assert.equal(staleResponse.status, 409);
-    const stalePayload = await staleResponse.json();
+    const stalePayload: any = await readJson(staleResponse);
     assert.equal(stalePayload.code, "VERSION_CONFLICT");
     assert.equal(stalePayload.currentVersion, actionPayload.state.version);
     assert.equal(stalePayload.state.version, actionPayload.state.version);
@@ -3421,7 +3467,7 @@ register("API games open ricollega il player umano corretto dopo logout e nuovo 
       body: JSON.stringify({ name: "Rebind Match" })
     });
     assert.equal(created.status, 201);
-    const createdPayload = await created.json();
+    const createdPayload: any = await readJson(created);
 
     const joinHuman = await fetch(baseUrl + "/api/join", {
       method: "POST",
@@ -3429,7 +3475,7 @@ register("API games open ricollega il player umano corretto dopo logout e nuovo 
       body: JSON.stringify({ sessionToken: ownerSession.sessionToken })
     });
     assert.equal(joinHuman.status, 200);
-    const humanJoinPayload = await joinHuman.json();
+    const humanJoinPayload: any = await readJson(joinHuman);
 
     const joinAi = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
@@ -3458,7 +3504,7 @@ register("API games open ricollega il player umano corretto dopo logout e nuovo 
       body: JSON.stringify({ username, password: TEST_PASSWORD })
     });
     assert.equal(reloginResponse.status, 200);
-    const reloginBody = await reloginResponse.json();
+    const reloginBody: any = await readJson(reloginResponse);
     const reloginPayload = {
       ...reloginBody,
       sessionToken: sessionTokenFromSetCookie(reloginResponse.headers.get("set-cookie"))
@@ -3470,10 +3516,10 @@ register("API games open ricollega il player umano corretto dopo logout e nuovo 
       body: JSON.stringify({ gameId: createdPayload.game.id })
     });
     assert.equal(reopened.status, 200);
-    const reopenedPayload = await reopened.json();
+    const reopenedPayload: any = await readJson(reopened);
     assert.equal(reopenedPayload.playerId, humanJoinPayload.playerId);
 
-    const ownedTerritory = reopenedPayload.state.map.find((territory) => territory.ownerId === humanJoinPayload.playerId);
+    const ownedTerritory = reopenedPayload.state.map.find((territory: any) => territory.ownerId === humanJoinPayload.playerId);
     const reinforceResponse = await fetch(baseUrl + "/api/action", {
       method: "POST",
       headers: authHeaders(reloginPayload.sessionToken),
@@ -3518,8 +3564,8 @@ register("API cards trade applica un set valido e persiste lo stato aggiornato",
     assert.equal(response.payload.bonus, 4);
     assert.equal(response.payload.state.reinforcementPool, 7);
     assert.equal(response.payload.state.cardState.discardCount, 3);
-    assert.equal(response.payload.state.players.find((player) => player.id === first.id).cardCount, 0);
-    assert.deepEqual(context.app.state.discardPile.map((card) => card.id), ["api-t1", "api-t2", "api-t3"]);
+    assert.equal(response.payload.state.players.find((player: any) => player.id === first.id).cardCount, 0);
+    assert.deepEqual(context.app.state.discardPile.map((card: any) => card.id), ["api-t1", "api-t2", "api-t3"]);
   });
 });
 
@@ -3535,7 +3581,7 @@ register("API card flow rimescola il discard e continua l'award a fine turno", a
     state.reinforcementPool = 3;
     state.territories.aurora = { ownerId: first.id, armies: 2 };
     state.territories.bastion = { ownerId: first.id, armies: 1 };
-    const cpu = state.players.find((player) => player.id !== first.id);
+    const cpu = state.players.find((player: any) => player.id !== first.id);
     state.territories.cinder = { ownerId: cpu.id, armies: 2 };
     state.territories.delta = { ownerId: cpu.id, armies: 1 };
     state.hands[first.id] = [
@@ -3554,7 +3600,7 @@ register("API card flow rimescola il discard e continua l'award a fine turno", a
     }, authHeaders(login.sessionToken));
 
     assert.equal(tradeResponse.statusCode, 200);
-    assert.deepEqual(context.app.state.discardPile.map((card) => card.id), ['flow-t1', 'flow-t2', 'flow-t3']);
+    assert.deepEqual(context.app.state.discardPile.map((card: any) => card.id), ['flow-t1', 'flow-t2', 'flow-t3']);
 
     context.app.state.reinforcementPool = 0;
     context.app.state.turnPhase = 'fortify';
@@ -3632,7 +3678,7 @@ register("API ai join + endTurn esegue automaticamente il turno AI", async () =>
       body: JSON.stringify({ sessionToken: humanSession.sessionToken })
     });
     assert.equal(joinHuman.status, 200);
-    const humanJoinPayload = await joinHuman.json();
+    const humanJoinPayload: any = await readJson(joinHuman);
 
     const joinAi = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
@@ -3640,7 +3686,7 @@ register("API ai join + endTurn esegue automaticamente il turno AI", async () =>
       body: JSON.stringify({ name: "CPU Basic" })
     });
     assert.equal(joinAi.status, 201);
-    const aiJoinPayload = await joinAi.json();
+    const aiJoinPayload: any = await readJson(joinAi);
     assert.equal(aiJoinPayload.player.isAi, true);
 
     const startResponse = await fetch(baseUrl + "/api/start", {
@@ -3649,10 +3695,10 @@ register("API ai join + endTurn esegue automaticamente il turno AI", async () =>
       body: JSON.stringify({ sessionToken: humanSession.sessionToken, playerId: humanJoinPayload.playerId })
     });
     assert.equal(startResponse.status, 200);
-    const started = await startResponse.json();
-    assert.equal(started.state.players.some((player) => player.isAi), true);
+    const started: any = await readJson(startResponse);
+    assert.equal(started.state.players.some((player: any) => player.isAi), true);
 
-    const ownedTerritoryId = started.state.map.find((territory) => territory.ownerId === humanJoinPayload.playerId).id;
+    const ownedTerritoryId = started.state.map.find((territory: any) => territory.ownerId === humanJoinPayload.playerId).id;
     let currentState = started.state;
 
     while (currentState.reinforcementPool > 0) {
@@ -3667,7 +3713,7 @@ register("API ai join + endTurn esegue automaticamente il turno AI", async () =>
         })
       });
       assert.equal(reinforceResponse.status, 200);
-      currentState = (await reinforceResponse.json()).state;
+      currentState = (await readJson(reinforceResponse)).state;
     }
 
     const toFortify = await fetch(baseUrl + "/api/action", {
@@ -3691,12 +3737,12 @@ register("API ai join + endTurn esegue automaticamente il turno AI", async () =>
       })
     });
     assert.equal(finishTurn.status, 200);
-    const finishedPayload = await finishTurn.json();
+    const finishedPayload: any = await readJson(finishTurn);
 
     assert.equal(finishedPayload.state.currentPlayerId, humanJoinPayload.playerId);
     assert.equal(finishedPayload.state.turnPhase, "reinforcement");
     assert.equal(finishedPayload.state.reinforcementPool >= 3, true);
-    assert.equal(finishedPayload.state.log.some((line) => line.indexOf("CPU Basic") !== -1), true);
+    assert.equal(finishedPayload.state.log.some((line: any) => line.indexOf("CPU Basic") !== -1), true);
   });
 });
 
@@ -3716,7 +3762,7 @@ register("API games open riprende automaticamente una partita salvata sul turno 
       body: JSON.stringify({ sessionToken: ownerSession.sessionToken })
     });
     assert.equal(joinHuman.status, 200);
-    const humanJoinPayload = await joinHuman.json();
+    const humanJoinPayload: any = await readJson(joinHuman);
 
     const joinAi = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
@@ -3731,9 +3777,9 @@ register("API games open riprende automaticamente una partita salvata sul turno 
       body: JSON.stringify({ sessionToken: ownerSession.sessionToken, playerId: humanJoinPayload.playerId })
     });
     assert.equal(startResponse.status, 200);
-    let currentState = (await startResponse.json()).state;
+    let currentState: any = (await readJson(startResponse)).state;
 
-    const ownedTerritoryId = currentState.map.find((territory) => territory.ownerId === humanJoinPayload.playerId).id;
+    const ownedTerritoryId = currentState.map.find((territory: any) => territory.ownerId === humanJoinPayload.playerId).id;
 
     while (currentState.reinforcementPool > 0) {
       const reinforceResponse = await fetch(baseUrl + "/api/action", {
@@ -3747,7 +3793,7 @@ register("API games open riprende automaticamente una partita salvata sul turno 
         })
       });
       assert.equal(reinforceResponse.status, 200);
-      currentState = (await reinforceResponse.json()).state;
+      currentState = (await readJson(reinforceResponse)).state;
     }
 
     const toFortify = await fetch(baseUrl + "/api/action", {
@@ -3776,12 +3822,12 @@ register("API games open riprende automaticamente una partita salvata sul turno 
       headers: authHeaders(ownerSession.sessionToken)
     });
     assert.equal(stateDuringAiTurn.status, 200);
-    const resumedPayload = await stateDuringAiTurn.json();
+    const resumedPayload: any = await readJson(stateDuringAiTurn);
 
     assert.equal(resumedPayload.currentPlayerId, humanJoinPayload.playerId);
     assert.equal(resumedPayload.turnPhase, "reinforcement");
     assert.equal(resumedPayload.reinforcementPool >= 3, true);
-    assert.equal(resumedPayload.log.some((line) => line.indexOf("CPU Resume") !== -1), true);
+    assert.equal(resumedPayload.log.some((line: any) => line.indexOf("CPU Resume") !== -1), true);
 
     const reopenResponse = await fetch(baseUrl + "/api/games/open", {
       method: "POST",
@@ -3789,7 +3835,7 @@ register("API games open riprende automaticamente una partita salvata sul turno 
       body: JSON.stringify({ gameId: resumedPayload.gameId })
     });
     assert.equal(reopenResponse.status, 200);
-    const reopenPayload = await reopenResponse.json();
+    const reopenPayload: any = await readJson(reopenResponse);
 
     assert.equal(reopenPayload.state.currentPlayerId, humanJoinPayload.playerId);
     assert.equal(reopenPayload.state.turnPhase, "reinforcement");
@@ -3809,7 +3855,7 @@ register("API games open consente all'admin di aprire una partita protetta altru
       body: JSON.stringify({ name: "Admin open test" })
     });
     assert.equal(created.status, 201);
-    const createdPayload = await created.json();
+    const createdPayload: any = await readJson(created);
 
     const openResponse = await fetch(baseUrl + "/api/games/open", {
       method: "POST",
@@ -3817,7 +3863,7 @@ register("API games open consente all'admin di aprire una partita protetta altru
       body: JSON.stringify({ gameId: createdPayload.game.id })
     });
     assert.equal(openResponse.status, 200);
-    const openPayload = await openResponse.json();
+    const openPayload: any = await readJson(openResponse);
     assert.equal(openPayload.game.id, createdPayload.game.id);
   });
 });
@@ -3846,7 +3892,7 @@ register("API start consente all'admin di avviare una partita protetta altrui", 
     const openResponse = await fetch(baseUrl + "/api/games/open", {
       method: "POST",
       headers: authHeaders(adminSession.sessionToken),
-      body: JSON.stringify({ gameId: (await created.json()).game.id })
+      body: JSON.stringify({ gameId: (await readJson(created)).game.id })
     });
     assert.equal(openResponse.status, 200);
 
@@ -3856,7 +3902,7 @@ register("API start consente all'admin di avviare una partita protetta altrui", 
       body: JSON.stringify({ sessionToken: adminSession.sessionToken })
     });
     assert.equal(adminJoin.status, 201);
-    const adminJoinPayload = await adminJoin.json();
+    const adminJoinPayload: any = await readJson(adminJoin);
 
     const startResponse = await fetch(baseUrl + "/api/start", {
       method: "POST",
@@ -3864,7 +3910,7 @@ register("API start consente all'admin di avviare una partita protetta altrui", 
       body: JSON.stringify({ sessionToken: adminSession.sessionToken, playerId: adminJoinPayload.playerId })
     });
     assert.equal(startResponse.status, 200);
-    const startPayload = await startResponse.json();
+    const startPayload: any = await readJson(startResponse);
     assert.equal(startPayload.state.phase, "active");
   });
 });
@@ -3895,14 +3941,14 @@ register("API profile espone statistiche giocatore aggregate", async () => {
       headers: authHeaders(userSession.sessionToken),
       body: JSON.stringify({ sessionToken: userSession.sessionToken })
     });
-    const joinUserPayload = await joinUser.json();
+    const joinUserPayload: any = await readJson(joinUser);
 
     const loginOther = await fetch(baseUrl + "/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: other, password: TEST_PASSWORD })
     });
-    const otherSessionBody = await loginOther.json();
+    const otherSessionBody: any = await readJson(loginOther);
     const otherSession = {
       ...otherSessionBody,
       sessionToken: sessionTokenFromSetCookie(loginOther.headers.get("set-cookie"))
@@ -3926,7 +3972,7 @@ register("API profile espone statistiche giocatore aggregate", async () => {
       headers: authHeaders(userSession.sessionToken)
     });
     assert.equal(profileResponse.status, 200);
-    const profilePayload = await profileResponse.json();
+    const profilePayload: any = await readJson(profileResponse);
     assert.equal(profilePayload.profile.playerName, userSession.user.username);
     assert.equal(profilePayload.profile.gamesInProgress, 1);
     assert.equal(profilePayload.profile.gamesPlayed, 0);
@@ -3944,7 +3990,7 @@ register("API profile preferences theme persiste il tema utente validato", async
       body: JSON.stringify({ theme: "midnight" })
     });
     assert.equal(themeResponse.status, 200);
-    const themePayload = await themeResponse.json();
+    const themePayload: any = await readJson(themeResponse);
     assert.equal(themePayload.preferences.theme, "midnight");
     assert.equal(themePayload.user.preferences.theme, "midnight");
 
@@ -3952,7 +3998,7 @@ register("API profile preferences theme persiste il tema utente validato", async
       headers: authHeaders(session.sessionToken)
     });
     assert.equal(profileResponse.status, 200);
-    const profilePayload = await profileResponse.json();
+    const profilePayload: any = await readJson(profileResponse);
     assert.equal(profilePayload.profile.preferences.theme, "midnight");
 
     const invalidThemeResponse = await fetch(baseUrl + "/api/profile/preferences/theme", {
@@ -3985,7 +4031,7 @@ register("GET /api/state risponde con lo stato pubblico", async () => {
 
     const response = await fetch(`${baseUrl}/api/state`);
     assert.equal(response.status, 200);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(Array.isArray(payload.map), true);
     assert.equal(Array.isArray(payload.continents), true);
     assert.equal(payload.cardState.maxHandBeforeForcedTrade, STANDARD_MAX_HAND_BEFORE_FORCED_TRADE);
@@ -3998,7 +4044,7 @@ register("GET /api/health espone lo stato del datastore sqlite", async () => {
   await withServer(async (baseUrl, context) => {
     const response = await fetch(`${baseUrl}/api/health`);
     assert.equal(response.status, 200);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(payload.ok, true);
     assert.equal(payload.storage.storage, "sqlite");
     assert.equal(payload.storage.journalMode, "WAL");
@@ -4101,7 +4147,7 @@ register("GET /api/state espone lastCombat dopo un attacco", async () => {
 
     const response = await fetch(`${baseUrl}/api/state`);
     assert.equal(response.status, 200);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.deepEqual(payload.lastCombat, attack.combat);
     assert.equal(payload.lastCombat.comparisons[0].winner, "attacker");
     assert.equal(payload.lastCombat.conqueredTerritory, true);
@@ -4129,8 +4175,8 @@ register("API state espone solo la mano del player autenticato risolto", async (
     assert.equal(response.statusCode, 200);
     assert.equal(response.payload.playerId, first.id);
     assert.equal(Array.isArray(response.payload.playerHand), true);
-    assert.deepEqual(response.payload.playerHand.map((card) => card.id), ["hand-1", "hand-2", "hand-3"]);
-    assert.equal(response.payload.players.find((player) => player.id === first.id).cardCount, 3);
+    assert.deepEqual(response.payload.playerHand.map((card: any) => card.id), ["hand-1", "hand-2", "hand-3"]);
+    assert.equal(response.payload.players.find((player: any) => player.id === first.id).cardCount, 3);
     assert.equal(Object.prototype.hasOwnProperty.call(response.payload.players[0], "hand"), false);
   });
 });
@@ -4151,7 +4197,7 @@ register("API surrender mantiene lo snapshot per-user anche dopo la resa", async
       body: JSON.stringify({ sessionToken: ownerSession.sessionToken })
     });
     assert.equal(joinOwner.status, 200);
-    const ownerPayload = await joinOwner.json();
+    const ownerPayload: any = await readJson(joinOwner);
 
     const otherSession = await createAuthenticatedSession(baseUrl, uniqueName("surrender_other"));
     const joinOther = await fetch(baseUrl + "/api/join", {
@@ -4179,9 +4225,9 @@ register("API surrender mantiene lo snapshot per-user anche dopo la resa", async
     });
 
     assert.equal(response.status, 200);
-    const payload = await response.json();
+    const payload: any = await readJson(response);
     assert.equal(payload.state.playerId, ownerPayload.playerId);
-    assert.equal(payload.state.players.find((player) => player.id === ownerPayload.playerId).surrendered, true);
+    assert.equal(payload.state.players.find((player: any) => player.id === ownerPayload.playerId).surrendered, true);
     assert.equal(Object.prototype.hasOwnProperty.call(payload, "rounds"), false);
   });
 });
@@ -4202,7 +4248,7 @@ register("API register + login + join completa il flusso di accesso", async () =
       body: JSON.stringify({ username: unique, password: TEST_PASSWORD })
     });
     assert.equal(loginResponse.status, 200);
-    const loginBody = await loginResponse.json();
+    const loginBody: any = await readJson(loginResponse);
     const loginPayload = {
       ...loginBody,
       sessionToken: sessionTokenFromSetCookie(loginResponse.headers.get("set-cookie"))
@@ -4223,7 +4269,7 @@ async function run() {
     try {
       await test.fn();
       console.log("PASS", test.name);
-    } catch (error) {
+    } catch (error: any) {
       failures += 1;
       console.error("FAIL", test.name);
       console.error(error && error.stack ? error.stack : error);
@@ -4239,3 +4285,4 @@ async function run() {
 }
 
 run();
+

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -57,6 +57,7 @@ const { missingRequiredDeployEnv, shouldValidateDeployEnv } = require("../backen
 const { createApp } = require("../backend/server.cjs");
 const { sendJson, localizedPayload, sendLocalizedError } = require("../backend/http-response.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("../backend/routes/account.cjs");
+const { handleGameActionRoute } = require("../backend/routes/game-actions.cjs");
 const { handleAttackGameActionRoute } = require("../backend/routes/game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("../backend/routes/game-actions-basic.cjs");
 const { handleTurnGameActionRoute } = require("../backend/routes/game-actions-turn.cjs");
@@ -1333,6 +1334,106 @@ register("game management route apre una partita e risolve il player autenticato
       players: 1
     },
     playerId: "player-1"
+  });
+});
+
+register("game action route segnala il version conflict prima di eseguire mutazioni", async () => {
+  const res = makeMockResponse();
+
+  await handleGameActionRoute({
+    req: { method: "POST", headers: {} },
+    res,
+    body: { playerId: "player-1", type: "reinforce", expectedVersion: 2 },
+    url: new URL("http://127.0.0.1/api/action"),
+    requireAuth: async () => ({ user: { id: "user-1", username: "Alice" } }),
+    loadGameContext: async () => ({
+      state: { territories: { alpha: {} }, players: [{ id: "player-1", linkedUserId: "user-1" }] },
+      gameId: "game-1",
+      version: 3,
+      gameName: "Nuova partita"
+    }),
+    getTargetGameId: () => "game-1",
+    playerBelongsToUser: () => true,
+    persistGameContext: async () => {
+      throw new Error("persistGameContext should not be called");
+    },
+    persistWithAiTurns: async () => {
+      throw new Error("persistWithAiTurns should not be called");
+    },
+    broadcastGame: () => {
+      throw new Error("broadcastGame should not be called");
+    },
+    snapshotForUser: (state, gameId, version, gameName, user) => ({
+      gameId,
+      version,
+      gameName,
+      playerId: user.id,
+      territories: Object.keys(state.territories).length
+    }),
+    consumeQueuedAttackRandom: () => null,
+    localizedPayload,
+    sendJson,
+    sendLocalizedError
+  });
+
+  assert.equal(res.statusCode, 409);
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+    messageKey: "server.versionConflict",
+    messageParams: {},
+    code: "VERSION_CONFLICT",
+    currentVersion: 3,
+    state: {
+      gameId: "game-1",
+      version: 3,
+      gameName: "Nuova partita",
+      playerId: "user-1",
+      territories: 1
+    }
+  });
+});
+
+register("game action route rifiuta player non associato all'utente", async () => {
+  const res = makeMockResponse();
+
+  await handleGameActionRoute({
+    req: { method: "POST", headers: {} },
+    res,
+    body: { playerId: "player-2", type: "endTurn" },
+    url: new URL("http://127.0.0.1/api/action"),
+    requireAuth: async () => ({ user: { id: "user-1", username: "Alice" } }),
+    loadGameContext: async () => ({
+      state: { territories: {}, players: [{ id: "player-2", linkedUserId: "other-user" }] },
+      gameId: "game-1",
+      version: 3,
+      gameName: "Nuova partita"
+    }),
+    getTargetGameId: () => "game-1",
+    playerBelongsToUser: () => false,
+    persistGameContext: async () => {
+      throw new Error("persistGameContext should not be called");
+    },
+    persistWithAiTurns: async () => {
+      throw new Error("persistWithAiTurns should not be called");
+    },
+    broadcastGame: () => {
+      throw new Error("broadcastGame should not be called");
+    },
+    snapshotForUser: () => {
+      throw new Error("snapshotForUser should not be called");
+    },
+    consumeQueuedAttackRandom: () => null,
+    localizedPayload,
+    sendJson,
+    sendLocalizedError
+  });
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "Giocatore non valido.",
+    messageKey: "game.invalidPlayer",
+    messageParams: {},
+    code: null
   });
 });
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -3224,7 +3224,8 @@ register("API game session persists mutations across reopen", async () => {
 register("API game session restores active game across app recreation", async () => {
   const tempUsers = path.join(__dirname, `tmp-users-${Date.now()}-restore.json`);
   const tempGames = path.join(__dirname, `tmp-games-${Date.now()}-restore.json`);
-  let app = createApp({ dataFile: tempUsers, gamesFile: tempGames });
+  const tempSessions = path.join(__dirname, `tmp-sessions-${Date.now()}-restore.json`);
+  let app = createApp({ dataFile: tempUsers, gamesFile: tempGames, sessionsFile: tempSessions });
 
   try {
   const firstSession = await createAuthenticatedAppSession(app, uniqueName("restore"));
@@ -3237,7 +3238,7 @@ register("API game session restores active game across app recreation", async ()
     await fetchGame(app, "/api/games/open", { method: "POST", headers: authHeaders(firstSession.sessionToken), body: { gameId: createdGameId } });
 
     app.server.close();
-    app = createApp({ dataFile: tempUsers, gamesFile: tempGames });
+    app = createApp({ dataFile: tempUsers, gamesFile: tempGames, sessionsFile: tempSessions });
 
     const relogin = await app.auth.loginWithPassword(firstSession.user.username, TEST_PASSWORD);
     assert.equal(relogin.ok, true);
@@ -3256,6 +3257,7 @@ register("API game session restores active game across app recreation", async ()
     }
     if (fs.existsSync(tempUsers)) fs.unlinkSync(tempUsers);
     if (fs.existsSync(tempGames)) fs.unlinkSync(tempGames);
+    if (fs.existsSync(tempSessions)) fs.unlinkSync(tempSessions);
   }
 });
 

--- a/scripts/start-e2e.cts
+++ b/scripts/start-e2e.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 process.env.E2E = "true";
 const path = require("path");
 const { createApp } = require("../backend/server.cjs");

--- a/scripts/sync-public-assets.cts
+++ b/scripts/sync-public-assets.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const fs = require("fs");
 const path = require("path");
 
@@ -6,7 +5,7 @@ const rootDir = process.cwd();
 const sourceDir = path.join(rootDir, "frontend", "public");
 const targetDir = path.join(rootDir, "public");
 
-function copyDirectory(source, target) {
+function copyDirectory(source: string, target: string): void {
   fs.rmSync(target, { recursive: true, force: true });
   fs.mkdirSync(target, { recursive: true });
   fs.cpSync(source, target, { recursive: true });

--- a/shared/api-contracts.cts
+++ b/shared/api-contracts.cts
@@ -1,0 +1,76 @@
+export interface ThemePreferences {
+  theme?: string | null;
+}
+
+export interface PublicUserContract {
+  id: string;
+  username: string;
+  role?: string;
+  authMethods?: string[];
+  hasEmail?: boolean;
+  preferences?: ThemePreferences;
+}
+
+export interface GameSummaryContract {
+  id: string;
+  name: string;
+  phase: string;
+  playerCount: number;
+  updatedAt: string;
+}
+
+export interface GameOptionsResponseContract {
+  ruleSets: Array<Record<string, unknown>>;
+  maps: Array<Record<string, unknown>>;
+  diceRuleSets: Array<Record<string, unknown>>;
+  playerRange: {
+    min: number;
+    max: number;
+  };
+}
+
+export interface AuthSessionResponseContract {
+  user: PublicUserContract;
+}
+
+export interface ParticipatingGameLobbyContract {
+  playerName: string;
+  statusLabel: string;
+  focusLabel: string;
+  turnPhaseLabel: string;
+  territoryCount: number;
+  cardCount: number;
+}
+
+export interface ParticipatingGameContract extends GameSummaryContract {
+  totalPlayers: number | null;
+  mapName: string | null;
+  myLobby: ParticipatingGameLobbyContract;
+}
+
+export interface ProfileContract {
+  playerName: string;
+  gamesPlayed: number;
+  wins: number;
+  losses: number;
+  gamesInProgress: number;
+  participatingGames: ParticipatingGameContract[];
+  winRate: number | null;
+  hasHistory: boolean;
+  placeholders: {
+    recentGames: boolean;
+    ranking: boolean;
+  };
+  preferences?: ThemePreferences;
+}
+
+export interface ProfileResponseContract {
+  profile: ProfileContract;
+}
+
+export interface GameMutationResponseContract {
+  ok: boolean;
+  state?: Record<string, unknown>;
+  playerId?: string | null;
+  game?: Record<string, unknown>;
+}

--- a/tests/gameplay/ai/ai-player.test.cts
+++ b/tests/gameplay/ai/ai-player.test.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const {
   chooseAttack,
@@ -11,7 +10,37 @@ const { createCard, CardType } = require("../../../shared/models.cjs");
 const { makePlayers, makeState, makeTerritory, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
 const { createFixedRandom, rollsToRandomValues } = require("../helpers/random.cjs");
 
-function createAiState(options = {}) {
+type ExtendedAiState = ReturnType<typeof makeState> & {
+  mapTerritories: ReturnType<typeof makeTerritory>[];
+  hands: Record<string, ReturnType<typeof createCard>[]>;
+  discardPile: ReturnType<typeof createCard>[];
+  deck: ReturnType<typeof createCard>[];
+  tradeCount: number;
+  pendingConquest: {
+    fromId: string;
+    toId: string;
+    minArmies: number;
+    maxArmies: number;
+  } | null;
+};
+
+type AiStateOptions = {
+  mapTerritories?: ReturnType<typeof makeTerritory>[];
+  players?: ReturnType<typeof makePlayers>;
+  territories?: ReturnType<typeof territoryStates>;
+  turnPhase?: string;
+  currentTurnIndex?: number;
+  reinforcementPool?: number;
+  hands?: Record<string, ReturnType<typeof createCard>[]>;
+  discardPile?: ReturnType<typeof createCard>[];
+  deck?: ReturnType<typeof createCard>[];
+  tradeCount?: number;
+  pendingConquest?: ExtendedAiState["pendingConquest"];
+};
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function createAiState(options: AiStateOptions = {}): ExtendedAiState {
   const territories = options.mapTerritories || [
     makeTerritory("a", ["b"]),
     makeTerritory("b", ["a", "c"]),
@@ -33,7 +62,7 @@ function createAiState(options = {}) {
     turnPhase: options.turnPhase || TurnPhase.REINFORCEMENT,
     currentTurnIndex: options.currentTurnIndex || 0,
     reinforcementPool: options.reinforcementPool || 0
-  });
+  }) as ExtendedAiState;
 
   state.mapTerritories = territories;
   state.hands = options.hands || {};
@@ -176,4 +205,3 @@ register("runAiTurn trades cards, attacks, resolves conquest, and ends the turn"
   assert.equal(state.hands.p1.length, 4);
   assert.equal(state.discardPile.length, 3);
 });
-

--- a/tests/gameplay/combat/attack-validation.test.cts
+++ b/tests/gameplay/combat/attack-validation.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { validateAttackAttempt } = require("../../../backend/engine/attack-validation.cjs");
 const { makeGraph, makePlayers, makeState, makeTerritory, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function setupValidationState() {
   const territories = [
@@ -76,4 +77,3 @@ register("validateAttackAttempt rejects attacker territories with fewer than two
   assert.equal(result.ok, false);
   assert.equal(result.code, "INSUFFICIENT_ARMIES");
 });
-

--- a/tests/gameplay/combat/banzai-attack.test.cts
+++ b/tests/gameplay/combat/banzai-attack.test.cts
@@ -1,8 +1,17 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { resolveBanzaiAttack } = require("../../../backend/engine/banzai-attack.cjs");
 const { createFixedRandom, rollsToRandomValues } = require("../helpers/random.cjs");
 const { makePlayers, makeState, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
+
+type BanzaiRound = {
+  round: number;
+  defenderArmiesRemaining: number;
+  attackerArmiesRemaining: number;
+  attackDiceCount: number;
+  conqueredTerritory?: boolean;
+};
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function setupBanzaiState() {
   const state = makeState({
@@ -35,9 +44,9 @@ register("resolveBanzaiAttack loops server-side until conquest and returns synth
 
   assert.equal(result.ok, true);
   assert.equal(result.rounds.length, 3);
-  assert.deepEqual(result.rounds.map((round) => round.round), [1, 2, 3]);
-  assert.deepEqual(result.rounds.map((round) => round.defenderArmiesRemaining), [2, 1, 0]);
-  assert.deepEqual(result.rounds.map((round) => round.attackerArmiesRemaining), [4, 3, 3]);
+  assert.deepEqual(result.rounds.map((round: BanzaiRound) => round.round), [1, 2, 3]);
+  assert.deepEqual(result.rounds.map((round: BanzaiRound) => round.defenderArmiesRemaining), [2, 1, 0]);
+  assert.deepEqual(result.rounds.map((round: BanzaiRound) => round.attackerArmiesRemaining), [4, 3, 3]);
   assert.equal(result.rounds[2].conqueredTerritory, true);
   assert.equal(result.pendingConquest.fromId, "aurora");
   assert.equal(result.pendingConquest.toId, "bastion");
@@ -77,4 +86,3 @@ register("resolveBanzaiAttack normalizes attack dice as armies drop", () => {
   assert.equal(state.territories.bastion.armies, 0);
   assert.equal(state.pendingConquest.toId, "bastion");
 });
-

--- a/tests/gameplay/combat/combat-resolution.test.cts
+++ b/tests/gameplay/combat/combat-resolution.test.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { resolveSingleAttackRoll } = require("../../../backend/engine/combat-resolution.cjs");
 const { compareCombatDice, rollCombatDice } = require("../../../backend/engine/combat-dice.cjs");
@@ -10,6 +9,16 @@ const {
 } = require("../../../shared/dice.cjs");
 const { createFixedRandom, rollsToRandomValues } = require("../helpers/random.cjs");
 const { makeGraph, makePlayers, makeState, makeTerritory, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
+
+type CombatComparison = {
+  winner: string;
+};
+
+type DiceRuleSummary = {
+  id: string;
+};
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function setupCombatState(attackerArmies = 4, defenderArmies = 2) {
   const territories = [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])];
@@ -108,7 +117,7 @@ register("defense 3 dice rule set espone l'opzione difensiva estesa", () => {
   assert.equal(ruleSet.attackerMaxDice, 3);
   assert.equal(ruleSet.defenderMaxDice, 3);
 
-  const listedIds = listDiceRuleSets().map((entry) => entry.id);
+  const listedIds = listDiceRuleSets().map((entry: DiceRuleSummary) => entry.id);
   assert.equal(listedIds.includes(DEFENSE_THREE_DICE_RULE_SET_ID), true);
 });
 
@@ -136,6 +145,5 @@ register("combat dice helpers tirano ordinato e confrontano in modo puro", () =>
   const compared = compareCombatDice([2, 6, 4], [5, 1], { defenderWinsTies: true });
   assert.deepEqual(compared.attackerRolls, [6, 4, 2]);
   assert.deepEqual(compared.defenderRolls, [5, 1]);
-  assert.deepEqual(compared.comparisons.map((entry) => entry.winner), ["attacker", "attacker"]);
+  assert.deepEqual(compared.comparisons.map((entry: CombatComparison) => entry.winner), ["attacker", "attacker"]);
 });
-

--- a/tests/gameplay/conquest/conquest-resolution.test.cts
+++ b/tests/gameplay/conquest/conquest-resolution.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { resolveConquest } = require("../../../backend/engine/conquest-resolution.cjs");
 const { makePlayers, makeState, territoryStates } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function makeCombatResult() {
   return {
@@ -58,4 +59,3 @@ register("resolveConquest rejects moves that leave the source empty", () => {
   assert.equal(result.ok, false);
   assert.equal(result.code, "MOVE_EXCEEDS_AVAILABLE");
 });
-

--- a/tests/gameplay/fortify/fortify-movement.test.cts
+++ b/tests/gameplay/fortify/fortify-movement.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { moveFortifyArmies } = require("../../../backend/engine/fortify-movement.cjs");
 const { makeGraph, makePlayers, makeState, makeTerritory, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function setupFortifyState() {
   const territories = [
@@ -74,4 +75,3 @@ register("moveFortifyArmies blocks a repeated fortify in the same turn", () => {
   assert.equal(result.ok, false);
   assert.equal(result.code, "FORTIFY_ALREADY_USED");
 });
-

--- a/tests/gameplay/helpers/random.cts
+++ b/tests/gameplay/helpers/random.cts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-function createFixedRandom(sequence) {
+function createFixedRandom(sequence: number[]): () => number {
   const values = Array.isArray(sequence) ? sequence.slice() : [];
   let index = 0;
 
@@ -14,7 +13,7 @@ function createFixedRandom(sequence) {
   };
 }
 
-function rollsToRandomValues(rolls) {
+function rollsToRandomValues(rolls: number[]): number[] {
   return rolls.map((roll) => {
     if (!Number.isInteger(roll) || roll < 1 || roll > 6) {
       throw new Error("Dice rolls must be integers between 1 and 6.");

--- a/tests/gameplay/helpers/state-builder.cts
+++ b/tests/gameplay/helpers/state-builder.cts
@@ -1,8 +1,29 @@
-// @ts-nocheck
-const { createContinent, createGameState, createPlayer, createTerritory, TurnPhase } = require("../../../shared/models.cjs");
-const { buildMapGraph } = require("../../../shared/map-graph.cjs");
+const { createContinent, createGameState, createPlayer, createTerritory, TurnPhase } = require("../../../shared/models.cjs") as typeof import("../../../shared/models.cjs");
+const { buildMapGraph } = require("../../../shared/map-graph.cjs") as typeof import("../../../shared/map-graph.cjs");
+import type { Continent, GameState, Player, Territory, TurnPhaseValue } from "../../../shared/models.cjs";
 
-function makePlayer(id, name, overrides = {}) {
+type TerritoryStateInput = Pick<Territory, "id"> & {
+  ownerId?: string | null;
+  armies?: number | null;
+};
+
+type StateOptions = {
+  phase?: GameState["phase"];
+  turnPhase?: TurnPhaseValue;
+  players?: Player[];
+  territories?: GameState["territories"];
+  continents?: Continent[];
+  currentTurnIndex?: number;
+  reinforcementPool?: number;
+  winnerId?: string | null;
+  log?: GameState["log"];
+  lastAction?: GameState["lastAction"];
+  pendingConquest?: GameState["pendingConquest"];
+  fortifyUsed?: boolean;
+  fortifyMoveUsed?: boolean;
+};
+
+function makePlayer(id: string, name: string, overrides: Partial<Player> = {}): Player {
   return createPlayer({
     id,
     name,
@@ -12,11 +33,11 @@ function makePlayer(id, name, overrides = {}) {
   });
 }
 
-function makePlayers(names = ["Alice", "Bob"]) {
+function makePlayers(names: string[] = ["Alice", "Bob"]): Player[] {
   return names.map((name, index) => makePlayer(`p${index + 1}`, name));
 }
 
-function makeTerritory(id, neighbors = [], overrides = {}) {
+function makeTerritory(id: string, neighbors: string[] = [], overrides: Partial<Territory> = {}): Territory {
   return createTerritory({
     id,
     name: overrides.name || id.charAt(0).toUpperCase() + id.slice(1),
@@ -28,7 +49,7 @@ function makeTerritory(id, neighbors = [], overrides = {}) {
   });
 }
 
-function makeContinent(id, territoryIds, bonus = 0, overrides = {}) {
+function makeContinent(id: string, territoryIds: string[], bonus: number = 0, overrides: Partial<Continent> = {}): Continent {
   return createContinent({
     id,
     name: overrides.name || id.charAt(0).toUpperCase() + id.slice(1),
@@ -38,17 +59,18 @@ function makeContinent(id, territoryIds, bonus = 0, overrides = {}) {
   });
 }
 
-function territoryStates(entries) {
+function territoryStates(entries: TerritoryStateInput[]): GameState["territories"] {
   return entries.reduce((accumulator, entry) => {
-    accumulator[entry.id] = {
+    const territoryId = String(entry.id || "");
+    accumulator[territoryId] = {
       ownerId: entry.ownerId || null,
       armies: entry.armies == null ? 0 : entry.armies
     };
     return accumulator;
-  }, {});
+  }, {} as GameState["territories"]);
 }
 
-function makeState(options = {}) {
+function makeState(options: StateOptions = {}): GameState {
   const state = createGameState({
     phase: options.phase || "active",
     turnPhase: options.turnPhase || TurnPhase.REINFORCEMENT,
@@ -63,11 +85,11 @@ function makeState(options = {}) {
     pendingConquest: options.pendingConquest || null,
     fortifyUsed: Boolean(options.fortifyUsed)
   });
-  state.fortifyMoveUsed = Boolean(options.fortifyMoveUsed);
+  (state as GameState & { fortifyMoveUsed?: boolean }).fortifyMoveUsed = Boolean(options.fortifyMoveUsed);
   return state;
 }
 
-function makeMapDefinition(territories, continents = []) {
+function makeMapDefinition(territories: Territory[], continents: Continent[] = []) {
   return {
     territories: territories.map((territory) => ({
       territory,
@@ -77,7 +99,7 @@ function makeMapDefinition(territories, continents = []) {
   };
 }
 
-function makeGraph(territories) {
+function makeGraph(territories: Territory[]) {
   return buildMapGraph(territories);
 }
 

--- a/tests/gameplay/regression/full-flows.test.cts
+++ b/tests/gameplay/regression/full-flows.test.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { createInitialGameState } = require("../../../backend/engine/game-setup.cjs");
 const { calculateReinforcements } = require("../../../backend/engine/reinforcement-calculator.cjs");
@@ -9,6 +8,8 @@ const { moveFortifyArmies } = require("../../../backend/engine/fortify-movement.
 const { createFixedRandom, rollsToRandomValues } = require("../helpers/random.cjs");
 const { makeGraph, makeMapDefinition, makePlayers, makeState, makeTerritory, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
 
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
 register("regression: setup to reinforcement placement keeps state coherent", () => {
   const players = makePlayers(["Alice", "Bob"]);
   const territories = [makeTerritory("a", ["b"]), makeTerritory("b", ["a"]), makeTerritory("c", []), makeTerritory("d", [])];
@@ -17,7 +18,10 @@ register("regression: setup to reinforcement placement keeps state coherent", ()
   const reinforcements = calculateReinforcements(state, currentPlayer.id);
   state.reinforcementPool = reinforcements.totalReinforcements;
 
-  const owned = Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === currentPlayer.id);
+  const owned = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === currentPlayer.id);
+  if (!owned) {
+    throw new Error("Expected the current player to own at least one territory.");
+  }
   const placed = placeReinforcement(state, currentPlayer.id, owned);
 
   assert.equal(placed.remainingReinforcements, reinforcements.totalReinforcements - 1);
@@ -75,4 +79,3 @@ register("regression: fortify move updates end-of-turn board slice coherently", 
   assert.equal(state.territories.a.armies, 3);
   assert.equal(state.territories.c.armies, 2);
 });
-

--- a/tests/gameplay/reinforcement/map-continent-bonuses.test.cts
+++ b/tests/gameplay/reinforcement/map-continent-bonuses.test.cts
@@ -1,10 +1,15 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const classicMiniMap = require("../../../shared/maps/classic-mini.cjs");
 const middleEarthMap = require("../../../shared/maps/middle-earth.cjs");
 const worldClassicMap = require("../../../shared/maps/world-classic.cjs");
 
-function bonusMapFor(map) {
+type ContinentBonusMap = {
+  continents: Array<{ id: string; bonus: number }>;
+};
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function bonusMapFor(map: ContinentBonusMap): Record<string, number> {
   return Object.fromEntries(map.continents.map((continent) => [continent.id, continent.bonus]));
 }
 

--- a/tests/gameplay/reinforcement/reinforcement-calculation.test.cts
+++ b/tests/gameplay/reinforcement/reinforcement-calculation.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { calculateReinforcements } = require("../../../backend/engine/reinforcement-calculator.cjs");
 const { makeContinent, makePlayers, makeState, territoryStates } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 register("calculateReinforcements enforces a minimum of 3", () => {
   const players = makePlayers(["Alice", "Bob"]);
@@ -49,4 +50,3 @@ register("calculateReinforcements rejects unknown players", () => {
   const state = makeState({ players: makePlayers(["Alice"]) });
   assert.throws(() => calculateReinforcements(state, "missing"), /unknown player/i);
 });
-

--- a/tests/gameplay/reinforcement/reinforcement-placement.test.cts
+++ b/tests/gameplay/reinforcement/reinforcement-placement.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { placeReinforcement } = require("../../../backend/engine/reinforcement-placement.cjs");
 const { makePlayers, makeState, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 register("placeReinforcement adds one army and decreases the pool on owned territory", () => {
   const state = makeState({
@@ -44,4 +45,3 @@ register("placeReinforcement fails on territories not owned by the current playe
 
   assert.throws(() => placeReinforcement(state, "p1", "a"), /owned territories/i);
 });
-

--- a/tests/gameplay/setup/game-setup.test.cts
+++ b/tests/gameplay/setup/game-setup.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { createInitialGameState } = require("../../../backend/engine/game-setup.cjs");
 const { makeMapDefinition, makePlayers, makeTerritory } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 register("createInitialGameState assigns all territories with owners and one army", () => {
   const players = makePlayers(["Alice", "Bob", "Cara"]);
@@ -46,4 +47,3 @@ register("createInitialGameState rejects duplicate player ids", () => {
 
   assert.throws(() => createInitialGameState(makeMapDefinition(territories), players), /duplicate player id/i);
 });
-

--- a/tests/gameplay/turn-flow/turn-flow.test.cts
+++ b/tests/gameplay/turn-flow/turn-flow.test.cts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const {
   TurnPhase,
@@ -11,6 +10,18 @@ const {
 } = require("../../../backend/engine/game-engine.cjs");
 const { findSupportedMap } = require("../../../shared/maps/index.cjs");
 const { createFixedRandom } = require("../helpers/random.cjs");
+
+type TerritoryOwnerState = {
+  ownerId: string | null;
+  armies: number;
+};
+
+type PlayerRef = {
+  id: string;
+  surrendered?: boolean;
+};
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function setupLiveGame() {
   const state = createInitialState();
@@ -25,7 +36,10 @@ function setupLiveGame() {
 register("applyReinforcement transitions from reinforcement to attack when pool reaches zero", () => {
   const state = setupLiveGame();
   const currentPlayer = state.players[state.currentTurnIndex];
-  const ownedTerritoryId = Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === currentPlayer.id);
+  const ownedTerritoryId = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === currentPlayer.id);
+  if (!ownedTerritoryId) {
+    throw new Error("Expected at least one owned territory for the current player.");
+  }
 
   while (state.reinforcementPool > 0) {
     const result = applyReinforcement(state, currentPlayer.id, ownedTerritoryId);
@@ -39,7 +53,10 @@ register("applyReinforcement transitions from reinforcement to attack when pool 
 register("applyReinforcement supports batched placement in a single action", () => {
   const state = setupLiveGame();
   const currentPlayer = state.players[state.currentTurnIndex];
-  const ownedTerritoryId = Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === currentPlayer.id);
+  const ownedTerritoryId = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === currentPlayer.id);
+  if (!ownedTerritoryId) {
+    throw new Error("Expected at least one owned territory for the current player.");
+  }
   const startingArmies = state.territories[ownedTerritoryId].armies;
   const totalReinforcements = state.reinforcementPool;
 
@@ -54,7 +71,10 @@ register("applyReinforcement supports batched placement in a single action", () 
 register("endTurn transitions from attack to fortify before advancing the turn", () => {
   const state = setupLiveGame();
   const currentPlayer = state.players[state.currentTurnIndex];
-  const ownedTerritoryId = Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === currentPlayer.id);
+  const ownedTerritoryId = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === currentPlayer.id);
+  if (!ownedTerritoryId) {
+    throw new Error("Expected at least one owned territory for the current player.");
+  }
 
   while (state.reinforcementPool > 0) {
     applyReinforcement(state, currentPlayer.id, ownedTerritoryId);
@@ -69,7 +89,10 @@ register("endTurn transitions from attack to fortify before advancing the turn",
 register("endTurn from fortify advances to the next active player reinforcement phase", () => {
   const state = setupLiveGame();
   const firstPlayer = state.players[state.currentTurnIndex];
-  const ownedTerritoryId = Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === firstPlayer.id);
+  const ownedTerritoryId = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === firstPlayer.id);
+  if (!ownedTerritoryId) {
+    throw new Error("Expected at least one owned territory for the current player.");
+  }
 
   while (state.reinforcementPool > 0) {
     applyReinforcement(state, firstPlayer.id, ownedTerritoryId);
@@ -96,7 +119,7 @@ register("advanceTurn awards continent bonuses through the game engine reinforce
   state.turnPhase = TurnPhase.FORTIFY;
   state.reinforcementPool = 0;
 
-  Object.keys(state.territories).forEach((territoryId) => {
+  Object.keys(state.territories).forEach((territoryId: string) => {
     state.territories[territoryId] = { ownerId: "p2", armies: 1 };
   });
 
@@ -123,7 +146,7 @@ register("endTurn fails clearly when reinforcements are still available", () => 
 register("advanceTurn skips players with zero territories and can finish the game", () => {
   const state = setupLiveGame();
   state.currentTurnIndex = 0;
-  Object.keys(state.territories).forEach((territoryId) => {
+  Object.keys(state.territories).forEach((territoryId: string) => {
     state.territories[territoryId].ownerId = "p1";
   });
   state.turnPhase = TurnPhase.FORTIFY;
@@ -138,18 +161,25 @@ register("advanceTurn skips players with zero territories and can finish the gam
 register("surrenderPlayer during the active turn hands off play to the next surviving player", () => {
   const state = setupLiveGame();
   state.players.push({ id: "p3", name: "Carol", color: "#333333", connected: true });
-  const reassignedTerritoryId = Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === "p2");
+  const reassignedTerritoryId = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === "p2");
+  if (!reassignedTerritoryId) {
+    throw new Error("Expected at least one territory owned by p2.");
+  }
   state.territories[reassignedTerritoryId].ownerId = "p3";
   state.territories[reassignedTerritoryId].armies = 1;
   const currentPlayer = state.players[state.currentTurnIndex];
 
   const result = surrenderPlayer(state, currentPlayer.id);
 
+  const surrenderedTerritoryId = Object.keys(state.territories).find((territoryId: string) => state.territories[territoryId].ownerId === currentPlayer.id);
+  if (!surrenderedTerritoryId) {
+    throw new Error("Expected surrendered player to keep at least one owned territory.");
+  }
   assert.equal(result.ok, true);
   assert.equal(state.phase, "active");
   assert.equal(state.players[state.currentTurnIndex].id, "p2");
-  assert.equal(state.players.find((player) => player.id === currentPlayer.id).surrendered, true);
-  assert.equal(state.territories[Object.keys(state.territories).find((territoryId) => state.territories[territoryId].ownerId === currentPlayer.id)].ownerId, currentPlayer.id);
+  assert.equal(state.players.find((player: PlayerRef) => player.id === currentPlayer.id).surrendered, true);
+  assert.equal(state.territories[surrenderedTerritoryId].ownerId, currentPlayer.id);
   assert.equal(state.turnPhase, TurnPhase.REINFORCEMENT);
   assert.equal(state.reinforcementPool >= 3, true);
 });

--- a/tests/gameplay/victory/elimination-and-victory.test.cts
+++ b/tests/gameplay/victory/elimination-and-victory.test.cts
@@ -1,6 +1,10 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { createInitialState, declareWinnerIfNeeded, getMapTerritories, publicState, surrenderPlayer } = require("../../../backend/engine/game-engine.cjs");
+
+type TerritoryRef = { id: string };
+type PublicPlayer = { id: string; eliminated: boolean; territoryCount: number };
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 function setupLiveState() {
   const state = createInitialState();
@@ -9,7 +13,7 @@ function setupLiveState() {
     { id: "p1", name: "Alice", color: "#111111", connected: true },
     { id: "p2", name: "Bob", color: "#222222", connected: true }
   ];
-  getMapTerritories(state).forEach((territory) => {
+  getMapTerritories(state).forEach((territory: TerritoryRef) => {
     state.territories[territory.id] = { ownerId: "p1", armies: 1 };
   });
   return state;
@@ -18,7 +22,7 @@ function setupLiveState() {
 register("publicState marks players with zero territories as eliminated", () => {
   const state = setupLiveState();
   const snapshot = publicState(state);
-  const player = snapshot.players.find((entry) => entry.id === "p2");
+  const player = snapshot.players.find((entry: PublicPlayer) => entry.id === "p2");
   assert.equal(player.eliminated, true);
 });
 
@@ -27,7 +31,7 @@ register("publicState keeps players with territories active", () => {
   const territoryId = getMapTerritories(state)[0].id;
   state.territories[territoryId].ownerId = "p2";
   const snapshot = publicState(state);
-  const player = snapshot.players.find((entry) => entry.id === "p2");
+  const player = snapshot.players.find((entry: PublicPlayer) => entry.id === "p2");
   assert.equal(player.eliminated, false);
 });
 
@@ -50,15 +54,15 @@ register("declareWinnerIfNeeded does not assign victory while more than one play
 register("surrenderPlayer elimina il giocatore e assegna la vittoria se resta un solo vivo", () => {
   const state = setupLiveState();
   state.territories[getMapTerritories(state)[0].id].ownerId = "p2";
-  const ownedBefore = publicState(state).players.find((entry) => entry.id === "p2").territoryCount;
+  const ownedBefore = publicState(state).players.find((entry: PublicPlayer) => entry.id === "p2").territoryCount;
 
   const result = surrenderPlayer(state, "p2");
 
   assert.equal(result.ok, true);
   assert.equal(state.winnerId, "p1");
   assert.equal(state.phase, "finished");
-  assert.equal(publicState(state).players.find((entry) => entry.id === "p2").eliminated, true);
-  assert.equal(publicState(state).players.find((entry) => entry.id === "p2").territoryCount, ownedBefore);
+  assert.equal(publicState(state).players.find((entry: PublicPlayer) => entry.id === "p2").eliminated, true);
+  assert.equal(publicState(state).players.find((entry: PublicPlayer) => entry.id === "p2").territoryCount, ownedBefore);
 });
 
 register("declareWinnerIfNeeded chiude la partita quando restano solo AI attive", () => {
@@ -68,8 +72,8 @@ register("declareWinnerIfNeeded chiude la partita quando restano solo AI attive"
     { id: "p2", name: "Bot Alpha", color: "#222222", connected: true, isAi: true },
     { id: "p3", name: "Bot Beta", color: "#333333", connected: true, isAi: true }
   ];
-  const territoryIds = getMapTerritories(state).map((territory) => territory.id);
-  territoryIds.forEach((territoryId, index) => {
+  const territoryIds = getMapTerritories(state).map((territory: TerritoryRef) => territory.id);
+  territoryIds.forEach((territoryId: string, index: number) => {
     state.territories[territoryId] = { ownerId: index % 2 === 0 ? "p2" : "p3", armies: 1 };
   });
 
@@ -79,5 +83,3 @@ register("declareWinnerIfNeeded chiude la partita quando restano solo AI attive"
   assert.equal(state.phase, "finished");
   assert.equal(state.winnerId, null);
 });
-
-

--- a/tests/gameplay/victory/victory-detection.test.cts
+++ b/tests/gameplay/victory/victory-detection.test.cts
@@ -1,7 +1,8 @@
-// @ts-nocheck
 const assert = require("node:assert/strict");
 const { detectVictory } = require("../../../backend/engine/victory-detection.cjs");
 const { makePlayers, makeState, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
 
 register("detectVictory declares victory when only one active player remains", () => {
   const state = makeState({

--- a/tests/register-harness.d.ts
+++ b/tests/register-harness.d.ts
@@ -1,0 +1,1 @@
+declare function register(name: string, fn: () => void | Promise<void>): void;

--- a/tsconfig.frontend.json
+++ b/tsconfig.frontend.json
@@ -6,8 +6,7 @@
     "strict": false,
     "allowJs": false,
     "checkJs": false,
-    "noCheck": true,
-    "noEmitOnError": false,
+    "noEmitOnError": true,
     "incremental": true,
     "outDir": "./frontend/public",
     "rootDir": "./frontend/src",
@@ -15,6 +14,6 @@
     "types": ["node"],
     "skipLibCheck": true
   },
-  "include": ["frontend/src/**/*.mts"],
+  "include": ["frontend/src/**/*"],
   "exclude": ["node_modules", "frontend/public", "frontend/.tsbuild"]
 }


### PR DESCRIPTION
## What changed
- hardened the TypeScript foundation for the frontend build by enabling real frontend typechecking and adding a dedicated `typecheck:frontend` script
- introduced shared API contracts plus typed frontend DOM/error helpers to reduce implicit `null` handling and centralize string-render helpers
- extracted backend HTTP response helpers and split account/health route handling out of `backend/server.cts`
- removed `@ts-nocheck` from a first set of backend utility modules and tightened typings in smaller backend slices
- added direct tests for the new backend helper modules and route handlers, while keeping existing integration and gameplay coverage green

## Why
This moves NetRisk closer to a TypeScript-first, reviewable architecture without rewriting the app or moving game rules out of the engine modules.

## Validation
- `npm run typecheck`
- `npm run typecheck:frontend`
- `npm test`
- `npm run coverage`
- `npm run test:all:e2e`

## Notes
- `frontend/public/*` changes are generated build output from the frontend TypeScript build and import sync step.
- this PR intentionally keeps some larger follow-up refactors for later slices, especially the remaining `@ts-nocheck` modules and further decomposition of `frontend/src/app.mts`.
