### PR TITLE
[codex] follow up module asset review fixes

### DIFF
--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -696,7 +696,17 @@ function loadClientManifest(moduleRoot: string, manifest: NetRiskModuleManifest)
   const warnings: string[] = [];
   const errors: string[] = [];
   const relativeClientManifestPath = manifest.entrypoints?.clientManifest || "client-manifest.json";
-  const absoluteClientManifestPath = path.join(moduleRoot, relativeClientManifestPath);
+  const absoluteClientManifestPath = path.resolve(moduleRoot, relativeClientManifestPath);
+
+  if (absoluteClientManifestPath !== moduleRoot && !absoluteClientManifestPath.startsWith(moduleRoot + path.sep)) {
+    errors.push(`Client manifest "${relativeClientManifestPath}" escapes the module directory.`);
+    return {
+      clientManifest: null,
+      clientManifestPath: null,
+      warnings,
+      errors
+    };
+  }
 
   if (!fs.existsSync(absoluteClientManifestPath)) {
     if (manifest.entrypoints?.clientManifest) {

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -121,8 +121,6 @@ function resolveProjectRoot() {
 }
 
 const projectRoot = resolveProjectRoot();
-const publicDir = path.join(projectRoot, "public");
-const modulesDir = path.join(projectRoot, "modules");
 const port = process.env.PORT || 3000;
 const sessionCookieName = "netrisk_session";
 const supportedSiteThemes = new Set(listSupportedThemeIds());
@@ -251,6 +249,8 @@ function clearSessionCookie(req: Request): string {
 
 function createApp(options: CreateAppOptions = {}) {
   const runtimeProjectRoot = options.projectRoot || projectRoot;
+  const runtimePublicDir = path.join(runtimeProjectRoot, "public");
+  const runtimeModulesDir = path.join(runtimeProjectRoot, "modules");
 
   if (shouldValidateDeployEnv(process.env)) {
     const missingEnvKeys = missingRequiredDeployEnv(process.env);
@@ -1066,7 +1066,7 @@ function createApp(options: CreateAppOptions = {}) {
 
   function serveStatic(res: Response, url: URL) {
     const isModuleAssetRequest = url.pathname.indexOf("/modules/") === 0;
-    const staticRoot = isModuleAssetRequest ? modulesDir : publicDir;
+    const staticRoot = isModuleAssetRequest ? runtimeModulesDir : runtimePublicDir;
     const relativePath = isModuleAssetRequest
       ? url.pathname.replace(/^\/modules\//, "")
       : (url.pathname === "/"

--- a/frontend/src/shell.mts
+++ b/frontend/src/shell.mts
@@ -326,7 +326,7 @@ async function fetchModuleOptions(): Promise<ModuleOptionsResponse | null> {
 
 function resolveModuleStylesheetHref(moduleId: string, stylesheet: string): string | null {
   const trimmed = String(stylesheet || "").trim();
-  if (!trimmed || /^https?:\/\//i.test(trimmed)) {
+  if (!trimmed || /^[a-z][a-z0-9+.-]*:/i.test(trimmed) || /^\/\//.test(trimmed)) {
     return null;
   }
 

--- a/tests/gameplay/regression/module-runtime.test.cts
+++ b/tests/gameplay/regression/module-runtime.test.cts
@@ -11,6 +11,7 @@ type MockResponse = {
   statusCode: number;
   headers: HeaderMap;
   body: string;
+  setHeader(name: string, value: string): void;
   writeHead(statusCode: number, nextHeaders?: HeaderMap): void;
   end(chunk?: string): void;
 };
@@ -18,6 +19,12 @@ type MockResponse = {
 type CallAppResult = {
   statusCode: number;
   payload: any;
+};
+
+type CallRequestResult = {
+  statusCode: number;
+  headers: HeaderMap;
+  body: string;
 };
 
 function register(name: string, fn: () => unknown | Promise<unknown>) {
@@ -30,6 +37,9 @@ function makeMockResponse(): MockResponse {
     statusCode: 200,
     headers,
     body: "",
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
     writeHead(statusCode: number, nextHeaders: HeaderMap = {}) {
       this.statusCode = statusCode;
       Object.assign(headers, nextHeaders);
@@ -59,6 +69,31 @@ async function callApp(app: any, method: string, pathname: string, body?: any, h
   return {
     statusCode: res.statusCode,
     payload: res.body ? JSON.parse(res.body) : null
+  };
+}
+
+async function callRequest(app: any, method: string, pathname: string, headers: HeaderMap = {}): Promise<CallRequestResult> {
+  const req = new (require("events").EventEmitter)();
+  req.method = method;
+  req.url = pathname;
+  req.headers = { host: "127.0.0.1", ...headers };
+  req.destroy = () => {};
+
+  const res = makeMockResponse();
+
+  await new Promise<void>((resolve) => {
+    const originalEnd = res.end.bind(res);
+    res.end = (chunk = "") => {
+      originalEnd(chunk);
+      resolve();
+    };
+    app.handleRequest(req, res);
+  });
+
+  return {
+    statusCode: res.statusCode,
+    headers: res.headers,
+    body: res.body
   };
 }
 
@@ -112,7 +147,9 @@ async function withModuleServer(
     }
 
     if (moduleEntry.serverEntryPath && typeof moduleEntry.serverEntrySource === "string") {
-      fs.writeFileSync(path.join(moduleRoot, moduleEntry.serverEntryPath), moduleEntry.serverEntrySource);
+      const serverEntryFilePath = path.join(moduleRoot, moduleEntry.serverEntryPath);
+      fs.mkdirSync(path.dirname(serverEntryFilePath), { recursive: true });
+      fs.writeFileSync(serverEntryFilePath, moduleEntry.serverEntrySource);
     }
   });
 
@@ -226,6 +263,61 @@ register("module runtime scandisce moduli validi e invalidi ed espone catalogo e
     assert.equal(optionsResponse.payload.gameModules.some((entry: any) => entry.id === "demo.valid"), true);
     assert.equal(optionsResponse.payload.uiSlots.some((entry: any) => entry.itemId === "demo.valid.briefing"), true);
     assert.equal(optionsResponse.payload.gameplayProfiles.some((entry: any) => entry.id === "demo.valid.gameplay"), true);
+  });
+});
+
+register("module runtime rifiuta client manifest che escono dalla directory del modulo", async () => {
+  await withModuleServer([
+    {
+      dir: "escape.client-manifest",
+      manifest: {
+        schemaVersion: 1,
+        id: "escape.client-manifest",
+        version: "1.0.0",
+        displayName: "Escape Client Manifest",
+        engineVersion: "1.0.0",
+        kind: "ui",
+        capabilities: [],
+        entrypoints: {
+          clientManifest: "../../stolen.json"
+        }
+      }
+    }
+  ], async ({ app, adminSessionToken }) => {
+    const catalogResponse = await callApp(app, "GET", "/api/modules", undefined, authHeaders(adminSessionToken));
+    assert.equal(catalogResponse.statusCode, 200);
+
+    const escapedModule = catalogResponse.payload.modules.find((entry: any) => entry.id === "escape.client-manifest");
+    assert.equal(Boolean(escapedModule), true);
+    assert.equal(escapedModule.status, "incompatible");
+    assert.equal(
+      escapedModule.errors.some((entry: string) => entry.includes('Client manifest "../../stolen.json" escapes the module directory.')),
+      true
+    );
+  });
+});
+
+register("module runtime serve gli asset modulo dal projectRoot runtime", async () => {
+  await withModuleServer([
+    {
+      dir: "demo.runtime-assets",
+      manifest: {
+        schemaVersion: 1,
+        id: "demo.runtime-assets",
+        version: "1.0.0",
+        displayName: "Runtime Assets",
+        engineVersion: "1.0.0",
+        kind: "ui",
+        capabilities: []
+      },
+      serverEntryPath: "assets/runtime-only.css",
+      serverEntrySource: ".runtime-only { color: red; }"
+    }
+  ], async ({ app }) => {
+    const staticResponse = await callRequest(app, "GET", "/modules/demo.runtime-assets/assets/runtime-only.css");
+    assert.equal(staticResponse.statusCode, 200);
+    assert.equal(staticResponse.headers["Content-Type"], "text/css; charset=utf-8");
+    assert.match(staticResponse.body, /runtime-only/);
   });
 });
 


### PR DESCRIPTION
## Summary
- reject protocol-relative and scheme-based module stylesheet URLs in the frontend shell
- reject client manifest paths that escape a module directory
- serve /modules/* from the runtime projectRoot used by createApp
- add regression coverage for client manifest traversal and runtime project-root static assets

## Testing
- npm run typecheck
- npm run typecheck:frontend
- npm run test:gameplay
- npm test
- npm run coverage