### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 NetRisk Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -256,3 +256,7 @@ The game screen also includes:
 - attack dice selector with default coherent to selected territory
 - latest combat summary panel with dice and comparison
 - current player card panel with set selection and trade submission
+
+## License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
   },
   "dependencies": {
     "@vercel/speed-insights": "^2.0.0"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
### Motivation
- Add an explicit MIT license file to clarify open-source usage and distribution rights.

### Description
- Added `LICENSE` at the repository root containing the standard MIT License text and copyright set to `2026 NetRisk Contributors`.

### Testing
- Verified creation and commit of the file using `git status --short`, `git commit`, and inspected the file with `nl -ba LICENSE`, all commands succeeded.