### PR TITLE
[codex] Follow-up: scope profile query cache per authenticated user

### DIFF
--- a/frontend/react-shell/src/profile-route.tsx
+++ b/frontend/react-shell/src/profile-route.tsx
@@ -60,7 +60,7 @@ export function ProfileRoute() {
   }, [committedTheme]);
 
   const profileQuery = useQuery({
-    queryKey: profileDetailQueryKey,
+    queryKey: profileDetailQueryKey(String(authenticatedUser?.id ?? "anonymous")),
     queryFn: () =>
       getProfile({
         errorMessage: t("profile.errors.unavailable"),
@@ -111,7 +111,7 @@ export function ProfileRoute() {
       applyShellTheme(storedTheme);
       setSelectedTheme(storedTheme);
       setThemeFeedbackMode("saved");
-      await queryClient.invalidateQueries({ queryKey: profileDetailQueryKey });
+      await queryClient.invalidateQueries({ queryKey: profileDetailQueryKey(currentUser.id) });
     } catch (error) {
       applyShellTheme(previousTheme);
       setSelectedTheme(previousTheme);

--- a/frontend/react-shell/src/react-query.ts
+++ b/frontend/react-shell/src/react-query.ts
@@ -12,4 +12,6 @@ export const queryClient = new QueryClient({
   }
 });
 
-export const profileDetailQueryKey = ["profile", "detail"] as const;
+export function profileDetailQueryKey(userId: string) {
+  return ["profile", "detail", userId] as const;
+}


### PR DESCRIPTION
## Summary
- scope the profile React Query key by authenticated user id
- use the same user-scoped key for the profile route query and theme-preference invalidation
- prevent cached profile data from leaking across authenticated sessions on the same client

## Root Cause
The profile cache key was global (`["profile", "detail"]`), so multiple authenticated users could reuse the same cached payload on a shared client session.

## Validation
- `npm run typecheck:react-shell`
- `npm run build:react-shell`
- `npm run lint`
- `npm run test:all`