### PR TITLE
[codex] Introduce TanStack Query + Zustand profile pilot

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,6 +12,7 @@ L'applicazione include già:
 - validazione runtime condivisa dei payload auth/profile tra backend e frontend
 - layer client API frontend tipizzato per i flussi migrati `profile` e `lobby`
 - shell React + Vite parallela servita su `/react/` senza sostituire la UI legacy
+- convenzioni React shell con TanStack Query per server state e Zustand limitato a shell/session UI
 - lobby, creazione partita, join player umani e bot AI
 - setup partita 2-4 giocatori con mappe supportate
 - ciclo turno completo (`reinforcement` -> `attack` -> `fortify` -> `finished`)
@@ -32,6 +33,7 @@ Sorgente TypeScript (`.mts`) della UI web, della shell condivisa, dell'i18n e de
 
 `/frontend/react-shell`  
 Shell React + Vite parallela, con alias verso `frontend/src/core` e `shared`, usata come percorso di migrazione incrementale.
+Per il pilot attuale del profilo usa TanStack Query per il server state e Zustand solo per stato locale di shell/sessione.
 
 `/frontend/src/core/api`  
 Boundary HTTP frontend framework-agnostic: request helpers tipizzati, parsing/validazione condivisa ed error translation per i flussi UI migrati.
@@ -163,6 +165,7 @@ Categorie future da trattare con lo stesso modello:
 - Pipeline React shell: `frontend/react-shell` viene buildata con Vite in `public/react/`, con `base=/react/` e proxy dev `/api` verso `VITE_BACKEND_TARGET`.
 - Boundary validation frontend: `frontend/src/core/validated-json.mts` valida le risposte condivise prima del consumo UI.
 - Boundary transport frontend: `frontend/src/core/api/http.mts` e `frontend/src/core/api/client.mts` centralizzano `fetch`, body JSON, validazione runtime, session handling ed error translation per i flussi `profile` e `lobby`.
+- React server-state ownership: nella shell React le query remote stanno in TanStack Query; Zustand non sostituisce il backend e resta confinato a stato locale/sessione della shell.
 - Datastore supportati:
   - SQLite locale (default sviluppo)
   - Supabase (quando configurato via env)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Today the project includes:
 - shared runtime validation for auth/profile payloads at backend and frontend boundaries
 - typed frontend API client helpers for the migrated `profile` and `lobby` flows
 - parallel React + Vite smoke shell served at `/react/`, isolated from the legacy pages
+- TanStack Query + Zustand conventions in the React shell, with a minimal `/react/profile` pilot
 - initial lobby and reopening saved games
 - creation of a new game with supported map, selectable dice ruleset, and configurable turn time limit
 - joining with human players and adding AI bots
@@ -79,6 +80,7 @@ npm run dev:react-shell
 
 The parallel React + Vite shell is reachable at `http://localhost:5173/react/` in development and at `/react/` from the main server after `npm run build:ts`.
 The Vite dev server proxies `/api` to `VITE_BACKEND_TARGET`, which defaults to `http://127.0.0.1:3000`.
+Within the React shell, TanStack Query now owns server state for the migrated profile pilot, while Zustand is limited to local shell/session state.
 
 ## Datastore configuration
 
@@ -353,6 +355,7 @@ Main frontend screens currently available:
 The UI is designed to stay thin: it displays state received from the server and sends actions via API.
 For the migrated `profile` and `lobby` pages, raw network details now live in the typed frontend client layer under `frontend/src/core/api/`, so page modules stay focused on rendering and UI state.
 The React shell follows the same rule: it reuses the shared typed client and does not duplicate game rules locally.
+For the current React pilot, TanStack Query is used only for remote profile state and mutations, while Zustand is reserved for shell-local session state and UI ownership.
 
 From a naming perspective, frontend pages currently display title `Frontline Dominion`, while the technical project domain continues to use `NetRisk`.
 

--- a/e2e/smoke/react-shell.spec.ts
+++ b/e2e/smoke/react-shell.spec.ts
@@ -1,6 +1,6 @@
 const { test, expect } = require("@playwright/test");
 
-const { resetGame, uniqueUser } = require("../support/game-helpers");
+const { attachSessionCookie, resetGame, uniqueUser } = require("../support/game-helpers");
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -53,19 +53,123 @@ test("authenticated sessions can open a protected react route directly", async (
   await resetGame(page);
 
   const sessionToken = await createAuthenticatedSession(page, uniqueUser("react_shell_profile"));
-  await page.context().addCookies([{
-    name: "netrisk_session",
-    value: sessionToken,
-    url: "http://127.0.0.1:3100",
-    httpOnly: true,
-    sameSite: "Lax"
-  }]);
+  await attachSessionCookie(page, sessionToken);
 
   await page.goto("/react/profile");
 
   await expect(page).toHaveURL(/\/react\/profile$/);
   await expect(page.getByTestId("react-shell-profile-page")).toBeVisible();
   await expect(page.getByTestId("react-shell-session-status")).toContainText(/Authenticated/i);
+});
+
+test("react profile pilot shows query loading before rendering authenticated data", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_prof_load"));
+  await attachSessionCookie(page, sessionToken);
+
+  let releaseProfileResponse;
+  const profileResponseReleased = new Promise((resolve) => {
+    releaseProfileResponse = resolve;
+  });
+
+  await page.route("**/api/profile", async (route) => {
+    await profileResponseReleased;
+    await route.continue();
+  });
+
+  const navigation = page.goto("/react/profile");
+  await expect(page.getByTestId("react-shell-profile-loading")).toBeVisible();
+  releaseProfileResponse();
+  await navigation;
+
+  await expect(page.getByTestId("react-shell-profile-metrics")).toBeVisible();
+  await expect(page.getByTestId("react-shell-profile-theme-select")).toHaveValue("command");
+});
+
+test("react profile theme mutation keeps shell theme coherent across navigation", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_theme"));
+  await attachSessionCookie(page, sessionToken);
+
+  await page.goto("/react/profile");
+
+  const themeSelect = page.getByTestId("react-shell-profile-theme-select");
+  await expect(themeSelect).toHaveValue("command");
+
+  await themeSelect.selectOption("midnight");
+
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "midnight");
+  await expect(themeSelect).toHaveValue("midnight");
+  await expect(page.getByTestId("react-shell-profile-theme-status")).toContainText(
+    /Theme applied|Tema applicato|Midnight|Mezzanotte/
+  );
+  await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("netrisk.theme"))).toBe(
+    "midnight"
+  );
+
+  await page.goto("/react/lobby");
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "midnight");
+
+  await page.goto("/react/profile");
+  await expect(page.getByTestId("react-shell-profile-theme-select")).toHaveValue("midnight");
+});
+
+test("react profile shows controlled feedback when the query payload is invalid", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_prof_bad"));
+  await attachSessionCookie(page, sessionToken);
+
+  await page.route("**/api/profile", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        profile: {
+          playerName: 99
+        }
+      })
+    });
+  });
+
+  await page.goto("/react/profile");
+
+  await expect(page.getByTestId("react-shell-profile-error")).toBeVisible();
+  await expect(page.getByTestId("react-shell-profile-error")).toContainText(
+    /Unable to load the profile|Impossibile caricare il profilo/
+  );
+});
+
+test("react profile restores the previous theme when the mutation fails", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_theme_err"));
+  await attachSessionCookie(page, sessionToken);
+
+  await page.route("**/api/profile/preferences/theme", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: "Theme update failed."
+      })
+    });
+  });
+
+  await page.goto("/react/profile");
+
+  const themeSelect = page.getByTestId("react-shell-profile-theme-select");
+  await expect(themeSelect).toHaveValue("command");
+
+  await themeSelect.selectOption("ember");
+
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "command");
+  await expect(themeSelect).toHaveValue("command");
+  await expect(page.getByTestId("react-shell-profile-theme-status")).toContainText(
+    /Save failed|Salvataggio non riuscito|Theme update failed|Richiesta fallita/
+  );
 });
 
 test("react login returns the user to the protected route that triggered it", async ({ page }) => {

--- a/frontend/react-shell/src/App.tsx
+++ b/frontend/react-shell/src/App.tsx
@@ -1,5 +1,12 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+
 import { AppRoutes } from "@react-shell/routes";
+import { queryClient } from "@react-shell/react-query";
 
 export function App() {
-  return <AppRoutes />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AppRoutes />
+    </QueryClientProvider>
+  );
 }

--- a/frontend/react-shell/src/auth-store.ts
+++ b/frontend/react-shell/src/auth-store.ts
@@ -1,0 +1,61 @@
+import { startTransition } from "react";
+
+import type { AuthSessionResponse } from "@frontend-generated/shared-runtime-validation.mts";
+
+import { create } from "zustand";
+
+export type SessionUser = AuthSessionResponse["user"];
+
+export type AuthState =
+  | {
+      status: "loading";
+    }
+  | {
+      status: "authenticated";
+      user: SessionUser;
+    }
+  | {
+      status: "unauthenticated";
+      message: string;
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+type AuthStore = {
+  state: AuthState;
+  setState(state: AuthState): void;
+  updateAuthenticatedUser(user: SessionUser): void;
+};
+
+export const initialAuthState: AuthState = {
+  status: "loading"
+};
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  state: initialAuthState,
+  setState(state) {
+    set({ state });
+  },
+  updateAuthenticatedUser(user) {
+    set({
+      state: {
+        status: "authenticated",
+        user
+      }
+    });
+  }
+}));
+
+export function setAuthState(state: AuthState): void {
+  startTransition(() => {
+    useAuthStore.getState().setState(state);
+  });
+}
+
+export function updateAuthenticatedUser(user: SessionUser): void {
+  startTransition(() => {
+    useAuthStore.getState().updateAuthenticatedUser(user);
+  });
+}

--- a/frontend/react-shell/src/auth.tsx
+++ b/frontend/react-shell/src/auth.tsx
@@ -1,35 +1,16 @@
-import {
-  createContext,
-  startTransition,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode
-} from "react";
+import { createContext, useContext, useEffect, useRef, type ReactNode } from "react";
 
 import { getSession, login, logout } from "@frontend-core/api/client.mts";
 import type { ApiClientError } from "@frontend-core/api/http.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
-
-type SessionUser = Awaited<ReturnType<typeof getSession>>["user"];
-
-type AuthState =
-  | {
-      status: "loading";
-    }
-  | {
-      status: "authenticated";
-      user: SessionUser;
-    }
-  | {
-      status: "unauthenticated";
-      message: string;
-    }
-  | {
-      status: "error";
-      message: string;
-    };
+import {
+  initialAuthState,
+  setAuthState,
+  useAuthStore,
+  type AuthState,
+  type SessionUser
+} from "@react-shell/auth-store";
+import { applyShellTheme } from "@react-shell/theme";
 
 type AuthContextValue = {
   state: AuthState;
@@ -39,10 +20,6 @@ type AuthContextValue = {
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-const initialState: AuthState = {
-  status: "loading"
-};
 
 function requestMessages(scope: string) {
   return {
@@ -82,8 +59,16 @@ async function resolveSessionState(): Promise<AuthState> {
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<AuthState>(initialState);
+  const state = useAuthStore((store) => store.state);
   const requestIdRef = useRef(0);
+
+  function commitState(nextState: AuthState): void {
+    if (nextState.status === "authenticated") {
+      applyShellTheme(nextState.user.preferences?.theme || null);
+    }
+
+    setAuthState(nextState);
+  }
 
   useEffect(() => {
     let isActive = true;
@@ -92,18 +77,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
 
-      startTransition(() => {
-        setState(initialState);
-      });
+      setAuthState(initialAuthState);
 
       const nextState = await resolveSessionState();
       if (!isActive || requestIdRef.current !== requestId) {
         return;
       }
 
-      startTransition(() => {
-        setState(nextState);
-      });
+      commitState(nextState);
     }
 
     void bootstrap();
@@ -117,28 +98,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
 
-    startTransition(() => {
-      setState(initialState);
-    });
+    setAuthState(initialAuthState);
 
     const nextState = await resolveSessionState();
     if (requestIdRef.current !== requestId) {
       return;
     }
 
-    startTransition(() => {
-      setState(nextState);
-    });
+    commitState(nextState);
   }
 
   async function signIn(credentials: { username: string; password: string }): Promise<SessionUser> {
     const response = await login(credentials, requestMessages("credentials"));
 
-    startTransition(() => {
-      setState({
-        status: "authenticated",
-        user: response.user
-      });
+    commitState({
+      status: "authenticated",
+      user: response.user
     });
 
     return response.user;
@@ -153,11 +128,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     }
 
-    startTransition(() => {
-      setState({
-        status: "unauthenticated",
-        message: "Signed out."
-      });
+    setAuthState({
+      status: "unauthenticated",
+      message: "Signed out."
     });
   }
 

--- a/frontend/react-shell/src/main.tsx
+++ b/frontend/react-shell/src/main.tsx
@@ -3,10 +3,12 @@ import ReactDOM from "react-dom/client";
 import { resolveLocale, setLocale } from "@frontend-i18n";
 
 import { App } from "@react-shell/App";
+import { applyShellTheme } from "@react-shell/theme";
 
 import "./styles.css";
 
 setLocale(resolveLocale());
+applyShellTheme(null);
 
 const rootElement = document.querySelector("#root");
 if (!rootElement) {

--- a/frontend/react-shell/src/profile-route.tsx
+++ b/frontend/react-shell/src/profile-route.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { getProfile, updateThemePreference } from "@frontend-core/api/client.mts";
+import { normalizeTheme } from "@frontend-core/contracts.mts";
+import { messageFromError } from "@frontend-core/errors.mts";
+import { formatDate, t } from "@frontend-i18n";
+
+import { useAuth } from "@react-shell/auth";
+import { updateAuthenticatedUser } from "@react-shell/auth-store";
+import { profileDetailQueryKey } from "@react-shell/react-query";
+import { applyShellTheme, shellThemes, themeLabel } from "@react-shell/theme";
+
+function phaseLabel(phase: string): string {
+  if (phase === "active") {
+    return t("common.phase.active");
+  }
+
+  if (phase === "finished") {
+    return t("common.phase.finished");
+  }
+
+  return t("common.phase.lobby");
+}
+
+function formatUpdatedAt(value: string | null | undefined): string {
+  if (!value) {
+    return t("common.notAvailable");
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return t("common.notAvailable");
+  }
+
+  return formatDate(parsed, {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+export function ProfileRoute() {
+  const { state, refresh } = useAuth();
+  const queryClient = useQueryClient();
+  const authenticatedUser = state.status === "authenticated" ? state.user : null;
+  const committedTheme = normalizeTheme(authenticatedUser?.preferences?.theme || null);
+  const [selectedTheme, setSelectedTheme] = useState(committedTheme);
+  const [themeFeedbackMode, setThemeFeedbackMode] = useState<"idle" | "saving" | "saved" | "error">(
+    "idle"
+  );
+  const [themeErrorMessage, setThemeErrorMessage] = useState("");
+
+  useEffect(() => {
+    setSelectedTheme(committedTheme);
+    applyShellTheme(committedTheme);
+  }, [committedTheme]);
+
+  const profileQuery = useQuery({
+    queryKey: profileDetailQueryKey,
+    queryFn: () =>
+      getProfile({
+        errorMessage: t("profile.errors.unavailable"),
+        fallbackMessage: t("profile.errors.loadFailed")
+      })
+  });
+
+  const themeMutation = useMutation({
+    mutationFn: (theme: string) =>
+      updateThemePreference(theme, {
+        errorMessage: t("errors.requestFailed"),
+        fallbackMessage: t("profile.preferences.status.saveFailed", {
+          theme: themeLabel(theme)
+        })
+      })
+  });
+
+  if (!authenticatedUser) {
+    return null;
+  }
+
+  const currentUser = authenticatedUser;
+
+  async function handleProfileRetry(): Promise<void> {
+    await refresh();
+    await profileQuery.refetch();
+  }
+
+  async function handleThemeChange(nextTheme: string): Promise<void> {
+    const previousTheme = committedTheme;
+
+    setSelectedTheme(nextTheme);
+    setThemeFeedbackMode("saving");
+    setThemeErrorMessage("");
+
+    try {
+      const response = await themeMutation.mutateAsync(nextTheme);
+      const syncedUser = {
+        ...currentUser,
+        ...response.user,
+        preferences: response.preferences || response.user.preferences || currentUser.preferences
+      };
+      const storedTheme = normalizeTheme(
+        response.preferences?.theme || response.user.preferences?.theme || nextTheme
+      );
+
+      updateAuthenticatedUser(syncedUser);
+      applyShellTheme(storedTheme);
+      setSelectedTheme(storedTheme);
+      setThemeFeedbackMode("saved");
+      await queryClient.invalidateQueries({ queryKey: profileDetailQueryKey });
+    } catch (error) {
+      applyShellTheme(previousTheme);
+      setSelectedTheme(previousTheme);
+      setThemeFeedbackMode("error");
+      setThemeErrorMessage(
+        messageFromError(
+          error,
+          t("profile.preferences.status.saveFailed", {
+            theme: themeLabel(previousTheme)
+          })
+        )
+      );
+    }
+  }
+
+  const themeStatusMessage =
+    themeFeedbackMode === "saving"
+      ? t("profile.preferences.status.saving")
+      : themeFeedbackMode === "saved"
+        ? t("profile.preferences.status.saved", { theme: themeLabel(selectedTheme) })
+        : themeFeedbackMode === "error"
+          ? themeErrorMessage
+          : t("profile.preferences.status.current", { theme: themeLabel(committedTheme) });
+
+  const profile = profileQuery.data?.profile || null;
+  const activeGames = Array.isArray(profile?.participatingGames) ? profile.participatingGames : [];
+  const activeGamesLabel = t(
+    activeGames.length === 1 ? "profile.games.activeCount.one" : "profile.games.activeCount.other",
+    { count: activeGames.length }
+  );
+
+  return (
+    <section data-testid="react-shell-profile-page">
+      <p className="status-label">{t("profile.eyebrow")}</p>
+      <h2>{currentUser.username}</h2>
+      <p className="status-copy">{t("profile.subtitle")}</p>
+
+      <div className="profile-pilot-grid">
+        <section className="placeholder-card profile-pilot-card">
+          <div className="card-header profile-pilot-card-header">
+            <div>
+              <p className="status-label">{t("profile.preferences.eyebrow")}</p>
+              <h3>{t("profile.preferences.heading")}</h3>
+            </div>
+            <span className="status-pill">{themeLabel(selectedTheme)}</span>
+          </div>
+
+          <p className="metric-copy">{t("profile.preferences.copy")}</p>
+
+          <label className="shell-field">
+            <span>{t("profile.preferences.label")}</span>
+            <select
+              value={selectedTheme}
+              disabled={themeMutation.isPending}
+              onChange={(event) => void handleThemeChange(event.target.value)}
+              data-testid="react-shell-profile-theme-select"
+            >
+              {shellThemes.map((theme) => (
+                <option key={theme.id} value={theme.id}>
+                  {themeLabel(theme.id)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <p
+            className={`profile-theme-status${themeFeedbackMode === "error" ? " is-error" : ""}`}
+            data-testid="react-shell-profile-theme-status"
+          >
+            {themeStatusMessage}
+          </p>
+        </section>
+
+        <section className="placeholder-card profile-pilot-card profile-pilot-card-wide">
+          <div className="card-header profile-pilot-card-header">
+            <div>
+              <p className="status-label">{t("profile.heading")}</p>
+              <h3>{profile?.playerName || currentUser.username}</h3>
+            </div>
+            <span className="status-pill">{activeGamesLabel}</span>
+          </div>
+
+          {profileQuery.isLoading ? (
+            <div className="profile-query-state" data-testid="react-shell-profile-loading">
+              <p className="metric-copy">{t("profile.feedback")}</p>
+            </div>
+          ) : profileQuery.isError ? (
+            <div
+              className="profile-query-state profile-query-state-error"
+              data-testid="react-shell-profile-error"
+            >
+              <p className="metric-copy">
+                {messageFromError(profileQuery.error, t("profile.errors.loadFailed"))}
+              </p>
+              <div className="shell-actions">
+                <button
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleProfileRetry()}
+                >
+                  Retry profile
+                </button>
+              </div>
+            </div>
+          ) : profile ? (
+            <>
+              <div className="profile-metric-grid" data-testid="react-shell-profile-metrics">
+                <article className="profile-metric-card">
+                  <span>{t("profile.metrics.gamesPlayed")}</span>
+                  <strong>{profile.gamesPlayed}</strong>
+                </article>
+                <article className="profile-metric-card">
+                  <span>{t("profile.metrics.wins")}</span>
+                  <strong>{profile.wins}</strong>
+                </article>
+                <article className="profile-metric-card">
+                  <span>{t("profile.metrics.losses")}</span>
+                  <strong>{profile.losses}</strong>
+                </article>
+                <article className="profile-metric-card">
+                  <span>{t("profile.metrics.inProgress")}</span>
+                  <strong>{profile.gamesInProgress}</strong>
+                </article>
+                <article className="profile-metric-card">
+                  <span>{t("profile.metrics.winRate")}</span>
+                  <strong>{profile.winRate == null ? "--" : `${profile.winRate}%`}</strong>
+                </article>
+              </div>
+
+              {!profile.hasHistory ? (
+                <div className="profile-query-state" data-testid="react-shell-profile-empty">
+                  <p className="metric-copy">{t("profile.runtime.noStats")}</p>
+                </div>
+              ) : null}
+
+              <div className="profile-active-games">
+                <div className="card-header profile-pilot-card-header">
+                  <div>
+                    <p className="status-label">{t("profile.games.kicker")}</p>
+                    <h3>{activeGamesLabel}</h3>
+                  </div>
+                  {profileQuery.isFetching ? (
+                    <span className="status-pill muted">Syncing</span>
+                  ) : null}
+                </div>
+
+                {!activeGames.length ? (
+                  <p className="metric-copy">{t("profile.runtime.directiveNote.none")}</p>
+                ) : (
+                  <div className="profile-active-games-list">
+                    {activeGames.map((game) => (
+                      <article className="profile-active-game-card" key={game.id}>
+                        <div className="profile-active-game-copy">
+                          <strong>{game.name}</strong>
+                          <span>
+                            {game.mapName || game.mapId || t("common.notAvailable")} ·{" "}
+                            {phaseLabel(game.phase)}
+                          </span>
+                          <span>
+                            {t("profile.games.updatedAt", {
+                              updatedAt: formatUpdatedAt(game.updatedAt)
+                            })}
+                          </span>
+                        </div>
+
+                        <Link className="ghost-action" to={`/game/${encodeURIComponent(game.id)}`}>
+                          {t("profile.runtime.directive.resume")}
+                        </Link>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : null}
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/frontend/react-shell/src/react-query.ts
+++ b/frontend/react-shell/src/react-query.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false
+    },
+    mutations: {
+      retry: false
+    }
+  }
+});
+
+export const profileDetailQueryKey = ["profile", "detail"] as const;

--- a/frontend/react-shell/src/routes.tsx
+++ b/frontend/react-shell/src/routes.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-router-dom";
 
 import { useAuth, AuthProvider } from "@react-shell/auth";
+import { ProfileRoute } from "@react-shell/profile-route";
 import { messageFromError } from "@frontend-core/errors.mts";
 
 function normalizeNextPath(nextPath: string | null): string {
@@ -294,28 +295,6 @@ function LobbyPlaceholderPage() {
   );
 }
 
-function ProfilePlaceholderPage() {
-  return (
-    <PlaceholderPage
-      eyebrow="Profile"
-      title="React profile placeholder"
-      copy="The profile route is protected and isolated, so issue #101 can migrate the actual data flow without reshaping the shell."
-      details={
-        <>
-          <div className="placeholder-card">
-            <strong>Session-aware entry</strong>
-            <span>Protected pages no longer need ad-hoc auth checks in each screen.</span>
-          </div>
-          <div className="placeholder-card">
-            <strong>Boundary preserved</strong>
-            <span>The typed frontend API client remains the only transport layer entry point.</span>
-          </div>
-        </>
-      }
-    />
-  );
-}
-
 function GamePlaceholderPage() {
   const params = useParams();
 
@@ -504,7 +483,7 @@ export function AppRoutes() {
             <Route path="unauthorized" element={<UnauthorizedPage />} />
             <Route element={<ProtectedRoute />}>
               <Route path="lobby" element={<LobbyPlaceholderPage />} />
-              <Route path="profile" element={<ProfilePlaceholderPage />} />
+              <Route path="profile" element={<ProfileRoute />} />
               <Route path="game">
                 <Route index element={<GamePlaceholderPage />} />
                 <Route path=":gameId" element={<GamePlaceholderPage />} />

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -1,11 +1,59 @@
 :root {
-  color-scheme: light;
-  font-family: Aptos, "Trebuchet MS", "Segoe UI", sans-serif;
-  background:
+  --shell-bg:
     radial-gradient(circle at top left, rgba(237, 120, 71, 0.28), transparent 35%),
     radial-gradient(circle at top right, rgba(31, 92, 179, 0.22), transparent 28%),
     linear-gradient(180deg, #f7f3ea 0%, #ece5d8 100%);
-  color: #162033;
+  --shell-panel-bg: rgba(255, 252, 247, 0.86);
+  --shell-panel-soft: rgba(240, 235, 226, 0.72);
+  --shell-card-bg: rgba(240, 235, 226, 0.82);
+  --shell-border: rgba(22, 32, 51, 0.12);
+  --shell-copy: rgba(22, 32, 51, 0.78);
+  --shell-muted: rgba(22, 32, 51, 0.72);
+  --shell-heading: #162033;
+  --shell-accent: #ad4f1f;
+  --shell-button-bg: #162033;
+  --shell-button-hover: #24324f;
+  --shell-button-copy: #fef9f1;
+  color-scheme: light;
+  font-family: Aptos, "Trebuchet MS", "Segoe UI", sans-serif;
+  background: var(--shell-bg);
+  color: var(--shell-heading);
+}
+
+:root[data-theme="midnight"] {
+  --shell-bg:
+    radial-gradient(circle at top left, rgba(76, 77, 192, 0.24), transparent 35%),
+    radial-gradient(circle at top right, rgba(59, 155, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #101426 0%, #1a223d 100%);
+  --shell-panel-bg: rgba(24, 32, 56, 0.88);
+  --shell-panel-soft: rgba(19, 26, 48, 0.78);
+  --shell-card-bg: rgba(28, 38, 66, 0.82);
+  --shell-border: rgba(146, 169, 255, 0.22);
+  --shell-copy: rgba(232, 238, 255, 0.82);
+  --shell-muted: rgba(216, 225, 255, 0.72);
+  --shell-heading: #edf2ff;
+  --shell-accent: #9cb3ff;
+  --shell-button-bg: #dbe5ff;
+  --shell-button-hover: #ffffff;
+  --shell-button-copy: #162033;
+}
+
+:root[data-theme="ember"] {
+  --shell-bg:
+    radial-gradient(circle at top left, rgba(255, 149, 92, 0.32), transparent 30%),
+    radial-gradient(circle at top right, rgba(145, 37, 21, 0.22), transparent 30%),
+    linear-gradient(180deg, #221915 0%, #3d241d 100%);
+  --shell-panel-bg: rgba(58, 35, 29, 0.86);
+  --shell-panel-soft: rgba(77, 43, 34, 0.78);
+  --shell-card-bg: rgba(97, 57, 42, 0.78);
+  --shell-border: rgba(255, 191, 152, 0.22);
+  --shell-copy: rgba(255, 232, 218, 0.84);
+  --shell-muted: rgba(255, 223, 204, 0.74);
+  --shell-heading: #fff2e6;
+  --shell-accent: #ffb17e;
+  --shell-button-bg: #fff2e6;
+  --shell-button-hover: #ffffff;
+  --shell-button-copy: #162033;
 }
 
 * {
@@ -15,6 +63,8 @@
 body {
   margin: 0;
   min-height: 100vh;
+  background: var(--shell-bg);
+  color: var(--shell-heading);
 }
 
 button,
@@ -33,9 +83,9 @@ select {
 .hero-panel,
 .card-panel,
 .status-panel {
-  border: 1px solid rgba(22, 32, 51, 0.12);
+  border: 1px solid var(--shell-border);
   border-radius: 24px;
-  background: rgba(255, 252, 247, 0.86);
+  background: var(--shell-panel-bg);
   box-shadow: 0 24px 80px rgba(22, 32, 51, 0.08);
   backdrop-filter: blur(12px);
 }
@@ -51,7 +101,7 @@ select {
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: #ad4f1f;
+  color: var(--shell-accent);
 }
 
 .hero-panel h1,
@@ -72,7 +122,7 @@ select {
 .status-copy,
 .metric-copy,
 .footer-note {
-  color: rgba(22, 32, 51, 0.78);
+  color: var(--shell-copy);
 }
 
 .hero-copy {
@@ -94,7 +144,7 @@ select {
 .refresh-button {
   border-radius: 999px;
   padding: 0.7rem 1rem;
-  border: 1px solid rgba(22, 32, 51, 0.12);
+  border: 1px solid var(--shell-border);
 }
 
 .chip,
@@ -104,13 +154,13 @@ select {
 }
 
 .refresh-button {
-  background: #162033;
-  color: #fef9f1;
+  background: var(--shell-button-bg);
+  color: var(--shell-button-copy);
   cursor: pointer;
 }
 
 .refresh-button:hover {
-  background: #24324f;
+  background: var(--shell-button-hover);
 }
 
 .status-panel {
@@ -171,7 +221,7 @@ select {
   gap: 1rem;
   padding: 0.95rem 1rem;
   border-radius: 18px;
-  background: rgba(240, 235, 226, 0.82);
+  background: var(--shell-card-bg);
 }
 
 .game-list-item div {
@@ -180,7 +230,7 @@ select {
 }
 
 .game-list-item span {
-  color: rgba(22, 32, 51, 0.72);
+  color: var(--shell-muted);
   font-size: 0.92rem;
 }
 
@@ -208,7 +258,7 @@ select {
   gap: 1rem;
   padding: 1.25rem;
   border-radius: 20px;
-  background: rgba(240, 235, 226, 0.7);
+  background: var(--shell-panel-soft);
 }
 
 .shell-session-header {
@@ -221,7 +271,7 @@ select {
 }
 
 .shell-session-copy span {
-  color: rgba(22, 32, 51, 0.72);
+  color: var(--shell-muted);
 }
 
 .shell-grid {
@@ -246,21 +296,21 @@ select {
   padding: 0.9rem 1rem;
   text-decoration: none;
   color: inherit;
-  background: rgba(240, 235, 226, 0.82);
+  background: var(--shell-card-bg);
   border: 1px solid transparent;
 }
 
 .shell-nav-link:hover,
 .shell-nav-link.is-active {
-  border-color: rgba(22, 32, 51, 0.12);
+  border-color: var(--shell-border);
   background: rgba(255, 255, 255, 0.78);
 }
 
 .placeholder-card,
 .shell-form {
   border-radius: 18px;
-  border: 1px solid rgba(22, 32, 51, 0.1);
-  background: rgba(240, 235, 226, 0.72);
+  border: 1px solid var(--shell-border);
+  background: var(--shell-panel-soft);
 }
 
 .placeholder-card {
@@ -270,7 +320,7 @@ select {
 }
 
 .placeholder-card span {
-  color: rgba(22, 32, 51, 0.72);
+  color: var(--shell-muted);
 }
 
 .shell-form {
@@ -287,10 +337,19 @@ select {
 }
 
 .shell-field input {
-  border: 1px solid rgba(22, 32, 51, 0.14);
+  border: 1px solid var(--shell-border);
   border-radius: 14px;
   padding: 0.9rem 1rem;
   background: rgba(255, 255, 255, 0.85);
+  color: var(--shell-heading);
+}
+
+.shell-field select {
+  border: 1px solid var(--shell-border);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--shell-heading);
 }
 
 .shell-field input:focus-visible {
@@ -311,9 +370,9 @@ select {
   justify-content: center;
   border-radius: 999px;
   padding: 0.7rem 1rem;
-  border: 1px solid rgba(22, 32, 51, 0.12);
+  border: 1px solid var(--shell-border);
   background: rgba(255, 255, 255, 0.68);
-  color: #162033;
+  color: var(--shell-heading);
   text-decoration: none;
   cursor: pointer;
 }
@@ -329,6 +388,104 @@ select {
 .auth-feedback.is-error {
   margin: 0;
   color: #8f3610;
+}
+
+.profile-pilot-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.profile-pilot-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-pilot-card-wide {
+  align-content: start;
+}
+
+.profile-pilot-card-header {
+  margin-bottom: 0;
+}
+
+.profile-pilot-card-header h3 {
+  margin: 0.25rem 0 0;
+  font-size: 1.2rem;
+}
+
+.profile-theme-status {
+  margin: 0;
+  color: var(--shell-copy);
+}
+
+.profile-theme-status.is-error {
+  color: #8f3610;
+}
+
+.profile-query-state {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.profile-query-state-error {
+  border: 1px solid rgba(173, 79, 31, 0.22);
+}
+
+.profile-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.profile-metric-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.profile-metric-card span {
+  color: var(--shell-muted);
+  font-size: 0.9rem;
+}
+
+.profile-metric-card strong {
+  font-size: 1.45rem;
+}
+
+.profile-active-games {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.profile-active-games-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.profile-active-game-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.profile-active-game-copy {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.profile-active-game-copy span {
+  color: var(--shell-muted);
 }
 
 @media (max-width: 760px) {
@@ -357,8 +514,14 @@ select {
 
   .card-header,
   .game-list-item,
-  .shell-actions {
+  .shell-actions,
+  .profile-active-game-card {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .profile-pilot-grid,
+  .profile-metric-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/react-shell/src/theme.ts
+++ b/frontend/react-shell/src/theme.ts
@@ -1,0 +1,52 @@
+import {
+  DEFAULT_THEME,
+  findTheme,
+  normalizeTheme,
+  registeredThemes
+} from "@frontend-core/contracts.mts";
+import { t } from "@frontend-i18n";
+
+const THEME_STORAGE_KEY = "netrisk.theme";
+
+export const shellThemes = registeredThemes;
+
+function readStoredTheme(): string | null {
+  try {
+    return window.localStorage?.getItem(THEME_STORAGE_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function currentShellTheme(): string {
+  if (typeof document === "undefined") {
+    return normalizeTheme(readStoredTheme() || DEFAULT_THEME);
+  }
+
+  return normalizeTheme(
+    document.documentElement.dataset.theme || readStoredTheme() || DEFAULT_THEME
+  );
+}
+
+export function applyShellTheme(theme: string | null | undefined): string {
+  const nextTheme = normalizeTheme(theme || currentShellTheme());
+  if (typeof document !== "undefined") {
+    document.documentElement.dataset.theme = nextTheme;
+    if (document.body) {
+      document.body.dataset.theme = nextTheme;
+    }
+  }
+
+  try {
+    window.localStorage?.setItem(THEME_STORAGE_KEY, nextTheme);
+  } catch {
+    // Keep the resolved theme applied even when storage is unavailable.
+  }
+
+  return nextTheme;
+}
+
+export function themeLabel(theme: string): string {
+  const themeDefinition = findTheme(theme);
+  return themeDefinition ? t(themeDefinition.labelKey) : theme;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "netrisk",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.99.0",
         "@vercel/speed-insights": "^2.0.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.1",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -602,6 +604,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -655,7 +683,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1162,7 +1190,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2855,6 +2883,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
     "vite": "^8.0.8"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.99.0",
     "@vercel/speed-insights": "^2.0.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   }
 }


### PR DESCRIPTION
## Summary
- add TanStack Query to the React shell for remote profile state and mutations
- move React shell auth/session state onto a small Zustand store while keeping `useAuth()` and `AuthProvider` stable
- replace the `/react/profile` placeholder with a minimal real pilot that loads profile data, updates theme preference, and handles loading/error/empty states explicitly
- document the state-ownership rule: TanStack Query for server state, Zustand only for shell-local session/UI state

## What changed
- introduced a shared QueryClient setup and a domain query key convention for `['profile', 'detail']`
- added React shell theme helpers so the selected theme stays coherent across login, refresh, mutation success, and navigation
- kept the typed frontend API client as the only transport boundary and avoided any backend contract changes
- extended Playwright smoke coverage for profile query loading, invalid payload fallback, theme mutation success, and theme mutation rollback on failure
- updated README and ARCHITECTURE notes for the new React shell state ownership pattern

## Validation
- `npm run typecheck:react-shell`
- `npm run build:ts`
- `npm run lint`
- `npm test`
- `npm run test:e2e:smoke`
- `npm run format:check`

Closes #100
