### PR TITLE
[codex] Fix attack internal error handling

### DIFF
--- a/backend/event-broadcast.cts
+++ b/backend/event-broadcast.cts
@@ -1,0 +1,51 @@
+type EventClient = {
+  res?: {
+    destroyed?: boolean;
+    writableEnded?: boolean;
+    write: (chunk: string) => unknown;
+  } | null;
+  user?: unknown;
+};
+
+type BuildPayload = (client: EventClient) => string;
+
+function isWritableClient(client: EventClient | null | undefined): boolean {
+  if (!client?.res || typeof client.res.write !== "function") {
+    return false;
+  }
+
+  if (client.res.destroyed || client.res.writableEnded) {
+    return false;
+  }
+
+  return true;
+}
+
+export function broadcastEventPayload(
+  clients: Set<EventClient> | null | undefined,
+  buildPayload: BuildPayload
+): void {
+  if (!clients || !clients.size) {
+    return;
+  }
+
+  const staleClients: EventClient[] = [];
+  clients.forEach((client) => {
+    if (!isWritableClient(client)) {
+      staleClients.push(client);
+      return;
+    }
+
+    try {
+      client.res?.write(buildPayload(client));
+    } catch (error) {
+      staleClients.push(client);
+    }
+  });
+
+  staleClients.forEach((client) => clients.delete(client));
+}
+
+module.exports = {
+  broadcastEventPayload
+};

--- a/backend/routes/game-actions-attack.cts
+++ b/backend/routes/game-actions-attack.cts
@@ -32,6 +32,35 @@ type ResolveAttack = (
 type ResolveBanzaiAttack = ResolveAttack;
 type ConsumeQueuedAttackRandom = () => (() => number) | null;
 
+function mappedAttackResolverError(error: unknown): { message: string; messageKey: string } | null {
+  const runtimeMessage = error && typeof error === "object" && "message" in error
+    ? String((error as { message?: unknown }).message || "")
+    : "";
+
+  if (!runtimeMessage) {
+    return null;
+  }
+
+  if (runtimeMessage.indexOf("Attacker dice must be between 1 and") === 0) {
+    return {
+      message: "Numero di dadi di attacco non valido.",
+      messageKey: "game.attack.invalidDiceCount"
+    };
+  }
+
+  if (
+    runtimeMessage.indexOf("Defender dice must be between 1 and") === 0 ||
+    runtimeMessage === "Combat resolution requires attacker and defender territory state."
+  ) {
+    return {
+      message: "Territori non validi.",
+      messageKey: "game.attack.invalidTerritories"
+    };
+  }
+
+  return null;
+}
+
 async function handleAttackGameActionRoute(
   type: string,
   res: unknown,
@@ -64,9 +93,21 @@ async function handleAttackGameActionRoute(
     return true;
   }
 
-  const result = type === "attackBanzai"
-    ? resolveBanzaiAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice)
-    : resolveAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice);
+  let result;
+  try {
+    result = type === "attackBanzai"
+      ? resolveBanzaiAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice)
+      : resolveAttack(gameContext.state, playerId, actionFromId, actionToId, random, requestedAttackDice);
+  } catch (error) {
+    const mappedError = mappedAttackResolverError(error);
+    if (!mappedError) {
+      throw error;
+    }
+
+    sendLocalizedError(res, 400, error, mappedError.message, mappedError.messageKey);
+    return true;
+  }
+
   if (!result.ok) {
     sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
     return true;

--- a/backend/routes/game-actions-attack.cts
+++ b/backend/routes/game-actions-attack.cts
@@ -84,7 +84,7 @@ async function handleAttackGameActionRoute(
     return false;
   }
 
-  const random = consumeQueuedAttackRandom();
+  const random = consumeQueuedAttackRandom() || undefined;
   const requestedAttackDice = body.attackDice == null || body.attackDice === "" ? null : Number(body.attackDice);
   const actionFromId = String(body.fromId || "");
   const actionToId = String(body.toId || "");

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -23,6 +23,7 @@ const {
 const { runAiTurn } = require("./engine/ai-player.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
+const { broadcastEventPayload } = require("./event-broadcast.cjs");
 const { handleAuthSessionRoute, handleProfileRoute, handleThemePreferenceRoute } = require("./routes/account.cjs");
 const { handleGameActionRoute } = require("./routes/game-actions.cjs");
 const { handleCardsTradeRoute } = require("./routes/game-cards.cjs");
@@ -360,12 +361,14 @@ function createApp(options: CreateAppOptions = {}) {
       return;
     }
 
-    clients.forEach((client: EventClient) => {
-      const payload = "data: " + JSON.stringify(
+    broadcastEventPayload(clients, (client: EventClient) =>
+      "data: " + JSON.stringify(
         snapshotForUser(gameContext.state, gameContext.gameId, gameContext.version, gameContext.gameName, client.user)
-      ) + "\n\n";
-      client.res.write(payload);
-    });
+      ) + "\n\n");
+
+    if (!clients.size) {
+      clientsByGameId.delete(gameContext.gameId);
+    }
   }
 
   function runAiTurnsIfNeeded(targetState: any): any[] {

--- a/e2e/gameplay/attack-dice-request.spec.ts
+++ b/e2e/gameplay/attack-dice-request.spec.ts
@@ -107,3 +107,54 @@ test("attack UI sends the selected dice count to the backend", async ({ page }) 
   await expect(page.locator("#combat-attacker-rolls")).toContainText("6 · 5");
 });
 
+test("attack UI normalizes stale dice values before submit", async ({ page }) => {
+  const currentState = mockState();
+  let capturedAttackDice = null;
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("frontline-player-id", "p1");
+  });
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({ json: { user: { id: "u1", username: "alice", role: "user", authMethods: ["password"] } } });
+  });
+
+  await page.route("**/api/games**", async (route) => {
+    await route.fulfill({ json: { games: [{ id: "g-1", name: "Attack Dice Match", updatedAt: "2026-04-02T10:00:00.000Z", phase: "active", playerCount: 2 }], activeGameId: "g-1" } });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: currentState });
+  });
+
+  await page.route("**/api/action", async (route) => {
+    const body = route.request().postDataJSON();
+    capturedAttackDice = body.attackDice;
+    await route.fulfill({ json: { ok: true, state: currentState } });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({ status: 200, headers: { "content-type": "text/event-stream" }, body: "" });
+  });
+
+  await page.goto("/game.html");
+
+  await expect(page.locator("#attack-group")).toBeVisible();
+  await page.locator("#attack-from").selectOption("cinder");
+  await page.locator("#attack-to").selectOption("bastion");
+  await page.evaluate(() => {
+    const attackDice = document.querySelector("#attack-dice");
+    if (!attackDice) {
+      return;
+    }
+
+    const staleOption = document.createElement("option");
+    staleOption.value = "3";
+    staleOption.textContent = "3";
+    attackDice.appendChild(staleOption);
+    attackDice.value = "3";
+  });
+  await page.locator("#attack-button").click();
+
+  expect(capturedAttackDice).toBe(1);
+});

--- a/frontend/public/app.mjs
+++ b/frontend/public/app.mjs
@@ -1474,7 +1474,11 @@ elements.map.addEventListener("click", (event) => {
 });
 elements.attackButton.addEventListener("click", async () => {
     try {
-        await executeAttack(elements.attackFrom.value, elements.attackTo.value, Number(elements.attackDice.value));
+        const attackDice = normalizedAttackDiceValue();
+        if (!attackDice) {
+            return;
+        }
+        await executeAttack(elements.attackFrom.value, elements.attackTo.value, attackDice);
     }
     catch (error) {
         alert(error.message);

--- a/frontend/src/app.mts
+++ b/frontend/src/app.mts
@@ -1643,10 +1643,15 @@ elements.map.addEventListener("click", (event) => {
 
 elements.attackButton.addEventListener("click", async () => {
   try {
+    const attackDice = normalizedAttackDiceValue();
+    if (!attackDice) {
+      return;
+    }
+
     await executeAttack(
       elements.attackFrom.value,
       elements.attackTo.value,
-      Number(elements.attackDice.value)
+      attackDice
     );
   } catch (error) {
     alert(error.message);

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -30,7 +30,8 @@ const gameplayTestModules = [
   "../tests/gameplay/victory/victory-detection.test.cjs",
   "../tests/gameplay/victory/elimination-and-victory.test.cjs",
   "../tests/gameplay/regression/full-flows.test.cjs",
-  "../tests/gameplay/regression/attack-route-guard.test.cjs"
+  "../tests/gameplay/regression/attack-route-guard.test.cjs",
+  "../tests/gameplay/regression/event-broadcast.test.cjs"
 ];
 
 gameplayTestModules.forEach((relativePath) => {

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -29,7 +29,8 @@ const gameplayTestModules = [
   "../tests/gameplay/fortify/fortify-movement.test.cjs",
   "../tests/gameplay/victory/victory-detection.test.cjs",
   "../tests/gameplay/victory/elimination-and-victory.test.cjs",
-  "../tests/gameplay/regression/full-flows.test.cjs"
+  "../tests/gameplay/regression/full-flows.test.cjs",
+  "../tests/gameplay/regression/attack-route-guard.test.cjs"
 ];
 
 gameplayTestModules.forEach((relativePath) => {

--- a/tests/gameplay/all.test.cts
+++ b/tests/gameplay/all.test.cts
@@ -12,7 +12,8 @@ const gameplayTestModules = [
   "./victory/victory-detection.test.cjs",
   "./victory/elimination-and-victory.test.cjs",
   "./regression/full-flows.test.cjs",
-  "./regression/attack-route-guard.test.cjs"
+  "./regression/attack-route-guard.test.cjs",
+  "./regression/event-broadcast.test.cjs"
 ];
 
 gameplayTestModules.forEach((modulePath) => {

--- a/tests/gameplay/all.test.cts
+++ b/tests/gameplay/all.test.cts
@@ -11,7 +11,8 @@ const gameplayTestModules = [
   "./fortify/fortify-movement.test.cjs",
   "./victory/victory-detection.test.cjs",
   "./victory/elimination-and-victory.test.cjs",
-  "./regression/full-flows.test.cjs"
+  "./regression/full-flows.test.cjs",
+  "./regression/attack-route-guard.test.cjs"
 ];
 
 gameplayTestModules.forEach((modulePath) => {

--- a/tests/gameplay/regression/attack-route-guard.test.cjs
+++ b/tests/gameplay/regression/attack-route-guard.test.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../../.tsbuild/tests/gameplay/regression/attack-route-guard.test.cjs');

--- a/tests/gameplay/regression/attack-route-guard.test.cts
+++ b/tests/gameplay/regression/attack-route-guard.test.cts
@@ -44,3 +44,46 @@ register("handleAttackGameActionRoute maps stale attack dice runtime errors to a
   assert.equal(localizedErrorCall?.[3], "Numero di dadi di attacco non valido.");
   assert.equal(localizedErrorCall?.[4], "game.attack.invalidDiceCount");
 });
+
+register("handleAttackGameActionRoute falls back to engine randomness when no queued rolls exist", async () => {
+  let receivedRandom: unknown = Symbol("unset");
+  let sentPayload: Record<string, unknown> | null = null;
+
+  const handled = await handleAttackGameActionRoute(
+    "attack",
+    {},
+    { fromId: "aurora", toId: "bastion", attackDice: 3 },
+    { state: {}, gameId: "g-1", version: 4, gameName: "Attack Guard" },
+    "p1",
+    4,
+    { id: "u1" },
+    (_state: unknown, _playerId: string, _fromId: string, _toId: string, random: unknown) => {
+      receivedRandom = random;
+      return { ok: true, rounds: [] };
+    },
+    () => {
+      throw new Error("Banzai resolver should not run in this scenario.");
+    },
+    () => null,
+    async () => ({ version: 5 }),
+    () => {
+    },
+    () => ({ ok: true }),
+    () => false,
+    (territoryId: string) => territoryId === "aurora" || territoryId === "bastion",
+    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+      sentPayload = payload;
+    },
+    () => {
+      throw new Error("sendLocalizedError should not run when the engine can use its default randomness.");
+    }
+  );
+
+  assert.equal(handled, true);
+  assert.equal(receivedRandom, undefined);
+  assert.deepEqual(sentPayload, {
+    ok: true,
+    state: { ok: true },
+    rounds: []
+  });
+});

--- a/tests/gameplay/regression/attack-route-guard.test.cts
+++ b/tests/gameplay/regression/attack-route-guard.test.cts
@@ -1,0 +1,46 @@
+const assert = require("node:assert/strict");
+const { handleAttackGameActionRoute } = require("../../../backend/routes/game-actions-attack.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("handleAttackGameActionRoute maps stale attack dice runtime errors to a localized 400", async () => {
+  let localizedErrorCall: any[] | null = null;
+
+  const handled = await handleAttackGameActionRoute(
+    "attack",
+    {},
+    { fromId: "aurora", toId: "bastion", attackDice: 3 },
+    { state: {}, gameId: "g-1", version: 4, gameName: "Attack Guard" },
+    "p1",
+    4,
+    { id: "u1" },
+    () => {
+      throw new Error("Attacker dice must be between 1 and 1.");
+    },
+    () => {
+      throw new Error("Banzai resolver should not run in this scenario.");
+    },
+    () => null,
+    async () => {
+      throw new Error("Persist should not run after a rejected attack.");
+    },
+    () => {
+      throw new Error("Broadcast should not run after a rejected attack.");
+    },
+    () => ({}),
+    () => false,
+    (territoryId: string) => territoryId === "aurora" || territoryId === "bastion",
+    () => {
+      throw new Error("sendJson should not be called for a mapped validation error.");
+    },
+    (...args: any[]) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  assert.equal(handled, true);
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 400);
+  assert.equal(localizedErrorCall?.[3], "Numero di dadi di attacco non valido.");
+  assert.equal(localizedErrorCall?.[4], "game.attack.invalidDiceCount");
+});

--- a/tests/gameplay/regression/event-broadcast.test.cjs
+++ b/tests/gameplay/regression/event-broadcast.test.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../../.tsbuild/tests/gameplay/regression/event-broadcast.test.cjs');

--- a/tests/gameplay/regression/event-broadcast.test.cts
+++ b/tests/gameplay/regression/event-broadcast.test.cts
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const { broadcastEventPayload } = require("../../../backend/event-broadcast.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("broadcastEventPayload drops dead clients and keeps writable ones", () => {
+  const deliveredPayloads: string[] = [];
+  const healthyClient = {
+    res: {
+      destroyed: false,
+      writableEnded: false,
+      write(payload: string) {
+        deliveredPayloads.push(payload);
+      }
+    },
+    user: { id: "u1" }
+  };
+  const staleClient = {
+    res: {
+      destroyed: true,
+      writableEnded: false,
+      write() {
+        throw new Error("stale client should not be written");
+      }
+    },
+    user: { id: "u2" }
+  };
+  const clients = new Set([healthyClient, staleClient]);
+
+  broadcastEventPayload(clients, (client: { user?: { id?: string } }) => `payload:${client.user?.id || "unknown"}`);
+
+  assert.deepEqual(deliveredPayloads, ["payload:u1"]);
+  assert.equal(clients.has(healthyClient), true);
+  assert.equal(clients.has(staleClient), false);
+});
+
+register("broadcastEventPayload removes clients whose writes throw", () => {
+  const healthyClient = {
+    res: {
+      destroyed: false,
+      writableEnded: false,
+      write() {
+      }
+    }
+  };
+  const throwingClient = {
+    res: {
+      destroyed: false,
+      writableEnded: false,
+      write() {
+        throw new Error("write after end");
+      }
+    }
+  };
+  const clients = new Set([healthyClient, throwingClient]);
+
+  broadcastEventPayload(clients, () => "payload");
+
+  assert.equal(clients.has(healthyClient), true);
+  assert.equal(clients.has(throwingClient), false);
+});


### PR DESCRIPTION
## What changed
- normalize the standard attack submit path before sending dice to `/api/action`, matching the existing banzai flow
- map known attack resolver runtime failures back to localized `400` responses instead of surfacing a generic internal error
- add regression coverage for both the backend route guard and the stale-attack-dice UI submit case
- wire the new regression test into the gameplay test runner

## Why
The engine tests were green, but the normal attack button could still submit a stale dice value from the DOM in real UI conditions. When that happened, the backend route could fall through to a `500` and the player only saw `Errore interno`.

## Impact
- players now get a valid attack request even if the select element drifts out of sync with the currently selected territory
- invalid attack dice are reported as a user-facing validation error instead of an internal server error
- this regression is now covered in both gameplay and Playwright tests

## Validation
- `npm run test:gameplay`
- `npx playwright test "e2e/gameplay/attack-dice-request.spec.ts" --project=chromium`