### PR TITLE
[codex] Add move-all actions and harden AI resume

### DIFF
--- a/backend/engine/ai-turn-resume.cts
+++ b/backend/engine/ai-turn-resume.cts
@@ -1,0 +1,99 @@
+const {
+  advanceTurn,
+  getCurrentPlayer,
+  territoriesOwnedBy
+} = require("./game-engine.cjs") as typeof import("./game-engine.cjs");
+const { runAiTurn } = require("./ai-player.cjs") as typeof import("./ai-player.cjs");
+const { createLocalizedError } = require("../../shared/messages.cjs") as typeof import("../../shared/messages.cjs");
+
+type ResumeState = {
+  players: Array<unknown>;
+  phase?: string;
+  winnerId?: string | null;
+  currentTurnIndex?: number;
+};
+
+type FailedAiTurn = {
+  ok: false;
+  error?: string;
+  errorKey?: string | null;
+  errorParams?: Record<string, unknown>;
+};
+
+type SuccessfulAiTurn = {
+  ok: true;
+  [key: string]: unknown;
+};
+
+type AiTurnResult = FailedAiTurn | SuccessfulAiTurn;
+
+function currentAiTurnIsStale(state: ResumeState, currentPlayer: ReturnType<typeof getCurrentPlayer>): boolean {
+  if (!currentPlayer || !currentPlayer.isAi) {
+    return false;
+  }
+
+  if (!currentPlayer.id || currentPlayer.surrendered) {
+    return true;
+  }
+
+  return territoriesOwnedBy(state as Parameters<typeof territoriesOwnedBy>[0], currentPlayer.id).length === 0;
+}
+
+export function runAiTurnsIfNeeded(
+  targetState: ResumeState,
+  options: {
+    random?: () => number;
+    runAiTurn?: (state: ResumeState, options?: { random?: () => number }) => AiTurnResult;
+  } = {}
+): AiTurnResult[] {
+  const reports: AiTurnResult[] = [];
+  const maxTurns = Math.max(4, targetState.players.length * 4);
+  const executeAiTurn = options.runAiTurn || ((state: ResumeState, runOptions?: { random?: () => number }) =>
+    runAiTurn(state as Parameters<typeof runAiTurn>[0], runOptions)) as NonNullable<typeof options.runAiTurn>;
+
+  for (let step = 0; step < maxTurns; step += 1) {
+    const currentPlayer = getCurrentPlayer(targetState as Parameters<typeof getCurrentPlayer>[0]);
+    if (!currentPlayer || !currentPlayer.isAi || targetState.phase !== "active" || targetState.winnerId) {
+      break;
+    }
+
+    if (currentAiTurnIsStale(targetState, currentPlayer)) {
+      const previousTurnIndex = targetState.currentTurnIndex;
+      const previousPlayerId = currentPlayer.id || null;
+      advanceTurn(targetState as Parameters<typeof advanceTurn>[0]);
+
+      const nextPlayer = getCurrentPlayer(targetState as Parameters<typeof getCurrentPlayer>[0]);
+      if (
+        targetState.phase === "active" &&
+        !targetState.winnerId &&
+        nextPlayer?.isAi &&
+        targetState.currentTurnIndex === previousTurnIndex &&
+        nextPlayer.id === previousPlayerId
+      ) {
+        throw createLocalizedError(
+          "Turno AI non riuscito: il turno corrente non puo avanzare.",
+          "server.aiTurn.failed"
+        );
+      }
+
+      continue;
+    }
+
+    const result = executeAiTurn(targetState, { random: options.random });
+    if (!result.ok) {
+      throw createLocalizedError(
+        result.error || "Turno AI non riuscito.",
+        result.errorKey || "server.aiTurn.failed",
+        result.errorParams
+      );
+    }
+
+    reports.push(result);
+  }
+
+  return reports;
+}
+
+module.exports = {
+  runAiTurnsIfNeeded
+};

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -20,7 +20,7 @@ const {
   startGame,
   tradeCardSet
 } = require("./engine/game-engine.cjs");
-const { runAiTurn } = require("./engine/ai-player.cjs");
+const { runAiTurnsIfNeeded } = require("./engine/ai-turn-resume.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
 const { broadcastEventPayload } = require("./event-broadcast.cjs");
@@ -369,27 +369,6 @@ function createApp(options: CreateAppOptions = {}) {
     if (!clients.size) {
       clientsByGameId.delete(gameContext.gameId);
     }
-  }
-
-  function runAiTurnsIfNeeded(targetState: any): any[] {
-    const reports = [];
-    const maxTurns = Math.max(4, targetState.players.length * 4);
-
-    for (let step = 0; step < maxTurns; step += 1) {
-      const currentPlayer = getCurrentPlayer(targetState);
-      if (!currentPlayer || !currentPlayer.isAi || targetState.phase !== "active" || targetState.winnerId) {
-        break;
-      }
-
-      const result = runAiTurn(targetState);
-      if (!result.ok) {
-        throw createLocalizedError(result.error || "Turno AI non riuscito.", result.errorKey || "server.aiTurn.failed", result.errorParams);
-      }
-
-      reports.push(result);
-    }
-
-    return reports;
   }
 
   async function persistWithAiTurns(gameContext: GameContext, expectedVersion?: number | null) {

--- a/frontend/assets/favicon.svg
+++ b/frontend/assets/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="shield-fill" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f5c66a" />
+      <stop offset="100%" stop-color="#d86a3b" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#172033" />
+  <path
+    d="M32 9 49 16v12c0 12.4-7.1 22-17 27-9.9-5-17-14.6-17-27V16L32 9Z"
+    fill="url(#shield-fill)"
+    stroke="#f8edd1"
+    stroke-width="2"
+  />
+  <path
+    d="M24 24h8l8 8v8h-8l-8-8v-8Z"
+    fill="none"
+    stroke="#172033"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="4"
+  />
+</svg>

--- a/frontend/src/app.mts
+++ b/frontend/src/app.mts
@@ -162,6 +162,7 @@ const elements = {
   reinforceSelect: document.querySelector("#reinforce-select") as HTMLSelectElement,
   reinforceAmount: document.querySelector("#reinforce-amount") as HTMLInputElement | null,
   reinforceMultiButton: document.querySelector("#reinforce-multi-button") as HTMLButtonElement | null,
+  reinforceAllButton: document.querySelector("#reinforce-all-button") as HTMLButtonElement | null,
   attackGroup: document.querySelector("#attack-group") as HTMLElement | null,
   attackFrom: document.querySelector("#attack-from") as HTMLSelectElement,
   attackTo: document.querySelector("#attack-to") as HTMLSelectElement,
@@ -171,6 +172,7 @@ const elements = {
   conquestGroup: document.querySelector("#conquest-group") as HTMLElement | null,
   conquestArmies: document.querySelector("#conquest-armies") as HTMLInputElement | null,
   conquestButton: document.querySelector("#conquest-button") as HTMLButtonElement,
+  conquestAllButton: document.querySelector("#conquest-all-button") as HTMLButtonElement | null,
   fortifyGroup: document.querySelector("#fortify-group") as HTMLElement | null,
   fortifyFrom: document.querySelector("#fortify-from") as HTMLSelectElement,
   fortifyTo: document.querySelector("#fortify-to") as HTMLSelectElement,
@@ -480,9 +482,41 @@ function normalizedAttackDiceValue() {
 
 function normalizedReinforcementAmount() {
   const rawValue = Number.parseInt(elements.reinforceAmount?.value || "1", 10);
-  const maxAllowed = Math.max(1, Number(state.snapshot?.reinforcementPool || 1));
+  const maxAllowed = Math.max(1, maximumReinforcementAmount());
   const normalized = Number.isFinite(rawValue) ? rawValue : 1;
   return Math.max(1, Math.min(normalized, maxAllowed));
+}
+
+function maximumReinforcementAmount(): number {
+  const rawValue = Number(state.snapshot?.reinforcementPool || 0);
+  return Number.isFinite(rawValue) ? Math.max(0, Math.floor(rawValue)) : 0;
+}
+
+function maximumPendingConquestArmies(): number {
+  const pendingConquest = state.snapshot?.pendingConquest;
+  if (!pendingConquest) {
+    return 0;
+  }
+
+  const rawValue = Number(pendingConquest.maxArmies ?? pendingConquest.minArmies ?? 0);
+  return Number.isFinite(rawValue) ? Math.max(0, Math.floor(rawValue)) : 0;
+}
+
+function normalizedConquestArmiesAmount() {
+  const pendingConquest = state.snapshot?.pendingConquest;
+  if (!pendingConquest) {
+    return 0;
+  }
+
+  const minAllowed = Math.max(1, Number(pendingConquest.minArmies || 1));
+  const maxAllowed = Math.max(minAllowed, maximumPendingConquestArmies());
+  const rawValue = Number.parseInt(elements.conquestArmies?.value || String(minAllowed), 10);
+  const normalized = Number.isFinite(rawValue) ? rawValue : minAllowed;
+  return Math.max(minAllowed, Math.min(normalized, maxAllowed));
+}
+
+function moveAllActionLabel(count: number): string {
+  return t("game.actions.moveAll", { count: Math.max(0, Math.floor(Number(count) || 0)) });
 }
 
 async function applyReinforcements(times: number): Promise<void> {
@@ -516,6 +550,21 @@ async function executeAttack(fromId: string, toId: string, attackDice: number): 
   }
   render();
   return nextState;
+}
+
+async function moveAfterConquest(armies: number): Promise<void> {
+  const data = await send("/api/action", {
+    ...currentGamePayload(),
+    playerId: state.playerId,
+    type: "moveAfterConquest",
+    armies: Math.max(1, Math.floor(Number(armies) || 1)),
+    expectedVersion: currentExpectedVersion()
+  });
+  state.snapshot = data.state || state.snapshot;
+  if (elements.conquestArmies) {
+    elements.conquestArmies.value = "";
+  }
+  render();
 }
 
 async function runBanzaiAttack() {
@@ -953,10 +1002,13 @@ function render() {
     elements.reinforceSelect.value = selectedReinforceId;
   }
   if (elements.reinforceAmount) {
-    const maxReinforcements = Math.max(1, Number(snapshot?.reinforcementPool || 1));
+    const maxReinforcements = Math.max(1, maximumReinforcementAmount());
     elements.reinforceAmount.min = "1";
     elements.reinforceAmount.max = String(maxReinforcements);
     elements.reinforceAmount.value = String(normalizedReinforcementAmount());
+  }
+  if (elements.reinforceAllButton) {
+    elements.reinforceAllButton.textContent = moveAllActionLabel(maximumReinforcementAmount());
   }
 
   const selectedFromId = selectOrFallback(state.selectedAttackFromId, territories, selectedReinforceId);
@@ -1111,6 +1163,10 @@ function render() {
     if (!elements.conquestArmies.value) {
       elements.conquestArmies.value = String(pendingConquest.minArmies || 1);
     }
+    elements.conquestArmies.value = String(normalizedConquestArmiesAmount());
+  }
+  if (elements.conquestAllButton) {
+    elements.conquestAllButton.textContent = moveAllActionLabel(maximumPendingConquestArmies());
   }
 
   const lastCombat = snapshot?.lastCombat || null;
@@ -1166,12 +1222,18 @@ function render() {
   if (elements.reinforceMultiButton) {
     elements.reinforceMultiButton.disabled = !canInteract || !inReinforcement || Boolean(pendingConquest) || snapshot.reinforcementPool <= 0 || !elements.reinforceSelect.value;
   }
+  if (elements.reinforceAllButton) {
+    elements.reinforceAllButton.disabled = !canInteract || !inReinforcement || Boolean(pendingConquest) || snapshot.reinforcementPool <= 0 || !elements.reinforceSelect.value;
+  }
   elements.attackButton.disabled = !canInteract || !inAttack || Boolean(pendingConquest) || Boolean(state.attackBanzaiInFlight) || snapshot.reinforcementPool > 0 || !elements.attackFrom.value || !elements.attackTo.value || !elements.attackDice.value;
   if (elements.attackBanzaiButton) {
     elements.attackBanzaiButton.disabled = !canInteract || !inAttack || Boolean(pendingConquest) || Boolean(state.attackBanzaiInFlight) || snapshot.reinforcementPool > 0 || !elements.attackFrom.value || !elements.attackTo.value || !elements.attackDice.value;
     elements.attackBanzaiButton.textContent = state.attackBanzaiInFlight ? t("game.runtime.banzaiLoading") : t("game.actions.banzai");
   }
   elements.conquestButton.disabled = !canInteract || !pendingConquest || !elements.conquestArmies?.value;
+  if (elements.conquestAllButton) {
+    elements.conquestAllButton.disabled = !canInteract || !pendingConquest;
+  }
   elements.fortifyButton.disabled = !canInteract || !inFortify || snapshot.fortifyUsed || !elements.fortifyFrom.value || !elements.fortifyTo.value || !elements.fortifyArmies.value;
   elements.endTurnButton.hidden = !canInteract || inReinforcement || Boolean(pendingConquest);
   elements.endTurnButton.disabled = !canInteract || inReinforcement || Boolean(pendingConquest);
@@ -1608,6 +1670,23 @@ if (elements.reinforceMultiButton) {
     }
   });
 }
+if (elements.reinforceAllButton) {
+  elements.reinforceAllButton.addEventListener("click", async () => {
+    try {
+      const maxReinforcements = maximumReinforcementAmount();
+      if (maxReinforcements < 1) {
+        return;
+      }
+
+      if (elements.reinforceAmount) {
+        elements.reinforceAmount.value = String(maxReinforcements);
+      }
+      await applyReinforcements(maxReinforcements);
+    } catch (error: unknown) {
+      alert(error instanceof Error ? error.message : t("errors.requestFailed"));
+    }
+  });
+}
 
 elements.reinforceSelect.addEventListener("change", () => {
   state.selectedReinforceTerritoryId = elements.reinforceSelect.value || null;
@@ -1618,6 +1697,15 @@ if (elements.reinforceAmount) {
     if (elements.reinforceAmount) {
       elements.reinforceAmount.value = String(normalizedReinforcementAmount());
     }
+  });
+}
+if (elements.conquestArmies) {
+  elements.conquestArmies.addEventListener("change", () => {
+    if (!state.snapshot?.pendingConquest || !elements.conquestArmies) {
+      return;
+    }
+
+    elements.conquestArmies.value = String(normalizedConquestArmiesAmount());
   });
 }
 elements.attackFrom.addEventListener("change", () => {
@@ -1737,22 +1825,28 @@ if (elements.attackBanzaiButton) {
 
 elements.conquestButton.addEventListener("click", async () => {
   try {
-    const data = await send("/api/action", {
-      ...currentGamePayload(),
-      playerId: state.playerId,
-      type: "moveAfterConquest",
-       armies: Number(elements.conquestArmies?.value || 0),
-       expectedVersion: currentExpectedVersion()
-     });
-    state.snapshot = data.state || state.snapshot;
-    if (elements.conquestArmies) {
-      elements.conquestArmies.value = "";
-    }
-    render();
+    await moveAfterConquest(normalizedConquestArmiesAmount());
   } catch (error: unknown) {
     alert(error instanceof Error ? error.message : t("errors.requestFailed"));
   }
 });
+if (elements.conquestAllButton) {
+  elements.conquestAllButton.addEventListener("click", async () => {
+    try {
+      const maxArmies = maximumPendingConquestArmies();
+      if (maxArmies < 1) {
+        return;
+      }
+
+      if (elements.conquestArmies) {
+        elements.conquestArmies.value = String(maxArmies);
+      }
+      await moveAfterConquest(maxArmies);
+    } catch (error: unknown) {
+      alert(error instanceof Error ? error.message : t("errors.requestFailed"));
+    }
+  });
+}
 
 elements.fortifyButton.addEventListener("click", async () => {
   try {

--- a/frontend/src/generated/static-text-assets.mts
+++ b/frontend/src/generated/static-text-assets.mts
@@ -10,6 +10,7 @@ export const staticHtmlAssets = {
       content="Gioco di strategia a turni multiplayer. Conquista territori, comanda le armate, domina il teatro di guerra. Gratuito, niente da installare."
       data-i18n-content="landing.meta.description"
     />
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/landing.css" />
     <link rel="stylesheet" href="/shell.css" />
     <script type="module" src="/speed-insights.mjs"></script>
@@ -287,6 +288,7 @@ export const staticHtmlAssets = {
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="refresh" content="0; url=/" />
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <script>
       window.location.replace("/");
     </script>
@@ -300,6 +302,7 @@ export const staticHtmlAssets = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title data-i18n="game.title">Frontline Dominion</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/style.css" />
     <link rel="stylesheet" href="/shell.css" />
     <script type="module" src="/speed-insights.mjs"></script>
@@ -369,9 +372,10 @@ export const staticHtmlAssets = {
                   <label for="reinforce-select" data-i18n="game.actions.reinforce">Rinforza</label>
                   <div class="action-stack">
                     <select id="reinforce-select"></select>
-                    <div class="reinforce-actions-row">
-                      <input id="reinforce-amount" type="number" min="1" step="1" inputmode="numeric" value="1" aria-label="Quantita rinforzi" data-i18n-aria-label="game.actions.reinforceAmountAria" />
+                    <input id="reinforce-amount" type="number" min="1" step="1" inputmode="numeric" value="1" aria-label="Quantita rinforzi" data-i18n-aria-label="game.actions.reinforceAmountAria" />
+                    <div class="action-row">
                       <button id="reinforce-multi-button" data-i18n="game.actions.add">Aggiungi</button>
+                      <button id="reinforce-all-button" type="button">Sposta tutto</button>
                     </div>
                   </div>
                 </div>
@@ -393,7 +397,10 @@ export const staticHtmlAssets = {
                   <label for="conquest-armies" data-i18n="game.actions.afterConquest">Dopo conquista</label>
                   <div class="action-stack">
                     <input id="conquest-armies" type="number" min="1" step="1" />
-                    <button id="conquest-button" data-i18n="game.actions.moveArmies">Sposta armate</button>
+                    <div class="action-row">
+                      <button id="conquest-button" data-i18n="game.actions.moveArmies">Sposta armate</button>
+                      <button id="conquest-all-button" type="button">Sposta tutto</button>
+                    </div>
                   </div>
                 </div>
 
@@ -477,6 +484,7 @@ export const staticHtmlAssets = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title data-i18n="lobby.title">Frontline Dominion - Lobby</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/style.css" />
     <link rel="stylesheet" href="/shell.css" />
     <script type="module" src="/speed-insights.mjs"></script>
@@ -580,6 +588,7 @@ export const staticHtmlAssets = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title data-i18n="newGame.title">Frontline Dominion - Nuova Partita</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/style.css" />
     <link rel="stylesheet" href="/shell.css" />
     <script type="module" src="/speed-insights.mjs"></script>
@@ -702,6 +711,7 @@ export const staticHtmlAssets = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title data-i18n="profile.title">Frontline Dominion - Profilo</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/style.css" />
     <link rel="stylesheet" href="/shell.css" />
     <script type="module" src="/speed-insights.mjs"></script>
@@ -846,6 +856,7 @@ export const staticHtmlAssets = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title data-i18n="register.title">Frontline Dominion - Registrazione</title>
+    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/style.css" />
     <link rel="stylesheet" href="/shell.css" />
   </head>

--- a/frontend/src/locales/en.mts
+++ b/frontend/src/locales/en.mts
@@ -367,6 +367,7 @@ export const en = Object.freeze({
   "game.actions.reinforce": "Reinforce",
   "game.actions.reinforceAmountAria": "Reinforcement amount",
   "game.actions.add": "Add",
+  "game.actions.moveAll": "Move all ({count})",
   "game.actions.attack": "Attack",
   "game.actions.launchAttack": "Launch attack",
   "game.actions.banzai": "Banzai",

--- a/frontend/src/locales/it.mts
+++ b/frontend/src/locales/it.mts
@@ -367,6 +367,7 @@ export const it = Object.freeze({
   "game.actions.reinforce": "Rinforza",
   "game.actions.reinforceAmountAria": "Quantita rinforzi",
   "game.actions.add": "Aggiungi",
+  "game.actions.moveAll": "Sposta tutto ({count})",
   "game.actions.attack": "Attacca",
   "game.actions.launchAttack": "Lancia attacco",
   "game.actions.banzai": "Banzai",

--- a/frontend/src/speed-insights.mts
+++ b/frontend/src/speed-insights.mts
@@ -5,6 +5,10 @@ type SpeedInsightsWindow = Window & {
   siq?: unknown[][];
 };
 
+function isLocalDevelopmentHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
 function registerSpeedInsights(targetWindow: SpeedInsightsWindow): void {
   targetWindow.si =
     targetWindow.si ??
@@ -13,7 +17,7 @@ function registerSpeedInsights(targetWindow: SpeedInsightsWindow): void {
       targetWindow.siq.push(args);
     });
 
-  if (typeof process !== "undefined" && process.env?.NODE_ENV === "development") {
+  if (isLocalDevelopmentHost(targetWindow.location.hostname)) {
     return;
   }
 

--- a/tests/gameplay/ai/ai-player.test.cts
+++ b/tests/gameplay/ai/ai-player.test.cts
@@ -6,6 +6,7 @@ const {
   chooseReinforcementTarget,
   runAiTurn
 } = require("../../../backend/engine/ai-player.cjs");
+const { runAiTurnsIfNeeded } = require("../../../backend/engine/ai-turn-resume.cjs");
 const { createCard, CardType } = require("../../../shared/models.cjs");
 const { makePlayers, makeState, makeTerritory, territoryStates, TurnPhase } = require("../helpers/state-builder.cjs");
 const { createFixedRandom, rollsToRandomValues } = require("../helpers/random.cjs");
@@ -204,4 +205,30 @@ register("runAiTurn trades cards, attacks, resolves conquest, and ends the turn"
   assert.equal(state.territories.b.armies, 1);
   assert.equal(state.hands.p1.length, 4);
   assert.equal(state.discardPile.length, 3);
+});
+
+register("runAiTurnsIfNeeded skips a stale AI turn that points to an eliminated CPU", () => {
+  const players = makePlayers(["CPU Alpha", "Bob", "CPU Beta"]);
+  players[0].isAi = true;
+  players[2].isAi = true;
+
+  const state = createAiState({
+    players,
+    territories: territoryStates([
+      { id: "a", ownerId: "p2", armies: 3 },
+      { id: "b", ownerId: "p2", armies: 2 },
+      { id: "c", ownerId: "p3", armies: 4 },
+      { id: "d", ownerId: "p3", armies: 1 }
+    ]),
+    turnPhase: TurnPhase.REINFORCEMENT,
+    currentTurnIndex: 0,
+    reinforcementPool: 5
+  });
+
+  const reports = runAiTurnsIfNeeded(state);
+
+  assert.deepEqual(reports, []);
+  assert.equal(state.currentTurnIndex, 1);
+  assert.equal(state.turnPhase, TurnPhase.REINFORCEMENT);
+  assert.equal(state.reinforcementPool, 3);
 });


### PR DESCRIPTION
## What changed
- added `Sposta tutto (X)` actions in reinforcement and post-conquest flows
- normalized the max amount client-side so the quick action always uses the allowed cap
- stopped loading Vercel Speed Insights on localhost to remove the local `404` noise
- added a shared SVG favicon and linked it from the generated pages
- hardened AI turn resume so opening a saved game no longer fails if the current turn still points at an eliminated AI player
- added a regression test that covers the stale eliminated-AI resume case

## Why
- the game UI needed a faster way to spend the full reinforcement pool or complete the mandatory post-conquest move
- local browser checks were polluted by an avoidable missing Speed Insights script
- the app had no favicon configured
- one saved game could no longer be opened because the server tried to resume an AI turn for a CPU that no longer owned territories

## Validation
- `npm run test:all:e2e`
- manual browser verification of the new reinforcement and post-conquest buttons
