### PR TITLE
[codex] Issue 101 PR2: React lobby and new game flows

### DIFF
--- a/e2e/smoke/react-shell-lobby.spec.ts
+++ b/e2e/smoke/react-shell-lobby.spec.ts
@@ -1,0 +1,209 @@
+const { test, expect } = require("@playwright/test");
+
+const { attachSessionCookie, resetGame, uniqueUser } = require("../support/game-helpers");
+
+async function createAuthenticatedSession(page, username, password = "secret123") {
+  const registerResponse = await page.request.post("/api/auth/register", {
+    data: { username, password }
+  });
+  await expect(registerResponse.ok()).toBeTruthy();
+
+  const loginResponse = await page.request.post("/api/auth/login", {
+    data: { username, password }
+  });
+  await expect(loginResponse.ok()).toBeTruthy();
+
+  const sessionToken = loginResponse.headers()["set-cookie"]?.match(/netrisk_session=([^;]+)/)?.[1];
+  expect(sessionToken).toBeTruthy();
+
+  return sessionToken;
+}
+
+async function loadGameState(page, sessionToken, gameId) {
+  const stateResponse = await page.request.get(`/api/state?gameId=${encodeURIComponent(gameId)}`, {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` }
+  });
+  await expect(stateResponse.ok()).toBeTruthy();
+  return stateResponse.json();
+}
+
+test("react lobby redirects guests to the login route", async ({ page }) => {
+  await resetGame(page);
+
+  await page.goto("/react/lobby");
+
+  await expect(page).toHaveURL(/\/react\/login\?next=%2Flobby$/);
+  await expect(page.getByTestId("react-shell-login-page")).toBeVisible();
+});
+
+test("react lobby shows 15 sessions initially and loads more on scroll", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_lobby_owner"));
+
+  for (let index = 0; index < 18; index += 1) {
+    const createResponse = await page.request.post("/api/games", {
+      headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` },
+      data: {
+        name: uniqueUser(`react_lobby_${String(index + 1).padStart(2, "0")}`),
+        totalPlayers: 2,
+        players: [
+          { slot: 1, type: "human" },
+          { slot: 2, type: "ai" }
+        ]
+      }
+    });
+    await expect(createResponse.ok()).toBeTruthy();
+  }
+
+  await attachSessionCookie(page, sessionToken);
+  await page.goto("/react/lobby");
+
+  const rows = page.locator("[data-testid^='react-shell-lobby-row-']");
+  await expect(rows).toHaveCount(15);
+  await expect(page.getByTestId("react-shell-lobby-load-more")).toContainText(/15/);
+
+  await page.getByTestId("react-shell-lobby-load-more").scrollIntoViewIfNeeded();
+
+  await expect.poll(async () => rows.count()).toBe(19);
+  await expect(page.getByTestId("react-shell-lobby-load-more")).toContainText(/19/);
+});
+
+test("react lobby can open a selected game and hand off to the legacy board", async ({ page }) => {
+  await resetGame(page);
+
+  const ownerUsername = uniqueUser("rsh_lobby_owner_open");
+  const ownerSession = await createAuthenticatedSession(page, ownerUsername);
+  const gameName = uniqueUser("react_lobby_open");
+
+  const createResponse = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(ownerSession)}` },
+    data: {
+      name: gameName,
+      mapId: "world-classic",
+      totalPlayers: 2,
+      players: [
+        { slot: 1, type: "human" },
+        { slot: 2, type: "ai" }
+      ]
+    }
+  });
+  await expect(createResponse.ok()).toBeTruthy();
+  const createdGame = await createResponse.json();
+
+  await attachSessionCookie(page, ownerSession);
+  await page.goto("/react/lobby");
+
+  const targetRow = page.locator("[data-testid^='react-shell-lobby-row-']", {
+    hasText: gameName
+  });
+  await expect(targetRow).toBeVisible();
+  await targetRow.click();
+
+  await expect(page.getByTestId("react-shell-lobby-details")).toContainText(gameName);
+  await page.getByTestId("react-shell-lobby-open-selected").click();
+
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(
+    new RegExp(`/game/${createdGame.game.id}$`)
+  );
+  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+
+  const statePayload = await loadGameState(page, ownerSession, createdGame.game.id);
+  expect(
+    statePayload.players.some((player) => ownerUsername.startsWith(String(player.name || "")))
+  ).toBeTruthy();
+});
+
+test("react lobby can join an available game and hand off to the legacy board", async ({ page }) => {
+  await resetGame(page);
+
+  const ownerSession = await createAuthenticatedSession(page, uniqueUser("rsh_lobby_owner_join"));
+  const joinerUsername = uniqueUser("rsh_lobby_joiner");
+  const joinerSession = await createAuthenticatedSession(page, joinerUsername);
+  const gameName = uniqueUser("react_lobby_join");
+
+  const createResponse = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(ownerSession)}` },
+    data: {
+      name: gameName,
+      mapId: "world-classic",
+      totalPlayers: 2,
+      players: [
+        { slot: 1, type: "human" },
+        { slot: 2, type: "human" }
+      ]
+    }
+  });
+  await expect(createResponse.ok()).toBeTruthy();
+  const createdGame = await createResponse.json();
+
+  await attachSessionCookie(page, joinerSession);
+  await page.goto("/react/lobby");
+
+  const targetRow = page.locator("[data-testid^='react-shell-lobby-row-']", {
+    hasText: gameName
+  });
+  await expect(targetRow).toBeVisible();
+  await targetRow.click();
+
+  await expect(page.getByTestId("react-shell-lobby-details")).toContainText(gameName);
+  await expect(page.getByTestId("react-shell-lobby-join-selected")).toBeVisible();
+  await page.getByTestId("react-shell-lobby-join-selected").click();
+
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(
+    new RegExp(`/game/${createdGame.game.id}$`)
+  );
+  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+
+  const statePayload = await loadGameState(page, joinerSession, createdGame.game.id);
+  expect(
+    statePayload.players.some((player) => joinerUsername.startsWith(String(player.name || "")))
+  ).toBeTruthy();
+});
+
+test("react lobby shows controlled feedback when join fails", async ({ page }) => {
+  await resetGame(page);
+
+  const ownerSession = await createAuthenticatedSession(page, uniqueUser("rsh_lobby_owner_fail"));
+  const joinerSession = await createAuthenticatedSession(page, uniqueUser("rsh_lobby_joiner_fail"));
+  const gameName = uniqueUser("react_lobby_fail");
+
+  const createResponse = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(ownerSession)}` },
+    data: {
+      name: gameName,
+      totalPlayers: 2,
+      players: [
+        { slot: 1, type: "human" },
+        { slot: 2, type: "human" }
+      ]
+    }
+  });
+  await expect(createResponse.ok()).toBeTruthy();
+
+  await attachSessionCookie(page, joinerSession);
+  await page.route("**/api/join", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: "Join failed."
+      })
+    });
+  });
+
+  await page.goto("/react/lobby");
+
+  const targetRow = page.locator("[data-testid^='react-shell-lobby-row-']", {
+    hasText: gameName
+  });
+  await expect(targetRow).toBeVisible();
+  await targetRow.click();
+  await page.getByTestId("react-shell-lobby-join-selected").click();
+
+  await expect(page).toHaveURL(/\/react\/lobby$/);
+  await expect(page.getByTestId("react-shell-lobby-action-error")).toBeVisible();
+  await expect(page.getByTestId("react-shell-lobby-action-error")).toContainText(
+    /Join failed|Richiesta fallita/
+  );
+});

--- a/e2e/smoke/react-shell-new-game.spec.ts
+++ b/e2e/smoke/react-shell-new-game.spec.ts
@@ -1,0 +1,205 @@
+const { test, expect } = require("@playwright/test");
+const { DatabaseSync } = require("node:sqlite");
+
+const { attachSessionCookie, resetGame, uniqueUser } = require("../support/game-helpers");
+
+async function createAuthenticatedSession(page, username, password = "secret123") {
+  const registerResponse = await page.request.post("/api/auth/register", {
+    data: { username, password }
+  });
+  await expect(registerResponse.ok()).toBeTruthy();
+
+  const loginResponse = await page.request.post("/api/auth/login", {
+    data: { username, password }
+  });
+  await expect(loginResponse.ok()).toBeTruthy();
+
+  const sessionToken = loginResponse.headers()["set-cookie"]?.match(/netrisk_session=([^;]+)/)?.[1];
+  expect(sessionToken).toBeTruthy();
+
+  return sessionToken;
+}
+
+function currentGameId(url) {
+  return url.match(/\/game\/([^/?#]+)/)?.[1] || null;
+}
+
+async function loadGameState(page, sessionToken, gameId) {
+  const stateResponse = await page.request.get(`/api/state?gameId=${encodeURIComponent(gameId)}`, {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` }
+  });
+  await expect(stateResponse.ok()).toBeTruthy();
+  return stateResponse.json();
+}
+
+function promoteUserToAdmin(username) {
+  const dbFile = process.env.E2E_DB_FILE;
+  expect(dbFile).toBeTruthy();
+
+  const db = new DatabaseSync(dbFile);
+  try {
+    db.prepare("UPDATE users SET role = 'admin' WHERE lower(username) = lower(?)").run(username);
+  } finally {
+    db.close();
+  }
+}
+
+async function enableModule(page, sessionToken, moduleId) {
+  const response = await page.request.post(`/api/modules/${encodeURIComponent(moduleId)}/enable`, {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` }
+  });
+  await expect(response.ok()).toBeTruthy();
+}
+
+test("react new game shows loading before creation options render", async ({ page }) => {
+  await resetGame(page);
+
+  const sessionToken = await createAuthenticatedSession(page, uniqueUser("rsh_new_game_loading"));
+  await attachSessionCookie(page, sessionToken);
+
+  let releaseOptionsResponse;
+  const optionsResponseReleased = new Promise((resolve) => {
+    releaseOptionsResponse = resolve;
+  });
+
+  await page.route("**/api/game/options", async (route) => {
+    await optionsResponseReleased;
+    await route.continue();
+  });
+
+  const navigation = page.goto("/react/lobby/new");
+  await expect(page.getByTestId("react-shell-new-game-loading")).toBeVisible();
+  releaseOptionsResponse();
+  await navigation;
+
+  await expect(page.getByTestId("react-shell-lobby-create-page")).toBeVisible();
+});
+
+test("react new game creates a session and hands off to the legacy board", async ({ page }) => {
+  await resetGame(page);
+
+  const commander = uniqueUser("rsh_new_game_basic");
+  const sessionToken = await createAuthenticatedSession(page, commander);
+  const gameName = uniqueUser("react_new_game_basic");
+
+  await attachSessionCookie(page, sessionToken);
+  await page.goto("/react/lobby/new");
+
+  await expect(page.getByTestId("react-shell-lobby-create-page")).toBeVisible();
+  await page.getByTestId("react-shell-new-game-name").fill(gameName);
+  await page.getByTestId("react-shell-new-game-total-players").selectOption("3");
+  await page.getByTestId("react-shell-new-game-slot-2").selectOption("human");
+  await page.getByTestId("react-shell-new-game-slot-3").selectOption("ai");
+  await page.getByTestId("react-shell-new-game-submit").click();
+
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/game\/[^/?#]+$/);
+  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+
+  const gameId = currentGameId(page.url());
+  expect(gameId).toBeTruthy();
+
+  const statePayload = await loadGameState(page, sessionToken, gameId);
+  expect(statePayload.gameName).toBe(gameName);
+  expect(statePayload.phase).toBe("lobby");
+  expect(statePayload.gameConfig.totalPlayers).toBe(3);
+  expect(
+    statePayload.players.some((player) => commander.startsWith(String(player.name || "")))
+  ).toBeTruthy();
+});
+
+test("react new game supports advanced module, profile, and option selections", async ({ page }) => {
+  await resetGame(page);
+
+  const commander = uniqueUser("rsh_new_game_advanced");
+  const sessionToken = await createAuthenticatedSession(page, commander);
+  const gameName = uniqueUser("react_new_game_advanced");
+
+  promoteUserToAdmin(commander);
+  await enableModule(page, sessionToken, "demo.command-center");
+
+  await attachSessionCookie(page, sessionToken);
+  await page.goto("/react/lobby/new");
+
+  await expect(page.getByTestId("react-shell-lobby-create-page")).toBeVisible();
+  await page.getByTestId("react-shell-new-game-name").fill(gameName);
+  await page.getByTestId("react-shell-new-game-total-players").selectOption("4");
+  await page.getByTestId("react-shell-new-game-slot-2").selectOption("ai");
+  await page.getByTestId("react-shell-new-game-slot-3").selectOption("human");
+  await page.getByTestId("react-shell-new-game-slot-4").selectOption("ai");
+  await page.getByTestId("react-shell-new-game-customize-options").check();
+  await page.getByTestId("react-shell-new-game-map").selectOption("world-classic");
+  await page.getByTestId("react-shell-new-game-dice").selectOption("defense-3");
+  await page.getByTestId("react-shell-new-game-victory").selectOption("majority-control");
+
+  await page
+    .getByTestId("react-shell-new-game-preset")
+    .selectOption("demo.command-center.command-ops");
+  await expect(page.getByTestId("react-shell-new-game-map")).toHaveValue("world-classic");
+  await expect(page.getByTestId("react-shell-new-game-dice")).toHaveValue("defense-3");
+  await expect(page.getByTestId("react-shell-new-game-victory")).toHaveValue(
+    "majority-control"
+  );
+  await expect(
+    page.getByTestId("react-shell-new-game-module-demo.command-center")
+  ).toBeChecked();
+  await expect(page.getByTestId("react-shell-new-game-content-profile")).toHaveValue(
+    "demo.command-center.content"
+  );
+  await expect(page.getByTestId("react-shell-new-game-gameplay-profile")).toHaveValue(
+    "demo.command-center.gameplay"
+  );
+  await expect(page.getByTestId("react-shell-new-game-ui-profile")).toHaveValue(
+    "demo.command-center.ui"
+  );
+
+  await page.getByTestId("react-shell-new-game-ruleset").selectOption("classic-defense-3");
+  await page.getByTestId("react-shell-new-game-map").selectOption("classic-mini");
+  await page.getByTestId("react-shell-new-game-dice").selectOption("standard");
+  await page.getByTestId("react-shell-new-game-victory").selectOption("conquest");
+  await page.getByTestId("react-shell-new-game-theme").selectOption("ember");
+  await page.getByTestId("react-shell-new-game-piece-skin").selectOption("command-ring");
+  await page
+    .getByTestId("react-shell-new-game-content-profile")
+    .selectOption("demo.command-center.content");
+  await page
+    .getByTestId("react-shell-new-game-gameplay-profile")
+    .selectOption("demo.command-center.gameplay");
+  await page.getByTestId("react-shell-new-game-ui-profile").selectOption("demo.command-center.ui");
+
+  const timeoutValues = await page
+    .locator("[data-testid='react-shell-new-game-turn-timeout'] option")
+    .evaluateAll((options) =>
+      options.map((option) => option.value).filter((value) => value && /^\d+$/.test(value))
+    );
+  const selectedTurnTimeout = timeoutValues.at(-1) || timeoutValues[0] || "24";
+  await page.getByTestId("react-shell-new-game-turn-timeout").selectOption(selectedTurnTimeout);
+
+  await page.getByTestId("react-shell-new-game-submit").click();
+
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/game\/[^/?#]+$/);
+  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+
+  const gameId = currentGameId(page.url());
+  expect(gameId).toBeTruthy();
+
+  const statePayload = await loadGameState(page, sessionToken, gameId);
+  expect(statePayload.gameName).toBe(gameName);
+  expect(statePayload.phase).toBe("lobby");
+  expect(statePayload.gameConfig.totalPlayers).toBe(4);
+  expect(
+    statePayload.players.some((player) => commander.startsWith(String(player.name || "")))
+  ).toBeTruthy();
+  expect(statePayload.gameConfig.ruleSetId).toBe("classic-defense-3");
+  expect(statePayload.gameConfig.mapId).toBe("classic-mini");
+  expect(statePayload.gameConfig.diceRuleSetId).toBe("standard");
+  expect(statePayload.gameConfig.victoryRuleSetId).toBe("conquest");
+  expect(statePayload.gameConfig.themeId).toBe("ember");
+  expect(statePayload.gameConfig.pieceSkinId).toBe("command-ring");
+  expect(statePayload.gameConfig.turnTimeoutHours).toBe(Number(selectedTurnTimeout));
+  expect(statePayload.gameConfig.contentProfileId).toBe("demo.command-center.content");
+  expect(statePayload.gameConfig.gameplayProfileId).toBe("demo.command-center.gameplay");
+  expect(statePayload.gameConfig.uiProfileId).toBe("demo.command-center.ui");
+  expect(statePayload.gameConfig.activeModules.map((entry) => entry.id)).toContain(
+    "demo.command-center"
+  );
+});

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -1,0 +1,869 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+  ContentPackSummary,
+  CreateGameRequest,
+  GameListResponse,
+  GameOptionsResponse,
+  NetRiskGamePreset,
+  NetRiskModuleProfile,
+  RuleSetSummary
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+import { createGame, getGameOptions } from "@frontend-core/api/client.mts";
+import { messageFromError } from "@frontend-core/errors.mts";
+import { t } from "@frontend-i18n";
+
+import { openLegacyGame } from "@react-shell/legacy-game-handoff";
+import { storeCurrentPlayerId } from "@react-shell/player-session";
+import { gameOptionsQueryKey, lobbyGamesQueryKey } from "@react-shell/react-query";
+
+type NewGameFormState = {
+  name: string;
+  contentPackId: string;
+  ruleSetId: string;
+  mapId: string;
+  customizeOptions: boolean;
+  diceRuleSetId: string;
+  victoryRuleSetId: string;
+  themeId: string;
+  pieceSkinId: string;
+  turnTimeoutHours: string;
+  totalPlayers: number;
+  playerTypes: string[];
+  selectedModuleIds: string[];
+  gamePresetId: string;
+  contentProfileId: string;
+  gameplayProfileId: string;
+  uiProfileId: string;
+};
+
+function firstId<T extends { id: string }>(entries: T[] | null | undefined): string {
+  return entries?.[0]?.id || "";
+}
+
+function ensurePlayerTypes(playerTypes: string[], totalPlayers: number): string[] {
+  return Array.from({ length: totalPlayers }, (_, index) => {
+    if (index === 0) {
+      return "human";
+    }
+
+    return playerTypes[index] === "ai" ? "ai" : "human";
+  });
+}
+
+function pickAvailableId<T extends { id: string }>(
+  preferredId: string | null | undefined,
+  entries: T[] | null | undefined
+): string {
+  if (preferredId && entries?.some((entry) => entry.id === preferredId)) {
+    return preferredId;
+  }
+
+  return firstId(entries);
+}
+
+function pickPresetId<T extends { id: string }>(
+  presetId: string | null | undefined,
+  currentId: string,
+  entries: T[] | null | undefined
+): string {
+  if (presetId && entries?.some((entry) => entry.id === presetId)) {
+    return presetId;
+  }
+
+  return pickAvailableId(currentId, entries);
+}
+
+function selectedContentPack(
+  options: GameOptionsResponse | undefined,
+  contentPackId: string
+): ContentPackSummary | null {
+  return options?.contentPacks?.find((entry) => entry.id === contentPackId) || null;
+}
+
+function selectedRuleSet(
+  options: GameOptionsResponse | undefined,
+  ruleSetId: string
+): RuleSetSummary | null {
+  return options?.ruleSets?.find((entry) => entry.id === ruleSetId) || null;
+}
+
+function applyContentPackDefaults(
+  formState: NewGameFormState,
+  options: GameOptionsResponse,
+  contentPackId: string
+): NewGameFormState {
+  const contentPack = selectedContentPack(options, contentPackId);
+  if (!contentPack) {
+    return {
+      ...formState,
+      contentPackId
+    };
+  }
+
+  return {
+    ...formState,
+    contentPackId,
+    mapId: pickAvailableId(contentPack.defaultMapId, options.maps),
+    diceRuleSetId: pickAvailableId(contentPack.defaultDiceRuleSetId, options.diceRuleSets)
+  };
+}
+
+function applyRuleSetDefaults(
+  formState: NewGameFormState,
+  options: GameOptionsResponse,
+  ruleSetId: string
+): NewGameFormState {
+  const ruleSet = selectedRuleSet(options, ruleSetId);
+  if (!ruleSet) {
+    return {
+      ...formState,
+      ruleSetId
+    };
+  }
+
+  return {
+    ...formState,
+    ruleSetId,
+    mapId: pickAvailableId(ruleSet.defaults.mapId, options.maps),
+    diceRuleSetId: pickAvailableId(ruleSet.defaults.diceRuleSetId, options.diceRuleSets),
+    victoryRuleSetId: pickAvailableId(ruleSet.defaults.victoryRuleSetId, options.victoryRuleSets),
+    themeId: pickAvailableId(ruleSet.defaults.themeId, options.themes),
+    pieceSkinId: pickAvailableId(ruleSet.defaults.pieceSkinId, options.pieceSkins)
+  };
+}
+
+function filterProfilesForSelectedModules(
+  profiles: NetRiskModuleProfile[] | null | undefined,
+  selectedModuleIds: string[]
+): NetRiskModuleProfile[] {
+  if (!profiles?.length) {
+    return [];
+  }
+
+  return profiles.filter((profile) => !profile.moduleId || selectedModuleIds.includes(profile.moduleId));
+}
+
+function sanitizeProfiles(
+  formState: NewGameFormState,
+  options: GameOptionsResponse
+): NewGameFormState {
+  const availableContentProfiles = filterProfilesForSelectedModules(
+    options.contentProfiles,
+    formState.selectedModuleIds
+  );
+  const availableGameplayProfiles = filterProfilesForSelectedModules(
+    options.gameplayProfiles,
+    formState.selectedModuleIds
+  );
+  const availableUiProfiles = filterProfilesForSelectedModules(
+    options.uiProfiles,
+    formState.selectedModuleIds
+  );
+
+  return {
+    ...formState,
+    contentProfileId: availableContentProfiles.some(
+      (profile) => profile.id === formState.contentProfileId
+    )
+      ? formState.contentProfileId
+      : "",
+    gameplayProfileId: availableGameplayProfiles.some(
+      (profile) => profile.id === formState.gameplayProfileId
+    )
+      ? formState.gameplayProfileId
+      : "",
+    uiProfileId: availableUiProfiles.some((profile) => profile.id === formState.uiProfileId)
+      ? formState.uiProfileId
+      : ""
+  };
+}
+
+function buildInitialForm(options: GameOptionsResponse): NewGameFormState {
+  const initialState: NewGameFormState = {
+    name: "",
+    contentPackId: firstId(options.contentPacks),
+    ruleSetId: firstId(options.ruleSets),
+    mapId: firstId(options.maps),
+    customizeOptions: false,
+    diceRuleSetId: firstId(options.diceRuleSets),
+    victoryRuleSetId: firstId(options.victoryRuleSets),
+    themeId: firstId(options.themes),
+    pieceSkinId: firstId(options.pieceSkins),
+    turnTimeoutHours: options.turnTimeoutHoursOptions?.[0]
+      ? String(options.turnTimeoutHoursOptions[0])
+      : "",
+    totalPlayers: Math.max(options.playerRange?.min || 2, 2),
+    playerTypes: ["human", "human"],
+    selectedModuleIds: [],
+    gamePresetId: "",
+    contentProfileId: "",
+    gameplayProfileId: "",
+    uiProfileId: ""
+  };
+
+  const withContentPackDefaults = applyContentPackDefaults(
+    initialState,
+    options,
+    initialState.contentPackId
+  );
+  return applyRuleSetDefaults(withContentPackDefaults, options, initialState.ruleSetId);
+}
+
+function applyGamePreset(
+  formState: NewGameFormState,
+  options: GameOptionsResponse,
+  gamePresetId: string
+): NewGameFormState {
+  if (!gamePresetId) {
+    return {
+      ...formState,
+      gamePresetId: ""
+    };
+  }
+
+  const preset =
+    options.gamePresets?.find((entry: NetRiskGamePreset) => entry.id === gamePresetId) || null;
+  if (!preset) {
+    return formState;
+  }
+
+  const nextState: NewGameFormState = {
+    ...formState,
+    gamePresetId: preset.id,
+    selectedModuleIds: Array.isArray(preset.activeModuleIds) ? preset.activeModuleIds : [],
+    contentProfileId: preset.contentProfileId || "",
+    gameplayProfileId: preset.gameplayProfileId || "",
+    uiProfileId: preset.uiProfileId || "",
+    contentPackId: pickPresetId(preset.defaults?.contentPackId, formState.contentPackId, options.contentPacks),
+    ruleSetId: pickPresetId(preset.defaults?.ruleSetId, formState.ruleSetId, options.ruleSets),
+    mapId: pickPresetId(preset.defaults?.mapId, formState.mapId, options.maps),
+    diceRuleSetId: pickPresetId(preset.defaults?.diceRuleSetId, formState.diceRuleSetId, options.diceRuleSets),
+    victoryRuleSetId: pickPresetId(
+      preset.defaults?.victoryRuleSetId,
+      formState.victoryRuleSetId,
+      options.victoryRuleSets
+    ),
+    themeId: pickPresetId(preset.defaults?.themeId, formState.themeId, options.themes),
+    pieceSkinId: pickPresetId(preset.defaults?.pieceSkinId, formState.pieceSkinId, options.pieceSkins)
+  };
+
+  return sanitizeProfiles(nextState, options);
+}
+
+function playerSlotDescription(type: string, index: number): string {
+  if (index === 0) {
+    return t("newGame.slot.locked");
+  }
+
+  return type === "ai" ? t("newGame.slot.aiDescription") : t("newGame.slot.humanDescription");
+}
+
+function setLobbyGamesCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  payload: GameListResponse
+): void {
+  queryClient.setQueryData(lobbyGamesQueryKey(), {
+    games: payload.games || [],
+    activeGameId: payload.activeGameId || null
+  });
+}
+
+export function LobbyCreateRoute() {
+  const queryClient = useQueryClient();
+  const [formState, setFormState] = useState<NewGameFormState | null>(null);
+  const [submitError, setSubmitError] = useState("");
+
+  const gameOptionsQuery = useQuery({
+    queryKey: gameOptionsQueryKey(),
+    queryFn: () =>
+      getGameOptions({
+        errorMessage: t("newGame.errors.loadOptions"),
+        fallbackMessage: t("newGame.errors.loadOptions")
+      })
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (request: CreateGameRequest) =>
+      createGame(request, {
+        errorMessage: t("errors.requestFailed"),
+        fallbackMessage: t("errors.requestFailed")
+      })
+  });
+
+  const options = gameOptionsQuery.data;
+  const availableModules = options?.modules?.filter((moduleEntry) => moduleEntry.id !== "core.base") || [];
+  const contentProfiles = filterProfilesForSelectedModules(
+    options?.contentProfiles,
+    formState?.selectedModuleIds || []
+  );
+  const gameplayProfiles = filterProfilesForSelectedModules(
+    options?.gameplayProfiles,
+    formState?.selectedModuleIds || []
+  );
+  const uiProfiles = filterProfilesForSelectedModules(
+    options?.uiProfiles,
+    formState?.selectedModuleIds || []
+  );
+
+  useEffect(() => {
+    if (!options || formState) {
+      return;
+    }
+
+    setFormState(buildInitialForm(options));
+  }, [formState, options]);
+
+  function updateFormState(nextState: NewGameFormState): void {
+    setFormState(options ? sanitizeProfiles(nextState, options) : nextState);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (!formState || createMutation.isPending) {
+      return;
+    }
+
+    setSubmitError("");
+
+    const request: CreateGameRequest = {
+      ...(formState.name.trim() ? { name: formState.name.trim() } : {}),
+      ...(formState.contentPackId ? { contentPackId: formState.contentPackId } : {}),
+      ...(formState.ruleSetId ? { ruleSetId: formState.ruleSetId } : {}),
+      ...(formState.mapId ? { mapId: formState.mapId } : {}),
+      ...(formState.diceRuleSetId ? { diceRuleSetId: formState.diceRuleSetId } : {}),
+      ...(formState.victoryRuleSetId ? { victoryRuleSetId: formState.victoryRuleSetId } : {}),
+      ...(formState.themeId ? { themeId: formState.themeId } : {}),
+      ...(formState.pieceSkinId ? { pieceSkinId: formState.pieceSkinId } : {}),
+      ...(formState.gamePresetId ? { gamePresetId: formState.gamePresetId } : {}),
+      ...(formState.selectedModuleIds.length ? { activeModuleIds: formState.selectedModuleIds } : {}),
+      ...(formState.contentProfileId ? { contentProfileId: formState.contentProfileId } : {}),
+      ...(formState.gameplayProfileId ? { gameplayProfileId: formState.gameplayProfileId } : {}),
+      ...(formState.uiProfileId ? { uiProfileId: formState.uiProfileId } : {}),
+      ...(formState.turnTimeoutHours
+        ? { turnTimeoutHours: Number(formState.turnTimeoutHours) }
+        : {}),
+      totalPlayers: formState.totalPlayers,
+      players: ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map((type, index) => ({
+        slot: index + 1,
+        type
+      }))
+    };
+
+    try {
+      const payload = await createMutation.mutateAsync(request);
+      storeCurrentPlayerId(payload.playerId);
+      setLobbyGamesCache(queryClient, {
+        games: payload.games || [],
+        activeGameId: payload.activeGameId || payload.game.id
+      });
+      openLegacyGame(payload.game.id);
+    } catch (error) {
+      setSubmitError(messageFromError(error, t("errors.requestFailed")));
+    }
+  }
+
+  if (gameOptionsQuery.isLoading && !options) {
+    return (
+      <section className="status-panel" data-testid="react-shell-new-game-loading">
+        <p className="status-label">{t("newGame.eyebrow")}</p>
+        <h2>{t("newGame.heading")}</h2>
+        <p className="status-copy">{t("newGame.errors.loadOptions")}</p>
+      </section>
+    );
+  }
+
+  if (gameOptionsQuery.isError && !options) {
+    return (
+      <section className="status-panel status-panel-error" data-testid="react-shell-new-game-error">
+        <p className="status-label">{t("newGame.eyebrow")}</p>
+        <h2>{t("newGame.heading")}</h2>
+        <p className="status-copy">
+          {messageFromError(gameOptionsQuery.error, t("newGame.errors.loadOptions"))}
+        </p>
+        <div className="shell-actions">
+          <button
+            type="button"
+            className="refresh-button"
+            onClick={() => void gameOptionsQuery.refetch()}
+          >
+            Retry setup
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (!options || !formState) {
+    return null;
+  }
+
+  return (
+    <section data-testid="react-shell-lobby-create-page">
+      <p className="status-label">{t("newGame.eyebrow")}</p>
+      <h2>{t("newGame.heading")}</h2>
+      <p className="status-copy">{t("newGame.copy")}</p>
+
+      {submitError ? (
+        <div
+          className="profile-query-state profile-query-state-error"
+          data-testid="react-shell-new-game-submit-error"
+        >
+          <p className="metric-copy">{submitError}</p>
+        </div>
+      ) : null}
+
+      <form className="shell-form new-game-form" onSubmit={(event) => void handleSubmit(event)}>
+        <div className="new-game-grid">
+          <section className="placeholder-card new-game-card">
+            <div className="card-header new-game-card-header">
+              <div>
+                <p className="status-label">{t("newGame.settings.heading")}</p>
+                <h3>{t("newGame.settings.copy")}</h3>
+              </div>
+              <Link className="ghost-action" to="/lobby">
+                {t("lobby.heading")}
+              </Link>
+            </div>
+
+            <label className="shell-field">
+              <span>{t("newGame.name.label")}</span>
+              <input
+                value={formState.name}
+                placeholder={t("newGame.name.placeholder")}
+                onChange={(event) =>
+                  updateFormState({
+                    ...formState,
+                    name: event.target.value
+                  })
+                }
+                data-testid="react-shell-new-game-name"
+              />
+            </label>
+
+            <label className="shell-field">
+              <span>{t("newGame.contentPack.label")}</span>
+              <select
+                value={formState.contentPackId}
+                onChange={(event) => {
+                  const nextState = applyContentPackDefaults(formState, options, event.target.value);
+                  updateFormState({
+                    ...nextState,
+                    gamePresetId: ""
+                  });
+                }}
+                data-testid="react-shell-new-game-content-pack"
+              >
+                {(options.contentPacks || []).map((contentPack) => (
+                  <option key={contentPack.id} value={contentPack.id}>
+                    {contentPack.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>{t("newGame.ruleset.label")}</span>
+              <select
+                value={formState.ruleSetId}
+                onChange={(event) => {
+                  const nextState = applyRuleSetDefaults(formState, options, event.target.value);
+                  updateFormState({
+                    ...nextState,
+                    gamePresetId: ""
+                  });
+                }}
+                data-testid="react-shell-new-game-ruleset"
+              >
+                {options.ruleSets.map((ruleSet) => (
+                  <option key={ruleSet.id} value={ruleSet.id}>
+                    {ruleSet.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>{t("newGame.map.label")}</span>
+              <select
+                value={formState.mapId}
+                onChange={(event) =>
+                  updateFormState({
+                    ...formState,
+                    mapId: event.target.value,
+                    gamePresetId: ""
+                  })
+                }
+                data-testid="react-shell-new-game-map"
+              >
+                {options.maps.map((map) => (
+                  <option key={map.id} value={map.id}>
+                    {map.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="new-game-inline-grid">
+              <label className="shell-field">
+                <span>{t("newGame.totalPlayers.label")}</span>
+                <select
+                  value={String(formState.totalPlayers)}
+                  onChange={(event) =>
+                    updateFormState({
+                      ...formState,
+                      totalPlayers: Number(event.target.value),
+                      playerTypes: ensurePlayerTypes(
+                        formState.playerTypes,
+                        Number(event.target.value)
+                      )
+                    })
+                  }
+                  data-testid="react-shell-new-game-total-players"
+                >
+                  {Array.from(
+                    {
+                      length: Math.max((options.playerRange?.max || 4) - (options.playerRange?.min || 2) + 1, 1)
+                    },
+                    (_, index) => (options.playerRange?.min || 2) + index
+                  ).map((playerCount) => (
+                    <option key={playerCount} value={playerCount}>
+                      {playerCount}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="shell-field">
+                <span>{t("newGame.turnTimeout.label")}</span>
+                <select
+                  value={formState.turnTimeoutHours}
+                  onChange={(event) =>
+                    updateFormState({
+                      ...formState,
+                      turnTimeoutHours: event.target.value
+                    })
+                  }
+                  data-testid="react-shell-new-game-turn-timeout"
+                >
+                  {options.turnTimeoutHoursOptions.map((hours) => (
+                    <option key={hours} value={String(hours)}>
+                      {t("newGame.turnTimeout.option", { hours })}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </section>
+
+          <section className="placeholder-card new-game-card">
+            <div className="card-header new-game-card-header">
+              <div>
+                <p className="status-label">{t("newGame.options.heading")}</p>
+                <h3>{t("newGame.options.copy")}</h3>
+              </div>
+              <label className="new-game-toggle">
+                <input
+                  type="checkbox"
+                  checked={formState.customizeOptions}
+                  onChange={(event) =>
+                    updateFormState({
+                      ...formState,
+                      customizeOptions: event.target.checked
+                    })
+                  }
+                  data-testid="react-shell-new-game-customize-options"
+                />
+                <span>{t("newGame.options.customizeLabel")}</span>
+              </label>
+            </div>
+
+            {formState.customizeOptions ? (
+              <div className="new-game-advanced-grid">
+                <label className="shell-field">
+                  <span>{t("newGame.dice.label")}</span>
+                  <select
+                    value={formState.diceRuleSetId}
+                    onChange={(event) =>
+                      updateFormState({
+                        ...formState,
+                        diceRuleSetId: event.target.value,
+                        gamePresetId: ""
+                      })
+                    }
+                    data-testid="react-shell-new-game-dice"
+                  >
+                    {options.diceRuleSets.map((ruleSet) => (
+                      <option key={ruleSet.id} value={ruleSet.id}>
+                        {ruleSet.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("newGame.victory.label")}</span>
+                  <select
+                    value={formState.victoryRuleSetId}
+                    onChange={(event) =>
+                      updateFormState({
+                        ...formState,
+                        victoryRuleSetId: event.target.value,
+                        gamePresetId: ""
+                      })
+                    }
+                    data-testid="react-shell-new-game-victory"
+                  >
+                    {options.victoryRuleSets.map((ruleSet) => (
+                      <option key={ruleSet.id} value={ruleSet.id}>
+                        {ruleSet.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("newGame.theme.label")}</span>
+                  <select
+                    value={formState.themeId}
+                    onChange={(event) =>
+                      updateFormState({
+                        ...formState,
+                        themeId: event.target.value,
+                        gamePresetId: ""
+                      })
+                    }
+                    data-testid="react-shell-new-game-theme"
+                  >
+                    {options.themes.map((theme) => (
+                      <option key={theme.id} value={theme.id}>
+                        {theme.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("newGame.pieceSkin.label")}</span>
+                  <select
+                    value={formState.pieceSkinId}
+                    onChange={(event) =>
+                      updateFormState({
+                        ...formState,
+                        pieceSkinId: event.target.value,
+                        gamePresetId: ""
+                      })
+                    }
+                    data-testid="react-shell-new-game-piece-skin"
+                  >
+                    {options.pieceSkins.map((pieceSkin) => (
+                      <option key={pieceSkin.id} value={pieceSkin.id}>
+                        {pieceSkin.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            ) : (
+              <p className="metric-copy">{t("newGame.options.copy")}</p>
+            )}
+
+            {(options.gamePresets?.length || availableModules.length || contentProfiles.length || gameplayProfiles.length || uiProfiles.length) ? (
+              <div className="new-game-modules-stack">
+                {options.gamePresets?.length ? (
+                  <label className="shell-field">
+                    <span>Preset</span>
+                    <select
+                      value={formState.gamePresetId}
+                      onChange={(event) =>
+                        updateFormState(applyGamePreset(formState, options, event.target.value))
+                      }
+                      data-testid="react-shell-new-game-preset"
+                    >
+                      <option value="">{t("common.notAvailable")}</option>
+                      {options.gamePresets.map((preset) => (
+                        <option key={preset.id} value={preset.id}>
+                          {preset.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+
+                {availableModules.length ? (
+                  <div className="new-game-module-list" data-testid="react-shell-new-game-modules">
+                    {availableModules.map((moduleEntry) => {
+                      const isChecked = formState.selectedModuleIds.includes(moduleEntry.id);
+                      return (
+                        <label className="new-game-module-item" key={moduleEntry.id}>
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            onChange={(event) => {
+                              const nextSelectedModuleIds = event.target.checked
+                                ? [...formState.selectedModuleIds, moduleEntry.id]
+                                : formState.selectedModuleIds.filter((entry) => entry !== moduleEntry.id);
+                              updateFormState({
+                                ...formState,
+                                selectedModuleIds: nextSelectedModuleIds,
+                                gamePresetId: ""
+                              });
+                            }}
+                            data-testid={`react-shell-new-game-module-${moduleEntry.id}`}
+                          />
+                          <span>
+                            <strong>{moduleEntry.displayName}</strong>
+                            <small>{moduleEntry.description || moduleEntry.kind || moduleEntry.id}</small>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : null}
+
+                <div className="new-game-advanced-grid">
+                  <label className="shell-field">
+                    <span>Content profile</span>
+                    <select
+                      value={formState.contentProfileId}
+                      onChange={(event) =>
+                        updateFormState({
+                          ...formState,
+                          contentProfileId: event.target.value,
+                          gamePresetId: ""
+                        })
+                      }
+                      data-testid="react-shell-new-game-content-profile"
+                    >
+                      <option value="">{t("common.notAvailable")}</option>
+                      {contentProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.id}>
+                          {profile.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="shell-field">
+                    <span>Gameplay profile</span>
+                    <select
+                      value={formState.gameplayProfileId}
+                      onChange={(event) =>
+                        updateFormState({
+                          ...formState,
+                          gameplayProfileId: event.target.value,
+                          gamePresetId: ""
+                        })
+                      }
+                      data-testid="react-shell-new-game-gameplay-profile"
+                    >
+                      <option value="">{t("common.notAvailable")}</option>
+                      {gameplayProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.id}>
+                          {profile.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="shell-field">
+                    <span>UI profile</span>
+                    <select
+                      value={formState.uiProfileId}
+                      onChange={(event) =>
+                        updateFormState({
+                          ...formState,
+                          uiProfileId: event.target.value,
+                          gamePresetId: ""
+                        })
+                      }
+                      data-testid="react-shell-new-game-ui-profile"
+                    >
+                      <option value="">{t("common.notAvailable")}</option>
+                      {uiProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.id}>
+                          {profile.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+              </div>
+            ) : null}
+          </section>
+        </div>
+
+        <section className="placeholder-card new-game-card">
+          <div className="card-header new-game-card-header">
+            <div>
+              <p className="status-label">{t("newGame.playerSlots.heading")}</p>
+              <h3>{t("newGame.playerSlots.copy")}</h3>
+            </div>
+            <span className="status-pill">{formState.totalPlayers}</span>
+          </div>
+
+          <div className="new-game-slot-grid">
+            {ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map((playerType, index) => (
+              <article className="new-game-slot-card" key={`slot-${index + 1}`}>
+                <div className="new-game-slot-head">
+                  <strong>{t("newGame.slot.playerLabel", { number: index + 1 })}</strong>
+                  {index === 0 ? (
+                    <span className="status-pill">{t("newGame.slot.creatorBadge")}</span>
+                  ) : null}
+                </div>
+
+                {index === 0 ? (
+                  <div className="new-game-slot-copy">
+                    <span>{t("newGame.slot.humanOption")}</span>
+                    <small>{playerSlotDescription(playerType, index)}</small>
+                  </div>
+                ) : (
+                  <label className="shell-field">
+                    <span>{t("newGame.slot.typeLabel")}</span>
+                    <select
+                      value={playerType}
+                      onChange={(event) => {
+                        const nextPlayerTypes = ensurePlayerTypes(
+                          formState.playerTypes,
+                          formState.totalPlayers
+                        );
+                        nextPlayerTypes[index] = event.target.value;
+                        updateFormState({
+                          ...formState,
+                          playerTypes: nextPlayerTypes
+                        });
+                      }}
+                      data-testid={`react-shell-new-game-slot-${index + 1}`}
+                    >
+                      <option value="human">{t("newGame.slot.humanOption")}</option>
+                      <option value="ai">{t("newGame.slot.aiOption")}</option>
+                    </select>
+                    <small>{playerSlotDescription(playerType, index)}</small>
+                  </label>
+                )}
+              </article>
+            ))}
+          </div>
+
+          <div className="shell-actions">
+            <button
+              type="submit"
+              className="refresh-button"
+              disabled={createMutation.isPending}
+              data-testid="react-shell-new-game-submit"
+            >
+              {createMutation.isPending ? t("newGame.feedback.creating") : t("newGame.createOpen")}
+            </button>
+            <Link className="ghost-action" to="/lobby">
+              {t("lobby.heading")}
+            </Link>
+          </div>
+        </section>
+      </form>
+    </section>
+  );
+}

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -1,0 +1,457 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { GameListResponse, GameSummary } from "@frontend-generated/shared-runtime-validation.mts";
+
+import { joinGame, listGames, openGame } from "@frontend-core/api/client.mts";
+import { messageFromError } from "@frontend-core/errors.mts";
+import { formatDate, t } from "@frontend-i18n";
+
+import { openLegacyGame } from "@react-shell/legacy-game-handoff";
+import { storeCurrentPlayerId } from "@react-shell/player-session";
+import { lobbyGamesQueryKey } from "@react-shell/react-query";
+
+const VISIBLE_GAMES_BATCH_SIZE = 15;
+
+function formatUpdatedTime(value: string | null | undefined): string {
+  if (!value) {
+    return t("common.notAvailable");
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return t("common.notAvailable");
+  }
+
+  return formatDate(parsed, {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function phaseLabel(phase: string): string {
+  if (phase === "active") {
+    return t("common.phase.active");
+  }
+
+  if (phase === "finished") {
+    return t("common.phase.finished");
+  }
+
+  return t("common.phase.lobby");
+}
+
+function summarizeIdentifiers(values: Array<string | null | undefined>, limit = 3): string {
+  const normalizedValues = values.filter((value): value is string => Boolean(value));
+  if (!normalizedValues.length) {
+    return t("common.notAvailable");
+  }
+
+  if (normalizedValues.length <= limit) {
+    return normalizedValues.join(", ");
+  }
+
+  return `${normalizedValues.slice(0, limit).join(", ")} +${normalizedValues.length - limit}`;
+}
+
+function summarizeSelectedProfiles(game: GameSummary | null): string {
+  return summarizeIdentifiers([game?.contentProfileId, game?.gameplayProfileId, game?.uiProfileId]);
+}
+
+function summarizeActiveModules(game: GameSummary | null): string {
+  return summarizeIdentifiers(game?.activeModules?.map((entry) => entry.id) || []);
+}
+
+function readinessLabel(game: GameSummary): string {
+  if (game.phase === "finished") {
+    return t("lobby.readiness.archive");
+  }
+
+  if (game.phase === "active") {
+    return t("lobby.readiness.active");
+  }
+
+  if (game.playerCount >= 2) {
+    return t("lobby.readiness.ready");
+  }
+
+  return t("lobby.readiness.waiting");
+}
+
+function gameCapacityLabel(game: GameSummary | null): string {
+  if (!game) {
+    return t("common.notAvailable");
+  }
+
+  const configuredPlayers = Number(game.totalPlayers ?? 0);
+  const maxPlayers =
+    Number.isInteger(configuredPlayers) && configuredPlayers > 0 ? configuredPlayers : 4;
+
+  return `${game.playerCount}/${maxPlayers}`;
+}
+
+function canJoinGame(game: GameSummary | null): boolean {
+  if (!game || game.phase !== "lobby") {
+    return false;
+  }
+
+  const configuredPlayers = Number(game.totalPlayers ?? 0);
+  const maxPlayers =
+    Number.isInteger(configuredPlayers) && configuredPlayers > 0 ? configuredPlayers : 4;
+
+  return game.playerCount < maxPlayers;
+}
+
+function setLobbyGamesCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  payload: GameListResponse
+): void {
+  queryClient.setQueryData(lobbyGamesQueryKey(), {
+    games: payload.games || [],
+    activeGameId: payload.activeGameId || null
+  });
+}
+
+export function LobbyRoute() {
+  const queryClient = useQueryClient();
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
+  const [visibleGameCount, setVisibleGameCount] = useState(VISIBLE_GAMES_BATCH_SIZE);
+  const [actionError, setActionError] = useState("");
+
+  const lobbyQuery = useQuery({
+    queryKey: lobbyGamesQueryKey(),
+    queryFn: () =>
+      listGames({
+        errorMessage: t("lobby.errors.loadGames"),
+        fallbackMessage: t("lobby.errors.loadGames")
+      })
+  });
+
+  const openMutation = useMutation({
+    mutationFn: (gameId: string) =>
+      openGame(gameId, {
+        errorMessage: t("errors.requestFailed"),
+        fallbackMessage: t("errors.requestFailed")
+      })
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: (gameId: string) =>
+      joinGame(gameId, {
+        errorMessage: t("errors.requestFailed"),
+        fallbackMessage: t("errors.requestFailed")
+      })
+  });
+
+  const games = lobbyQuery.data?.games || [];
+  const activeGameId = lobbyQuery.data?.activeGameId || null;
+
+  useEffect(() => {
+    if (!games.length) {
+      setSelectedGameId(null);
+      setVisibleGameCount(VISIBLE_GAMES_BATCH_SIZE);
+      return;
+    }
+
+    setSelectedGameId((current) => {
+      if (current && games.some((game) => game.id === current)) {
+        return current;
+      }
+
+      return activeGameId || games[0]?.id || null;
+    });
+
+    setVisibleGameCount((current) =>
+      Math.min(games.length, Math.max(VISIBLE_GAMES_BATCH_SIZE, current))
+    );
+  }, [activeGameId, games]);
+
+  const canLoadMoreGames = visibleGameCount < games.length;
+  const visibleGames = games.slice(0, visibleGameCount);
+  const selectedGame = games.find((game) => game.id === selectedGameId) || null;
+  const readyGames = games.filter((game) => game.phase === "lobby" && game.playerCount >= 2).length;
+  const activeGame = games.find((game) => game.id === activeGameId) || null;
+  const actionPending = openMutation.isPending || joinMutation.isPending;
+
+  useEffect(() => {
+    const node = loadMoreRef.current;
+    if (!node || !canLoadMoreGames || typeof IntersectionObserver !== "function") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const firstEntry = entries[0];
+        if (!firstEntry?.isIntersecting) {
+          return;
+        }
+
+        setVisibleGameCount((current) =>
+          Math.min(games.length, current + VISIBLE_GAMES_BATCH_SIZE)
+        );
+      },
+      {
+        root: null,
+        rootMargin: "0px 0px 240px 0px",
+        threshold: 0.1
+      }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [canLoadMoreGames, games.length]);
+
+  async function handleRetry(): Promise<void> {
+    setActionError("");
+    await lobbyQuery.refetch();
+  }
+
+  async function handleOpenSelectedGame(): Promise<void> {
+    if (!selectedGame) {
+      return;
+    }
+
+    setActionError("");
+
+    try {
+      const payload = await openMutation.mutateAsync(selectedGame.id);
+      storeCurrentPlayerId(payload.playerId);
+      if (payload.games) {
+        setLobbyGamesCache(queryClient, {
+          games: payload.games,
+          activeGameId: payload.activeGameId || selectedGame.id
+        });
+      }
+      openLegacyGame(selectedGame.id);
+    } catch (error) {
+      setActionError(messageFromError(error, t("errors.requestFailed")));
+    }
+  }
+
+  async function handleJoinSelectedGame(): Promise<void> {
+    if (!selectedGame || !canJoinGame(selectedGame)) {
+      return;
+    }
+
+    setActionError("");
+
+    try {
+      const payload = await joinMutation.mutateAsync(selectedGame.id);
+      storeCurrentPlayerId(payload.playerId);
+      await queryClient.invalidateQueries({ queryKey: lobbyGamesQueryKey() });
+      openLegacyGame(selectedGame.id);
+    } catch (error) {
+      setActionError(messageFromError(error, t("errors.requestFailed")));
+    }
+  }
+
+  if (lobbyQuery.isLoading && !lobbyQuery.data) {
+    return (
+      <section className="status-panel" data-testid="react-shell-lobby-loading">
+        <p className="status-label">{t("lobby.eyebrow")}</p>
+        <h2>{t("lobby.heading")}</h2>
+        <p className="status-copy">{t("lobby.loading")}</p>
+      </section>
+    );
+  }
+
+  if (lobbyQuery.isError && !games.length) {
+    return (
+      <section className="status-panel status-panel-error" data-testid="react-shell-lobby-error">
+        <p className="status-label">{t("lobby.eyebrow")}</p>
+        <h2>{t("lobby.heading")}</h2>
+        <p className="status-copy">
+          {messageFromError(lobbyQuery.error, t("lobby.errors.loadGames"))}
+        </p>
+        <div className="shell-actions">
+          <button type="button" className="refresh-button" onClick={() => void handleRetry()}>
+            Retry lobby
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="react-shell-lobby-page">
+      <p className="status-label">{t("lobby.eyebrow")}</p>
+      <h2>{t("lobby.heading")}</h2>
+      <p className="status-copy">{t("lobby.copy")}</p>
+
+      {actionError ? (
+        <div
+          className="profile-query-state profile-query-state-error"
+          data-testid="react-shell-lobby-action-error"
+        >
+          <p className="metric-copy">{actionError}</p>
+        </div>
+      ) : null}
+
+      <div className="lobby-summary-grid">
+        <article className="placeholder-card lobby-summary-card">
+          <p className="status-label">{t("lobby.visibleSessions.label")}</p>
+          <strong>{games.length}</strong>
+          <span>{t("lobby.visibleSessions.copy")}</span>
+        </article>
+        <article className="placeholder-card lobby-summary-card">
+          <p className="status-label">{t("lobby.readySessions.label")}</p>
+          <strong>{readyGames}</strong>
+          <span>{t("lobby.readySessions.copy")}</span>
+        </article>
+        <article className="placeholder-card lobby-summary-card">
+          <p className="status-label">{t("lobby.focus.label")}</p>
+          <strong>{activeGame?.name || t("lobby.focus.value")}</strong>
+          <span>
+            {activeGame
+              ? t("lobby.focus.activeNote", { phase: phaseLabel(activeGame.phase) })
+              : t("lobby.focus.selectNote")}
+          </span>
+        </article>
+      </div>
+
+      <div className="lobby-shell-grid">
+        <section className="placeholder-card lobby-list-panel">
+          <div className="card-header lobby-panel-header">
+            <div>
+              <p className="status-label">{t("lobby.availableSessions.heading")}</p>
+              <h3>{t("lobby.availableSessions.copy")}</h3>
+            </div>
+            <Link className="refresh-button" to="/lobby/new">
+              {t("lobby.createGame")}
+            </Link>
+          </div>
+
+          {!games.length ? (
+            <div className="lobby-empty-state" data-testid="react-shell-lobby-empty">
+              <p className="metric-copy">{t("lobby.empty")}</p>
+              <div className="shell-actions">
+                <Link className="ghost-action" to="/lobby/new">
+                  {t("lobby.createGame")}
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="lobby-session-list" data-testid="react-shell-lobby-list">
+              {visibleGames.map((game) => (
+                <button
+                  key={game.id}
+                  type="button"
+                  className={`lobby-session-row${selectedGame?.id === game.id ? " is-selected" : ""}`}
+                  onClick={() => setSelectedGameId(game.id)}
+                  data-testid={`react-shell-lobby-row-${game.id}`}
+                >
+                  <div className="lobby-session-primary">
+                    <strong>{game.name}</strong>
+                    <span>{game.mapName || game.mapId || t("common.classicMini")}</span>
+                  </div>
+
+                  <div className="lobby-session-meta">
+                    <span className="status-pill">{phaseLabel(game.phase)}</span>
+                    <span>{gameCapacityLabel(game)}</span>
+                    <span>{formatUpdatedTime(game.updatedAt)}</span>
+                  </div>
+                </button>
+              ))}
+
+              <div
+                ref={loadMoreRef}
+                className="lobby-load-more-state"
+                data-testid="react-shell-lobby-load-more"
+              >
+                {canLoadMoreGames
+                  ? t("lobby.loadMore.partial", {
+                      visible: visibleGames.length,
+                      total: games.length
+                    })
+                  : t("lobby.loadMore.complete", { total: games.length })}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="placeholder-card lobby-detail-panel" data-testid="react-shell-lobby-details">
+          <div className="card-header lobby-panel-header">
+            <div>
+              <p className="status-label">{t("lobby.details.heading")}</p>
+              <h3>{selectedGame?.name || t("lobby.details.emptyBadge")}</h3>
+            </div>
+            {selectedGame ? <span className="status-pill">{phaseLabel(selectedGame.phase)}</span> : null}
+          </div>
+
+          {!selectedGame ? (
+            <div className="lobby-empty-state">
+              <p className="metric-copy">{t("lobby.details.emptyExtended")}</p>
+            </div>
+          ) : (
+            <>
+              <p className="metric-copy">
+                {t("lobby.details.summary", {
+                  readiness: readinessLabel(selectedGame),
+                  phase: phaseLabel(selectedGame.phase)
+                })}
+              </p>
+
+              <div className="lobby-detail-grid">
+                <article className="lobby-detail-item">
+                  <span>{t("lobby.details.map")}</span>
+                  <strong>{selectedGame.mapName || selectedGame.mapId || t("common.classicMini")}</strong>
+                </article>
+                <article className="lobby-detail-item">
+                  <span>{t("lobby.details.playersPresent")}</span>
+                  <strong>{gameCapacityLabel(selectedGame)}</strong>
+                </article>
+                <article className="lobby-detail-item">
+                  <span>{t("lobby.details.status")}</span>
+                  <strong>{readinessLabel(selectedGame)}</strong>
+                </article>
+                <article className="lobby-detail-item">
+                  <span>{t("lobby.details.updated")}</span>
+                  <strong>{formatUpdatedTime(selectedGame.updatedAt)}</strong>
+                </article>
+                <article className="lobby-detail-item">
+                  <span>{t("lobby.details.profiles")}</span>
+                  <strong>{summarizeSelectedProfiles(selectedGame)}</strong>
+                </article>
+                <article className="lobby-detail-item">
+                  <span>{t("lobby.details.modules")}</span>
+                  <strong>{summarizeActiveModules(selectedGame)}</strong>
+                </article>
+              </div>
+
+              <p className="metric-copy">{t("lobby.details.note")}</p>
+
+              <div className="shell-actions">
+                <button
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleOpenSelectedGame()}
+                  disabled={actionPending}
+                  data-testid="react-shell-lobby-open-selected"
+                >
+                  {openMutation.isPending ? "Opening..." : t("lobby.openSelected")}
+                </button>
+
+                {canJoinGame(selectedGame) ? (
+                  <button
+                    type="button"
+                    className="ghost-action"
+                    onClick={() => void handleJoinSelectedGame()}
+                    disabled={actionPending}
+                    data-testid="react-shell-lobby-join-selected"
+                  >
+                    {joinMutation.isPending ? "Joining..." : t("lobby.details.joinOpen")}
+                  </button>
+                ) : null}
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/frontend/react-shell/src/player-session.ts
+++ b/frontend/react-shell/src/player-session.ts
@@ -1,0 +1,14 @@
+const PLAYER_ID_STORAGE_KEY = "frontline-player-id";
+
+export function storeCurrentPlayerId(playerId: string | null | undefined): void {
+  try {
+    if (playerId) {
+      window.localStorage.setItem(PLAYER_ID_STORAGE_KEY, playerId);
+      return;
+    }
+
+    window.localStorage.removeItem(PLAYER_ID_STORAGE_KEY);
+  } catch {
+    // Preserve navigation behavior even if storage is unavailable.
+  }
+}

--- a/frontend/react-shell/src/routes.tsx
+++ b/frontend/react-shell/src/routes.tsx
@@ -14,6 +14,8 @@ import {
 } from "react-router-dom";
 
 import { useAuth, AuthProvider } from "@react-shell/auth";
+import { LobbyCreateRoute } from "@react-shell/lobby-create-route";
+import { LobbyRoute } from "@react-shell/lobby-route";
 import { ProfileRoute } from "@react-shell/profile-route";
 import { messageFromError } from "@frontend-core/errors.mts";
 
@@ -273,28 +275,6 @@ function PlaceholderPage({
   );
 }
 
-function LobbyPlaceholderPage() {
-  return (
-    <PlaceholderPage
-      eyebrow="Lobby"
-      title="React lobby placeholder"
-      copy="This protected route now lives inside the React shell and is ready for the first migrated functional slice."
-      details={
-        <>
-          <div className="placeholder-card">
-            <strong>Route guard ready</strong>
-            <span>Unauthenticated access is redirected through the React login page.</span>
-          </div>
-          <div className="placeholder-card">
-            <strong>Stable composition</strong>
-            <span>Header, navigation, and main content are now separate layout slots.</span>
-          </div>
-        </>
-      }
-    />
-  );
-}
-
 function GamePlaceholderPage() {
   const params = useParams();
 
@@ -482,7 +462,10 @@ export function AppRoutes() {
             <Route path="login" element={<LoginPage />} />
             <Route path="unauthorized" element={<UnauthorizedPage />} />
             <Route element={<ProtectedRoute />}>
-              <Route path="lobby" element={<LobbyPlaceholderPage />} />
+              <Route path="lobby">
+                <Route index element={<LobbyRoute />} />
+                <Route path="new" element={<LobbyCreateRoute />} />
+              </Route>
               <Route path="profile" element={<ProfileRoute />} />
               <Route path="game">
                 <Route index element={<GamePlaceholderPage />} />

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -488,6 +488,163 @@ select {
   color: var(--shell-muted);
 }
 
+.lobby-summary-grid,
+.lobby-shell-grid,
+.new-game-grid,
+.new-game-advanced-grid,
+.new-game-inline-grid,
+.new-game-slot-grid,
+.lobby-detail-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.lobby-summary-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1.5rem;
+}
+
+.lobby-summary-card,
+.lobby-list-panel,
+.lobby-detail-panel,
+.new-game-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.lobby-summary-card strong,
+.new-game-card h3,
+.lobby-panel-header h3,
+.new-game-card-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.lobby-summary-card span,
+.new-game-module-item small,
+.new-game-slot-copy small,
+.shell-field small {
+  color: var(--shell-muted);
+}
+
+.lobby-shell-grid {
+  grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
+  margin-top: 1rem;
+  align-items: start;
+}
+
+.lobby-panel-header,
+.new-game-card-header {
+  margin-bottom: 0;
+}
+
+.lobby-session-list,
+.new-game-modules-stack,
+.new-game-module-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.lobby-session-row,
+.new-game-module-item {
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.lobby-session-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.lobby-session-row.is-selected {
+  border-color: var(--shell-accent);
+}
+
+.lobby-session-row:hover {
+  border-color: var(--shell-border);
+}
+
+.lobby-session-primary,
+.lobby-session-meta {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.lobby-session-primary span,
+.lobby-session-meta span,
+.lobby-load-more-state,
+.lobby-detail-item span {
+  color: var(--shell-muted);
+}
+
+.lobby-load-more-state {
+  padding: 0.85rem 1rem 0;
+}
+
+.lobby-detail-grid,
+.new-game-inline-grid,
+.new-game-advanced-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.lobby-detail-item,
+.new-game-slot-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.new-game-form {
+  margin-top: 1.5rem;
+}
+
+.new-game-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.new-game-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--shell-copy);
+}
+
+.new-game-module-item {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+}
+
+.new-game-module-item span,
+.new-game-slot-copy {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.new-game-slot-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.new-game-slot-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.lobby-empty-state {
+  display: grid;
+  gap: 0.75rem;
+}
+
 @media (max-width: 760px) {
   .react-shell-page {
     width: min(100% - 1.25rem, 100%);
@@ -515,13 +672,22 @@ select {
   .card-header,
   .game-list-item,
   .shell-actions,
-  .profile-active-game-card {
+  .profile-active-game-card,
+  .lobby-session-row,
+  .new-game-slot-head {
     flex-direction: column;
     align-items: flex-start;
   }
 
   .profile-pilot-grid,
-  .profile-metric-grid {
+  .profile-metric-grid,
+  .lobby-summary-grid,
+  .lobby-shell-grid,
+  .new-game-grid,
+  .new-game-advanced-grid,
+  .new-game-inline-grid,
+  .new-game-slot-grid,
+  .lobby-detail-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- replace the `/react/lobby` placeholder with a real authenticated lobby flow backed by TanStack Query
- add the protected `/react/lobby/new` creation flow using the typed shared boundaries from PR1
- hand off `open`, `join`, and `create` back to the legacy `/game/:id` gameplay route while keeping the legacy HTML fallbacks in place

## Issue
- Refs #101

## Validation
- `npm run typecheck`
- `npm run test:all`
- `npm run test:e2e -- e2e/smoke/react-shell-lobby.spec.ts e2e/smoke/react-shell-new-game.spec.ts`

## Notes
- stacked on #118
- parity gap tracked: the React shell still does not render declarative module UI slot contributions for `lobby.page` and `new-game.sidebar`; `/lobby.html` and `/new-game.html` remain available as transition fallbacks until that surface is migrated.
