### PR TITLE
[codex] Fix map reload flicker

### DIFF
--- a/frontend/src/app.mts
+++ b/frontend/src/app.mts
@@ -1111,6 +1111,7 @@ function render() {
   if (nextMapSignature !== renderedMapSignature) {
     setMarkup(elements.map, snapshot ? buildGraphMarkup(snapshot) : "");
     renderedMapSignature = nextMapSignature;
+    fitMapBoardToViewport();
     queueMapBoardFit();
   } else {
     updateMapTerritoryHighlights();


### PR DESCRIPTION
## What changed
- applied the map board viewport fit immediately after the map markup is rendered
- kept the existing queued fit pass for post-layout stabilization and window resize handling

## Why
The map briefly rendered at an oversized width on page reload before being resized to the viewport. That produced a visible flicker on first paint.

## Impact
- smoother initial map render on reload
- no gameplay or backend logic changes
- change remains isolated to the frontend game view

## Validation
- `npm run typecheck:frontend`
- `npm run build:frontend`