### PR TITLE
[codex] Add typed frontend API client for profile and lobby

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,7 @@ L'applicazione include già:
 
 - autenticazione (register/login/logout), profilo utente e preferenze tema
 - validazione runtime condivisa dei payload auth/profile tra backend e frontend
+- layer client API frontend tipizzato per i flussi migrati `profile` e `lobby`
 - lobby, creazione partita, join player umani e bot AI
 - setup partita 2-4 giocatori con mappe supportate
 - ciclo turno completo (`reinforcement` -> `attack` -> `fortify` -> `finished`)
@@ -26,6 +27,9 @@ Mappe correnti: `classic-mini`, `middle-earth`, `world-classic`.
 
 `/frontend/src`  
 Sorgente TypeScript (`.mts`) della UI web, della shell condivisa, dell'i18n e della manifest static site.
+
+`/frontend/src/core/api`  
+Boundary HTTP frontend framework-agnostic: request helpers tipizzati, parsing/validazione condivisa ed error translation per i flussi UI migrati.
 
 `/frontend/assets`  
 Asset sorgente frontend (mappe e media) sincronizzati nella build pubblica.
@@ -146,6 +150,7 @@ Categorie future da trattare con lo stesso modello:
 - Runtime deploy: entrypoint `api/index.ts` che espone `createApp()` dal backend compilato.
 - Pipeline frontend: `frontend/src` viene compilato e materializzato in `public/` tramite gli script di build.
 - Boundary validation frontend: `frontend/src/core/validated-json.mts` valida le risposte condivise prima del consumo UI.
+- Boundary transport frontend: `frontend/src/core/api/http.mts` e `frontend/src/core/api/client.mts` centralizzano `fetch`, body JSON, validazione runtime, session handling ed error translation per i flussi `profile` e `lobby`.
 - Datastore supportati:
   - SQLite locale (default sviluppo)
   - Supabase (quando configurato via env)
@@ -156,6 +161,7 @@ Categorie future da trattare con lo stesso modello:
 ## Flusso sintetico applicativo
 
 1. Il client invia azioni o richieste via route backend.
+   Per i flussi UI gia migrati (`profile` e `lobby`), il client passa attraverso il layer `frontend/src/core/api` invece di fare `fetch` inline nei moduli pagina.
 2. Il backend autentica/autorizza utente e valida versione stato.
 3. Le route delegano al motore (`backend/engine`) la logica di dominio.
 4. Il backend salva lo stato e notifica eventuali listener eventi.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Today the project includes:
 
 - user registration, login, logout, and profile
 - shared runtime validation for auth/profile payloads at backend and frontend boundaries
+- typed frontend API client helpers for the migrated `profile` and `lobby` flows
 - initial lobby and reopening saved games
 - creation of a new game with supported map, selectable dice ruleset, and configurable turn time limit
 - joining with human players and adding AI bots
@@ -211,7 +212,7 @@ The architecture follows a simple principle: frontend renders and sends actions,
 - `public`
   Static web interface output generated from the frontend sources and served by the runtime.
 - `frontend/src`
-  TypeScript frontend sources for pages, shell, i18n, fetch helpers, and generated shared imports.
+  TypeScript frontend sources for pages, shell, i18n, typed API client helpers, and generated shared imports.
 - `backend`
   HTTP server, authentication, authorization, game session persistence, new game configuration.
 - `backend/engine`
@@ -276,6 +277,7 @@ The shared constructs exposed by `shared/models.cjs` are:
 - `listContentModules`
 
 For runtime contract validation shared by backend and frontend, see `shared/runtime-validation.cts`.
+For the current framework-agnostic frontend transport boundary used by the migrated `profile` and `lobby` flows, see `frontend/src/core/api/`.
 
 Game state notably contains:
 
@@ -310,6 +312,7 @@ Main frontend screens currently available:
 - `register.html`: new account creation
 
 The UI is designed to stay thin: it displays state received from the server and sends actions via API.
+For the migrated `profile` and `lobby` pages, raw network details now live in the typed frontend client layer under `frontend/src/core/api/`, so page modules stay focused on rendering and UI state.
 
 From a naming perspective, frontend pages currently display title `Frontline Dominion`, while the technical project domain continues to use `NetRisk`.
 

--- a/backend/routes/game-management.cts
+++ b/backend/routes/game-management.cts
@@ -46,6 +46,12 @@ type SnapshotForState = (
 type ResumeAiTurnsForRead = (gameContext: any) => Promise<any>;
 type ResolvePlayerForUser = (state: any, user: unknown) => any;
 
+const {
+  gameIdRequestSchema,
+  gameMutationResponseSchema
+} = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+
 async function handleCreateGameRoute(
   req: unknown,
   res: unknown,
@@ -136,24 +142,46 @@ async function handleOpenGameRoute(
     return;
   }
 
+  const parsedBody = parseRequestOrSendError(
+    res as import("node:http").ServerResponse,
+    body,
+    gameIdRequestSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedBody) {
+    return;
+  }
+
   try {
-    const gameRecord = await getGame(body.gameId);
+    const gameRecord = await getGame(parsedBody.gameId);
     authorize("game:open", {
       user: authContext.user,
       game: gameRecord.game,
       state: gameRecord.state
     });
-    const opened = await openGame(body.gameId);
+    const opened = await openGame(parsedBody.gameId);
     await resumeAiTurnsForRead(opened);
     const resolvedPlayer = resolvePlayerForUser(opened.state, authContext.user);
-    sendJson(res, 200, {
-      ok: true,
-      game: opened.game,
-      games: await listGames(),
-      activeGameId: opened.game.id,
-      state: snapshotForState(opened.state, opened.game.id, opened.game.version, opened.game.name),
-      playerId: resolvedPlayer ? resolvedPlayer.id : null
-    });
+    sendValidatedJson(
+      res as import("node:http").ServerResponse,
+      200,
+      {
+        ok: true,
+        game: opened.game,
+        games: await listGames(),
+        activeGameId: opened.game.id,
+        state: snapshotForState(
+          opened.state,
+          opened.game.id,
+          opened.game.version,
+          opened.game.name
+        ),
+        playerId: resolvedPlayer ? resolvedPlayer.id : null
+      },
+      gameMutationResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError
+    );
   } catch (error: any) {
     const statusCode = error.statusCode || 400;
     sendLocalizedError(

--- a/backend/routes/game-overview.cts
+++ b/backend/routes/game-overview.cts
@@ -12,18 +12,39 @@ type ListTurnTimeoutHoursOptions = () => unknown;
 type ListPlayerPieceSets = () => unknown;
 type ListContentPacks = () => unknown;
 type GetExtraGameOptions = () => Record<string, unknown> | Promise<Record<string, unknown>>;
+type SendLocalizedError = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  input: Record<string, unknown> | null,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams?: Record<string, unknown>,
+  code?: string | null,
+  extra?: Record<string, unknown>
+) => void;
+
+const { gameListResponseSchema } = require("../../shared/runtime-validation.cjs");
+const { sendValidatedJson } = require("../route-validation.cjs");
 
 async function handleGamesListRoute(
   res: unknown,
   listGames: ListGames,
   getTargetGameId: GetTargetGameId,
   sendJson: SendJson,
-  url: URL
+  url: URL,
+  sendLocalizedError: SendLocalizedError
 ): Promise<void> {
-  sendJson(res, 200, {
-    games: await listGames(),
-    activeGameId: getTargetGameId({}, url)
-  });
+  sendValidatedJson(
+    res as import("node:http").ServerResponse,
+    200,
+    {
+      games: await listGames(),
+      activeGameId: getTargetGameId({}, url)
+    },
+    gameListResponseSchema,
+    sendJson as SendJson,
+    sendLocalizedError
+  );
 }
 
 async function handleGameOptionsRoute(

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -45,6 +45,12 @@ type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
 
+const {
+  gameIdRequestSchema,
+  gameMutationResponseSchema
+} = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+
 async function handleAiJoinRoute(
   res: unknown,
   body: Record<string, any>,
@@ -107,7 +113,21 @@ async function handleJoinRoute(
     return;
   }
 
-  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const resolvedBody = {
+    ...body,
+    gameId: getTargetGameId(body, url)
+  };
+  const parsedBody = parseRequestOrSendError(
+    res as import("node:http").ServerResponse,
+    resolvedBody,
+    gameIdRequestSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedBody) {
+    return;
+  }
+
+  const gameContext = await loadGameContext(parsedBody.gameId);
   const result = addPlayer(gameContext.state, authContext.user.username, {
     linkedUserId: authContext.user.id
   });
@@ -125,16 +145,23 @@ async function handleJoinRoute(
 
   await persistGameContext(gameContext);
   broadcastGame(gameContext);
-  sendJson(res, result.rejoined ? 200 : 201, {
-    playerId: result.player.id,
-    state: snapshotForState(
-      gameContext.state,
-      gameContext.gameId,
-      gameContext.version,
-      gameContext.gameName
-    ),
-    user: publicUser(authContext.user)
-  });
+  sendValidatedJson(
+    res as import("node:http").ServerResponse,
+    result.rejoined ? 200 : 201,
+    {
+      playerId: result.player.id,
+      state: snapshotForState(
+        gameContext.state,
+        gameContext.gameId,
+        gameContext.version,
+        gameContext.gameName
+      ),
+      user: publicUser(authContext.user)
+    },
+    gameMutationResponseSchema,
+    sendJson as SendJson,
+    sendLocalizedError as SendLocalizedError
+  );
 }
 
 async function handleStartRoute(

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -727,7 +727,8 @@ function createApp(options: CreateAppOptions = {}) {
         () => gameSessions.listGames(),
         getTargetGameId,
         sendJson,
-        url
+        url,
+        sendLocalizedError
       );
       return;
     }

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -1,0 +1,126 @@
+import {
+  authSessionResponseSchema,
+  gameIdRequestSchema,
+  gameListResponseSchema,
+  gameMutationResponseSchema,
+  loginRequestSchema,
+  loginResponseSchema,
+  logoutResponseSchema,
+  profileResponseSchema,
+  themePreferenceRequestSchema,
+  themePreferenceResponseSchema
+} from "../../generated/shared-runtime-validation.mjs";
+import type {
+  AuthSessionResponse,
+  GameListResponse,
+  GameMutationResponse,
+  LoginResponse,
+  LogoutResponse,
+  ProfileResponse,
+  ThemePreferenceResponse
+} from "../../generated/shared-runtime-validation.mjs";
+import { requestJson } from "./http.mjs";
+
+type ClientMessages = {
+  errorMessage: string;
+  fallbackMessage?: string;
+};
+
+export function getSession(messages: ClientMessages): Promise<AuthSessionResponse> {
+  return requestJson({
+    path: "/api/auth/session",
+    responseSchema: authSessionResponseSchema,
+    responseSchemaName: "AuthSessionResponse",
+    ...messages
+  });
+}
+
+export function login(
+  credentials: {
+    username: string;
+    password: string;
+  },
+  messages: ClientMessages
+): Promise<LoginResponse> {
+  return requestJson({
+    path: "/api/auth/login",
+    method: "POST",
+    body: credentials,
+    requestSchema: loginRequestSchema,
+    requestSchemaName: "LoginRequest",
+    responseSchema: loginResponseSchema,
+    responseSchemaName: "LoginResponse",
+    ...messages
+  });
+}
+
+export function logout(messages: ClientMessages): Promise<LogoutResponse> {
+  return requestJson({
+    path: "/api/auth/logout",
+    method: "POST",
+    body: {},
+    responseSchema: logoutResponseSchema,
+    responseSchemaName: "LogoutResponse",
+    ...messages
+  });
+}
+
+export function getProfile(messages: ClientMessages): Promise<ProfileResponse> {
+  return requestJson({
+    path: "/api/profile",
+    responseSchema: profileResponseSchema,
+    responseSchemaName: "ProfileResponse",
+    ...messages
+  });
+}
+
+export function updateThemePreference(
+  theme: string,
+  messages: ClientMessages
+): Promise<ThemePreferenceResponse> {
+  return requestJson({
+    path: "/api/profile/preferences/theme",
+    method: "PUT",
+    body: { theme },
+    requestSchema: themePreferenceRequestSchema,
+    requestSchemaName: "ThemePreferenceRequest",
+    responseSchema: themePreferenceResponseSchema,
+    responseSchemaName: "ThemePreferenceResponse",
+    ...messages
+  });
+}
+
+export function listGames(messages: ClientMessages): Promise<GameListResponse> {
+  return requestJson({
+    path: "/api/games",
+    responseSchema: gameListResponseSchema,
+    responseSchemaName: "GameListResponse",
+    ...messages
+  });
+}
+
+export function openGame(gameId: string, messages: ClientMessages): Promise<GameMutationResponse> {
+  return requestJson({
+    path: "/api/games/open",
+    method: "POST",
+    body: { gameId },
+    requestSchema: gameIdRequestSchema,
+    requestSchemaName: "GameIdRequest",
+    responseSchema: gameMutationResponseSchema,
+    responseSchemaName: "GameMutationResponse",
+    ...messages
+  });
+}
+
+export function joinGame(gameId: string, messages: ClientMessages): Promise<GameMutationResponse> {
+  return requestJson({
+    path: "/api/join",
+    method: "POST",
+    body: { gameId },
+    requestSchema: gameIdRequestSchema,
+    requestSchemaName: "GameIdRequest",
+    responseSchema: gameMutationResponseSchema,
+    responseSchemaName: "GameMutationResponse",
+    ...messages
+  });
+}

--- a/frontend/src/core/api/http.mts
+++ b/frontend/src/core/api/http.mts
@@ -1,0 +1,114 @@
+import { parseWithSchema } from "../../generated/shared-runtime-validation.mjs";
+import { translateServerMessage } from "../../i18n.mjs";
+import { readValidatedJson } from "../validated-json.mjs";
+
+type ValidationSchema<T> = {
+  safeParse(input: unknown): { success: true; data: T } | { success: false; error: unknown };
+};
+
+export type ApiClientError = Error & {
+  code?: string | null;
+};
+
+type JsonRequestOptions<TRequest, TResponse> = {
+  path: string;
+  method?: "GET" | "POST" | "PUT";
+  body?: TRequest;
+  requestSchema?: ValidationSchema<TRequest>;
+  requestSchemaName?: string;
+  responseSchema: ValidationSchema<TResponse>;
+  responseSchemaName: string;
+  errorMessage: string;
+  fallbackMessage?: string;
+};
+
+function toApiClientError(
+  message: string,
+  options: {
+    cause?: unknown;
+    code?: string | null;
+  } = {}
+): ApiClientError {
+  const error = new Error(message, {
+    cause: options.cause
+  }) as ApiClientError;
+
+  if (options.code !== undefined) {
+    error.code = options.code;
+  }
+
+  return error;
+}
+
+function extractErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || !("code" in payload)) {
+    return null;
+  }
+
+  const code = payload.code;
+  return typeof code === "string" && code ? code : null;
+}
+
+async function tryReadJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function requestJson<TRequest, TResponse>({
+  path,
+  method = "GET",
+  body,
+  requestSchema,
+  requestSchemaName,
+  responseSchema,
+  responseSchemaName,
+  errorMessage,
+  fallbackMessage
+}: JsonRequestOptions<TRequest, TResponse>): Promise<TResponse> {
+  const resolvedFallbackMessage = fallbackMessage || errorMessage;
+  const headers: Record<string, string> = {
+    Accept: "application/json"
+  };
+
+  let payloadBody: string | undefined;
+  if (body !== undefined) {
+    const parsedBody = requestSchema
+      ? parseWithSchema(requestSchema, body, {
+          schemaName: requestSchemaName || "request",
+          message: errorMessage
+        })
+      : body;
+    headers["Content-Type"] = "application/json";
+    payloadBody = JSON.stringify(parsedBody);
+  }
+
+  const response = await fetch(path, {
+    method,
+    credentials: "same-origin",
+    headers,
+    ...(payloadBody ? { body: payloadBody } : {})
+  });
+
+  if (!response.ok) {
+    const payload = await tryReadJson(response);
+    throw toApiClientError(translateServerMessage(payload, errorMessage), {
+      code: extractErrorCode(payload)
+    });
+  }
+
+  try {
+    return await readValidatedJson(
+      response,
+      responseSchema,
+      resolvedFallbackMessage,
+      responseSchemaName
+    );
+  } catch (error: unknown) {
+    throw toApiClientError(resolvedFallbackMessage, {
+      cause: error
+    });
+  }
+}

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -134,6 +134,12 @@ export const themePreferenceResponseSchema = objectSchema({
 
 export type ThemePreferenceResponse = z.infer<typeof themePreferenceResponseSchema>;
 
+export const logoutResponseSchema = objectSchema({
+  ok: z.literal(true)
+});
+
+export type LogoutResponse = z.infer<typeof logoutResponseSchema>;
+
 export const netRiskModuleReferenceSchema = objectSchema({
   id: z.string().min(1),
   version: z.string().min(1)
@@ -160,6 +166,37 @@ export const gameSummarySchema = objectSchema({
 });
 
 export type GameSummary = z.infer<typeof gameSummarySchema>;
+
+export const gameIdRequestSchema = objectSchema({
+  gameId: z.string().min(1)
+});
+
+export type GameIdRequest = z.infer<typeof gameIdRequestSchema>;
+
+export const gameListResponseSchema = objectSchema({
+  games: z.array(gameSummarySchema),
+  activeGameId: z.string().min(1).nullable().optional()
+});
+
+export type GameListResponse = z.infer<typeof gameListResponseSchema>;
+
+export const gameMutationGameSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1).nullable().optional()
+});
+
+export type GameMutationGame = z.infer<typeof gameMutationGameSchema>;
+
+export const gameMutationResponseSchema = objectSchema({
+  ok: z.literal(true).optional(),
+  user: publicUserSchema.optional(),
+  playerId: z.string().min(1).nullable().optional(),
+  game: gameMutationGameSchema.optional(),
+  games: z.array(gameSummarySchema).optional(),
+  activeGameId: z.string().min(1).nullable().optional()
+});
+
+export type GameMutationResponse = z.infer<typeof gameMutationResponseSchema>;
 
 export const participatingGameLobbySchema = objectSchema({
   playerName: z.string().min(1),

--- a/frontend/src/lobby.mts
+++ b/frontend/src/lobby.mts
@@ -1,14 +1,8 @@
 import { closest as closestElement, maybeQuery, setMarkup } from "./core/dom.mjs";
+import { getSession, joinGame, listGames, login, logout, openGame } from "./core/api/client.mjs";
 import { mountModuleSlotSection } from "./core/module-slots.mjs";
-import type {
-  GameListResponse,
-  GameSummary,
-  LoginResponse,
-  MutationResponse,
-  PublicUser,
-  SessionResponse
-} from "./core/types.mjs";
-import { formatDate, t, translateServerMessage } from "./i18n.mjs";
+import type { GameSummary, PublicUser } from "./core/types.mjs";
+import { formatDate, t } from "./i18n.mjs";
 
 const VISIBLE_GAMES_BATCH_SIZE = 15;
 
@@ -208,15 +202,13 @@ function setSession(user: PublicUser | null | undefined): void {
 }
 
 async function loginWithCredentials(username: string, password: string): Promise<void> {
-  const response = await fetch("/api/auth/login", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password })
-  });
-  const data = (await response.json()) as LoginResponse;
-  if (!response.ok) {
-    throw new Error(translateServerMessage(data, t("errors.loginFailed")));
-  }
+  const data = await login(
+    { username, password },
+    {
+      errorMessage: t("errors.loginFailed"),
+      fallbackMessage: t("errors.loginFailed")
+    }
+  );
 
   setSession(data.user);
   await loadGameList();
@@ -515,27 +507,6 @@ function setupInfiniteScroll() {
   gameListObserver.observe(elements.gameListLoadMoreState);
 }
 
-async function send(path: string, body: unknown): Promise<MutationResponse> {
-  const response = await fetch(path, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify(body)
-  });
-
-  const data = (await response.json()) as MutationResponse;
-  if (!response.ok) {
-    const error = new Error(translateServerMessage(data, t("errors.requestFailed"))) as Error & {
-      code?: string | null;
-    };
-    error.code = data.code || null;
-    throw error;
-  }
-
-  return data;
-}
-
 async function loadGameList(options: { renderOnChange?: boolean } = {}): Promise<void> {
   const renderOnChange = options.renderOnChange !== false;
   state.gameListState = "loading";
@@ -545,11 +516,10 @@ async function loadGameList(options: { renderOnChange?: boolean } = {}): Promise
   }
 
   try {
-    const response = await fetch("/api/games");
-    const data = (await response.json()) as GameListResponse;
-    if (!response.ok) {
-      throw new Error(translateServerMessage(data, t("lobby.errors.loadGames")));
-    }
+    const data = await listGames({
+      errorMessage: t("lobby.errors.loadGames"),
+      fallbackMessage: t("lobby.errors.loadGames")
+    });
 
     state.gameList = data.games || [];
     resetVisibleGameCount();
@@ -576,7 +546,10 @@ function navigateToGameRoute(gameId: string): void {
 }
 
 async function openGameById(gameId: string): Promise<void> {
-  const data = await send("/api/games/open", { gameId });
+  const data = await openGame(gameId, {
+    errorMessage: t("errors.requestFailed"),
+    fallbackMessage: t("errors.requestFailed")
+  });
   state.gameList = data.games || [];
   resetVisibleGameCount();
   state.currentGameId = data.activeGameId || null;
@@ -611,7 +584,10 @@ async function handleJoinSelectedGame() {
   }
 
   try {
-    await send("/api/join", { gameId: selected.id });
+    await joinGame(selected.id, {
+      errorMessage: t("errors.requestFailed"),
+      fallbackMessage: t("errors.requestFailed")
+    });
     await openGameById(selected.id);
   } catch (error: unknown) {
     state.gameListState = "error";
@@ -668,13 +644,10 @@ elements.gameSessionDetails?.addEventListener("click", (event: Event) => {
 async function restoreSession(options: { renderOnChange?: boolean } = {}): Promise<void> {
   const renderOnChange = options.renderOnChange !== false;
   try {
-    const response = await fetch("/api/auth/session");
-
-    if (!response.ok) {
-      throw new Error(t("auth.sessionExpired"));
-    }
-
-    const data = (await response.json()) as SessionResponse;
+    const data = await getSession({
+      errorMessage: t("auth.sessionExpired"),
+      fallbackMessage: t("auth.sessionExpired")
+    });
     setSession(data.user);
   } catch (_error: unknown) {
     setSession(null);
@@ -724,7 +697,10 @@ if (elements.headerLoginForm) {
 
 elements.logoutButton?.addEventListener("click", async () => {
   try {
-    await send("/api/auth/logout", {});
+    await logout({
+      errorMessage: t("errors.requestFailed"),
+      fallbackMessage: t("errors.requestFailed")
+    });
   } catch (_error: unknown) {}
 
   setSession(null);

--- a/frontend/src/profile.mts
+++ b/frontend/src/profile.mts
@@ -1,5 +1,11 @@
 import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
-import { readValidatedJson } from "./core/validated-json.mjs";
+import {
+  getProfile,
+  getSession,
+  login,
+  logout,
+  updateThemePreference
+} from "./core/api/client.mjs";
 import { messageFromError } from "./core/errors.mjs";
 import type {
   GameOptionsResponse,
@@ -10,19 +16,9 @@ import type {
   ModulesCatalogResponse,
   NetRiskUiSlotContribution
 } from "./core/types.mjs";
-import {
-  authSessionResponseSchema,
-  loginResponseSchema,
-  profileResponseSchema,
-  themePreferenceResponseSchema
-} from "./generated/shared-runtime-validation.mjs";
 import type {
-  AuthSessionResponse,
-  LoginResponse,
   ProfileContract as ProfileSummary,
-  ProfileResponse,
-  PublicUser,
-  ThemePreferenceResponse
+  PublicUser
 } from "./generated/shared-runtime-validation.mjs";
 import { formatDate, t, translateServerMessage } from "./i18n.mjs";
 
@@ -209,67 +205,11 @@ function isNavigationAbort(error: unknown): boolean {
   return typeof error === "object" && "name" in error && error.name === "AbortError";
 }
 
-async function persistThemePreference(theme: string): Promise<ThemePreferenceResponse> {
-  const response = await fetch("/api/profile/preferences/theme", {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ theme })
+async function persistThemePreference(theme: string) {
+  return updateThemePreference(theme, {
+    errorMessage: t("errors.requestFailed"),
+    fallbackMessage: t("profile.preferences.status.saveFailed", { theme: themeLabel(theme) })
   });
-  if (!response.ok) {
-    const payload = await response.json();
-    throw new Error(translateServerMessage(payload, t("errors.requestFailed")));
-  }
-
-  return readValidatedJson(
-    response,
-    themePreferenceResponseSchema,
-    t("profile.preferences.status.saveFailed", { theme: themeLabel(theme) }),
-    "ThemePreferenceResponse"
-  );
-}
-
-function normalizeSessionUser(session: AuthSessionResponse): PublicUser {
-  return session.user;
-}
-
-function normalizeLoginUser(response: LoginResponse): PublicUser {
-  return response.user;
-}
-
-async function readSessionResponse(response: Response): Promise<AuthSessionResponse> {
-  if (!response.ok) {
-    throw new Error(t("profile.errors.loginRequired"));
-  }
-
-  return readValidatedJson(
-    response,
-    authSessionResponseSchema,
-    t("profile.errors.loadFailed"),
-    "AuthSessionResponse"
-  );
-}
-
-async function readProfileResponse(response: Response): Promise<ProfileResponse> {
-  if (!response.ok) {
-    const payload = await response.json();
-    throw new Error(translateServerMessage(payload, t("profile.errors.unavailable")));
-  }
-
-  return readValidatedJson(
-    response,
-    profileResponseSchema,
-    t("profile.errors.loadFailed"),
-    "ProfileResponse"
-  );
-}
-
-async function readLoginResponse(response: Response): Promise<LoginResponse> {
-  if (!response.ok) {
-    const payload = await response.json();
-    throw new Error(translateServerMessage(payload, t("errors.loginFailed")));
-  }
-
-  return readValidatedJson(response, loginResponseSchema, t("errors.loginFailed"), "LoginResponse");
 }
 
 function renderAuthArea(user: PublicUser | null): void {
@@ -881,12 +821,14 @@ async function loadProfile() {
   let sessionUser: PublicUser | null = null;
 
   try {
-    const sessionResponse = await fetch("/api/auth/session");
-    const session = await readSessionResponse(sessionResponse);
+    const session = await getSession({
+      errorMessage: t("profile.errors.loginRequired"),
+      fallbackMessage: t("profile.errors.loadFailed")
+    });
     if (requestId !== profileRequestId) {
       return;
     }
-    sessionUser = normalizeSessionUser(session);
+    sessionUser = session.user;
     currentSessionUser = sessionUser;
     themeManager.applyUserTheme(sessionUser);
     elements.authStatus.textContent = t("profile.auth.loggedIn", {
@@ -897,8 +839,10 @@ async function loadProfile() {
     showThemePreferences(true);
     syncThemePreference({ preferredTheme: themeManager.getThemeFromUser(sessionUser) });
     await loadModuleCatalog(sessionUser);
-    const profileResponse = await fetch("/api/profile");
-    const payload = await readProfileResponse(profileResponse);
+    const payload = await getProfile({
+      errorMessage: t("profile.errors.unavailable"),
+      fallbackMessage: t("profile.errors.loadFailed")
+    });
     if (requestId !== profileRequestId) {
       return;
     }
@@ -954,17 +898,18 @@ if (elements.headerLoginForm) {
 
     try {
       setHeaderAuthFeedback("");
-      const response = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password })
-      });
-      const data = await readLoginResponse(response);
+      const data = await login(
+        { username, password },
+        {
+          errorMessage: t("errors.loginFailed"),
+          fallbackMessage: t("errors.loginFailed")
+        }
+      );
 
       if (elements.headerAuthPassword) {
         elements.headerAuthPassword.value = "";
       }
-      currentSessionUser = normalizeLoginUser(data);
+      currentSessionUser = data.user;
       await loadProfile();
     } catch (error: unknown) {
       setHeaderAuthFeedback(messageFromError(error, t("errors.loginFailed")));
@@ -990,12 +935,9 @@ elements.logoutButton.addEventListener("click", async () => {
   }
 
   try {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({})
+    await logout({
+      errorMessage: t("errors.requestFailed"),
+      fallbackMessage: t("errors.requestFailed")
     });
   } catch (_error: unknown) {}
 });

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -21,6 +21,7 @@ const gameplayTestModules = [
   "../tests/gameplay/shared/map-graph.test.cjs",
   "../tests/gameplay/shared/map-loader.test.cjs",
   "../tests/gameplay/shared/continent-loader.test.cjs",
+  "../tests/gameplay/shared/runtime-validation.test.cjs",
   "../tests/gameplay/ai/ai-player.test.cjs",
   "../tests/gameplay/setup/game-setup.test.cjs",
   "../tests/gameplay/turn-flow/turn-flow.test.cjs",

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -1630,82 +1630,85 @@ register("frontend API client valida sessione, profilo e lobby list al boundary"
   const client = await getFrontendApiClientModule();
   const calls: Array<{ input: string; init: Record<string, unknown> | undefined }> = [];
 
-  await withMockFetch(async (input: string, init?: Record<string, unknown>) => {
-    calls.push({ input, init });
+  await withMockFetch(
+    async (input: string, init?: Record<string, unknown>) => {
+      calls.push({ input, init });
 
-    if (input === "/api/auth/session") {
-      return {
-        ok: true,
-        async json() {
-          return {
-            user: {
-              id: "user-1",
-              username: "Alice"
-            }
-          };
-        }
-      };
-    }
-
-    if (input === "/api/profile") {
-      return {
-        ok: true,
-        async json() {
-          return {
-            profile: {
-              playerName: "Alice",
-              gamesPlayed: 3,
-              wins: 2,
-              losses: 1,
-              gamesInProgress: 1,
-              participatingGames: [],
-              winRate: 67,
-              hasHistory: true,
-              placeholders: {
-                recentGames: false,
-                ranking: false
-              }
-            }
-          };
-        }
-      };
-    }
-
-    return {
-      ok: true,
-      async json() {
+      if (input === "/api/auth/session") {
         return {
-          games: [
-            {
-              id: "game-1",
-              name: "Campaign",
-              phase: "lobby",
-              playerCount: 2,
-              updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
-            }
-          ],
-          activeGameId: "game-1"
+          ok: true,
+          async json() {
+            return {
+              user: {
+                id: "user-1",
+                username: "Alice"
+              }
+            };
+          }
         };
       }
-    };
-  }, async () => {
-    const session = await client.getSession({
-      errorMessage: "Sessione scaduta",
-      fallbackMessage: "Sessione non leggibile"
-    });
-    const profile = await client.getProfile({
-      errorMessage: "Profilo non disponibile",
-      fallbackMessage: "Profilo non valido"
-    });
-    const games = await client.listGames({
-      errorMessage: "Lobby non disponibile",
-      fallbackMessage: "Lobby non valida"
-    });
 
-    assert.equal(session.user.username, "Alice");
-    assert.equal(profile.profile.gamesPlayed, 3);
-    assert.equal(games.games[0].id, "game-1");
-  });
+      if (input === "/api/profile") {
+        return {
+          ok: true,
+          async json() {
+            return {
+              profile: {
+                playerName: "Alice",
+                gamesPlayed: 3,
+                wins: 2,
+                losses: 1,
+                gamesInProgress: 1,
+                participatingGames: [],
+                winRate: 67,
+                hasHistory: true,
+                placeholders: {
+                  recentGames: false,
+                  ranking: false
+                }
+              }
+            };
+          }
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return {
+            games: [
+              {
+                id: "game-1",
+                name: "Campaign",
+                phase: "lobby",
+                playerCount: 2,
+                updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+              }
+            ],
+            activeGameId: "game-1"
+          };
+        }
+      };
+    },
+    async () => {
+      const session = await client.getSession({
+        errorMessage: "Sessione scaduta",
+        fallbackMessage: "Sessione non leggibile"
+      });
+      const profile = await client.getProfile({
+        errorMessage: "Profilo non disponibile",
+        fallbackMessage: "Profilo non valido"
+      });
+      const games = await client.listGames({
+        errorMessage: "Lobby non disponibile",
+        fallbackMessage: "Lobby non valida"
+      });
+
+      assert.equal(session.user.username, "Alice");
+      assert.equal(profile.profile.gamesPlayed, 3);
+      assert.equal(games.games[0].id, "game-1");
+    }
+  );
 
   assert.deepEqual(
     calls.map((entry) => entry.input),
@@ -1717,111 +1720,126 @@ register("frontend API client valida sessione, profilo e lobby list al boundary"
   );
 });
 
-register("frontend API client traduce gli errori server e preserva il code per le mutazioni lobby", async () => {
-  const client = await getFrontendApiClientModule();
+register(
+  "frontend API client traduce gli errori server e preserva il code per le mutazioni lobby",
+  async () => {
+    const client = await getFrontendApiClientModule();
 
-  await withMockFetch(async () => {
-    return {
-      ok: false,
-      async json() {
+    await withMockFetch(
+      async () => {
         return {
-          error: "Conflitto versione",
-          code: "VERSION_CONFLICT"
+          ok: false,
+          async json() {
+            return {
+              error: "Conflitto versione",
+              code: "VERSION_CONFLICT"
+            };
+          }
         };
-      }
-    };
-  }, async () => {
-    await assert.rejects(
-      async () =>
-        client.openGame("game-1", {
-          errorMessage: "Richiesta fallita",
-          fallbackMessage: "Risposta non valida"
-        }),
-      (error: Error & { code?: string | null }) => {
-        assert.equal(error.message, "Conflitto versione");
-        assert.equal(error.code, "VERSION_CONFLICT");
-        return true;
+      },
+      async () => {
+        await assert.rejects(
+          async () =>
+            client.openGame("game-1", {
+              errorMessage: "Richiesta fallita",
+              fallbackMessage: "Risposta non valida"
+            }),
+          (error: Error & { code?: string | null }) => {
+            assert.equal(error.message, "Conflitto versione");
+            assert.equal(error.code, "VERSION_CONFLICT");
+            return true;
+          }
+        );
       }
     );
-  });
-});
+  }
+);
 
-register("frontend API client segnala fallback deterministico quando la risposta valida lo schema fallisce", async () => {
-  const client = await getFrontendApiClientModule();
+register(
+  "frontend API client segnala fallback deterministico quando la risposta valida lo schema fallisce",
+  async () => {
+    const client = await getFrontendApiClientModule();
 
-  await withMockFetch(async () => {
-    return {
-      ok: true,
-      async json() {
+    await withMockFetch(
+      async () => {
         return {
-          games: [
-            {
-              id: "game-1",
-              name: "Campaign",
-              phase: "lobby",
-              playerCount: "two",
-              updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
-            }
-          ]
+          ok: true,
+          async json() {
+            return {
+              games: [
+                {
+                  id: "game-1",
+                  name: "Campaign",
+                  phase: "lobby",
+                  playerCount: "two",
+                  updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+                }
+              ]
+            };
+          }
         };
-      }
-    };
-  }, async () => {
-    await assert.rejects(
-      async () =>
-        client.listGames({
-          errorMessage: "Lobby non disponibile",
-          fallbackMessage: "Lobby non valida"
-        }),
-      (error: Error) => {
-        assert.equal(error.message, "Lobby non valida");
-        return true;
+      },
+      async () => {
+        await assert.rejects(
+          async () =>
+            client.listGames({
+              errorMessage: "Lobby non disponibile",
+              fallbackMessage: "Lobby non valida"
+            }),
+          (error: Error) => {
+            assert.equal(error.message, "Lobby non valida");
+            return true;
+          }
+        );
       }
     );
-  });
-});
+  }
+);
 
 register("frontend API client invia body JSON tipizzati per join e logout", async () => {
   const client = await getFrontendApiClientModule();
   const requests: Array<{ input: string; init?: Record<string, unknown> }> = [];
 
-  await withMockFetch(async (input: string, init?: Record<string, unknown>) => {
-    requests.push({ input, init });
+  await withMockFetch(
+    async (input: string, init?: Record<string, unknown>) => {
+      requests.push({ input, init });
 
-    if (input === "/api/auth/logout") {
-      return {
-        ok: true,
-        async json() {
-          return { ok: true };
-        }
-      };
-    }
-
-    return {
-      ok: true,
-      async json() {
+      if (input === "/api/auth/logout") {
         return {
-          playerId: "player-1",
-          user: {
-            id: "user-1",
-            username: "Alice"
+          ok: true,
+          async json() {
+            return { ok: true };
           }
         };
       }
-    };
-  }, async () => {
-    const joinResponse = await client.joinGame("game-1", {
-      errorMessage: "Join fallito",
-      fallbackMessage: "Join non valido"
-    });
-    const logoutResponse = await client.logout({
-      errorMessage: "Logout fallito",
-      fallbackMessage: "Logout non valido"
-    });
 
-    assert.equal(joinResponse.playerId, "player-1");
-    assert.equal(logoutResponse.ok, true);
-  });
+      return {
+        ok: true,
+        async json() {
+          return {
+            playerId: "player-1",
+            user: {
+              id: "user-1",
+              username: "Alice"
+            }
+          };
+        }
+      };
+    },
+    async () => {
+      const joinResponse = await client.joinGame("game-1", {
+        errorMessage: "Join fallito",
+        fallbackMessage: "Join non valido"
+      });
+      const logoutResponse = await client.logout({
+        errorMessage: "Logout fallito",
+        fallbackMessage: "Logout non valido"
+      });
+
+      assert.equal(joinResponse.playerId, "player-1");
+      assert.equal(logoutResponse.ok, true);
+    }
+  );
 
   assert.equal(requests[0]?.input, "/api/join");
   assert.equal(requests[1]?.input, "/api/auth/logout");

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { pathToFileURL } = require("url");
 const projectRoot = path.resolve(__dirname, "..", "..");
@@ -80,6 +81,8 @@ const {
   handleCreateGameRoute,
   handleOpenGameRoute
 } = require("../backend/routes/game-management.cjs");
+const { handleJoinRoute } = require("../backend/routes/game-setup.cjs");
+const { handleGamesListRoute } = require("../backend/routes/game-overview.cjs");
 const { handleHealthRoute } = require("../backend/routes/health.cjs");
 const { randomHex, secureRandom } = require("../backend/random.cjs");
 const { pruneBackups } = require("./backup-datastore.cjs");
@@ -134,6 +137,7 @@ const TEST_PASSWORD = "Secret123!";
 const frontendI18nModulePromise = import(
   pathToFileURL(path.join(projectRoot, "public", "i18n.mjs")).href
 );
+let frontendApiClientModulePromise: Promise<any> | null = null;
 
 function register(name: string, fn: TestFn) {
   tests.push({ name, fn });
@@ -207,6 +211,54 @@ async function fetchGame(app: any, pathname: string, options: FetchGameOptions =
 
 async function readJson(response: any): Promise<any> {
   return response.json();
+}
+
+async function withMockFetch<T>(
+  implementation: (input: string, init?: Record<string, unknown>) => Promise<any>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previousFetch = global.fetch;
+  global.fetch = implementation as typeof fetch;
+
+  try {
+    return await fn();
+  } finally {
+    global.fetch = previousFetch;
+  }
+}
+
+function getFrontendApiClientModule(): Promise<any> {
+  if (frontendApiClientModulePromise) {
+    return frontendApiClientModulePromise;
+  }
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-frontend-client-"));
+  const tempPublicRoot = path.join(tempRoot, "public");
+  fs.cpSync(path.join(projectRoot, "public", "core"), path.join(tempPublicRoot, "core"), {
+    recursive: true,
+    force: true
+  });
+  fs.cpSync(path.join(projectRoot, "public", "generated"), path.join(tempPublicRoot, "generated"), {
+    recursive: true,
+    force: true
+  });
+  fs.cpSync(path.join(projectRoot, "public", "locales"), path.join(tempPublicRoot, "locales"), {
+    recursive: true,
+    force: true
+  });
+  fs.cpSync(path.join(projectRoot, "public", "vendor"), path.join(tempRoot, "vendor"), {
+    recursive: true,
+    force: true
+  });
+  fs.copyFileSync(
+    path.join(projectRoot, "public", "i18n.mjs"),
+    path.join(tempPublicRoot, "i18n.mjs")
+  );
+
+  frontendApiClientModulePromise = import(
+    pathToFileURL(path.join(tempPublicRoot, "core", "api", "client.mjs")).href
+  );
+  return frontendApiClientModulePromise;
 }
 
 function sessionTokenFromSetCookie(rawSetCookie: string | string[] | null | undefined): string {
@@ -1434,7 +1486,15 @@ register("game management route apre una partita e risolve il player autenticato
       game: { id: gameId, name: "Nuova partita", version: 3 },
       state: { players: [{ id: "player-1", linkedUserId: "user-1" }] }
     }),
-    async () => [{ id: "game-1", name: "Nuova partita" }],
+    async () => [
+      {
+        id: "game-1",
+        name: "Nuova partita",
+        phase: "lobby",
+        playerCount: 1,
+        updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+      }
+    ],
     async (gameContext: any) => {
       gameContext.game.version = 4;
       gameContext.state.players.push({ id: "ai-2", linkedUserId: null, isAi: true });
@@ -1456,7 +1516,15 @@ register("game management route apre una partita e risolve il player autenticato
   assert.deepEqual(JSON.parse(res.body), {
     ok: true,
     game: { id: "game-1", name: "Nuova partita", version: 4 },
-    games: [{ id: "game-1", name: "Nuova partita" }],
+    games: [
+      {
+        id: "game-1",
+        name: "Nuova partita",
+        phase: "lobby",
+        playerCount: 1,
+        updatedAt: "2026-04-17T08:30:00.000Z"
+      }
+    ],
     activeGameId: "game-1",
     state: {
       gameId: "game-1",
@@ -1466,6 +1534,301 @@ register("game management route apre una partita e risolve il player autenticato
     },
     playerId: "player-1"
   });
+});
+
+register("game overview route valida la risposta lista partite prima di inviarla", async () => {
+  const res = makeMockResponse();
+
+  await handleGamesListRoute(
+    res,
+    async () => [
+      {
+        name: "Payload incompleto",
+        phase: "lobby",
+        playerCount: 2,
+        updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+      }
+    ],
+    () => null,
+    sendJson,
+    new URL("http://127.0.0.1/api/games"),
+    sendLocalizedError
+  );
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(JSON.parse(res.body).code, "RESPONSE_VALIDATION_FAILED");
+});
+
+register("game management route rifiuta gameId non valido prima di aprire la partita", async () => {
+  const res = makeMockResponse();
+
+  await handleOpenGameRoute(
+    { method: "POST", headers: {} },
+    res,
+    {},
+    async () => ({ user: { id: "user-1", username: "Alice" } }),
+    () => {
+      throw new Error("authorize non dovrebbe essere chiamato per body invalido");
+    },
+    async () => {
+      throw new Error("getGame non dovrebbe essere chiamato per body invalido");
+    },
+    async () => {
+      throw new Error("openGame non dovrebbe essere chiamato per body invalido");
+    },
+    async () => [],
+    async () => ({ shouldPersist: false, forcedTurn: false }),
+    () => null,
+    () => ({}),
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(JSON.parse(res.body).code, "REQUEST_VALIDATION_FAILED");
+});
+
+register("game join route valida la risposta outbound prima di inviarla", async () => {
+  const res = makeMockResponse();
+
+  await handleJoinRoute(
+    { method: "POST", headers: {} },
+    res,
+    { gameId: "game-1" },
+    new URL("http://127.0.0.1/api/join"),
+    async () => ({ user: { id: "user-1", username: "Alice" } }),
+    async () => ({
+      state: { players: [] },
+      gameId: "game-1",
+      version: 2,
+      gameName: "Nuova partita"
+    }),
+    (_body: Record<string, unknown>) => String(_body.gameId || ""),
+    () => ({
+      ok: true,
+      player: { id: "player-1" }
+    }),
+    async () => undefined,
+    () => undefined,
+    (_state: any, gameId: string | null, version: number | null, gameName: string | null) => ({
+      gameId,
+      version,
+      gameName
+    }),
+    () => ({
+      username: "Alice"
+    }),
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(JSON.parse(res.body).code, "RESPONSE_VALIDATION_FAILED");
+});
+
+register("frontend API client valida sessione, profilo e lobby list al boundary", async () => {
+  const client = await getFrontendApiClientModule();
+  const calls: Array<{ input: string; init: Record<string, unknown> | undefined }> = [];
+
+  await withMockFetch(async (input: string, init?: Record<string, unknown>) => {
+    calls.push({ input, init });
+
+    if (input === "/api/auth/session") {
+      return {
+        ok: true,
+        async json() {
+          return {
+            user: {
+              id: "user-1",
+              username: "Alice"
+            }
+          };
+        }
+      };
+    }
+
+    if (input === "/api/profile") {
+      return {
+        ok: true,
+        async json() {
+          return {
+            profile: {
+              playerName: "Alice",
+              gamesPlayed: 3,
+              wins: 2,
+              losses: 1,
+              gamesInProgress: 1,
+              participatingGames: [],
+              winRate: 67,
+              hasHistory: true,
+              placeholders: {
+                recentGames: false,
+                ranking: false
+              }
+            }
+          };
+        }
+      };
+    }
+
+    return {
+      ok: true,
+      async json() {
+        return {
+          games: [
+            {
+              id: "game-1",
+              name: "Campaign",
+              phase: "lobby",
+              playerCount: 2,
+              updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+            }
+          ],
+          activeGameId: "game-1"
+        };
+      }
+    };
+  }, async () => {
+    const session = await client.getSession({
+      errorMessage: "Sessione scaduta",
+      fallbackMessage: "Sessione non leggibile"
+    });
+    const profile = await client.getProfile({
+      errorMessage: "Profilo non disponibile",
+      fallbackMessage: "Profilo non valido"
+    });
+    const games = await client.listGames({
+      errorMessage: "Lobby non disponibile",
+      fallbackMessage: "Lobby non valida"
+    });
+
+    assert.equal(session.user.username, "Alice");
+    assert.equal(profile.profile.gamesPlayed, 3);
+    assert.equal(games.games[0].id, "game-1");
+  });
+
+  assert.deepEqual(
+    calls.map((entry) => entry.input),
+    ["/api/auth/session", "/api/profile", "/api/games"]
+  );
+  assert.ok(
+    calls.every((entry) => entry.init?.credentials === "same-origin"),
+    "all client requests should use same-origin credentials"
+  );
+});
+
+register("frontend API client traduce gli errori server e preserva il code per le mutazioni lobby", async () => {
+  const client = await getFrontendApiClientModule();
+
+  await withMockFetch(async () => {
+    return {
+      ok: false,
+      async json() {
+        return {
+          error: "Conflitto versione",
+          code: "VERSION_CONFLICT"
+        };
+      }
+    };
+  }, async () => {
+    await assert.rejects(
+      async () =>
+        client.openGame("game-1", {
+          errorMessage: "Richiesta fallita",
+          fallbackMessage: "Risposta non valida"
+        }),
+      (error: Error & { code?: string | null }) => {
+        assert.equal(error.message, "Conflitto versione");
+        assert.equal(error.code, "VERSION_CONFLICT");
+        return true;
+      }
+    );
+  });
+});
+
+register("frontend API client segnala fallback deterministico quando la risposta valida lo schema fallisce", async () => {
+  const client = await getFrontendApiClientModule();
+
+  await withMockFetch(async () => {
+    return {
+      ok: true,
+      async json() {
+        return {
+          games: [
+            {
+              id: "game-1",
+              name: "Campaign",
+              phase: "lobby",
+              playerCount: "two",
+              updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+            }
+          ]
+        };
+      }
+    };
+  }, async () => {
+    await assert.rejects(
+      async () =>
+        client.listGames({
+          errorMessage: "Lobby non disponibile",
+          fallbackMessage: "Lobby non valida"
+        }),
+      (error: Error) => {
+        assert.equal(error.message, "Lobby non valida");
+        return true;
+      }
+    );
+  });
+});
+
+register("frontend API client invia body JSON tipizzati per join e logout", async () => {
+  const client = await getFrontendApiClientModule();
+  const requests: Array<{ input: string; init?: Record<string, unknown> }> = [];
+
+  await withMockFetch(async (input: string, init?: Record<string, unknown>) => {
+    requests.push({ input, init });
+
+    if (input === "/api/auth/logout") {
+      return {
+        ok: true,
+        async json() {
+          return { ok: true };
+        }
+      };
+    }
+
+    return {
+      ok: true,
+      async json() {
+        return {
+          playerId: "player-1",
+          user: {
+            id: "user-1",
+            username: "Alice"
+          }
+        };
+      }
+    };
+  }, async () => {
+    const joinResponse = await client.joinGame("game-1", {
+      errorMessage: "Join fallito",
+      fallbackMessage: "Join non valido"
+    });
+    const logoutResponse = await client.logout({
+      errorMessage: "Logout fallito",
+      fallbackMessage: "Logout non valido"
+    });
+
+    assert.equal(joinResponse.playerId, "player-1");
+    assert.equal(logoutResponse.ok, true);
+  });
+
+  assert.equal(requests[0]?.input, "/api/join");
+  assert.equal(requests[1]?.input, "/api/auth/logout");
+  assert.equal(requests[0]?.init?.method, "POST");
+  assert.equal(requests[1]?.init?.method, "POST");
+  assert.equal(requests[0]?.init?.body, JSON.stringify({ gameId: "game-1" }));
+  assert.equal(requests[1]?.init?.body, JSON.stringify({}));
 });
 
 register("game action route segnala il version conflict prima di eseguire mutazioni", async () => {

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -133,6 +133,12 @@ export const themePreferenceResponseSchema = objectSchema({
 
 export type ThemePreferenceResponse = z.infer<typeof themePreferenceResponseSchema>;
 
+export const logoutResponseSchema = objectSchema({
+  ok: z.literal(true)
+});
+
+export type LogoutResponse = z.infer<typeof logoutResponseSchema>;
+
 export const netRiskModuleReferenceSchema = objectSchema({
   id: z.string().min(1),
   version: z.string().min(1)
@@ -159,6 +165,37 @@ export const gameSummarySchema = objectSchema({
 });
 
 export type GameSummary = z.infer<typeof gameSummarySchema>;
+
+export const gameIdRequestSchema = objectSchema({
+  gameId: z.string().min(1)
+});
+
+export type GameIdRequest = z.infer<typeof gameIdRequestSchema>;
+
+export const gameListResponseSchema = objectSchema({
+  games: z.array(gameSummarySchema),
+  activeGameId: z.string().min(1).nullable().optional()
+});
+
+export type GameListResponse = z.infer<typeof gameListResponseSchema>;
+
+export const gameMutationGameSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1).nullable().optional()
+});
+
+export type GameMutationGame = z.infer<typeof gameMutationGameSchema>;
+
+export const gameMutationResponseSchema = objectSchema({
+  ok: z.literal(true).optional(),
+  user: publicUserSchema.optional(),
+  playerId: z.string().min(1).nullable().optional(),
+  game: gameMutationGameSchema.optional(),
+  games: z.array(gameSummarySchema).optional(),
+  activeGameId: z.string().min(1).nullable().optional()
+});
+
+export type GameMutationResponse = z.infer<typeof gameMutationResponseSchema>;
 
 export const participatingGameLobbySchema = objectSchema({
   playerName: z.string().min(1),

--- a/tests/gameplay/shared/runtime-validation.test.cts
+++ b/tests/gameplay/shared/runtime-validation.test.cts
@@ -1,7 +1,11 @@
 const assert = require("node:assert/strict");
 const {
   authSessionResponseSchema,
+  gameIdRequestSchema,
+  gameListResponseSchema,
+  gameMutationResponseSchema,
   loginRequestSchema,
+  logoutResponseSchema,
   parseWithSchema,
   profileResponseSchema,
   themePreferenceResponseSchema,
@@ -72,11 +76,57 @@ register("shared runtime validation parses the auth/profile slice payloads", () 
       theme: "midnight"
     }
   });
+  const gameIdRequest = parseWithSchema(gameIdRequestSchema, {
+    gameId: "g-1"
+  });
+  const gameListResponse = parseWithSchema(gameListResponseSchema, {
+    games: [
+      {
+        id: "g-1",
+        name: "Campaign",
+        phase: "lobby",
+        playerCount: 2,
+        updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString(),
+        totalPlayers: 4,
+        mapName: "World Classic"
+      }
+    ],
+    activeGameId: "g-1"
+  });
+  const gameMutationResponse = parseWithSchema(gameMutationResponseSchema, {
+    ok: true,
+    game: {
+      id: "g-1",
+      name: "Campaign"
+    },
+    games: [
+      {
+        id: "g-1",
+        name: "Campaign",
+        phase: "lobby",
+        playerCount: 2,
+        updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+      }
+    ],
+    activeGameId: "g-1",
+    playerId: "p-1",
+    user: {
+      id: "u-1",
+      username: "commander"
+    }
+  });
+  const logoutResponse = parseWithSchema(logoutResponseSchema, {
+    ok: true
+  });
 
   assert.equal(loginRequest.username, "commander");
   assert.equal(sessionResponse.user.username, "commander");
   assert.equal(profileResponse.profile.participatingGames.length, 1);
   assert.equal(themePreferenceResponse.preferences.theme, "midnight");
+  assert.equal(gameIdRequest.gameId, "g-1");
+  assert.equal(gameListResponse.games[0].id, "g-1");
+  assert.equal(gameMutationResponse.playerId, "p-1");
+  assert.equal(logoutResponse.ok, true);
 });
 
 register("shared runtime validation exposes deterministic validation issue paths", () => {
@@ -115,5 +165,35 @@ register("shared runtime validation exposes deterministic validation issue paths
     validationErrors.every(
       (entry: { message: string }) => typeof entry.message === "string" && entry.message.length > 0
     )
+  );
+});
+
+register("shared runtime validation validates lobby route payload shapes", () => {
+  const invalidGameList = gameListResponseSchema.safeParse({
+    games: [
+      {
+        id: "g-1",
+        name: "Campaign",
+        phase: "lobby",
+        playerCount: "two",
+        updatedAt: new Date("2026-04-17T08:30:00.000Z").toISOString()
+      }
+    ]
+  });
+  const invalidJoinResponse = gameMutationResponseSchema.safeParse({
+    user: {
+      username: "commander"
+    }
+  });
+
+  assert.equal(invalidGameList.success, false);
+  assert.equal(invalidJoinResponse.success, false);
+  assert.deepEqual(
+    toValidationErrors(invalidGameList.error).map((entry: { path: string }) => entry.path),
+    ["games.0.playerCount"]
+  );
+  assert.deepEqual(
+    toValidationErrors(invalidJoinResponse.error).map((entry: { path: string }) => entry.path),
+    ["user.id"]
   );
 });


### PR DESCRIPTION
Closes #97

## Summary
- add a typed frontend API client layer for the migrated `profile` and `lobby` flows
- centralize fetch, JSON parsing, runtime validation, session handling, and error translation
- remove direct fetch usage from `profile.mts` and `lobby.mts` for the scoped flows in this issue
- document the new frontend transport boundary in `README.md` and `ARCHITECTURE.md`

## What Changed
- extend shared runtime validation with lobby list, game mutation, logout, and `gameId` request schemas
- validate `/api/games`, `/api/games/open`, and `/api/join` responses on the backend using the existing route validation helpers
- add `frontend/src/core/api/http.mts` and `frontend/src/core/api/client.mts` as a framework-agnostic frontend API layer
- refactor `frontend/src/profile.mts` and `frontend/src/lobby.mts` to consume the new client layer
- add shared, backend, and frontend-client tests for success paths, validation failures, and translated errors
- update repository docs so the architecture notes describe the typed frontend API boundary now used by the migrated flows

## Why
The migrated UI flows needed a reusable typed transport boundary so legacy pages and future React consumers can share the same request, response, and error handling rules without embedding raw `fetch` details in UI modules.

## Validation
- `npm run format:check`
- `npm run test:all`
