### PR TITLE
[codex] Issue 101 PR1: typed boundaries and React profile parity

### DIFF
--- a/backend/routes/game-management.cts
+++ b/backend/routes/game-management.cts
@@ -47,6 +47,8 @@ type ResumeAiTurnsForRead = (gameContext: any) => Promise<any>;
 type ResolvePlayerForUser = (state: any, user: unknown) => any;
 
 const {
+  createGameRequestSchema,
+  createGameResponseSchema,
   gameIdRequestSchema,
   gameMutationResponseSchema
 } = require("../../shared/runtime-validation.cjs");
@@ -73,9 +75,19 @@ async function handleCreateGameRoute(
     return;
   }
 
+  const parsedBody = parseRequestOrSendError(
+    res as import("node:http").ServerResponse,
+    body,
+    createGameRequestSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedBody) {
+    return;
+  }
+
   try {
     const policy = authorize("game:create", { user: authContext.user });
-    const configured = await createConfiguredInitialState(body);
+    const configured = await createConfiguredInitialState(parsedBody);
     const creatorJoin = addPlayer(configured.state, authContext.user.username, {
       linkedUserId: policy.actor.id
     });
@@ -101,15 +113,22 @@ async function handleCreateGameRoute(
       version: created.game.version,
       state: created.state
     });
-    sendJson(res, 201, {
-      ok: true,
-      game: created.game,
-      games: await listGames(),
-      activeGameId: created.game.id,
-      state: snapshot(),
-      config: configured.config,
-      playerId: creatorJoin.player.id
-    });
+    sendValidatedJson(
+      res as import("node:http").ServerResponse,
+      201,
+      {
+        ok: true,
+        game: created.game,
+        games: await listGames(),
+        activeGameId: created.game.id,
+        state: snapshot(),
+        config: configured.config,
+        playerId: creatorJoin.player.id
+      },
+      createGameResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError
+    );
   } catch (error: any) {
     const statusCode = error.statusCode || 400;
     sendLocalizedError(

--- a/backend/routes/game-overview.cts
+++ b/backend/routes/game-overview.cts
@@ -23,7 +23,10 @@ type SendLocalizedError = (
   extra?: Record<string, unknown>
 ) => void;
 
-const { gameListResponseSchema } = require("../../shared/runtime-validation.cjs");
+const {
+  gameListResponseSchema,
+  gameOptionsResponseSchema
+} = require("../../shared/runtime-validation.cjs");
 const { sendValidatedJson } = require("../route-validation.cjs");
 
 async function handleGamesListRoute(
@@ -59,9 +62,10 @@ async function handleGameOptionsRoute(
   sendJson: SendJson,
   listPlayerPieceSets?: ListPlayerPieceSets,
   listContentPacks?: ListContentPacks,
-  getExtraGameOptions?: GetExtraGameOptions
+  getExtraGameOptions?: GetExtraGameOptions,
+  sendLocalizedError?: SendLocalizedError
 ): Promise<void> {
-  sendJson(res, 200, {
+  const payload = {
     ruleSets: listRuleSets(),
     maps: listMaps(),
     diceRuleSets: listDiceRuleSets(),
@@ -73,7 +77,21 @@ async function handleGameOptionsRoute(
     turnTimeoutHoursOptions: listTurnTimeoutHoursOptions(),
     playerRange: { min: 2, max: 4 },
     ...(typeof getExtraGameOptions === "function" ? await getExtraGameOptions() : {})
-  });
+  };
+
+  if (!sendLocalizedError) {
+    sendJson(res, 200, payload);
+    return;
+  }
+
+  sendValidatedJson(
+    res as import("node:http").ServerResponse,
+    200,
+    payload,
+    gameOptionsResponseSchema,
+    sendJson as SendJson,
+    sendLocalizedError
+  );
 }
 
 module.exports = {

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -764,7 +764,8 @@ function createApp(options: CreateAppOptions = {}) {
             uiProfiles: moduleOptions.uiProfiles,
             uiSlots: moduleOptions.uiSlots
           };
-        }
+        },
+        sendLocalizedError
       );
       return;
     }

--- a/e2e/smoke/react-shell.spec.ts
+++ b/e2e/smoke/react-shell.spec.ts
@@ -87,6 +87,22 @@ test("react profile pilot shows query loading before rendering authenticated dat
   await expect(page.getByTestId("react-shell-profile-theme-select")).toHaveValue("command");
 });
 
+test("react profile shows the empty-history state for a new authenticated user", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_prof_empty"));
+  await attachSessionCookie(page, sessionToken);
+
+  await page.goto("/react/profile");
+
+  await expect(page.getByTestId("react-shell-profile-page")).toBeVisible();
+  await expect(page.getByTestId("react-shell-profile-metrics")).toBeVisible();
+  await expect(page.getByTestId("react-shell-profile-empty")).toBeVisible();
+  await expect(page.getByTestId("react-shell-profile-empty")).toContainText(
+    /No stats available|Nessuna statistica disponibile/
+  );
+});
+
 test("react profile theme mutation keeps shell theme coherent across navigation", async ({ page }) => {
   await resetGame(page);
 
@@ -140,6 +156,46 @@ test("react profile shows controlled feedback when the query payload is invalid"
   await expect(page.getByTestId("react-shell-profile-error")).toContainText(
     /Unable to load the profile|Impossibile caricare il profilo/
   );
+});
+
+test("react profile participating games hand off to the legacy gameplay route", async ({ page }) => {
+  await resetGame(page);
+
+  const username = uniqueUser("rsh_prof_game");
+  const sessionToken = await createAuthenticatedSession(page, username);
+  const gameName = `React profile ${Date.now().toString(36).slice(-4)}`;
+
+  const createGameResponse = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` },
+    data: {
+      name: gameName,
+      mapId: "world-classic",
+      totalPlayers: 2,
+      players: [
+        { slot: 1, type: "human" },
+        { slot: 2, type: "ai" }
+      ]
+    }
+  });
+  await expect(createGameResponse.ok()).toBeTruthy();
+  const createdGame = await createGameResponse.json();
+
+  await attachSessionCookie(page, sessionToken);
+  await page.goto("/react/profile");
+
+  const openLink = page.getByTestId(`react-shell-profile-open-${createdGame.game.id}`);
+  await expect(openLink).toBeVisible();
+  await expect(openLink).toHaveAttribute("href", new RegExp(`/game/${createdGame.game.id}$`));
+  await expect(page.getByText(gameName)).toBeVisible();
+
+  await openLink.click();
+
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(
+    new RegExp(`/game/${createdGame.game.id}$`)
+  );
+  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+  await expect(page.locator("#game-map-meta")).toContainText("World Classic", { timeout: 15000 });
+  await expect(page.locator("#players")).toContainText(username, { timeout: 15000 });
 });
 
 test("react profile restores the previous theme when the mutation fails", async ({ page }) => {

--- a/frontend/react-shell/src/legacy-game-handoff.ts
+++ b/frontend/react-shell/src/legacy-game-handoff.ts
@@ -1,0 +1,7 @@
+export function buildLegacyGamePath(gameId: string): string {
+  return `/game/${encodeURIComponent(gameId)}`;
+}
+
+export function openLegacyGame(gameId: string): void {
+  window.location.assign(buildLegacyGamePath(gameId));
+}

--- a/frontend/react-shell/src/profile-route.tsx
+++ b/frontend/react-shell/src/profile-route.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -10,6 +9,7 @@ import { formatDate, t } from "@frontend-i18n";
 
 import { useAuth } from "@react-shell/auth";
 import { updateAuthenticatedUser } from "@react-shell/auth-store";
+import { buildLegacyGamePath } from "@react-shell/legacy-game-handoff";
 import { profileDetailQueryKey } from "@react-shell/react-query";
 import { applyShellTheme, shellThemes, themeLabel } from "@react-shell/theme";
 
@@ -61,6 +61,7 @@ export function ProfileRoute() {
 
   const profileQuery = useQuery({
     queryKey: profileDetailQueryKey(String(authenticatedUser?.id ?? "anonymous")),
+    enabled: Boolean(authenticatedUser),
     queryFn: () =>
       getProfile({
         errorMessage: t("profile.errors.unavailable"),
@@ -277,9 +278,13 @@ export function ProfileRoute() {
                           </span>
                         </div>
 
-                        <Link className="ghost-action" to={`/game/${encodeURIComponent(game.id)}`}>
+                        <a
+                          className="ghost-action"
+                          href={buildLegacyGamePath(game.id)}
+                          data-testid={`react-shell-profile-open-${game.id}`}
+                        >
                           {t("profile.runtime.directive.resume")}
-                        </Link>
+                        </a>
                       </article>
                     ))}
                   </div>

--- a/frontend/react-shell/src/react-query.ts
+++ b/frontend/react-shell/src/react-query.ts
@@ -15,3 +15,11 @@ export const queryClient = new QueryClient({
 export function profileDetailQueryKey(userId: string) {
   return ["profile", "detail", userId] as const;
 }
+
+export function lobbyGamesQueryKey() {
+  return ["lobby", "games"] as const;
+}
+
+export function gameOptionsQueryKey() {
+  return ["lobby", "game-options"] as const;
+}

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -1,7 +1,10 @@
 import {
   authSessionResponseSchema,
+  createGameRequestSchema,
+  createGameResponseSchema,
   gameIdRequestSchema,
   gameListResponseSchema,
+  gameOptionsResponseSchema,
   gameMutationResponseSchema,
   loginRequestSchema,
   loginResponseSchema,
@@ -12,6 +15,9 @@ import {
 } from "../../generated/shared-runtime-validation.mjs";
 import type {
   AuthSessionResponse,
+  CreateGameRequest,
+  CreateGameResponse,
+  GameOptionsResponse,
   GameListResponse,
   GameMutationResponse,
   LoginResponse,
@@ -95,6 +101,31 @@ export function listGames(messages: ClientMessages): Promise<GameListResponse> {
     path: "/api/games",
     responseSchema: gameListResponseSchema,
     responseSchemaName: "GameListResponse",
+    ...messages
+  });
+}
+
+export function getGameOptions(messages: ClientMessages): Promise<GameOptionsResponse> {
+  return requestJson({
+    path: "/api/game/options",
+    responseSchema: gameOptionsResponseSchema,
+    responseSchemaName: "GameOptionsResponse",
+    ...messages
+  });
+}
+
+export function createGame(
+  request: CreateGameRequest,
+  messages: ClientMessages
+): Promise<CreateGameResponse> {
+  return requestJson({
+    path: "/api/games",
+    method: "POST",
+    body: request,
+    requestSchema: createGameRequestSchema,
+    requestSchemaName: "CreateGameRequest",
+    responseSchema: createGameResponseSchema,
+    responseSchemaName: "CreateGameResponse",
     ...messages
   });
 }

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -325,8 +325,9 @@ export const diceRuleSetSchema = objectSchema({
 export type DiceRuleSet = z.infer<typeof diceRuleSetSchema>;
 
 export const playerSlotConfigSchema = objectSchema({
-  slot: z.number().int(),
-  type: z.string().min(1)
+  slot: z.number().int().optional(),
+  type: z.string().min(1).optional(),
+  name: z.string().min(1).nullable().optional()
 });
 
 export type PlayerSlotConfig = z.infer<typeof playerSlotConfigSchema>;
@@ -359,6 +360,8 @@ export const gameSummarySchema = objectSchema({
   phase: z.string().min(1),
   playerCount: z.number(),
   updatedAt: z.string().min(1),
+  contentPackId: z.string().nullable().optional(),
+  diceRuleSetId: z.string().nullable().optional(),
   totalPlayers: z.number().nullable().optional(),
   mapName: z.string().nullable().optional(),
   mapId: z.string().nullable().optional(),

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -140,12 +140,218 @@ export const logoutResponseSchema = objectSchema({
 
 export type LogoutResponse = z.infer<typeof logoutResponseSchema>;
 
+export const victoryRuleSetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export type VictoryRuleSet = z.infer<typeof victoryRuleSetSchema>;
+
+export const visualThemeSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export type VisualTheme = z.infer<typeof visualThemeSchema>;
+
+export const pieceSkinSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  renderStyleId: z.string().min(1),
+  usesPlayerColor: z.boolean(),
+  assetBaseUrl: z.string().min(1).nullable().optional()
+});
+
+export type PieceSkin = z.infer<typeof pieceSkinSchema>;
+
+export const netRiskModuleProfileSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1).nullable().optional(),
+  moduleId: z.string().min(1).nullable().optional()
+});
+
+export type NetRiskModuleProfile = z.infer<typeof netRiskModuleProfileSchema>;
+
+export const netRiskGamePresetDefaultsSchema = objectSchema({
+  contentPackId: z.string().min(1).nullable().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional()
+});
+
+export type NetRiskGamePresetDefaults = z.infer<typeof netRiskGamePresetDefaultsSchema>;
+
+export const netRiskGamePresetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1).nullable().optional(),
+  moduleId: z.string().min(1).nullable().optional(),
+  activeModuleIds: z.array(z.string().min(1)).optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  defaults: netRiskGamePresetDefaultsSchema.nullable().optional()
+});
+
+export type NetRiskGamePreset = z.infer<typeof netRiskGamePresetSchema>;
+
+export const netRiskUiSlotContributionSchema = objectSchema({
+  slotId: z.string().min(1),
+  itemId: z.string().min(1),
+  title: z.string().min(1),
+  kind: z.string().min(1),
+  order: z.number().optional(),
+  description: z.string().min(1).nullable().optional(),
+  route: z.string().min(1).nullable().optional()
+});
+
+export type NetRiskUiSlotContribution = z.infer<typeof netRiskUiSlotContributionSchema>;
+
+export const netRiskContentContributionSchema = objectSchema({
+  mapIds: z.array(z.string().min(1)).optional(),
+  siteThemeIds: z.array(z.string().min(1)).optional(),
+  pieceSkinIds: z.array(z.string().min(1)).optional(),
+  playerPieceSetIds: z.array(z.string().min(1)).optional(),
+  contentPackIds: z.array(z.string().min(1)).optional(),
+  diceRuleSetIds: z.array(z.string().min(1)).optional(),
+  cardRuleSetIds: z.array(z.string().min(1)).optional(),
+  victoryRuleSetIds: z.array(z.string().min(1)).optional(),
+  fortifyRuleSetIds: z.array(z.string().min(1)).optional(),
+  reinforcementRuleSetIds: z.array(z.string().min(1)).optional()
+});
+
+export type NetRiskContentContribution = z.infer<typeof netRiskContentContributionSchema>;
+
 export const netRiskModuleReferenceSchema = objectSchema({
   id: z.string().min(1),
   version: z.string().min(1)
 });
 
 export type NetRiskModuleReference = z.infer<typeof netRiskModuleReferenceSchema>;
+
+export const installedModuleSummarySchema = objectSchema({
+  id: z.string().min(1),
+  version: z.string().min(1).nullable(),
+  displayName: z.string().min(1),
+  description: z.string().min(1).nullable().optional(),
+  kind: z.string().min(1).nullable(),
+  sourcePath: z.string().min(1),
+  status: z.string().min(1),
+  enabled: z.boolean(),
+  compatible: z.boolean(),
+  warnings: z.array(z.string()),
+  errors: z.array(z.string()),
+  capabilities: z.array(z.record(z.string(), z.unknown()))
+});
+
+export type InstalledModuleSummary = z.infer<typeof installedModuleSummarySchema>;
+
+export const playerPieceSetSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  paletteSize: z.number()
+});
+
+export type PlayerPieceSetSummary = z.infer<typeof playerPieceSetSummarySchema>;
+
+export const contentPackSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  defaultSiteThemeId: z.string().min(1),
+  defaultMapId: z.string().min(1),
+  defaultDiceRuleSetId: z.string().min(1),
+  defaultCardRuleSetId: z.string().min(1),
+  defaultVictoryRuleSetId: z.string().min(1),
+  defaultPieceSetId: z.string().min(1)
+});
+
+export type ContentPackSummary = z.infer<typeof contentPackSummarySchema>;
+
+export const continentBonusSummarySchema = objectSchema({
+  name: z.string().min(1),
+  bonus: z.number(),
+  territoryCount: z.number()
+});
+
+export type ContinentBonusSummary = z.infer<typeof continentBonusSummarySchema>;
+
+export const mapSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  territoryCount: z.number(),
+  continentCount: z.number(),
+  continentBonuses: z.array(continentBonusSummarySchema).optional()
+});
+
+export type MapSummary = z.infer<typeof mapSummarySchema>;
+
+export const ruleSetDefaultsSchema = objectSchema({
+  extensionSchemaVersion: z.number(),
+  mapId: z.string().min(1),
+  diceRuleSetId: z.string().min(1),
+  victoryRuleSetId: z.string().min(1),
+  themeId: z.string().min(1),
+  pieceSkinId: z.string().min(1)
+});
+
+export type RuleSetDefaults = z.infer<typeof ruleSetDefaultsSchema>;
+
+export const ruleSetSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  defaults: ruleSetDefaultsSchema,
+  defaultDiceRuleSetId: z.string().min(1).optional(),
+  defaultVictoryRuleSetId: z.string().min(1).optional()
+});
+
+export type RuleSetSummary = z.infer<typeof ruleSetSummarySchema>;
+
+export const diceRuleSetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  attackerMaxDice: z.number(),
+  defenderMaxDice: z.number()
+});
+
+export type DiceRuleSet = z.infer<typeof diceRuleSetSchema>;
+
+export const playerSlotConfigSchema = objectSchema({
+  slot: z.number().int(),
+  type: z.string().min(1)
+});
+
+export type PlayerSlotConfig = z.infer<typeof playerSlotConfigSchema>;
+
+export const createGameRequestSchema = objectSchema({
+  name: z.string().min(1).optional(),
+  totalPlayers: z.number().int().optional(),
+  contentPackId: z.string().min(1).optional(),
+  ruleSetId: z.string().min(1).optional(),
+  mapId: z.string().min(1).optional(),
+  diceRuleSetId: z.string().min(1).optional(),
+  victoryRuleSetId: z.string().min(1).optional(),
+  pieceSetId: z.string().min(1).optional(),
+  themeId: z.string().min(1).optional(),
+  pieceSkinId: z.string().min(1).optional(),
+  gamePresetId: z.string().min(1).optional(),
+  activeModuleIds: z.array(z.string().min(1)).optional(),
+  contentProfileId: z.string().min(1).optional(),
+  gameplayProfileId: z.string().min(1).optional(),
+  uiProfileId: z.string().min(1).optional(),
+  turnTimeoutHours: z.number().int().optional(),
+  players: z.array(playerSlotConfigSchema).optional()
+});
+
+export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;
 
 export const gameSummarySchema = objectSchema({
   id: z.string().min(1),
@@ -180,6 +386,31 @@ export const gameListResponseSchema = objectSchema({
 
 export type GameListResponse = z.infer<typeof gameListResponseSchema>;
 
+export const gameOptionsResponseSchema = objectSchema({
+  ruleSets: z.array(ruleSetSummarySchema),
+  maps: z.array(mapSummarySchema),
+  diceRuleSets: z.array(diceRuleSetSchema),
+  victoryRuleSets: z.array(victoryRuleSetSchema),
+  themes: z.array(visualThemeSchema),
+  pieceSkins: z.array(pieceSkinSchema),
+  modules: z.array(installedModuleSummarySchema).optional(),
+  enabledModules: z.array(netRiskModuleReferenceSchema).optional(),
+  gamePresets: z.array(netRiskGamePresetSchema).optional(),
+  contentProfiles: z.array(netRiskModuleProfileSchema).optional(),
+  gameplayProfiles: z.array(netRiskModuleProfileSchema).optional(),
+  uiProfiles: z.array(netRiskModuleProfileSchema).optional(),
+  uiSlots: z.array(netRiskUiSlotContributionSchema).optional(),
+  playerPieceSets: z.array(playerPieceSetSummarySchema).optional(),
+  contentPacks: z.array(contentPackSummarySchema).optional(),
+  turnTimeoutHoursOptions: z.array(z.number().int()),
+  playerRange: objectSchema({
+    min: z.number().int(),
+    max: z.number().int()
+  })
+});
+
+export type GameOptionsResponse = z.infer<typeof gameOptionsResponseSchema>;
+
 export const gameMutationGameSchema = objectSchema({
   id: z.string().min(1),
   name: z.string().min(1).nullable().optional()
@@ -197,6 +428,18 @@ export const gameMutationResponseSchema = objectSchema({
 });
 
 export type GameMutationResponse = z.infer<typeof gameMutationResponseSchema>;
+
+export const createGameResponseSchema = objectSchema({
+  ok: z.literal(true),
+  playerId: z.string().min(1).nullable().optional(),
+  game: gameMutationGameSchema,
+  games: z.array(gameSummarySchema),
+  activeGameId: z.string().min(1).nullable().optional(),
+  state: z.record(z.string(), z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional()
+});
+
+export type CreateGameResponse = z.infer<typeof createGameResponseSchema>;
 
 export const participatingGameLobbySchema = objectSchema({
   playerName: z.string().min(1),

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -325,31 +325,31 @@ export const diceRuleSetSchema = objectSchema({
 export type DiceRuleSet = z.infer<typeof diceRuleSetSchema>;
 
 export const playerSlotConfigSchema = objectSchema({
-  slot: z.number().int().optional(),
-  type: z.string().min(1).optional(),
+  slot: z.number().int().nullable().optional(),
+  type: z.string().min(1).nullable().optional(),
   name: z.string().min(1).nullable().optional()
 });
 
 export type PlayerSlotConfig = z.infer<typeof playerSlotConfigSchema>;
 
 export const createGameRequestSchema = objectSchema({
-  name: z.string().min(1).optional(),
-  totalPlayers: z.number().int().optional(),
-  contentPackId: z.string().min(1).optional(),
-  ruleSetId: z.string().min(1).optional(),
-  mapId: z.string().min(1).optional(),
-  diceRuleSetId: z.string().min(1).optional(),
-  victoryRuleSetId: z.string().min(1).optional(),
-  pieceSetId: z.string().min(1).optional(),
-  themeId: z.string().min(1).optional(),
-  pieceSkinId: z.string().min(1).optional(),
-  gamePresetId: z.string().min(1).optional(),
-  activeModuleIds: z.array(z.string().min(1)).optional(),
-  contentProfileId: z.string().min(1).optional(),
-  gameplayProfileId: z.string().min(1).optional(),
-  uiProfileId: z.string().min(1).optional(),
-  turnTimeoutHours: z.number().int().optional(),
-  players: z.array(playerSlotConfigSchema).optional()
+  name: z.string().min(1).nullable().optional(),
+  totalPlayers: z.number().int().nullable().optional(),
+  contentPackId: z.string().min(1).nullable().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional(),
+  gamePresetId: z.string().min(1).nullable().optional(),
+  activeModuleIds: z.array(z.string().min(1)).nullable().optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  turnTimeoutHours: z.number().int().nullable().optional(),
+  players: z.array(playerSlotConfigSchema).nullable().optional()
 });
 
 export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -4084,6 +4084,50 @@ register("API games crea una sessione da configurazione strutturata", async () =
   });
 });
 
+register("API games accetta null per i campi opzionali e applica i default", async () => {
+  await withServer(async (baseUrl) => {
+    const session = await createAuthenticatedSession(baseUrl, uniqueName("creator"));
+    const response = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: authHeaders(session.sessionToken),
+      body: JSON.stringify({
+        name: null,
+        totalPlayers: null,
+        contentPackId: null,
+        ruleSetId: null,
+        mapId: null,
+        diceRuleSetId: null,
+        victoryRuleSetId: null,
+        pieceSetId: null,
+        themeId: null,
+        pieceSkinId: null,
+        gamePresetId: null,
+        activeModuleIds: null,
+        contentProfileId: null,
+        gameplayProfileId: null,
+        uiProfileId: null,
+        turnTimeoutHours: null,
+        players: null
+      })
+    });
+
+    assert.equal(response.status, 201);
+    const payload: any = await readJson(response);
+    assert.equal(payload.game.name.startsWith("Partita "), true);
+    assert.equal(typeof payload.config.contentPackId, "string");
+    assert.equal(payload.config.contentPackId.length > 0, true);
+    assert.equal(typeof payload.config.ruleSetId, "string");
+    assert.equal(payload.config.ruleSetId.length > 0, true);
+    assert.equal(typeof payload.config.mapId, "string");
+    assert.equal(payload.config.mapId.length > 0, true);
+    assert.equal(payload.config.turnTimeoutHours, null);
+    assert.equal(payload.config.players.length, 2);
+    assert.equal(payload.state.players.length, 1);
+    assert.equal(payload.state.players[0].name, session.user.username);
+    assert.equal(payload.playerId != null, true);
+  });
+});
+
 register(
   "API cron scheduled jobs forza il turno scaduto e sincronizza lo stato attivo",
   async () => {

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -1421,6 +1421,7 @@ register("game management route crea una partita e collega il creatore", async (
   const res = makeMockResponse();
   const broadcasts: any[] = [];
   let replacedState: any = null;
+  const updatedAt = new Date("2026-04-17T08:30:00.000Z").toISOString();
 
   await handleCreateGameRoute(
     { method: "POST", headers: {} },
@@ -1443,7 +1444,15 @@ register("game management route crea una partita e collega il creatore", async (
       game: { id: "game-1", name: options.name, version: 1 },
       state
     }),
-    async () => [{ id: "game-1", name: "Nuova partita" }],
+    async () => [
+      {
+        id: "game-1",
+        name: "Nuova partita",
+        phase: "lobby",
+        playerCount: 1,
+        updatedAt
+      }
+    ],
     (state: any) => {
       replacedState = state;
     },
@@ -1461,7 +1470,15 @@ register("game management route crea una partita e collega il creatore", async (
   assert.deepEqual(JSON.parse(res.body), {
     ok: true,
     game: { id: "game-1", name: "Nuova partita", version: 1 },
-    games: [{ id: "game-1", name: "Nuova partita" }],
+    games: [
+      {
+        id: "game-1",
+        name: "Nuova partita",
+        phase: "lobby",
+        playerCount: 1,
+        updatedAt
+      }
+    ],
     activeGameId: "game-1",
     state: { snapshot: true },
     config: { mapId: "classic-mini" },

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -324,31 +324,31 @@ export const diceRuleSetSchema = objectSchema({
 export type DiceRuleSet = z.infer<typeof diceRuleSetSchema>;
 
 export const playerSlotConfigSchema = objectSchema({
-  slot: z.number().int().optional(),
-  type: z.string().min(1).optional(),
+  slot: z.number().int().nullable().optional(),
+  type: z.string().min(1).nullable().optional(),
   name: z.string().min(1).nullable().optional()
 });
 
 export type PlayerSlotConfig = z.infer<typeof playerSlotConfigSchema>;
 
 export const createGameRequestSchema = objectSchema({
-  name: z.string().min(1).optional(),
-  totalPlayers: z.number().int().optional(),
-  contentPackId: z.string().min(1).optional(),
-  ruleSetId: z.string().min(1).optional(),
-  mapId: z.string().min(1).optional(),
-  diceRuleSetId: z.string().min(1).optional(),
-  victoryRuleSetId: z.string().min(1).optional(),
-  pieceSetId: z.string().min(1).optional(),
-  themeId: z.string().min(1).optional(),
-  pieceSkinId: z.string().min(1).optional(),
-  gamePresetId: z.string().min(1).optional(),
-  activeModuleIds: z.array(z.string().min(1)).optional(),
-  contentProfileId: z.string().min(1).optional(),
-  gameplayProfileId: z.string().min(1).optional(),
-  uiProfileId: z.string().min(1).optional(),
-  turnTimeoutHours: z.number().int().optional(),
-  players: z.array(playerSlotConfigSchema).optional()
+  name: z.string().min(1).nullable().optional(),
+  totalPlayers: z.number().int().nullable().optional(),
+  contentPackId: z.string().min(1).nullable().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional(),
+  gamePresetId: z.string().min(1).nullable().optional(),
+  activeModuleIds: z.array(z.string().min(1)).nullable().optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  turnTimeoutHours: z.number().int().nullable().optional(),
+  players: z.array(playerSlotConfigSchema).nullable().optional()
 });
 
 export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -324,8 +324,9 @@ export const diceRuleSetSchema = objectSchema({
 export type DiceRuleSet = z.infer<typeof diceRuleSetSchema>;
 
 export const playerSlotConfigSchema = objectSchema({
-  slot: z.number().int(),
-  type: z.string().min(1)
+  slot: z.number().int().optional(),
+  type: z.string().min(1).optional(),
+  name: z.string().min(1).nullable().optional()
 });
 
 export type PlayerSlotConfig = z.infer<typeof playerSlotConfigSchema>;
@@ -358,6 +359,8 @@ export const gameSummarySchema = objectSchema({
   phase: z.string().min(1),
   playerCount: z.number(),
   updatedAt: z.string().min(1),
+  contentPackId: z.string().nullable().optional(),
+  diceRuleSetId: z.string().nullable().optional(),
   totalPlayers: z.number().nullable().optional(),
   mapName: z.string().nullable().optional(),
   mapId: z.string().nullable().optional(),

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -139,12 +139,218 @@ export const logoutResponseSchema = objectSchema({
 
 export type LogoutResponse = z.infer<typeof logoutResponseSchema>;
 
+export const victoryRuleSetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export type VictoryRuleSet = z.infer<typeof victoryRuleSetSchema>;
+
+export const visualThemeSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export type VisualTheme = z.infer<typeof visualThemeSchema>;
+
+export const pieceSkinSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  renderStyleId: z.string().min(1),
+  usesPlayerColor: z.boolean(),
+  assetBaseUrl: z.string().min(1).nullable().optional()
+});
+
+export type PieceSkin = z.infer<typeof pieceSkinSchema>;
+
+export const netRiskModuleProfileSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1).nullable().optional(),
+  moduleId: z.string().min(1).nullable().optional()
+});
+
+export type NetRiskModuleProfile = z.infer<typeof netRiskModuleProfileSchema>;
+
+export const netRiskGamePresetDefaultsSchema = objectSchema({
+  contentPackId: z.string().min(1).nullable().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional()
+});
+
+export type NetRiskGamePresetDefaults = z.infer<typeof netRiskGamePresetDefaultsSchema>;
+
+export const netRiskGamePresetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1).nullable().optional(),
+  moduleId: z.string().min(1).nullable().optional(),
+  activeModuleIds: z.array(z.string().min(1)).optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  defaults: netRiskGamePresetDefaultsSchema.nullable().optional()
+});
+
+export type NetRiskGamePreset = z.infer<typeof netRiskGamePresetSchema>;
+
+export const netRiskUiSlotContributionSchema = objectSchema({
+  slotId: z.string().min(1),
+  itemId: z.string().min(1),
+  title: z.string().min(1),
+  kind: z.string().min(1),
+  order: z.number().optional(),
+  description: z.string().min(1).nullable().optional(),
+  route: z.string().min(1).nullable().optional()
+});
+
+export type NetRiskUiSlotContribution = z.infer<typeof netRiskUiSlotContributionSchema>;
+
+export const netRiskContentContributionSchema = objectSchema({
+  mapIds: z.array(z.string().min(1)).optional(),
+  siteThemeIds: z.array(z.string().min(1)).optional(),
+  pieceSkinIds: z.array(z.string().min(1)).optional(),
+  playerPieceSetIds: z.array(z.string().min(1)).optional(),
+  contentPackIds: z.array(z.string().min(1)).optional(),
+  diceRuleSetIds: z.array(z.string().min(1)).optional(),
+  cardRuleSetIds: z.array(z.string().min(1)).optional(),
+  victoryRuleSetIds: z.array(z.string().min(1)).optional(),
+  fortifyRuleSetIds: z.array(z.string().min(1)).optional(),
+  reinforcementRuleSetIds: z.array(z.string().min(1)).optional()
+});
+
+export type NetRiskContentContribution = z.infer<typeof netRiskContentContributionSchema>;
+
 export const netRiskModuleReferenceSchema = objectSchema({
   id: z.string().min(1),
   version: z.string().min(1)
 });
 
 export type NetRiskModuleReference = z.infer<typeof netRiskModuleReferenceSchema>;
+
+export const installedModuleSummarySchema = objectSchema({
+  id: z.string().min(1),
+  version: z.string().min(1).nullable(),
+  displayName: z.string().min(1),
+  description: z.string().min(1).nullable().optional(),
+  kind: z.string().min(1).nullable(),
+  sourcePath: z.string().min(1),
+  status: z.string().min(1),
+  enabled: z.boolean(),
+  compatible: z.boolean(),
+  warnings: z.array(z.string()),
+  errors: z.array(z.string()),
+  capabilities: z.array(z.record(z.string(), z.unknown()))
+});
+
+export type InstalledModuleSummary = z.infer<typeof installedModuleSummarySchema>;
+
+export const playerPieceSetSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  paletteSize: z.number()
+});
+
+export type PlayerPieceSetSummary = z.infer<typeof playerPieceSetSummarySchema>;
+
+export const contentPackSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  defaultSiteThemeId: z.string().min(1),
+  defaultMapId: z.string().min(1),
+  defaultDiceRuleSetId: z.string().min(1),
+  defaultCardRuleSetId: z.string().min(1),
+  defaultVictoryRuleSetId: z.string().min(1),
+  defaultPieceSetId: z.string().min(1)
+});
+
+export type ContentPackSummary = z.infer<typeof contentPackSummarySchema>;
+
+export const continentBonusSummarySchema = objectSchema({
+  name: z.string().min(1),
+  bonus: z.number(),
+  territoryCount: z.number()
+});
+
+export type ContinentBonusSummary = z.infer<typeof continentBonusSummarySchema>;
+
+export const mapSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  territoryCount: z.number(),
+  continentCount: z.number(),
+  continentBonuses: z.array(continentBonusSummarySchema).optional()
+});
+
+export type MapSummary = z.infer<typeof mapSummarySchema>;
+
+export const ruleSetDefaultsSchema = objectSchema({
+  extensionSchemaVersion: z.number(),
+  mapId: z.string().min(1),
+  diceRuleSetId: z.string().min(1),
+  victoryRuleSetId: z.string().min(1),
+  themeId: z.string().min(1),
+  pieceSkinId: z.string().min(1)
+});
+
+export type RuleSetDefaults = z.infer<typeof ruleSetDefaultsSchema>;
+
+export const ruleSetSummarySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  defaults: ruleSetDefaultsSchema,
+  defaultDiceRuleSetId: z.string().min(1).optional(),
+  defaultVictoryRuleSetId: z.string().min(1).optional()
+});
+
+export type RuleSetSummary = z.infer<typeof ruleSetSummarySchema>;
+
+export const diceRuleSetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  attackerMaxDice: z.number(),
+  defenderMaxDice: z.number()
+});
+
+export type DiceRuleSet = z.infer<typeof diceRuleSetSchema>;
+
+export const playerSlotConfigSchema = objectSchema({
+  slot: z.number().int(),
+  type: z.string().min(1)
+});
+
+export type PlayerSlotConfig = z.infer<typeof playerSlotConfigSchema>;
+
+export const createGameRequestSchema = objectSchema({
+  name: z.string().min(1).optional(),
+  totalPlayers: z.number().int().optional(),
+  contentPackId: z.string().min(1).optional(),
+  ruleSetId: z.string().min(1).optional(),
+  mapId: z.string().min(1).optional(),
+  diceRuleSetId: z.string().min(1).optional(),
+  victoryRuleSetId: z.string().min(1).optional(),
+  pieceSetId: z.string().min(1).optional(),
+  themeId: z.string().min(1).optional(),
+  pieceSkinId: z.string().min(1).optional(),
+  gamePresetId: z.string().min(1).optional(),
+  activeModuleIds: z.array(z.string().min(1)).optional(),
+  contentProfileId: z.string().min(1).optional(),
+  gameplayProfileId: z.string().min(1).optional(),
+  uiProfileId: z.string().min(1).optional(),
+  turnTimeoutHours: z.number().int().optional(),
+  players: z.array(playerSlotConfigSchema).optional()
+});
+
+export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;
 
 export const gameSummarySchema = objectSchema({
   id: z.string().min(1),
@@ -179,6 +385,31 @@ export const gameListResponseSchema = objectSchema({
 
 export type GameListResponse = z.infer<typeof gameListResponseSchema>;
 
+export const gameOptionsResponseSchema = objectSchema({
+  ruleSets: z.array(ruleSetSummarySchema),
+  maps: z.array(mapSummarySchema),
+  diceRuleSets: z.array(diceRuleSetSchema),
+  victoryRuleSets: z.array(victoryRuleSetSchema),
+  themes: z.array(visualThemeSchema),
+  pieceSkins: z.array(pieceSkinSchema),
+  modules: z.array(installedModuleSummarySchema).optional(),
+  enabledModules: z.array(netRiskModuleReferenceSchema).optional(),
+  gamePresets: z.array(netRiskGamePresetSchema).optional(),
+  contentProfiles: z.array(netRiskModuleProfileSchema).optional(),
+  gameplayProfiles: z.array(netRiskModuleProfileSchema).optional(),
+  uiProfiles: z.array(netRiskModuleProfileSchema).optional(),
+  uiSlots: z.array(netRiskUiSlotContributionSchema).optional(),
+  playerPieceSets: z.array(playerPieceSetSummarySchema).optional(),
+  contentPacks: z.array(contentPackSummarySchema).optional(),
+  turnTimeoutHoursOptions: z.array(z.number().int()),
+  playerRange: objectSchema({
+    min: z.number().int(),
+    max: z.number().int()
+  })
+});
+
+export type GameOptionsResponse = z.infer<typeof gameOptionsResponseSchema>;
+
 export const gameMutationGameSchema = objectSchema({
   id: z.string().min(1),
   name: z.string().min(1).nullable().optional()
@@ -196,6 +427,18 @@ export const gameMutationResponseSchema = objectSchema({
 });
 
 export type GameMutationResponse = z.infer<typeof gameMutationResponseSchema>;
+
+export const createGameResponseSchema = objectSchema({
+  ok: z.literal(true),
+  playerId: z.string().min(1).nullable().optional(),
+  game: gameMutationGameSchema,
+  games: z.array(gameSummarySchema),
+  activeGameId: z.string().min(1).nullable().optional(),
+  state: z.record(z.string(), z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional()
+});
+
+export type CreateGameResponse = z.infer<typeof createGameResponseSchema>;
 
 export const participatingGameLobbySchema = objectSchema({
   playerName: z.string().min(1),


### PR DESCRIPTION
## Summary
- add shared runtime validation for `GET /api/game/options` and `POST /api/games`
- expose typed `getGameOptions` and `createGame` helpers for migrated React flows
- bring `/react/profile` to issue-level parity for empty/history states and legacy gameplay handoff
- extend React shell smoke coverage for profile empty state and participating-game handoff

## Issue
- Refs #101

## Why
Issue #101 starts the first real React functional slice. This PR keeps the scope small by finishing the shared transport boundaries and making the migrated profile flow usable without changing backend authority or removing legacy pages.

## Impact
- React flows can consume validated game option and create-game payloads without raw `fetch` usage.
- Participating games opened from `/react/profile` now hand off to the working legacy gameplay route.
- Backend routes now validate the affected request/response boundaries with shared schemas.

## Validation
- `npm run typecheck`
- `npm run build:ts`
- `npm run test:e2e -- e2e/smoke/react-shell.spec.ts`

## Explicit parity gaps left for PR2 / later
- `/react/lobby` is still a placeholder in this PR.
- `/react/lobby/new` is not implemented yet in this PR.
- Legacy admin/module surfaces on the profile page remain legacy-only for now and are intentionally not treated as blockers for issue #101 unless product scope changes.
