### PR TITLE
[codex] Improve engine branch coverage

### DIFF
--- a/backend/routes/game-read.cts
+++ b/backend/routes/game-read.cts
@@ -56,7 +56,7 @@ async function handleEventsRoute(
   }
 
   const gameContext = await loadGameContext(gameId);
-  await resumeAiTurnsForRead(gameContext);
+  // Keep the event stream read-only. AI advancement already happens on open/state routes.
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -16,6 +16,9 @@ const tests: GameplayTest[] = [];
 };
 
 const gameplayTestModules = [
+  "../tests/gameplay/shared/map-graph.test.cjs",
+  "../tests/gameplay/shared/map-loader.test.cjs",
+  "../tests/gameplay/shared/continent-loader.test.cjs",
   "../tests/gameplay/ai/ai-player.test.cjs",
   "../tests/gameplay/setup/game-setup.test.cjs",
   "../tests/gameplay/turn-flow/turn-flow.test.cjs",

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -34,6 +34,7 @@ const gameplayTestModules = [
   "../tests/gameplay/victory/elimination-and-victory.test.cjs",
   "../tests/gameplay/regression/full-flows.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",
+  "../tests/gameplay/regression/game-read-routes.test.cjs",
   "../tests/gameplay/regression/event-broadcast.test.cjs"
 ];
 

--- a/tests/gameplay/all.test.cts
+++ b/tests/gameplay/all.test.cts
@@ -16,6 +16,7 @@ const gameplayTestModules = [
   "./victory/elimination-and-victory.test.cjs",
   "./regression/full-flows.test.cjs",
   "./regression/attack-route-guard.test.cjs",
+  "./regression/game-read-routes.test.cjs",
   "./regression/event-broadcast.test.cjs"
 ];
 

--- a/tests/gameplay/all.test.cts
+++ b/tests/gameplay/all.test.cts
@@ -1,4 +1,7 @@
 const gameplayTestModules = [
+  "./shared/map-graph.test.cjs",
+  "./shared/map-loader.test.cjs",
+  "./shared/continent-loader.test.cjs",
   "./setup/game-setup.test.cjs",
   "./turn-flow/turn-flow.test.cjs",
   "./reinforcement/reinforcement-calculation.test.cjs",

--- a/tests/gameplay/combat/attack-validation.test.cts
+++ b/tests/gameplay/combat/attack-validation.test.cts
@@ -40,6 +40,23 @@ register("validateAttackAttempt rejects attacks outside attack phase", () => {
   assert.equal(result.code, "INVALID_PHASE");
 });
 
+register("validateAttackAttempt rejects attacks while the game is not active", () => {
+  const { graph, state } = setupValidationState();
+  state.phase = "lobby";
+  const result = validateAttackAttempt(state, graph, "p1", "a", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "GAME_NOT_ACTIVE");
+});
+
+register("validateAttackAttempt rejects attackers that are not the current player", () => {
+  const { graph, state } = setupValidationState();
+  state.currentTurnIndex = 1;
+  const result = validateAttackAttempt(state, graph, "p1", "a", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "NOT_CURRENT_PLAYER");
+  assert.deepEqual(result.details, { currentPlayerId: "p2" });
+});
+
 register("validateAttackAttempt rejects non-enemy defender territories", () => {
   const { graph, state } = setupValidationState();
   const result = validateAttackAttempt(state, graph, "p1", "a", "c");
@@ -70,10 +87,58 @@ register("validateAttackAttempt rejects non-adjacent territories", () => {
   assert.equal(result.code, "NOT_ADJACENT");
 });
 
+register("validateAttackAttempt rejects unknown attacker territories from the graph", () => {
+  const { graph, state } = setupValidationState();
+  const result = validateAttackAttempt(state, graph, "p1", "missing", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "UNKNOWN_ATTACKER_TERRITORY");
+});
+
+register("validateAttackAttempt rejects unknown defender territories from the graph", () => {
+  const { graph, state } = setupValidationState();
+  const result = validateAttackAttempt(state, graph, "p1", "a", "missing");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "UNKNOWN_DEFENDER_TERRITORY");
+});
+
+register("validateAttackAttempt rejects missing attacker territory state", () => {
+  const { graph, state } = setupValidationState();
+  delete state.territories.a;
+  const result = validateAttackAttempt(state, graph, "p1", "a", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "MISSING_ATTACKER_STATE");
+});
+
+register("validateAttackAttempt rejects missing defender territory state", () => {
+  const { graph, state } = setupValidationState();
+  delete state.territories.b;
+  const result = validateAttackAttempt(state, graph, "p1", "a", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "MISSING_DEFENDER_STATE");
+});
+
+register("validateAttackAttempt rejects attacker territories not owned by the current player", () => {
+  const { graph, state } = setupValidationState();
+  state.territories.a.ownerId = "p2";
+  const result = validateAttackAttempt(state, graph, "p1", "a", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "ATTACKER_NOT_OWNED");
+  assert.deepEqual(result.details, { ownerId: "p2" });
+});
+
 register("validateAttackAttempt rejects attacker territories with fewer than two armies", () => {
   const { graph, state } = setupValidationState();
   state.territories.a.armies = 1;
   const result = validateAttackAttempt(state, graph, "p1", "a", "b");
   assert.equal(result.ok, false);
   assert.equal(result.code, "INSUFFICIENT_ARMIES");
+});
+
+register("validateAttackAttempt rejects defenders without an enemy owner", () => {
+  const { graph, state } = setupValidationState();
+  state.territories.b.ownerId = null;
+  const result = validateAttackAttempt(state, graph, "p1", "a", "b");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "DEFENDER_NOT_ENEMY");
+  assert.deepEqual(result.details, { ownerId: null });
 });

--- a/tests/gameplay/conquest/conquest-resolution.test.cts
+++ b/tests/gameplay/conquest/conquest-resolution.test.cts
@@ -30,6 +30,8 @@ register("resolveConquest changes owner and moves armies on a valid conquest", (
   assert.equal(state.territories.a.armies, 2);
   assert.equal(state.territories.b.ownerId, "p1");
   assert.equal(state.territories.b.armies, 2);
+  assert.equal(result.conquest.minimumMove, 2);
+  assert.equal(result.conquest.attackerArmiesRemaining, 2);
 });
 
 register("resolveConquest rejects moves below the minimum required", () => {
@@ -46,6 +48,59 @@ register("resolveConquest rejects moves below the minimum required", () => {
   assert.equal(result.code, "MOVE_BELOW_MINIMUM");
 });
 
+register("resolveConquest rejects conquest attempts before the defender has been eliminated", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 4 },
+      { id: "b", ownerId: "p2", armies: 1 }
+    ])
+  });
+
+  const result = resolveConquest(
+    state,
+    {
+      details: { playerId: "p1" },
+      combat: {
+        fromTerritoryId: "a",
+        toTerritoryId: "b",
+        attackDiceCount: 2,
+        defenderReducedToZero: false
+      }
+    },
+    2
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "CONQUEST_NOT_AVAILABLE");
+  assert.equal(state.territories.a.armies, 4);
+  assert.equal(state.territories.b.ownerId, "p2");
+  assert.equal(state.territories.b.armies, 1);
+});
+
+register("resolveConquest rejects non-integer move counts", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 4 },
+      { id: "b", ownerId: "p2", armies: 0 }
+    ])
+  });
+
+  const result = resolveConquest(state, makeCombatResult(), 1.5);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "INVALID_MOVE_COUNT");
+});
+
+register("resolveConquest throws when the attacker territory state is missing", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "b", ownerId: "p2", armies: 0 }])
+  });
+
+  assert.throws(() => resolveConquest(state, makeCombatResult(), 2), /attacker territory state/i);
+});
+
 register("resolveConquest rejects moves that leave the source empty", () => {
   const state = makeState({
     players: makePlayers(["Alice", "Bob"]),
@@ -58,4 +113,61 @@ register("resolveConquest rejects moves that leave the source empty", () => {
   const result = resolveConquest(state, makeCombatResult(), 3);
   assert.equal(result.ok, false);
   assert.equal(result.code, "MOVE_EXCEEDS_AVAILABLE");
+});
+
+register("resolveConquest throws when the combat result has no attacking player id", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 4 },
+      { id: "b", ownerId: "p2", armies: 0 }
+    ])
+  });
+
+  assert.throws(
+    () =>
+      resolveConquest(
+        state,
+        {
+          details: {},
+          combat: {
+            fromTerritoryId: "a",
+            toTerritoryId: "b",
+            attackDiceCount: 2,
+            defenderReducedToZero: true
+          }
+        },
+        2
+      ),
+    /attacking player id/i
+  );
+});
+
+register("resolveConquest defaults the minimum move to one army when combat dice are missing", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 3 },
+      { id: "b", ownerId: "p2", armies: 0 }
+    ])
+  });
+
+  const result = resolveConquest(
+    state,
+    {
+      details: { playerId: "p1" },
+      combat: {
+        fromTerritoryId: "a",
+        toTerritoryId: "b",
+        attackDiceCount: Number.NaN,
+        defenderReducedToZero: true
+      }
+    },
+    1
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.conquest.minimumMove, 1);
+  assert.equal(state.territories.a.armies, 2);
+  assert.equal(state.territories.b.armies, 1);
 });

--- a/tests/gameplay/regression/game-read-routes.test.cts
+++ b/tests/gameplay/regression/game-read-routes.test.cts
@@ -1,0 +1,247 @@
+const assert = require("node:assert/strict");
+const {
+  handleEventsRoute,
+  handleStateRoute
+} = require("../../../backend/routes/game-read.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("handleStateRoute resumes AI turns before returning the snapshot", async () => {
+  const calls: string[] = [];
+  let sentPayload: Record<string, unknown> | null = null;
+  const stateObject: Record<string, unknown> = { phase: "active" };
+  const gameContext = {
+    gameId: "g-1",
+    version: 7,
+    gameName: "State Route",
+    state: stateObject
+  };
+
+  await handleStateRoute(
+    { headers: {} },
+    {},
+    new URL("https://netrisk.test/api/state?gameId=g-1"),
+    async () => ({ ok: true, user: { id: "u-1" } }),
+    (_body: Record<string, unknown>, url: URL | null) => url?.searchParams.get("gameId") || null,
+    async () => {
+      calls.push("load");
+      return gameContext;
+    },
+    async (context: typeof gameContext) => {
+      calls.push("resume");
+      context.version = 8;
+      context.state = { ...context.state, resumed: true };
+      return [{ ok: true }];
+    },
+    async () => {
+      calls.push("session");
+      return { id: "fallback-user" };
+    },
+    () => {
+      calls.push("extract");
+      return "session-token";
+    },
+    (state: Record<string, unknown>, gameId: string | null, version: number | null, gameName: string | null, user: unknown) => ({
+      state,
+      gameId,
+      version,
+      gameName,
+      user
+    }),
+    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+      sentPayload = payload;
+    }
+  );
+
+  assert.deepEqual(calls, ["load", "resume"]);
+  assert.deepEqual(sentPayload, {
+    state: { phase: "active", resumed: true },
+    gameId: "g-1",
+    version: 8,
+    gameName: "State Route",
+    user: { id: "u-1" }
+  });
+});
+
+register("handleStateRoute falls back to the session user when authorizeGameRead has no linked user", async () => {
+  const calls: string[] = [];
+  let sentPayload: Record<string, unknown> | null = null;
+
+  await handleStateRoute(
+    { headers: {} },
+    {},
+    new URL("https://netrisk.test/api/state?gameId=g-2"),
+    async () => ({ ok: true, user: null }),
+    (_body: Record<string, unknown>, url: URL | null) => url?.searchParams.get("gameId") || null,
+    async () => ({
+      gameId: "g-2",
+      version: 3,
+      gameName: "Fallback User",
+      state: { phase: "active" }
+    }),
+    async () => {
+      calls.push("resume");
+      return [];
+    },
+    async (sessionToken: string | null) => {
+      calls.push("session");
+      assert.equal(sessionToken, "session-token");
+      return { id: "fallback-user" };
+    },
+    () => "session-token",
+    (state: Record<string, unknown>, gameId: string | null, version: number | null, gameName: string | null, user: unknown) => ({
+      state,
+      gameId,
+      version,
+      gameName,
+      user
+    }),
+    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+      sentPayload = payload;
+    }
+  );
+
+  assert.deepEqual(calls, ["resume", "session"]);
+  assert.ok(sentPayload);
+  const payload = sentPayload as unknown as { user: { id: string } };
+  assert.equal(payload.user.id, "fallback-user");
+});
+
+register("handleStateRoute returns early when authorizeGameRead blocks access", async () => {
+  let sendJsonCalled = false;
+
+  await handleStateRoute(
+    { headers: {} },
+    {},
+    new URL("https://netrisk.test/api/state?gameId=g-3"),
+    async () => null,
+    () => "g-3",
+    async () => {
+      throw new Error("loadGameContext should not run when access is denied.");
+    },
+    async () => {
+      throw new Error("resumeAiTurnsForRead should not run when access is denied.");
+    },
+    async () => {
+      throw new Error("getUserFromSession should not run when access is denied.");
+    },
+    () => {
+      throw new Error("extractSessionToken should not run when access is denied.");
+    },
+    () => {
+      throw new Error("snapshotForUser should not run when access is denied.");
+    },
+    () => {
+      sendJsonCalled = true;
+    }
+  );
+
+  assert.equal(sendJsonCalled, false);
+});
+
+register("handleEventsRoute keeps SSE reads non-mutating and streams the current snapshot", async () => {
+  const calls: string[] = [];
+  const writes: string[] = [];
+  const closeHandlers: Array<() => void> = [];
+  const stateObject: Record<string, unknown> = { phase: "active", currentTurnIndex: 2 };
+  const gameContext = {
+    gameId: "g-1",
+    version: 9,
+    gameName: "Events Route",
+    state: stateObject
+  };
+  const clientsByGameId = new Map<string, Set<{ res: unknown; user: unknown }>>();
+
+  const req = {
+    on(eventName: string, handler: () => void) {
+      if (eventName === "close") {
+        closeHandlers.push(handler);
+      }
+    }
+  };
+  const res = {
+    writeHead(_statusCode: number, _headers: Record<string, string>) {
+    },
+    write(chunk: string) {
+      writes.push(chunk);
+    }
+  };
+
+  await handleEventsRoute(
+    req,
+    res,
+    new URL("https://netrisk.test/api/events?gameId=g-1"),
+    async () => ({ ok: true, user: { id: "u-2" } }),
+    (_body: Record<string, unknown>, url: URL | null) => url?.searchParams.get("gameId") || null,
+    async () => {
+      calls.push("load");
+      return gameContext;
+    },
+    async () => {
+      calls.push("resume");
+      throw new Error("resumeAiTurnsForRead should not run for SSE reads.");
+    },
+    (state: Record<string, unknown>, gameId: string | null, version: number | null, gameName: string | null, user: unknown) => ({
+      state,
+      gameId,
+      version,
+      gameName,
+      user
+    }),
+    clientsByGameId
+  );
+
+  assert.deepEqual(calls, ["load"]);
+  assert.equal(writes.length, 1);
+  assert.equal(
+    writes[0],
+    "data: " + JSON.stringify({
+      state: stateObject,
+      gameId: "g-1",
+      version: 9,
+      gameName: "Events Route",
+      user: { id: "u-2" }
+    }) + "\n\n"
+  );
+  assert.equal(clientsByGameId.get("g-1")?.size, 1);
+  assert.equal(closeHandlers.length, 1);
+
+  closeHandlers[0]();
+  assert.equal(clientsByGameId.has("g-1"), false);
+});
+
+register("handleEventsRoute returns early when authorizeGameRead blocks access", async () => {
+  const clientsByGameId = new Map<string, Set<{ res: unknown; user: unknown }>>();
+  let writeHeadCalled = false;
+
+  await handleEventsRoute(
+    {
+      on() {
+      }
+    },
+    {
+      writeHead() {
+        writeHeadCalled = true;
+      },
+      write() {
+        throw new Error("write should not run when access is denied.");
+      }
+    },
+    new URL("https://netrisk.test/api/events?gameId=g-4"),
+    async () => null,
+    () => "g-4",
+    async () => {
+      throw new Error("loadGameContext should not run when access is denied.");
+    },
+    async () => {
+      throw new Error("resumeAiTurnsForRead should not run when access is denied.");
+    },
+    () => {
+      throw new Error("snapshotForUser should not run when access is denied.");
+    },
+    clientsByGameId
+  );
+
+  assert.equal(writeHeadCalled, false);
+  assert.equal(clientsByGameId.size, 0);
+});

--- a/tests/gameplay/reinforcement/reinforcement-placement.test.cts
+++ b/tests/gameplay/reinforcement/reinforcement-placement.test.cts
@@ -20,6 +20,12 @@ register("placeReinforcement adds one army and decreases the pool on owned terri
   assert.equal(result.remainingReinforcements, 2);
   assert.equal(state.territories.a.armies, 3);
   assert.equal(state.reinforcementPool, 2);
+  assert.deepEqual(state.lastAction, {
+    type: "reinforce",
+    playerId: "p1",
+    territoryId: "a",
+    summary: "Alice places 1 reinforcement on a."
+  });
 });
 
 register("placeReinforcement fails outside the reinforcement phase", () => {
@@ -32,6 +38,79 @@ register("placeReinforcement fails outside the reinforcement phase", () => {
   });
 
   assert.throws(() => placeReinforcement(state, "p1", "a"), /reinforcement phase/i);
+});
+
+register("placeReinforcement fails while the game is not active", () => {
+  const state = makeState({
+    phase: "lobby",
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 2 }]),
+    currentTurnIndex: 0,
+    reinforcementPool: 1,
+    turnPhase: TurnPhase.REINFORCEMENT
+  });
+
+  assert.throws(() => placeReinforcement(state, "p1", "a"), /game is active/i);
+});
+
+register("placeReinforcement fails when the acting player is not the current turn player", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 2 }]),
+    currentTurnIndex: 1,
+    reinforcementPool: 1,
+    turnPhase: TurnPhase.REINFORCEMENT
+  });
+
+  assert.throws(() => placeReinforcement(state, "p1", "a"), /current player/i);
+});
+
+register("placeReinforcement fails when no reinforcements remain", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 2 }]),
+    currentTurnIndex: 0,
+    reinforcementPool: 0,
+    turnPhase: TurnPhase.REINFORCEMENT
+  });
+
+  assert.throws(() => placeReinforcement(state, "p1", "a"), /No reinforcements/i);
+});
+
+register("placeReinforcement fails when the player id is missing", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 2 }]),
+    currentTurnIndex: 0,
+    reinforcementPool: 1,
+    turnPhase: TurnPhase.REINFORCEMENT
+  });
+
+  assert.throws(() => placeReinforcement(state, "", "a"), /player id/i);
+});
+
+register("placeReinforcement fails for unknown territories", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 2 }]),
+    currentTurnIndex: 0,
+    reinforcementPool: 1,
+    turnPhase: TurnPhase.REINFORCEMENT
+  });
+
+  assert.throws(() => placeReinforcement(state, "p1", "missing"), /Unknown territory/i);
+});
+
+register("placeReinforcement fails when the territory id is missing", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 2 }]),
+    currentTurnIndex: 0,
+    reinforcementPool: 1,
+    turnPhase: TurnPhase.REINFORCEMENT
+  });
+
+  assert.throws(() => placeReinforcement(state, "p1", ""), /territory id/i);
 });
 
 register("placeReinforcement fails on territories not owned by the current player", () => {

--- a/tests/gameplay/shared/continent-loader.test.cts
+++ b/tests/gameplay/shared/continent-loader.test.cts
@@ -1,0 +1,131 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { loadContinentsFromCsv } = require("../../../shared/continent-loader.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function withCsvFile(content: string, run: (filePath: string) => void) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-continent-loader-"));
+  const filePath = path.join(directory, "continents.csv");
+  fs.writeFileSync(filePath, content, "utf8");
+
+  try {
+    run(filePath);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+register("loadContinentsFromCsv parses a valid CSV with trimming and empty territory lists", () => {
+  withCsvFile(
+    [
+      "# comment",
+      " id , name , bonus , territoryIds ",
+      " north , North , 5 , alpha | beta ",
+      " islands , Islands , 2 , "
+    ].join("\n"),
+    (filePath) => {
+      const continents = loadContinentsFromCsv(filePath, { validTerritoryIds: ["alpha", "beta"] });
+
+      assert.equal(continents.source, path.resolve(filePath));
+      assert.deepEqual(
+        continents.continents.map((continent: any) => continent.id),
+        ["north", "islands"]
+      );
+      assert.deepEqual(continents.continents[0].territoryIds, ["alpha", "beta"]);
+      assert.deepEqual(continents.continents[1].territoryIds, []);
+      assert.equal(continents.continents[0].bonus, 5);
+    }
+  );
+});
+
+register("loadContinentsFromCsv rejects CSV files with missing headers", () => {
+  withCsvFile(
+    [
+      "id,name,bonus",
+      "north,North,5"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadContinentsFromCsv(filePath), /missing required headers: territoryIds/i);
+    }
+  );
+});
+
+register("loadContinentsFromCsv rejects invalid bonus values", () => {
+  withCsvFile(
+    [
+      "id,name,bonus,territoryIds",
+      "north,North,nope,alpha"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadContinentsFromCsv(filePath), /invalid bonus value/i);
+    }
+  );
+});
+
+register("loadContinentsFromCsv rejects rows without continent id", () => {
+  withCsvFile(
+    [
+      "id,name,bonus,territoryIds",
+      ",North,5,alpha"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadContinentsFromCsv(filePath), /missing continent id/i);
+    }
+  );
+});
+
+register("loadContinentsFromCsv rejects rows without continent name", () => {
+  withCsvFile(
+    [
+      "id,name,bonus,territoryIds",
+      "north,,5,alpha"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadContinentsFromCsv(filePath), /missing a name/i);
+    }
+  );
+});
+
+register("loadContinentsFromCsv rejects duplicate continent ids", () => {
+  withCsvFile(
+    [
+      "id,name,bonus,territoryIds",
+      "north,North,5,alpha",
+      "north,North 2,3,beta"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadContinentsFromCsv(filePath), /Duplicate continent id "north"/i);
+    }
+  );
+});
+
+register("loadContinentsFromCsv rejects unknown territory references when a valid territory list is provided", () => {
+  withCsvFile(
+    [
+      "id,name,bonus,territoryIds",
+      "north,North,5,missing"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(
+        () => loadContinentsFromCsv(filePath, { validTerritoryIds: ["alpha", "beta"] }),
+        /unknown territory "missing"/i
+      );
+    }
+  );
+});
+
+register("loadContinentsFromCsv allows territory references when no validation list is provided", () => {
+  withCsvFile(
+    [
+      "id,name,bonus,territoryIds",
+      "north,North,5,missing"
+    ].join("\n"),
+    (filePath) => {
+      const continents = loadContinentsFromCsv(filePath);
+      assert.deepEqual(continents.continents[0].territoryIds, ["missing"]);
+    }
+  );
+});

--- a/tests/gameplay/shared/map-graph.test.cts
+++ b/tests/gameplay/shared/map-graph.test.cts
@@ -1,0 +1,114 @@
+const assert = require("node:assert/strict");
+const { buildMapGraph } = require("../../../shared/map-graph.cjs");
+const { makeTerritory } = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("buildMapGraph builds a valid undirected graph and exposes adjacency queries", () => {
+  const graph = buildMapGraph([
+    { territory: makeTerritory("a", ["b", "c"]) },
+    makeTerritory("b", ["a", "c"]),
+    makeTerritory("c", ["a", "b"])
+  ]);
+
+  assert.equal(graph.size, 3);
+  assert.deepEqual(graph.territoryIds, ["a", "b", "c"]);
+  assert.equal(graph.edgeCount, 3);
+  assert.equal(graph.hasTerritory("a"), true);
+  assert.equal(graph.hasTerritory("missing"), false);
+  assert.deepEqual(graph.getNeighbors("a"), ["b", "c"]);
+  assert.equal(graph.areAdjacent("a", "b"), true);
+  assert.equal(graph.areAdjacent("b", "a"), true);
+  assert.equal(graph.areAdjacent("a", "a"), false);
+});
+
+register("buildMapGraph rejects non-array input", () => {
+  assert.throws(() => buildMapGraph(null as any), /requires an array/i);
+});
+
+register("buildMapGraph rejects entries without a territory id", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["b"]),
+        { territory: { id: null, neighbors: ["a"] } }
+      ] as any),
+    /missing an id/i
+  );
+});
+
+register("buildMapGraph rejects territories whose neighbors are not arrays", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["b"]),
+        { territory: { id: "b", neighbors: "a" } }
+      ] as any),
+    /neighbors as an array/i
+  );
+});
+
+register("buildMapGraph rejects duplicate territory ids", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["b"]),
+        makeTerritory("a", ["b"])
+      ]),
+    /Duplicate territory id "a"/i
+  );
+});
+
+register("buildMapGraph rejects self links", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["a"])
+      ]),
+    /cannot link to itself/i
+  );
+});
+
+register("buildMapGraph rejects unknown neighbors", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["missing"]),
+        makeTerritory("b", [])
+      ]),
+    /unknown neighbor "missing"/i
+  );
+});
+
+register("buildMapGraph rejects duplicate links declared by the same territory", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["b", "b"]),
+        makeTerritory("b", ["a"])
+      ]),
+    /duplicate link to "b"/i
+  );
+});
+
+register("buildMapGraph rejects non-bidirectional adjacency", () => {
+  assert.throws(
+    () =>
+      buildMapGraph([
+        makeTerritory("a", ["b"]),
+        makeTerritory("b", [])
+      ]),
+    /must be bidirectional/i
+  );
+});
+
+register("buildMapGraph rejects unknown territories in getNeighbors and areAdjacent", () => {
+  const graph = buildMapGraph([
+    makeTerritory("a", ["b"]),
+    makeTerritory("b", ["a"])
+  ]);
+
+  assert.throws(() => graph.getNeighbors("missing"), /Unknown territory "missing"/i);
+  assert.throws(() => graph.areAdjacent("missing", "a"), /Unknown territory "missing"/i);
+  assert.throws(() => graph.areAdjacent("a", "missing"), /Unknown territory "missing"/i);
+});

--- a/tests/gameplay/shared/map-loader.test.cts
+++ b/tests/gameplay/shared/map-loader.test.cts
@@ -1,0 +1,141 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { loadMapDefinitionFromCsv } = require("../../../shared/map-loader.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function withCsvFile(content: string, run: (filePath: string) => void) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-map-loader-"));
+  const filePath = path.join(directory, "map.csv");
+  fs.writeFileSync(filePath, content, "utf8");
+
+  try {
+    run(filePath);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+register("loadMapDefinitionFromCsv parses a valid CSV with trimming, comments, and empty neighbors", () => {
+  withCsvFile(
+    [
+      "# comment",
+      " id , name , continentId , x , y , neighbors ",
+      " alpha , Alpha , north , 0.10 , 0.20 , beta | gamma ",
+      " beta , Beta , north , 0.30 , 0.40 , alpha ",
+      " gamma , Gamma , south , 0.50 , 0.60 , "
+    ].join("\n"),
+    (filePath) => {
+      const map = loadMapDefinitionFromCsv(filePath);
+
+      assert.equal(map.source, path.resolve(filePath));
+      assert.deepEqual(
+        map.territories.map((entry: any) => entry.territory.id),
+        ["alpha", "beta", "gamma"]
+      );
+      assert.deepEqual(map.territories[0].territory.neighbors, ["beta", "gamma"]);
+      assert.deepEqual(map.territories[2].territory.neighbors, []);
+      assert.deepEqual(map.positions.alpha, { x: 0.1, y: 0.2 });
+      assert.deepEqual(map.positions.gamma, { x: 0.5, y: 0.6 });
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects CSV files with missing headers", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y",
+      "alpha,Alpha,north,0.1,0.2"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /missing required headers: neighbors/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects rows that do not match header length", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,Alpha,north,0.1,0.2"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /does not match the CSV header length/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects non-numeric coordinates", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,Alpha,north,nope,0.2,"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /invalid x coordinate/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects out-of-range coordinates", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,Alpha,north,1.2,0.2,"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /between 0 and 1/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects rows without territory id", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      ",Alpha,north,0.1,0.2,"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /missing territory id/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects rows without territory name", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,,north,0.1,0.2,"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /missing a name/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects duplicate territory ids", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,Alpha,north,0.1,0.2,beta",
+      "alpha,Alpha 2,north,0.3,0.4,beta"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /Duplicate territory id "alpha"/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects unknown neighbors", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,Alpha,north,0.1,0.2,missing"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /unknown neighbor "missing"/i);
+    }
+  );
+});


### PR DESCRIPTION
## Objective
Improve test coverage with emphasis on meaningful branch coverage in core validation paths, and apply a minimal backend fix only where tests and preview behavior exposed a real issue.

## Areas touched
- `tests/gameplay/combat/attack-validation.test.cts`
- `tests/gameplay/conquest/conquest-resolution.test.cts`
- `tests/gameplay/reinforcement/reinforcement-placement.test.cts`
- `tests/gameplay/shared/map-graph.test.cts`
- `tests/gameplay/shared/map-loader.test.cts`
- `tests/gameplay/shared/continent-loader.test.cts`
- `tests/gameplay/regression/game-read-routes.test.cts`
- `tests/gameplay/all.test.cts`
- `scripts/run-gameplay-tests.cts`
- `backend/routes/game-read.cts`

## Coverage
- Before: 86.40% lines, 68.22% branches, 81.72% functions
- Current: 87.45% lines, 70.53% branches, 82.05% functions
- Shared module branch coverage includes:
  - `map-graph`: 88.88%
  - `map-loader`: 84.00%
  - `continent-loader`: 88.37%

## Minimal fixes
- Treat `/api/events` as a read-only SSE endpoint and stop resuming AI turns from the event stream.
- AI advancement still happens on `/api/games/open` and `/api/state`, but no longer gets retriggered by the live event connection.

## Validation
- `npm run test:all`
- `npm run coverage`
- `npm run build:ts`
- `npm run typecheck`
- `npm run typecheck:frontend`
- `npm run test:e2e:smoke`
- `lint`: no `lint` script is defined in `package.json`

## Residual risks
- Branch coverage remains lower in some non-engine runtime modules, but this PR intentionally stays conservative and focused on high-value validation coverage plus one contained backend read-path fix.
- I could verify the PR checks and Vercel preview deployment are green, but I could not fully replay the exact private authenticated game session from the preview environment.
