### PR TITLE
Issue 102: React gameplay shell

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,10 +9,11 @@ NetRisk separa in modo netto presentazione, orchestrazione e regole. Il browser 
 L'applicazione include già:
 
 - autenticazione (register/login/logout), profilo utente e preferenze tema
-- validazione runtime condivisa dei payload auth/profile tra backend e frontend
-- layer client API frontend tipizzato per i flussi migrati `profile` e `lobby`
+- validazione runtime condivisa dei payload auth/profile, lobby e gameplay tra backend e frontend
+- layer client API frontend tipizzato per auth, profile, lobby, setup e gameplay
 - shell React + Vite parallela servita su `/react/` senza sostituire la UI legacy
-- convenzioni React shell con TanStack Query per server state e Zustand limitato a shell/session UI
+- convenzioni React shell con TanStack Query per route state remoto e Zustand limitato a shell/session UI
+- route React protette per login, lobby, new game, profile e gameplay core-playable su `/react/game/:gameId`
 - lobby, creazione partita, join player umani e bot AI
 - setup partita 2-4 giocatori con mappe supportate
 - ciclo turno completo (`reinforcement` -> `attack` -> `fortify` -> `finished`)
@@ -33,10 +34,10 @@ Sorgente TypeScript (`.mts`) della UI web, della shell condivisa, dell'i18n e de
 
 `/frontend/react-shell`  
 Shell React + Vite parallela, con alias verso `frontend/src/core` e `shared`, usata come percorso di migrazione incrementale.
-Per il pilot attuale del profilo usa TanStack Query per il server state e Zustand solo per stato locale di shell/sessione.
+Usa TanStack Query per snapshot/mutazioni remote e Zustand solo per stato locale di shell/sessione.
 
 `/frontend/src/core/api`  
-Boundary HTTP frontend framework-agnostic: request helpers tipizzati, parsing/validazione condivisa ed error translation per i flussi UI migrati.
+Boundary HTTP frontend framework-agnostic: request helpers tipizzati, parsing/validazione condivisa ed error translation per auth, profile, lobby, setup e gameplay.
 
 `/frontend/assets`  
 Asset sorgente frontend (mappe e media) sincronizzati nella build pubblica.
@@ -95,7 +96,7 @@ Suite Playwright per flussi end-to-end UI + API.
 - `core-domain.cts`: entità core (game state, player, territory, continent)
 - `game-actions.cts`: tipi azioni inviate dal client
 - `api-contracts.cts`: payload/contratti API condivisi
-- `runtime-validation.cts`: schemi runtime condivisi e shape uniforme degli errori di validazione
+- `runtime-validation.cts`: schemi runtime condivisi e shape uniforme degli errori di validazione, inclusi i boundary gameplay
 - `module-registry.cts`: primitive comune per registry/moduli estendibili
 - `cards.cts`: deck, set validi, progressione bonus trade
 - `dice.cts`: registry ruleset dadi (incluso `defense-three-dice`)
@@ -164,8 +165,8 @@ Categorie future da trattare con lo stesso modello:
 - Pipeline frontend: `frontend/src` viene compilato e materializzato in `public/` tramite gli script di build.
 - Pipeline React shell: `frontend/react-shell` viene buildata con Vite in `public/react/`, con `base=/react/` e proxy dev `/api` verso `VITE_BACKEND_TARGET`.
 - Boundary validation frontend: `frontend/src/core/validated-json.mts` valida le risposte condivise prima del consumo UI.
-- Boundary transport frontend: `frontend/src/core/api/http.mts` e `frontend/src/core/api/client.mts` centralizzano `fetch`, body JSON, validazione runtime, session handling ed error translation per i flussi `profile` e `lobby`.
-- React server-state ownership: nella shell React le query remote stanno in TanStack Query; Zustand non sostituisce il backend e resta confinato a stato locale/sessione della shell.
+- Boundary transport frontend: `frontend/src/core/api/http.mts` e `frontend/src/core/api/client.mts` centralizzano `fetch`, body JSON, validazione runtime, session handling, SSE payload parsing ed error translation per auth, profile, lobby, setup e gameplay.
+- React server-state ownership: nella shell React le query remote e le mutazioni stanno in TanStack Query; Zustand non sostituisce il backend e resta confinato a stato locale/sessione della shell.
 - Datastore supportati:
   - SQLite locale (default sviluppo)
   - Supabase (quando configurato via env)
@@ -177,7 +178,7 @@ Categorie future da trattare con lo stesso modello:
 ## Flusso sintetico applicativo
 
 1. Il client invia azioni o richieste via route backend.
-   Per i flussi UI gia migrati (`profile` e `lobby`), il client passa attraverso il layer `frontend/src/core/api` invece di fare `fetch` inline nei moduli pagina.
+   Per la shell React e i flussi UI legacy gia migrati, il client passa attraverso il layer `frontend/src/core/api` invece di fare `fetch` inline nei moduli pagina.
    La shell React riusa lo stesso boundary tipizzato invece di introdurre una seconda logica transport.
 2. Il backend autentica/autorizza utente e valida versione stato.
 3. Le route delegano al motore (`backend/engine`) la logica di dominio.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ In code and technical documentation, the project remains identified as `NetRisk`
 Today the project includes:
 
 - user registration, login, logout, and profile
-- shared runtime validation for auth/profile payloads at backend and frontend boundaries
-- typed frontend API client helpers for the migrated `profile` and `lobby` flows
-- parallel React + Vite smoke shell served at `/react/`, isolated from the legacy pages
-- TanStack Query + Zustand conventions in the React shell, with a minimal `/react/profile` pilot
+- shared runtime validation for auth/profile, lobby, and gameplay payloads at backend and frontend boundaries
+- typed frontend API client helpers for auth, profile, lobby, setup, and gameplay flows
+- parallel React + Vite shell served at `/react/`, isolated from the legacy pages
+- TanStack Query + Zustand conventions in the React shell, with protected login, lobby, new game, profile, and gameplay routes
 - initial lobby and reopening saved games
 - creation of a new game with supported map, selectable dice ruleset, and configurable turn time limit
 - joining with human players and adding AI bots
@@ -70,7 +70,7 @@ npm start
 ```
 
 Application available at `http://localhost:3000`.
-After `npm start`, the legacy pages are served from the same server, and the React smoke shell is also available at `http://localhost:3000/react/`.
+After `npm start`, the legacy pages are served from the same server, and the React shell is also available at `http://localhost:3000/react/`.
 
 React shell preview:
 
@@ -80,7 +80,7 @@ npm run dev:react-shell
 
 The parallel React + Vite shell is reachable at `http://localhost:5173/react/` in development and at `/react/` from the main server after `npm run build:ts`.
 The Vite dev server proxies `/api` to `VITE_BACKEND_TARGET`, which defaults to `http://127.0.0.1:3000`.
-Within the React shell, TanStack Query now owns server state for the migrated profile pilot, while Zustand is limited to local shell/session state.
+Within the React shell, TanStack Query owns route-level remote state such as gameplay snapshots and mutations, while Zustand is limited to local shell/session state.
 
 ## Datastore configuration
 
@@ -230,11 +230,12 @@ The `e2e` suite currently covers:
 - auth navigation between pages
 - profile states: loading, error, empty state
 - profile invalid payload fallback with controlled UI feedback
-- React shell smoke loading on `/react/` with controlled fallback rendering
+- React shell bootstrap, auth redirects, and protected route handling on `/react/*`
 - new game setup
-- main gameplay flows
+- legacy and React gameplay flows
 - attack dice selection and combat result display
 - card panel, successful trade, inline errors, and reward synchronization
+- React gameplay deep links, join/start, forced trade, legacy fallback, and version-conflict recovery
 - granular rendering checks that keep stable gameplay panels mounted during updates
 - visual baselines for the main battlefield, mobile lobby shell, and World Classic board layouts
 
@@ -317,7 +318,7 @@ The shared constructs exposed by `shared/models.cjs` are:
 - `listContentModules`
 
 For runtime contract validation shared by backend and frontend, see `shared/runtime-validation.cts`.
-For the current framework-agnostic frontend transport boundary used by the migrated `profile` and `lobby` flows, see `frontend/src/core/api/`.
+For the current framework-agnostic frontend transport boundary used by the React shell and migrated legacy pages, see `frontend/src/core/api/`.
 
 Game state notably contains:
 
@@ -350,12 +351,17 @@ Main frontend screens currently available:
 - `game.html`: active game
 - `profile.html`: user profile
 - `register.html`: new account creation
-- `/react/`: parallel React + Vite smoke shell
+- `/react/`: React shell bootstrap route
+- `/react/login`: React shell sign-in route
+- `/react/lobby`: React lobby route
+- `/react/lobby/new`: React new game route
+- `/react/profile`: React profile route
+- `/react/game/:gameId`: React gameplay route with explicit legacy fallback
 
 The UI is designed to stay thin: it displays state received from the server and sends actions via API.
-For the migrated `profile` and `lobby` pages, raw network details now live in the typed frontend client layer under `frontend/src/core/api/`, so page modules stay focused on rendering and UI state.
+For the React shell routes and migrated legacy pages, raw network details now live in the typed frontend client layer under `frontend/src/core/api/`, so page modules stay focused on rendering and UI state.
 The React shell follows the same rule: it reuses the shared typed client and does not duplicate game rules locally.
-For the current React pilot, TanStack Query is used only for remote profile state and mutations, while Zustand is reserved for shell-local session state and UI ownership.
+In the React shell, TanStack Query is used for route-level remote state and mutations, while Zustand is reserved for shell-local session state and UI ownership.
 
 From a naming perspective, frontend pages currently display title `Frontline Dominion`, while the technical project domain continues to use `NetRisk`.
 
@@ -364,6 +370,12 @@ The game screen also includes:
 - attack dice selector with default coherent to selected territory
 - latest combat summary panel with dice and comparison
 - current player card panel with set selection and trade submission
+
+On the React gameplay route, the shell also supports:
+
+- snapshot bootstrap plus live SSE refresh from the backend state
+- join/start, trade cards, reinforce, attack, move-after-conquest, fortify, end-turn, and surrender actions
+- explicit fallback navigation to the legacy `/game/:id` route for parity gaps or recovery
 
 ## License
 

--- a/TEST_GAPS.md
+++ b/TEST_GAPS.md
@@ -21,6 +21,8 @@
 - Backend gameplay rules and regression flows
 - Code quality baseline: ESLint warning-first rollout, Prettier enforcement, and dedicated CI quality workflow
 - Core E2E gameplay flows: reinforcement, attack/conquest, fortify handoff, turn guard, version conflict
+- React gameplay E2E: deep link, join/start, forced trade, legacy fallback, and version-conflict recovery
+- Frontend gameplay API client: typed state/start/action/trade helpers, SSE payload parsing, and version-conflict extraction
 - AI autoplay E2E
 - Authorization E2E: non-member denied on protected game open and direct game route read
 - Authorization E2E: creator can reopen a protected lobby from a direct game route
@@ -36,7 +38,7 @@
 - Vercel build pipeline: preview/prod build command compila TypeScript prima della sync asset
 - Shared runtime validation: auth/profile schemas, route validation failures, and controlled frontend fallback
 - Gameplay E2E: granular rendering reinforcement flow stabilized against async control population
-- React shell smoke route: `/react/` loads with controlled fallback rendering
+- React shell routes: bootstrap, auth redirects, lobby/profile/new game, and gameplay route rendering
 - TS-complete allowlist regression: React shell sources are allowed and tracked stray `.js` sources are rejected
 
 ## Missing

--- a/backend/routes/game-actions.cts
+++ b/backend/routes/game-actions.cts
@@ -2,6 +2,13 @@ const { handleAttackGameActionRoute } = require("./game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("./game-actions-basic.cjs");
 const { handleTurnGameActionRoute } = require("./game-actions-turn.cjs");
 const {
+  gameActionEnvelopeSchema,
+  gameActionRequestSchema,
+  gameMutationResponseSchema,
+  gameVersionConflictResponseSchema
+} = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const {
   applyFortify,
   applyReinforcement,
   endTurn,
@@ -101,25 +108,52 @@ async function handleGameActionRoute({
     return;
   }
 
-  const currentUser = authContext.user;
-  const playerId = body.playerId;
-  const type = body.type;
-  let expectedVersion: number | null = null;
-  if (body.expectedVersion != null) {
-    expectedVersion = Number(body.expectedVersion);
-    if (!Number.isInteger(expectedVersion) || expectedVersion < 1) {
-      sendLocalizedError(
-        res,
-        400,
-        null,
-        "expectedVersion non valida.",
-        "server.invalidExpectedVersion"
-      );
-      return;
-    }
+  if (
+    body.expectedVersion != null &&
+    (!Number.isInteger(Number(body.expectedVersion)) || Number(body.expectedVersion) < 1)
+  ) {
+    sendLocalizedError(
+      res,
+      400,
+      null,
+      "expectedVersion non valida.",
+      "server.invalidExpectedVersion"
+    );
+    return;
   }
 
-  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const resolvedBody = {
+    ...body,
+    gameId: getTargetGameId(body, url)
+  };
+  const parsedEnvelope = parseRequestOrSendError(
+    res as import("node:http").ServerResponse,
+    resolvedBody,
+    gameActionEnvelopeSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedEnvelope) {
+    return;
+  }
+
+  const currentUser = authContext.user;
+  const playerId = parsedEnvelope.playerId;
+  const type = parsedEnvelope.type;
+  const expectedVersion = parsedEnvelope.expectedVersion ?? null;
+  const nodeResponse = res as import("node:http").ServerResponse;
+  const sendGameplayMutationJson: SendJson = (targetRes, statusCode, payload, headers) => {
+    sendValidatedJson(
+      targetRes as import("node:http").ServerResponse,
+      statusCode,
+      payload,
+      gameMutationResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError,
+      headers
+    );
+  };
+
+  const gameContext = await loadGameContext(parsedEnvelope.gameId ?? null);
   const player = getPlayer(gameContext.state, playerId);
 
   if (!player || !playerBelongsToUser(player, currentUser)) {
@@ -132,38 +166,62 @@ async function handleGameActionRoute({
       return false;
     }
 
-    sendJson(res, 409, {
-      ...localizedPayload(error, error.message, error.messageKey || "server.versionConflict"),
-      code: error.code,
-      currentVersion: error.currentVersion,
-      state: snapshotForUser(
-        error.currentState,
-        gameContext.gameId,
-        error.currentVersion,
-        error.game?.name || gameContext.gameName,
-        currentUser
-      )
-    });
+    sendValidatedJson(
+      nodeResponse,
+      409,
+      {
+        ...localizedPayload(error, error.message, error.messageKey || "server.versionConflict"),
+        code: error.code,
+        currentVersion: error.currentVersion,
+        state: snapshotForUser(
+          error.currentState,
+          gameContext.gameId,
+          error.currentVersion,
+          error.game?.name || gameContext.gameName,
+          currentUser
+        )
+      },
+      gameVersionConflictResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError
+    );
     return true;
   }
 
   if (expectedVersion != null && expectedVersion !== gameContext.version) {
-    sendJson(res, 409, {
-      ...localizedPayload(
-        null,
-        "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
-        "server.versionConflict"
-      ),
-      code: "VERSION_CONFLICT",
-      currentVersion: gameContext.version,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        currentUser
-      )
-    });
+    sendValidatedJson(
+      nodeResponse,
+      409,
+      {
+        ...localizedPayload(
+          null,
+          "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+          "server.versionConflict"
+        ),
+        code: "VERSION_CONFLICT",
+        currentVersion: gameContext.version,
+        state: snapshotForUser(
+          gameContext.state,
+          gameContext.gameId,
+          gameContext.version,
+          gameContext.gameName,
+          currentUser
+        )
+      },
+      gameVersionConflictResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError
+    );
+    return;
+  }
+
+  const parsedBody = parseRequestOrSendError(
+    nodeResponse,
+    resolvedBody,
+    gameActionRequestSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedBody) {
     return;
   }
 
@@ -192,7 +250,7 @@ async function handleGameActionRoute({
       snapshotForUser,
       handleVersionConflict,
       isValidTerritoryId,
-      sendJson,
+      sendGameplayMutationJson,
       sendLocalizedError
     )
   ) {
@@ -216,7 +274,7 @@ async function handleGameActionRoute({
       snapshotForUser,
       handleVersionConflict,
       isValidTerritoryId,
-      sendJson,
+      sendGameplayMutationJson,
       sendLocalizedError
     )
   ) {
@@ -237,7 +295,7 @@ async function handleGameActionRoute({
       broadcastGame,
       snapshotForUser,
       handleVersionConflict,
-      sendJson,
+      sendGameplayMutationJson,
       sendLocalizedError
     )
   ) {

--- a/backend/routes/game-cards.cts
+++ b/backend/routes/game-cards.cts
@@ -1,3 +1,10 @@
+const {
+  gameMutationResponseSchema,
+  gameVersionConflictResponseSchema,
+  tradeCardsRequestSchema
+} = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+
 type SendJson = (
   res: unknown,
   statusCode: number,
@@ -34,11 +41,12 @@ type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type TradeCardSet = (state: any, playerId: string, cardIds: string[]) => any;
 type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
 type BroadcastGame = (gameContext: any) => void;
-type SnapshotForState = (
+type SnapshotForUser = (
   state: any,
   gameId: string | null,
   version: number | null,
-  gameName: string | null
+  gameName: string | null,
+  user: unknown
 ) => unknown;
 
 async function handleCardsTradeRoute(
@@ -54,7 +62,7 @@ async function handleCardsTradeRoute(
   tradeCardSet: TradeCardSet,
   persistGameContext: PersistGameContext,
   broadcastGame: BroadcastGame,
-  snapshotForState: SnapshotForState,
+  snapshotForUser: SnapshotForUser,
   sendJson: SendJson,
   sendLocalizedError: SendLocalizedError
 ): Promise<void> {
@@ -63,17 +71,9 @@ async function handleCardsTradeRoute(
     return;
   }
 
-  const gameContext = await loadGameContext(getTargetGameId(body, url));
-  const player = getPlayer(gameContext.state, body.playerId);
-  if (!player || !playerBelongsToUser(player, authContext.user)) {
-    sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
-    return;
-  }
-
-  const requestedVersion = body.expectedVersion == null ? null : Number(body.expectedVersion);
   if (
     body.expectedVersion != null &&
-    (!Number.isInteger(requestedVersion ?? NaN) || (requestedVersion ?? 0) < 1)
+    (!Number.isInteger(Number(body.expectedVersion)) || Number(body.expectedVersion) < 1)
   ) {
     sendLocalizedError(
       res,
@@ -84,29 +84,56 @@ async function handleCardsTradeRoute(
     );
     return;
   }
+
+  const resolvedBody = {
+    ...body,
+    gameId: getTargetGameId(body, url)
+  };
+  const parsedBody = parseRequestOrSendError(
+    res as import("node:http").ServerResponse,
+    resolvedBody,
+    tradeCardsRequestSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedBody) {
+    return;
+  }
+
+  const nodeResponse = res as import("node:http").ServerResponse;
+  const gameContext = await loadGameContext(parsedBody.gameId ?? null);
+  const player = getPlayer(gameContext.state, parsedBody.playerId);
+  if (!player || !playerBelongsToUser(player, authContext.user)) {
+    sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
+    return;
+  }
+
+  const requestedVersion = parsedBody.expectedVersion ?? null;
   if (requestedVersion != null && requestedVersion !== gameContext.version) {
-    sendLocalizedError(
-      res,
+    sendValidatedJson(
+      nodeResponse,
       409,
-      null,
-      "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
-      "server.versionConflict",
-      {},
-      "VERSION_CONFLICT",
       {
+        error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+        messageKey: "server.versionConflict",
+        messageParams: {},
+        code: "VERSION_CONFLICT",
         currentVersion: gameContext.version,
-        state: snapshotForState(
+        state: snapshotForUser(
           gameContext.state,
           gameContext.gameId,
           gameContext.version,
-          gameContext.gameName
+          gameContext.gameName,
+          authContext.user
         )
-      }
+      },
+      gameVersionConflictResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError
     );
     return;
   }
 
-  const result = tradeCardSet(gameContext.state, body.playerId, body.cardIds);
+  const result = tradeCardSet(gameContext.state, parsedBody.playerId, parsedBody.cardIds);
   if (!result.ok) {
     sendLocalizedError(res, 400, result, result.message, result.messageKey, result.messageParams);
     return;
@@ -116,23 +143,26 @@ async function handleCardsTradeRoute(
     await persistGameContext(gameContext, requestedVersion);
   } catch (error: any) {
     if (error && error.code === "VERSION_CONFLICT") {
-      sendLocalizedError(
-        res,
+      sendValidatedJson(
+        nodeResponse,
         409,
-        error,
-        error.message,
-        error.messageKey || "server.versionConflict",
-        {},
-        error.code,
         {
+          error: error.message,
+          messageKey: error.messageKey || "server.versionConflict",
+          messageParams: {},
+          code: error.code,
           currentVersion: error.currentVersion,
-          state: snapshotForState(
+          state: snapshotForUser(
             error.currentState,
             gameContext.gameId,
             error.currentVersion,
-            error.game?.name || gameContext.gameName
+            error.game?.name || gameContext.gameName,
+            authContext.user
           )
-        }
+        },
+        gameVersionConflictResponseSchema,
+        sendJson as SendJson,
+        sendLocalizedError as SendLocalizedError
       );
       return;
     }
@@ -141,17 +171,25 @@ async function handleCardsTradeRoute(
   }
 
   broadcastGame(gameContext);
-  sendJson(res, 200, {
-    ok: true,
-    bonus: result.bonus,
-    validation: result.validation,
-    state: snapshotForState(
-      gameContext.state,
-      gameContext.gameId,
-      gameContext.version,
-      gameContext.gameName
-    )
-  });
+  sendValidatedJson(
+    nodeResponse,
+    200,
+    {
+      ok: true,
+      bonus: result.bonus,
+      validation: result.validation,
+      state: snapshotForUser(
+        gameContext.state,
+        gameContext.gameId,
+        gameContext.version,
+        gameContext.gameName,
+        authContext.user
+      )
+    },
+    gameMutationResponseSchema,
+    sendJson as SendJson,
+    sendLocalizedError as SendLocalizedError
+  );
 }
 
 module.exports = {

--- a/backend/routes/game-cards.cts
+++ b/backend/routes/game-cards.cts
@@ -113,7 +113,8 @@ async function handleCardsTradeRoute(
       nodeResponse,
       409,
       {
-        error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+        error:
+          "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
         messageKey: "server.versionConflict",
         messageParams: {},
         code: "VERSION_CONFLICT",

--- a/backend/routes/game-read.cts
+++ b/backend/routes/game-read.cts
@@ -1,8 +1,25 @@
+const {
+  gameEventPayloadSchema,
+  gameStateResponseSchema,
+  toValidationErrors
+} = require("../../shared/runtime-validation.cjs");
+const { sendValidatedJson } = require("../route-validation.cjs");
+
 type SendJson = (
   res: unknown,
   statusCode: number,
   payload: unknown,
   headers?: Record<string, string>
+) => void;
+type SendLocalizedError = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  input: Record<string, unknown> | null,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams?: Record<string, unknown>,
+  code?: string | null,
+  extra?: Record<string, unknown>
 ) => void;
 type AuthorizeGameRead = (
   gameId: string | null,
@@ -38,7 +55,8 @@ async function handleStateRoute(
   getUserFromSession: GetUserFromSession,
   extractSessionToken: ExtractSessionToken,
   snapshotForUser: SnapshotForUser,
-  sendJson: SendJson
+  sendJson: SendJson,
+  sendLocalizedError?: SendLocalizedError
 ): Promise<void> {
   const gameId = getTargetGameId({}, url);
   const access = await authorizeGameRead(gameId, req, res, url);
@@ -52,16 +70,25 @@ async function handleStateRoute(
     access && access.user
       ? access.user
       : await getUserFromSession(extractSessionToken(req, {}, url));
-  sendJson(
-    res,
+  const payload = snapshotForUser(
+    gameContext.state,
+    gameContext.gameId,
+    gameContext.version,
+    gameContext.gameName,
+    sessionUser
+  );
+  if (typeof sendLocalizedError !== "function") {
+    sendJson(res, 200, payload);
+    return;
+  }
+
+  sendValidatedJson(
+    res as import("node:http").ServerResponse,
     200,
-    snapshotForUser(
-      gameContext.state,
-      gameContext.gameId,
-      gameContext.version,
-      gameContext.gameName,
-      sessionUser
-    )
+    payload,
+    gameStateResponseSchema,
+    sendJson as SendJson,
+    sendLocalizedError
   );
 }
 
@@ -74,7 +101,8 @@ async function handleEventsRoute(
   loadGameContext: LoadGameContext,
   resumeAiTurnsForRead: ResumeAiTurnsForRead,
   snapshotForUser: SnapshotForUser,
-  clientsByGameId: Map<string, Set<{ res: any; user: unknown }>>
+  clientsByGameId: Map<string, Set<{ res: any; user: unknown }>>,
+  sendLocalizedError?: SendLocalizedError
 ): Promise<void> {
   const gameId = getTargetGameId({}, url);
   const access = await authorizeGameRead(gameId, req, res, url);
@@ -84,6 +112,35 @@ async function handleEventsRoute(
 
   const gameContext = await loadGameContext(gameId);
   // Keep the event stream read-only. AI advancement already happens on open/state routes.
+  const initialPayload = snapshotForUser(
+    gameContext.state,
+    gameContext.gameId,
+    gameContext.version,
+    gameContext.gameName,
+    access.user || null
+  );
+  const initialPayloadResult =
+    typeof sendLocalizedError === "function"
+      ? gameEventPayloadSchema.safeParse(initialPayload)
+      : { success: true, data: initialPayload };
+  if (!initialPayloadResult.success) {
+    if (typeof sendLocalizedError !== "function") {
+      return;
+    }
+
+    sendLocalizedError(
+      res as import("node:http").ServerResponse,
+      500,
+      null,
+      "Risposta server non valida.",
+      "server.response.invalid",
+      {},
+      "RESPONSE_VALIDATION_FAILED",
+      { validationErrors: toValidationErrors(initialPayloadResult.error) }
+    );
+    return;
+  }
+
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
@@ -91,17 +148,7 @@ async function handleEventsRoute(
     "Access-Control-Allow-Origin": "*"
   });
   res.write(
-    "data: " +
-      JSON.stringify(
-        snapshotForUser(
-          gameContext.state,
-          gameContext.gameId,
-          gameContext.version,
-          gameContext.gameName,
-          access.user || null
-        )
-      ) +
-      "\n\n"
+    "data: " + JSON.stringify(initialPayloadResult.data) + "\n\n"
   );
   const key = gameContext.gameId || "__default__";
   if (!clientsByGameId.has(key)) {

--- a/backend/routes/game-read.cts
+++ b/backend/routes/game-read.cts
@@ -147,9 +147,7 @@ async function handleEventsRoute(
     Connection: "keep-alive",
     "Access-Control-Allow-Origin": "*"
   });
-  res.write(
-    "data: " + JSON.stringify(initialPayloadResult.data) + "\n\n"
-  );
+  res.write("data: " + JSON.stringify(initialPayloadResult.data) + "\n\n");
   const key = gameContext.gameId || "__default__";
   if (!clientsByGameId.has(key)) {
     clientsByGameId.set(key, new Set());

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -47,7 +47,9 @@ type StartGame = (state: any) => any;
 
 const {
   gameIdRequestSchema,
-  gameMutationResponseSchema
+  gameMutationResponseSchema,
+  gameVersionConflictResponseSchema,
+  startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
 
@@ -110,6 +112,20 @@ async function handleJoinRoute(
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
+    return;
+  }
+
+  if (
+    body.expectedVersion != null &&
+    (!Number.isInteger(Number(body.expectedVersion)) || Number(body.expectedVersion) < 1)
+  ) {
+    sendLocalizedError(
+      res,
+      400,
+      null,
+      "expectedVersion non valida.",
+      "server.invalidExpectedVersion"
+    );
     return;
   }
 
@@ -188,7 +204,23 @@ async function handleStartRoute(
     return;
   }
 
-  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const resolvedBody = {
+    ...body,
+    gameId: getTargetGameId(body, url)
+  };
+  const parsedBody = parseRequestOrSendError(
+    res as import("node:http").ServerResponse,
+    resolvedBody,
+    startGameRequestSchema,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (!parsedBody) {
+    return;
+  }
+
+  const nodeResponse = res as import("node:http").ServerResponse;
+  const expectedVersion = parsedBody.expectedVersion ?? null;
+  const gameContext = await loadGameContext(parsedBody.gameId ?? null);
   if (gameContext.state.phase !== "lobby") {
     sendLocalizedError(res, 400, null, "La partita e gia iniziata.", "server.game.alreadyStarted");
     return;
@@ -220,24 +252,84 @@ async function handleStartRoute(
     return;
   }
 
-  const player = getPlayer(gameContext.state, body.playerId);
+  if (expectedVersion != null && expectedVersion !== gameContext.version) {
+    sendValidatedJson(
+      nodeResponse,
+      409,
+      {
+        error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+        messageKey: "server.versionConflict",
+        messageParams: {},
+        code: "VERSION_CONFLICT",
+        currentVersion: gameContext.version,
+        state: snapshotForState(
+          gameContext.state,
+          gameContext.gameId,
+          gameContext.version,
+          gameContext.gameName
+        )
+      },
+      gameVersionConflictResponseSchema,
+      sendJson as SendJson,
+      sendLocalizedError as SendLocalizedError
+    );
+    return;
+  }
+
+  const player = getPlayer(gameContext.state, parsedBody.playerId);
   if (!player || !playerBelongsToUser(player, authContext.user)) {
     sendLocalizedError(res, 403, null, "Giocatore non valido.", "game.invalidPlayer");
     return;
   }
 
   startGame(gameContext.state);
-  await persistWithAiTurns(gameContext);
+  try {
+    await persistWithAiTurns(gameContext, expectedVersion);
+  } catch (error: any) {
+    if (error && error.code === "VERSION_CONFLICT") {
+      sendValidatedJson(
+        nodeResponse,
+        409,
+        {
+          error: error.message,
+          messageKey: error.messageKey || "server.versionConflict",
+          messageParams: {},
+          code: error.code,
+          currentVersion: error.currentVersion,
+          state: snapshotForState(
+            error.currentState,
+            gameContext.gameId,
+            error.currentVersion,
+            error.game?.name || gameContext.gameName
+          )
+        },
+        gameVersionConflictResponseSchema,
+        sendJson as SendJson,
+        sendLocalizedError as SendLocalizedError
+      );
+      return;
+    }
+
+    throw error;
+  }
   broadcastGame(gameContext);
-  sendJson(res, 200, {
-    ok: true,
-    state: snapshotForState(
-      gameContext.state,
-      gameContext.gameId,
-      gameContext.version,
-      gameContext.gameName
-    )
-  });
+  sendValidatedJson(
+    nodeResponse,
+    200,
+    {
+      ok: true,
+      playerId: parsedBody.playerId,
+      state: snapshotForState(
+        gameContext.state,
+        gameContext.gameId,
+        gameContext.version,
+        gameContext.gameName
+      )
+    },
+    gameMutationResponseSchema,
+    sendJson as SendJson,
+    sendLocalizedError as SendLocalizedError
+  );
 }
 
 module.exports = {

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -257,7 +257,8 @@ async function handleStartRoute(
       nodeResponse,
       409,
       {
-        error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+        error:
+          "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
         messageKey: "server.versionConflict",
         messageParams: {},
         code: "VERSION_CONFLICT",

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -220,14 +220,9 @@ async function handleStartRoute(
 
   const nodeResponse = res as import("node:http").ServerResponse;
   const expectedVersion = parsedBody.expectedVersion ?? null;
-  const gameContext = await loadGameContext(parsedBody.gameId ?? null);
-  if (gameContext.state.phase !== "lobby") {
-    sendLocalizedError(res, 400, null, "La partita e gia iniziata.", "server.game.alreadyStarted");
-    return;
-  }
 
   try {
-    const activeGame = await getGame(gameContext.gameId);
+    const activeGame = await getGame(parsedBody.gameId ?? null);
     authorize("game:start", { user: authContext.user, game: activeGame.game });
   } catch (error: any) {
     const statusCode = error.statusCode || 400;
@@ -238,6 +233,12 @@ async function handleStartRoute(
       "Avvio partita non autorizzato.",
       "server.game.startUnauthorized"
     );
+    return;
+  }
+
+  const gameContext = await loadGameContext(parsedBody.gameId ?? null);
+  if (gameContext.state.phase !== "lobby") {
+    sendLocalizedError(res, 400, null, "La partita e gia iniziata.", "server.game.alreadyStarted");
     return;
   }
 
@@ -283,6 +284,7 @@ async function handleStartRoute(
     return;
   }
 
+  gameContext.state = structuredClone(gameContext.state);
   startGame(gameContext.state);
   try {
     await persistWithAiTurns(gameContext, expectedVersion);

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -431,25 +431,22 @@ function createApp(options: CreateAppOptions = {}) {
       return;
     }
 
-    broadcastEventPayload(
-      clients,
-      (client: EventClient) => {
-        const payloadResult = gameEventPayloadSchema.safeParse(
-          snapshotForUser(
-            gameContext.state,
-            gameContext.gameId,
-            gameContext.version,
-            gameContext.gameName,
-            client.user
-          )
-        );
-        if (!payloadResult.success) {
-          throw new Error("Invalid gameplay event payload.");
-        }
-
-        return "data: " + JSON.stringify(payloadResult.data) + "\n\n";
+    broadcastEventPayload(clients, (client: EventClient) => {
+      const payloadResult = gameEventPayloadSchema.safeParse(
+        snapshotForUser(
+          gameContext.state,
+          gameContext.gameId,
+          gameContext.version,
+          gameContext.gameName,
+          client.user
+        )
+      );
+      if (!payloadResult.success) {
+        throw new Error("Invalid gameplay event payload.");
       }
-    );
+
+      return "data: " + JSON.stringify(payloadResult.data) + "\n\n";
+    });
 
     if (!clients.size) {
       clientsByGameId.delete(gameContext.gameId);

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -62,6 +62,7 @@ const {
 } = require("./routes/password-auth.cjs");
 const { handleScheduledJobsRoute } = require("./routes/scheduled-jobs.cjs");
 const { NETRISK_ENGINE_VERSION } = require("../shared/netrisk-modules.cjs");
+const { gameEventPayloadSchema } = require("../shared/runtime-validation.cjs");
 
 type Request = import("http").IncomingMessage;
 type Response = import("http").ServerResponse;
@@ -432,9 +433,8 @@ function createApp(options: CreateAppOptions = {}) {
 
     broadcastEventPayload(
       clients,
-      (client: EventClient) =>
-        "data: " +
-        JSON.stringify(
+      (client: EventClient) => {
+        const payloadResult = gameEventPayloadSchema.safeParse(
           snapshotForUser(
             gameContext.state,
             gameContext.gameId,
@@ -442,8 +442,13 @@ function createApp(options: CreateAppOptions = {}) {
             gameContext.gameName,
             client.user
           )
-        ) +
-        "\n\n"
+        );
+        if (!payloadResult.success) {
+          throw new Error("Invalid gameplay event payload.");
+        }
+
+        return "data: " + JSON.stringify(payloadResult.data) + "\n\n";
+      }
     );
 
     if (!clients.size) {
@@ -716,7 +721,8 @@ function createApp(options: CreateAppOptions = {}) {
         auth.getUserFromSession,
         extractSessionToken,
         snapshotForUser,
-        sendJson
+        sendJson,
+        sendLocalizedError
       );
       return;
     }
@@ -1039,7 +1045,8 @@ function createApp(options: CreateAppOptions = {}) {
         loadGameContext,
         resumeAiTurnsForRead,
         snapshotForUser,
-        clientsByGameId
+        clientsByGameId,
+        sendLocalizedError
       );
       return;
     }
@@ -1132,7 +1139,7 @@ function createApp(options: CreateAppOptions = {}) {
         tradeCardSet,
         persistGameContext,
         broadcastGame,
-        snapshotForState,
+        snapshotForUser,
         sendJson,
         sendLocalizedError
       );

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -33,9 +33,10 @@ Each run also uses a temporary SQLite database dedicated to that E2E instance, a
 - smoke test for app load
 - layout acceptance coverage for main shell, shared headers, and map fit
 - gameplay flows for reinforcement, attack/conquest, fortify handoff, surrender, relogin binding, and version conflict
+- React gameplay flows on `/react/game/:gameId`, including deep links, join/start, forced trade, legacy fallback, and version-conflict recovery
 - authorization flows for protected games, direct game routes, and spectator access
 - profile states: loading, error, empty, invalid payload fallback, participating games, and theme preference
-- smoke coverage for the parallel React shell served at `/react/`
+- React shell bootstrap, protected redirects, and route-level rendering on `/react/*`
 - new game setup happy path plus validation fallback when setup options become invalid
 - granular rendering coverage to catch unnecessary panel remounts during gameplay updates
 - visual baselines for main screen, secondary pages, mobile shells, and World Classic board layouts

--- a/e2e/smoke/react-shell-gameplay.spec.ts
+++ b/e2e/smoke/react-shell-gameplay.spec.ts
@@ -297,3 +297,254 @@ test("react gameplay handles the forced trade flow on the React route", async ({
     /Set valido|Valid set/
   );
 });
+
+test("react gameplay recovers from VERSION_CONFLICT by refreshing the snapshot and continuing the turn", async ({
+  page
+}) => {
+  function buildGameplayState(overrides = {}) {
+    const baseState = {
+      phase: "active",
+      turnPhase: "reinforcement",
+      players: [
+        {
+          id: "p1",
+          name: "alice",
+          color: "#e85d04",
+          connected: true,
+          isAi: false,
+          territoryCount: 1,
+          eliminated: false,
+          cardCount: 0
+        },
+        {
+          id: "p2",
+          name: "CPU",
+          color: "#0f4c5c",
+          connected: true,
+          isAi: true,
+          territoryCount: 1,
+          eliminated: false,
+          cardCount: 0
+        }
+      ],
+      map: [
+        {
+          id: "aurora",
+          name: "Aurora",
+          neighbors: ["bastion"],
+          continentId: "north",
+          ownerId: "p1",
+          armies: 3,
+          x: 0.2,
+          y: 0.3
+        },
+        {
+          id: "bastion",
+          name: "Bastion",
+          neighbors: ["aurora"],
+          continentId: "north",
+          ownerId: "p2",
+          armies: 1,
+          x: 0.65,
+          y: 0.45
+        }
+      ],
+      continents: [],
+      currentPlayerId: "p1",
+      reinforcementPool: 1,
+      winnerId: null,
+      gameConfig: {
+        mapId: "classic-mini",
+        mapName: "Classic Mini",
+        totalPlayers: 2,
+        players: [{ type: "human" }, { type: "ai" }]
+      },
+      log: ["Version conflict recovery"],
+      lastAction: null,
+      pendingConquest: null,
+      fortifyUsed: false,
+      conqueredTerritoryThisTurn: false,
+      cardState: {
+        ruleSetId: "standard",
+        tradeCount: 0,
+        deckCount: 5,
+        discardCount: 0,
+        nextTradeBonus: 4,
+        maxHandBeforeForcedTrade: 5,
+        currentPlayerMustTrade: false
+      },
+      diceRuleSet: {
+        id: "standard",
+        attackerMaxDice: 3,
+        defenderMaxDice: 2
+      },
+      attacksThisTurn: 0,
+      gameId: "g-conflict",
+      version: 4,
+      gameName: "Conflict Match",
+      playerId: "p1",
+      playerHand: []
+    };
+
+    return {
+      ...baseState,
+      ...overrides,
+      players: overrides.players || baseState.players,
+      map: overrides.map || baseState.map,
+      gameConfig: overrides.gameConfig || baseState.gameConfig,
+      cardState: {
+        ...baseState.cardState,
+        ...(overrides.cardState || {})
+      },
+      diceRuleSet: {
+        ...baseState.diceRuleSet,
+        ...(overrides.diceRuleSet || {})
+      },
+      playerHand: Object.prototype.hasOwnProperty.call(overrides, "playerHand")
+        ? overrides.playerHand
+        : baseState.playerHand,
+      log: Object.prototype.hasOwnProperty.call(overrides, "log") ? overrides.log : baseState.log,
+      pendingConquest: Object.prototype.hasOwnProperty.call(overrides, "pendingConquest")
+        ? overrides.pendingConquest
+        : baseState.pendingConquest
+    };
+  }
+
+  let currentState = buildGameplayState();
+  let actionCalls = 0;
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: { id: "u1", username: "alice", role: "user", authMethods: ["password"] }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: currentState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.route("**/api/action", async (route) => {
+    const payload = route.request().postDataJSON();
+    actionCalls += 1;
+
+    if (actionCalls === 1) {
+      expect(payload.type).toBe("reinforce");
+      expect(payload.expectedVersion).toBe(4);
+      expect(payload.territoryId).toBe("aurora");
+
+      currentState = buildGameplayState({
+        version: 5,
+        turnPhase: "attack",
+        reinforcementPool: 0,
+        map: [
+          {
+            id: "aurora",
+            name: "Aurora",
+            neighbors: ["bastion"],
+            continentId: "north",
+            ownerId: "p1",
+            armies: 4,
+            x: 0.2,
+            y: 0.3
+          },
+          {
+            id: "bastion",
+            name: "Bastion",
+            neighbors: ["aurora"],
+            continentId: "north",
+            ownerId: "p2",
+            armies: 1,
+            x: 0.65,
+            y: 0.45
+          }
+        ]
+      });
+
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+          code: "VERSION_CONFLICT",
+          currentVersion: 5,
+          state: { ...currentState }
+        })
+      });
+      return;
+    }
+
+    expect(payload.type).toBe("attack");
+    expect(payload.expectedVersion).toBe(5);
+    expect(payload.fromId).toBe("aurora");
+    expect(payload.toId).toBe("bastion");
+    expect(payload.attackDice).toBe(1);
+
+    currentState = buildGameplayState({
+      version: 6,
+      turnPhase: "attack",
+      reinforcementPool: 0,
+      pendingConquest: {
+        fromId: "aurora",
+        toId: "bastion",
+        minArmies: 1,
+        maxArmies: 3
+      },
+      lastCombat: {
+        fromTerritoryId: "aurora",
+        toTerritoryId: "bastion",
+        attackerPlayerId: "p1",
+        defenderPlayerId: "p2",
+        attackDiceCount: 1,
+        defendDiceCount: 1,
+        attackerRolls: [6],
+        defenderRolls: [1],
+        comparisons: [{ attackerDie: 6, defenderDie: 1, winner: "attacker" }],
+        conqueredTerritory: false,
+        defenderReducedToZero: true
+      }
+    });
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        state: { ...currentState }
+      })
+    });
+  });
+
+  await page.goto("/react/game/g-conflict");
+
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByTestId("status-summary")).toContainText(
+    /Rinforzi disponibili:\s*1/i
+  );
+
+  await page.getByRole("button", { name: "Aggiungi" }).click();
+
+  await expect(page.getByTestId("react-shell-game-feedback")).toContainText(
+    /Ho ricaricato lo stato piu recente|reloaded the latest state/i
+  );
+  await expect(page.getByTestId("status-summary")).toContainText(
+    /Rinforzi disponibili:\s*0/i
+  );
+  await expect(page.locator("#attack-group")).toBeVisible();
+
+  await page.locator("#attack-to").selectOption("bastion");
+  await page.locator("#attack-dice").selectOption("1");
+  await page.getByRole("button", { name: "Lancia attacco" }).click();
+
+  await expect(page.locator("#conquest-group")).toBeVisible();
+  await expect(page.locator("#conquest-armies")).toHaveAttribute("placeholder", "1");
+});

--- a/e2e/smoke/react-shell-gameplay.spec.ts
+++ b/e2e/smoke/react-shell-gameplay.spec.ts
@@ -1,0 +1,299 @@
+const { test, expect } = require("@playwright/test");
+
+const {
+  attachSessionCookie,
+  findAttackPair,
+  getReinforcementCount,
+  queueNextAttackRolls,
+  resetGame,
+  uniqueUser
+} = require("../support/game-helpers");
+
+async function createAuthenticatedSession(page, username, password = "secret123") {
+  const registerResponse = await page.request.post("/api/auth/register", {
+    data: { username, password }
+  });
+  await expect(registerResponse.ok()).toBeTruthy();
+
+  const loginResponse = await page.request.post("/api/auth/login", {
+    data: { username, password }
+  });
+  await expect(loginResponse.ok()).toBeTruthy();
+
+  const sessionToken = loginResponse.headers()["set-cookie"]?.match(/netrisk_session=([^;]+)/)?.[1];
+  expect(sessionToken).toBeTruthy();
+
+  return sessionToken;
+}
+
+async function createGame(page, sessionToken, payload) {
+  const response = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` },
+    data: payload
+  });
+  await expect(response.ok()).toBeTruthy();
+  return response.json();
+}
+
+async function joinGame(page, sessionToken, gameId) {
+  const response = await page.request.post("/api/join", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` },
+    data: { gameId }
+  });
+  await expect(response.ok()).toBeTruthy();
+  return response.json();
+}
+
+function mockTradeState({ playerHand, reinforcementPool = 3, mustTrade = false }) {
+  return {
+    phase: "active",
+    turnPhase: "reinforcement",
+    players: [
+      {
+        id: "p1",
+        name: "alice",
+        color: "#e85d04",
+        connected: true,
+        isAi: false,
+        territoryCount: 3,
+        eliminated: false,
+        cardCount: playerHand.length
+      },
+      {
+        id: "p2",
+        name: "CPU",
+        color: "#0f4c5c",
+        connected: true,
+        isAi: true,
+        territoryCount: 2,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "aurora",
+        name: "Aurora",
+        neighbors: ["bastion"],
+        continentId: "north",
+        ownerId: "p1",
+        armies: 3,
+        x: 0.2,
+        y: 0.3
+      },
+      {
+        id: "bastion",
+        name: "Bastion",
+        neighbors: ["aurora"],
+        continentId: "north",
+        ownerId: "p2",
+        armies: 1,
+        x: 0.65,
+        y: 0.45
+      }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool,
+    winnerId: null,
+    gameConfig: {
+      mapId: "classic-mini",
+      mapName: "Classic Mini",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    log: ["Trade React gameplay test"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: false,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 5,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: mustTrade
+    },
+    gameId: "g-1",
+    version: 4,
+    gameName: "React Trade Match",
+    playerId: "p1",
+    playerHand
+  };
+}
+
+test("react gameplay deep links support the core turn flow and the legacy fallback", async ({
+  browser
+}) => {
+  test.slow();
+
+  const ownerContext = await browser.newContext();
+  const joinerContext = await browser.newContext();
+  const ownerPage = await ownerContext.newPage();
+  const joinerPage = await joinerContext.newPage();
+
+  await resetGame(ownerPage);
+
+  const ownerUsername = uniqueUser("rsh_game_owner");
+  const joinerUsername = uniqueUser("rsh_game_joiner");
+  const ownerSession = await createAuthenticatedSession(ownerPage, ownerUsername);
+  const joinerSession = await createAuthenticatedSession(joinerPage, joinerUsername);
+
+  const createdGame = await createGame(ownerPage, ownerSession, {
+    name: uniqueUser("react_gameplay"),
+    totalPlayers: 2,
+    players: [
+      { slot: 1, type: "human" },
+      { slot: 2, type: "human" }
+    ]
+  });
+  await joinGame(joinerPage, joinerSession, createdGame.game.id);
+
+  await attachSessionCookie(ownerPage, ownerSession);
+  await attachSessionCookie(joinerPage, joinerSession);
+
+  await ownerPage.goto(`/react/game/${createdGame.game.id}`);
+  await joinerPage.goto(`/react/game/${createdGame.game.id}`);
+
+  await expect(ownerPage.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(joinerPage.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(ownerPage.getByText(createdGame.game.name)).toBeVisible();
+  await expect(ownerPage.getByRole("button", { name: "Avvia partita" })).toBeVisible();
+
+  await ownerPage.getByRole("button", { name: "Avvia partita" }).click();
+  await expect(ownerPage.getByTestId("phase-indicator")).not.toContainText(/Lobby/i, {
+    timeout: 15000
+  });
+
+  const displayedOwnerName = (await ownerPage.getByTestId("current-player-indicator").innerText()).trim();
+  const attackPair = await findAttackPair(ownerPage, displayedOwnerName);
+  const reinforceButton = ownerPage.getByRole("button", { name: "Aggiungi" });
+
+  for (;;) {
+    const reinforcementCount = await getReinforcementCount(ownerPage);
+    if (reinforcementCount <= 0) {
+      break;
+    }
+
+    await reinforceButton.click();
+  }
+
+  await expect(ownerPage.getByTestId("status-summary")).toContainText(
+    /Rinforzi disponibili:\s*0/i
+  );
+  await ownerPage.locator("#attack-from").selectOption(attackPair.fromId);
+  await ownerPage.locator("#attack-to").selectOption(attackPair.toId);
+  await ownerPage.locator("#attack-dice").selectOption("1");
+  await queueNextAttackRolls(ownerPage, 6, 1);
+  await ownerPage.getByRole("button", { name: "Lancia attacco" }).click();
+
+  await expect(ownerPage.locator("#conquest-group")).toBeVisible();
+  await ownerPage.locator("#conquest-armies").fill("1");
+  await ownerPage.getByRole("button", { name: "Sposta armate" }).click();
+
+  await ownerPage.locator("#end-turn-button").click();
+  await expect(ownerPage.locator("#fortify-group")).toBeVisible();
+  await expect(ownerPage.locator("#end-turn-button")).toHaveText("Termina turno");
+
+  await ownerPage.locator("#fortify-from").selectOption(attackPair.fromId);
+  await ownerPage.locator("#fortify-to").selectOption(attackPair.toId);
+  await ownerPage.locator("#fortify-armies").fill("1");
+  await ownerPage.locator("#fortify-button").click();
+
+  await expect(ownerPage.locator("#fortify-button")).toBeDisabled();
+  await expect(
+    ownerPage.locator(`[data-territory-id="${attackPair.toId}"] .territory-armies`)
+  ).toHaveText("2");
+
+  await ownerPage.locator("#end-turn-button").click();
+
+  await expect(joinerPage.getByTestId("status-summary")).toContainText(
+    /Rinforzi disponibili:\s*[1-9]\d*/i,
+    { timeout: 15000 }
+  );
+  await expect(joinerPage.getByRole("button", { name: "Aggiungi" })).toBeEnabled();
+  await expect(ownerPage.locator("#end-turn-button")).toBeHidden({ timeout: 15000 });
+
+  await ownerPage.getByRole("link", { name: "Legacy fallback" }).click();
+  await expect.poll(() => ownerPage.url(), { timeout: 15000 }).toMatch(
+    new RegExp(`/game/${createdGame.game.id}$`)
+  );
+  await expect(ownerPage.locator("#game-status")).toContainText(createdGame.game.name, {
+    timeout: 15000
+  });
+
+  await ownerContext.close();
+  await joinerContext.close();
+});
+
+test("react gameplay handles the forced trade flow on the React route", async ({ page }) => {
+  let currentState = mockTradeState({
+    playerHand: [
+      { id: "c1", type: "infantry", territoryId: "aurora" },
+      { id: "c2", type: "infantry", territoryId: "bastion" },
+      { id: "c3", type: "infantry", territoryId: "aurora" },
+      { id: "c4", type: "wild" }
+    ],
+    mustTrade: true
+  });
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: { id: "u1", username: "alice", role: "user", authMethods: ["password"] }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: currentState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.route("**/api/cards/trade", async (route) => {
+    const payload = route.request().postDataJSON();
+    expect(payload.cardIds).toEqual(["c1", "c2", "c3"]);
+
+    currentState = mockTradeState({
+      playerHand: [{ id: "c4", type: "wild" }],
+      reinforcementPool: 7,
+      mustTrade: false
+    });
+
+    await route.fulfill({ json: { ok: true, bonus: 4, state: { ...currentState } } });
+  });
+
+  await page.goto("/react/game/g-1");
+
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.locator("#trade-alert")).toBeVisible();
+  await expect(page.locator("#card-trade-group")).toBeVisible();
+  await expect(page.locator("#card-trade-alert")).toContainText(
+    /Devi scambiare subito 3 carte/i
+  );
+  await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(4);
+  await expect(page.locator("#card-trade-button")).toBeDisabled();
+
+  await page.locator('[data-card-id="c1"]').click();
+  await page.locator('[data-card-id="c2"]').click();
+  await page.locator('[data-card-id="c3"]').click();
+
+  await expect(page.locator("#card-trade-button")).toBeEnabled();
+  await page.locator("#card-trade-button").click();
+
+  await expect(page.getByTestId("status-summary")).toContainText("7");
+  await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(1);
+  await expect(page.locator("#card-trade-help")).toContainText("0/3 carte selezionate");
+  await expect(page.getByTestId("react-shell-game-feedback")).toContainText(
+    /Set valido|Valid set/
+  );
+});

--- a/e2e/smoke/react-shell-gameplay.spec.ts
+++ b/e2e/smoke/react-shell-gameplay.spec.ts
@@ -298,6 +298,148 @@ test("react gameplay handles the forced trade flow on the React route", async ({
   );
 });
 
+test("react gameplay ignores stale cached player ids from a different game", async ({ page }) => {
+  const lobbyState = {
+    phase: "lobby",
+    turnPhase: "reinforcement",
+    players: [
+      {
+        id: "host-player",
+        name: "host",
+        color: "#e85d04",
+        connected: true,
+        isAi: false,
+        territoryCount: 0,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "aurora",
+        name: "Aurora",
+        neighbors: ["bastion"],
+        continentId: "north",
+        ownerId: null,
+        armies: 0,
+        x: 0.2,
+        y: 0.3
+      },
+      {
+        id: "bastion",
+        name: "Bastion",
+        neighbors: ["aurora"],
+        continentId: "north",
+        ownerId: null,
+        armies: 0,
+        x: 0.65,
+        y: 0.45
+      }
+    ],
+    continents: [],
+    currentPlayerId: null,
+    reinforcementPool: 0,
+    winnerId: null,
+    gameConfig: {
+      mapId: "classic-mini",
+      mapName: "Classic Mini",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "human" }]
+    },
+    log: ["Stale player id regression"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: false,
+    attacksThisTurn: 0,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 5,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    gameId: "g-fresh",
+    version: 4,
+    gameName: "Fresh Lobby",
+    playerId: null,
+    playerHand: []
+  };
+
+  let currentState = lobbyState;
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "frontline-player-id",
+      JSON.stringify({
+        gameId: "g-stale",
+        playerId: "stale-player"
+      })
+    );
+  });
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: { id: "u1", username: "alice", role: "user", authMethods: ["password"] }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: currentState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.route("**/api/join", async (route) => {
+    currentState = {
+      ...lobbyState,
+      playerId: "joined-player",
+      players: [
+        ...lobbyState.players,
+        {
+          id: "joined-player",
+          name: "alice",
+          color: "#0f4c5c",
+          connected: true,
+          isAi: false,
+          territoryCount: 0,
+          eliminated: false,
+          cardCount: 0
+        }
+      ],
+      version: 5
+    };
+
+    await route.fulfill({
+      json: {
+        ok: true,
+        playerId: "joined-player",
+        state: currentState
+      }
+    });
+  });
+
+  await page.goto("/react/game/g-fresh");
+
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByRole("button", { name: /join|entra nella lobby|unisciti/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Avvia partita" })).toBeHidden();
+
+  await page.getByRole("button", { name: /join|entra nella lobby|unisciti/i }).click();
+
+  await expect(page.getByRole("button", { name: "Avvia partita" })).toBeVisible();
+});
+
 test("react gameplay recovers from VERSION_CONFLICT by refreshing the snapshot and continuing the turn", async ({
   page
 }) => {

--- a/e2e/smoke/react-shell-lobby.spec.ts
+++ b/e2e/smoke/react-shell-lobby.spec.ts
@@ -69,7 +69,7 @@ test("react lobby shows 15 sessions initially and loads more on scroll", async (
   await expect(page.getByTestId("react-shell-lobby-load-more")).toContainText(/19/);
 });
 
-test("react lobby can open a selected game and hand off to the legacy board", async ({ page }) => {
+test("react lobby can open a selected game and navigate to the React gameplay route", async ({ page }) => {
   await resetGame(page);
 
   const ownerUsername = uniqueUser("rsh_lobby_owner_open");
@@ -104,9 +104,10 @@ test("react lobby can open a selected game and hand off to the legacy board", as
   await page.getByTestId("react-shell-lobby-open-selected").click();
 
   await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(
-    new RegExp(`/game/${createdGame.game.id}$`)
+    new RegExp(`/react/game/${createdGame.game.id}$`)
   );
-  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByText(gameName)).toBeVisible();
 
   const statePayload = await loadGameState(page, ownerSession, createdGame.game.id);
   expect(
@@ -114,7 +115,7 @@ test("react lobby can open a selected game and hand off to the legacy board", as
   ).toBeTruthy();
 });
 
-test("react lobby can join an available game and hand off to the legacy board", async ({ page }) => {
+test("react lobby can join an available game and navigate to the React gameplay route", async ({ page }) => {
   await resetGame(page);
 
   const ownerSession = await createAuthenticatedSession(page, uniqueUser("rsh_lobby_owner_join"));
@@ -151,14 +152,17 @@ test("react lobby can join an available game and hand off to the legacy board", 
   await page.getByTestId("react-shell-lobby-join-selected").click();
 
   await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(
-    new RegExp(`/game/${createdGame.game.id}$`)
+    new RegExp(`/react/game/${createdGame.game.id}$`)
   );
-  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByText(gameName)).toBeVisible();
 
   const statePayload = await loadGameState(page, joinerSession, createdGame.game.id);
-  expect(
-    statePayload.players.some((player) => joinerUsername.startsWith(String(player.name || "")))
-  ).toBeTruthy();
+  const joinedPlayer =
+    statePayload.players.find((player) => player.id === statePayload.playerId) ||
+    statePayload.players.find((player) => joinerUsername.startsWith(String(player.name || "")));
+  expect(joinedPlayer).toBeTruthy();
+  await expect(page.getByTestId("current-player-indicator")).toContainText(String(joinedPlayer.name || ""));
 });
 
 test("react lobby shows controlled feedback when join fails", async ({ page }) => {

--- a/e2e/smoke/react-shell-new-game.spec.ts
+++ b/e2e/smoke/react-shell-new-game.spec.ts
@@ -21,7 +21,7 @@ async function createAuthenticatedSession(page, username, password = "secret123"
 }
 
 function currentGameId(url) {
-  return url.match(/\/game\/([^/?#]+)/)?.[1] || null;
+  return url.match(/\/(?:react\/)?game\/([^/?#]+)/)?.[1] || null;
 }
 
 async function loadGameState(page, sessionToken, gameId) {
@@ -75,7 +75,7 @@ test("react new game shows loading before creation options render", async ({ pag
   await expect(page.getByTestId("react-shell-lobby-create-page")).toBeVisible();
 });
 
-test("react new game creates a session and hands off to the legacy board", async ({ page }) => {
+test("react new game creates a session and opens the React gameplay route", async ({ page }) => {
   await resetGame(page);
 
   const commander = uniqueUser("rsh_new_game_basic");
@@ -92,8 +92,9 @@ test("react new game creates a session and hands off to the legacy board", async
   await page.getByTestId("react-shell-new-game-slot-3").selectOption("ai");
   await page.getByTestId("react-shell-new-game-submit").click();
 
-  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/game\/[^/?#]+$/);
-  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/react\/game\/[^/?#]+$/);
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByText(gameName)).toBeVisible();
 
   const gameId = currentGameId(page.url());
   expect(gameId).toBeTruthy();
@@ -176,8 +177,9 @@ test("react new game supports advanced module, profile, and option selections", 
 
   await page.getByTestId("react-shell-new-game-submit").click();
 
-  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/game\/[^/?#]+$/);
-  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/react\/game\/[^/?#]+$/);
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByText(gameName)).toBeVisible();
 
   const gameId = currentGameId(page.url());
   expect(gameId).toBeTruthy();

--- a/e2e/smoke/react-shell.spec.ts
+++ b/e2e/smoke/react-shell.spec.ts
@@ -158,7 +158,7 @@ test("react profile shows controlled feedback when the query payload is invalid"
   );
 });
 
-test("react profile participating games hand off to the legacy gameplay route", async ({ page }) => {
+test("react profile participating games open the React gameplay route", async ({ page }) => {
   await resetGame(page);
 
   const username = uniqueUser("rsh_prof_game");
@@ -185,16 +185,16 @@ test("react profile participating games hand off to the legacy gameplay route", 
 
   const openLink = page.getByTestId(`react-shell-profile-open-${createdGame.game.id}`);
   await expect(openLink).toBeVisible();
-  await expect(openLink).toHaveAttribute("href", new RegExp(`/game/${createdGame.game.id}$`));
+  await expect(openLink).toHaveAttribute("href", new RegExp(`/react/game/${createdGame.game.id}$`));
   await expect(page.getByText(gameName)).toBeVisible();
 
   await openLink.click();
 
   await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(
-    new RegExp(`/game/${createdGame.game.id}$`)
+    new RegExp(`/react/game/${createdGame.game.id}$`)
   );
-  await expect(page.locator("#game-status")).toContainText(gameName, { timeout: 15000 });
-  await expect(page.locator("#game-map-meta")).toContainText("World Classic", { timeout: 15000 });
+  await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
+  await expect(page.getByText(gameName)).toBeVisible();
   await expect(page.locator("#players")).toContainText(username, { timeout: 15000 });
 });
 
@@ -238,16 +238,41 @@ test("react login returns the user to the protected route that triggered it", as
   });
   await expect(registerResponse.ok()).toBeTruthy();
 
-  await page.goto("/react/game/game-99");
-  await expect(page).toHaveURL(/\/react\/login\?next=%2Fgame%2Fgame-99$/);
+  const loginResponse = await page.request.post("/api/auth/login", {
+    data: { username, password }
+  });
+  await expect(loginResponse.ok()).toBeTruthy();
+
+  const sessionToken = loginResponse.headers()["set-cookie"]?.match(/netrisk_session=([^;]+)/)?.[1];
+  expect(sessionToken).toBeTruthy();
+
+  const createGameResponse = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` },
+    data: {
+      name: `React login ${Date.now().toString(36).slice(-4)}`,
+      totalPlayers: 2,
+      players: [
+        { slot: 1, type: "human" },
+        { slot: 2, type: "ai" }
+      ]
+    }
+  });
+  await expect(createGameResponse.ok()).toBeTruthy();
+  const createdGame = await createGameResponse.json();
+
+  await page.context().clearCookies();
+
+  await page.goto(`/react/game/${createdGame.game.id}`);
+  await expect(page).toHaveURL(
+    new RegExp(`/react/login\\?next=%2Fgame%2F${createdGame.game.id}$`)
+  );
 
   await page.getByLabel("Username").fill(username);
   await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: "Sign in" }).click();
 
-  await expect(page).toHaveURL(/\/react\/game\/game-99$/);
+  await expect(page).toHaveURL(new RegExp(`/react/game/${createdGame.game.id}$`));
   await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
-  await expect(page.getByText("Selected game id: game-99")).toBeVisible();
 });
 
 test("react shell serves direct unknown routes into the SPA not-found page", async ({ page }) => {

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -231,7 +231,7 @@ export function GameRoute() {
     territoriesById[territory.id] = territory;
   }
 
-  const storedPlayerId = readCurrentPlayerId();
+  const storedPlayerId = readCurrentPlayerId(gameId || null);
   const myPlayerId = snapshot?.playerId || storedPlayerId || null;
   const me = myPlayerId ? playersById[myPlayerId] || null : null;
   const currentPlayer = snapshot?.currentPlayerId
@@ -315,10 +315,10 @@ export function GameRoute() {
     snapshot?.turnPhase === "fortify" ? t("game.actions.endTurn") : t("game.runtime.goToFortify");
 
   useEffect(() => {
-    if (snapshot?.playerId) {
-      storeCurrentPlayerId(snapshot.playerId);
+    if (snapshot?.playerId && gameId) {
+      storeCurrentPlayerId(snapshot.playerId, gameId);
     }
-  }, [snapshot?.playerId]);
+  }, [gameId, snapshot?.playerId]);
 
   useEffect(() => {
     setSelectedTradeCardIds((current) =>
@@ -329,9 +329,9 @@ export function GameRoute() {
   const applyMutationPayload = useEffectEvent(
     (payload: GameMutationResponse, options: { feedback?: string } = {}) => {
       if (payload.playerId) {
-        storeCurrentPlayerId(payload.playerId);
+        storeCurrentPlayerId(payload.playerId, gameId || payload.state?.gameId || null);
       } else if (payload.state?.playerId) {
-        storeCurrentPlayerId(payload.state.playerId);
+        storeCurrentPlayerId(payload.state.playerId, payload.state.gameId || gameId || null);
       }
 
       if (payload.state) {
@@ -355,7 +355,10 @@ export function GameRoute() {
     if (versionConflict) {
       queryClient.setQueryData(queryKey, versionConflict.state);
       if (versionConflict.state.playerId) {
-        storeCurrentPlayerId(versionConflict.state.playerId);
+        storeCurrentPlayerId(
+          versionConflict.state.playerId,
+          versionConflict.state.gameId || gameId || null
+        );
       }
       setActionError("");
       setFeedbackMessage(t("game.errors.versionConflict"));
@@ -374,7 +377,7 @@ export function GameRoute() {
     const nextPayload = parseGameEventPayload(JSON.parse(event.data));
     queryClient.setQueryData(gameplayStateQueryKey(gameId), nextPayload);
     if (nextPayload.playerId) {
-      storeCurrentPlayerId(nextPayload.playerId);
+      storeCurrentPlayerId(nextPayload.playerId, nextPayload.gameId || gameId);
     }
     setStreamStatus("live");
   });

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -109,7 +109,10 @@ function normalizeSelectNumber(
   return String(clamp(parsed, minimum, maximum));
 }
 
-function territoryOwnerName(territory: SnapshotTerritory, playersById: Record<string, SnapshotPlayer>): string {
+function territoryOwnerName(
+  territory: SnapshotTerritory,
+  playersById: Record<string, SnapshotPlayer>
+): string {
   if (!territory.ownerId) {
     return t("game.runtime.none");
   }
@@ -171,8 +174,8 @@ function GameEmptyRoute() {
       <p className="status-label">Game</p>
       <h2>{t("game.runtime.selectGameFromList")}</h2>
       <p className="status-copy">
-        {t("game.runtime.openGame")} via lobby/profile, then return here for the live React
-        gameplay route.
+        {t("game.runtime.openGame")} via lobby/profile, then return here for the live React gameplay
+        route.
       </p>
       <div className="shell-actions">
         <Link className="refresh-button" to="/lobby">
@@ -231,11 +234,15 @@ export function GameRoute() {
   const storedPlayerId = readCurrentPlayerId();
   const myPlayerId = snapshot?.playerId || storedPlayerId || null;
   const me = myPlayerId ? playersById[myPlayerId] || null : null;
-  const currentPlayer = snapshot?.currentPlayerId ? playersById[snapshot.currentPlayerId] || null : null;
+  const currentPlayer = snapshot?.currentPlayerId
+    ? playersById[snapshot.currentPlayerId] || null
+    : null;
   const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
   const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];
   const localizedLog = translateGameLogEntries(snapshot);
-  const myTerritories = (snapshot?.map || []).filter((territory) => territory.ownerId === myPlayerId);
+  const myTerritories = (snapshot?.map || []).filter(
+    (territory) => territory.ownerId === myPlayerId
+  );
   const currentVersion =
     snapshot && Number.isInteger(snapshot.version) ? snapshot.version : undefined;
   const isMyTurn = Boolean(
@@ -247,14 +254,18 @@ export function GameRoute() {
   const showJoinLobby = snapshot?.phase === "lobby" && !myPlayerId;
   const showStartGame = snapshot?.phase === "lobby" && Boolean(myPlayerId);
   const showReinforceGroup = Boolean(
-    isMyTurn && snapshot?.turnPhase === "reinforcement" && Number(snapshot?.reinforcementPool || 0) > 0
+    isMyTurn &&
+    snapshot?.turnPhase === "reinforcement" &&
+    Number(snapshot?.reinforcementPool || 0) > 0
   );
   const showAttackGroup = Boolean(
     isMyTurn && snapshot?.turnPhase === "attack" && !snapshot?.pendingConquest
   );
   const showConquestGroup = Boolean(isMyTurn && snapshot?.pendingConquest);
   const showFortifyGroup = Boolean(isMyTurn && snapshot?.turnPhase === "fortify");
-  const showEndTurn = Boolean(isMyTurn && snapshot?.phase === "active" && !snapshot?.pendingConquest);
+  const showEndTurn = Boolean(
+    isMyTurn && snapshot?.phase === "active" && !snapshot?.pendingConquest
+  );
   const showSurrender = Boolean(myPlayerId && snapshot?.phase === "active");
   const reinforceTerritoryId = selectOrFallback(
     selectedReinforceTerritoryId,
@@ -716,7 +727,10 @@ export function GameRoute() {
       ) : null}
 
       {actionError ? (
-        <div className="profile-query-state profile-query-state-error" data-testid="react-shell-game-action-error">
+        <div
+          className="profile-query-state profile-query-state-error"
+          data-testid="react-shell-game-action-error"
+        >
           <p className="metric-copy">{actionError}</p>
         </div>
       ) : null}
@@ -790,7 +804,9 @@ export function GameRoute() {
             style={{
               aspectRatio: mapAspectRatio(snapshot),
               ...(snapshot.mapVisual?.imageUrl
-                ? { backgroundImage: `linear-gradient(rgba(15, 22, 36, 0.18), rgba(15, 22, 36, 0.18)), url(${snapshot.mapVisual.imageUrl})` }
+                ? {
+                    backgroundImage: `linear-gradient(rgba(15, 22, 36, 0.18), rgba(15, 22, 36, 0.18)), url(${snapshot.mapVisual.imageUrl})`
+                  }
                 : {})
             }}
           >
@@ -852,7 +868,9 @@ export function GameRoute() {
           </div>
 
           <div className="game-map-legend">
-            <span>Map picks drive the form selections below. Rule validation stays on the backend.</span>
+            <span>
+              Map picks drive the form selections below. Rule validation stays on the backend.
+            </span>
           </div>
         </section>
 
@@ -863,7 +881,9 @@ export function GameRoute() {
                 <p className="status-label">{t("game.command.eyebrow")}</p>
                 <h3>{t("game.command.heading")}</h3>
               </div>
-              <span className="status-pill">{currentPlayer?.name || t("game.runtime.waiting")}</span>
+              <span className="status-pill">
+                {currentPlayer?.name || t("game.runtime.waiting")}
+              </span>
             </div>
 
             {showJoinLobby ? (
@@ -960,7 +980,11 @@ export function GameRoute() {
                 </button>
               </section>
 
-              <section id="reinforce-group" className="game-action-group" hidden={!showReinforceGroup}>
+              <section
+                id="reinforce-group"
+                className="game-action-group"
+                hidden={!showReinforceGroup}
+              >
                 <div className="card-header gameplay-subsection-header">
                   <div>
                     <p className="status-label">{t("game.actions.reinforce")}</p>
@@ -1050,7 +1074,9 @@ export function GameRoute() {
                     value={attackDiceCount}
                     onChange={(event) => setSelectedAttackDiceCount(event.target.value)}
                   >
-                    {!maxAttackDice ? <option value="">{t("game.runtime.noDiceAvailable")}</option> : null}
+                    {!maxAttackDice ? (
+                      <option value="">{t("game.runtime.noDiceAvailable")}</option>
+                    ) : null}
                     {Array.from({ length: maxAttackDice }, (_, index) => index + 1).map((count) => (
                       <option key={count} value={String(count)}>
                         {t("game.runtime.attackDiceOption", {
@@ -1077,12 +1103,18 @@ export function GameRoute() {
                     onClick={() => void handleAttack("attackBanzai")}
                     disabled={!attackFromId || !attackToId || !attackDiceCount || actionPending}
                   >
-                    {actionMutation.isPending ? t("game.runtime.banzaiLoading") : t("game.actions.banzai")}
+                    {actionMutation.isPending
+                      ? t("game.runtime.banzaiLoading")
+                      : t("game.actions.banzai")}
                   </button>
                 </div>
               </section>
 
-              <section id="conquest-group" className="game-action-group" hidden={!showConquestGroup}>
+              <section
+                id="conquest-group"
+                className="game-action-group"
+                hidden={!showConquestGroup}
+              >
                 <div className="card-header gameplay-subsection-header">
                   <div>
                     <p className="status-label">{t("game.actions.afterConquest")}</p>

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -1,0 +1,1316 @@
+import { useEffect, useEffectEvent, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+  GameMutationResponse,
+  GameSnapshot,
+  SnapshotCard,
+  SnapshotPlayer,
+  SnapshotTerritory
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+import type { ApiClientError } from "@frontend-core/api/http.mts";
+import {
+  extractGameVersionConflict,
+  getGameState,
+  joinGame,
+  parseGameEventPayload,
+  sendGameAction,
+  startGame,
+  tradeCards
+} from "@frontend-core/api/client.mts";
+import { messageFromError } from "@frontend-core/errors.mts";
+import { t, translateGameLogEntries, translateServerMessage } from "@frontend-i18n";
+
+import { useAuth } from "@react-shell/auth";
+import { buildLegacyGamePath } from "@react-shell/legacy-game-handoff";
+import { readCurrentPlayerId, storeCurrentPlayerId } from "@react-shell/player-session";
+import { gameplayStateQueryKey } from "@react-shell/react-query";
+
+type StreamStatus = "connecting" | "live" | "reconnecting";
+type SelectionOption = {
+  id: string;
+};
+
+function phaseLabel(phase: string | null | undefined): string {
+  if (phase === "active") {
+    return t("common.phase.active");
+  }
+
+  if (phase === "finished") {
+    return t("common.phase.finished");
+  }
+
+  return t("common.phase.lobby");
+}
+
+function turnPhaseLabel(turnPhase: string | null | undefined): string {
+  if (turnPhase === "reinforcement") {
+    return t("game.actions.reinforce");
+  }
+
+  if (turnPhase === "attack") {
+    return t("game.actions.attack");
+  }
+
+  if (turnPhase === "fortify") {
+    return t("game.actions.fortify");
+  }
+
+  return phaseLabel(turnPhase);
+}
+
+function selectOrFallback(
+  selectedId: string | null | undefined,
+  options: SelectionOption[],
+  fallbackId: string | null = null
+): string {
+  if (selectedId && options.some((option) => option.id === selectedId)) {
+    return selectedId;
+  }
+
+  if (fallbackId && options.some((option) => option.id === fallbackId)) {
+    return fallbackId;
+  }
+
+  return options[0]?.id || "";
+}
+
+function parsePositiveInteger(value: string, fallbackValue: number): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallbackValue;
+  }
+
+  return parsed;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function normalizeSelectNumber(
+  value: string,
+  minimum: number,
+  maximum: number,
+  fallbackValue: number
+): string {
+  if (maximum < minimum) {
+    return "";
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    return String(fallbackValue);
+  }
+
+  return String(clamp(parsed, minimum, maximum));
+}
+
+function territoryOwnerName(territory: SnapshotTerritory, playersById: Record<string, SnapshotPlayer>): string {
+  if (!territory.ownerId) {
+    return t("game.runtime.none");
+  }
+
+  return playersById[territory.ownerId]?.name || territory.ownerId;
+}
+
+function territoryOptionLabel(
+  territory: SnapshotTerritory,
+  playersById: Record<string, SnapshotPlayer>
+): string {
+  return `${territory.name} · ${territoryOwnerName(territory, playersById)} · ${territory.armies}`;
+}
+
+function mapAspectRatio(snapshot: GameSnapshot | null): string {
+  const width = Number(snapshot?.mapVisual?.aspectRatio?.width || 0);
+  const height = Number(snapshot?.mapVisual?.aspectRatio?.height || 0);
+  if (width > 0 && height > 0) {
+    return `${width} / ${height}`;
+  }
+
+  return "16 / 10";
+}
+
+function cardTypeLabel(card: SnapshotCard): string {
+  if (card.type === "infantry") {
+    return t("game.runtime.cardType.infantry");
+  }
+
+  if (card.type === "cavalry") {
+    return t("game.runtime.cardType.cavalry");
+  }
+
+  if (card.type === "artillery") {
+    return t("game.runtime.cardType.artillery");
+  }
+
+  if (card.type === "wild") {
+    return t("game.runtime.cardType.wild");
+  }
+
+  return t("game.runtime.cardType.default");
+}
+
+function translateGameplayError(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return translateServerMessage(
+      (error as ApiClientError).payload,
+      error.message || messageFromError(error, fallback) || fallback
+    );
+  }
+
+  return messageFromError(error, fallback);
+}
+
+function GameEmptyRoute() {
+  return (
+    <section className="status-panel" data-testid="react-shell-game-empty">
+      <p className="status-label">Game</p>
+      <h2>{t("game.runtime.selectGameFromList")}</h2>
+      <p className="status-copy">
+        {t("game.runtime.openGame")} via lobby/profile, then return here for the live React
+        gameplay route.
+      </p>
+      <div className="shell-actions">
+        <Link className="refresh-button" to="/lobby">
+          {t("lobby.heading")}
+        </Link>
+        <Link className="ghost-action" to="/profile">
+          {t("profile.heading")}
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export function GameRoute() {
+  const { gameId } = useParams();
+  const { state } = useAuth();
+  const queryClient = useQueryClient();
+  const [streamStatus, setStreamStatus] = useState<StreamStatus>("connecting");
+  const [actionError, setActionError] = useState("");
+  const [feedbackMessage, setFeedbackMessage] = useState("");
+  const [selectedReinforceTerritoryId, setSelectedReinforceTerritoryId] = useState("");
+  const [reinforceAmount, setReinforceAmount] = useState("1");
+  const [selectedAttackFromId, setSelectedAttackFromId] = useState("");
+  const [selectedAttackToId, setSelectedAttackToId] = useState("");
+  const [selectedAttackDiceCount, setSelectedAttackDiceCount] = useState("");
+  const [selectedFortifyFromId, setSelectedFortifyFromId] = useState("");
+  const [selectedFortifyToId, setSelectedFortifyToId] = useState("");
+  const [fortifyArmies, setFortifyArmies] = useState("1");
+  const [conquestArmies, setConquestArmies] = useState("");
+  const [selectedTradeCardIds, setSelectedTradeCardIds] = useState<string[]>([]);
+
+  const gameplayQuery = useQuery({
+    queryKey: gameplayStateQueryKey(gameId || "missing"),
+    enabled: Boolean(gameId),
+    queryFn: () =>
+      getGameState(gameId || "", {
+        errorMessage: t("game.errors.loadActiveGame"),
+        fallbackMessage: t("game.errors.loadActiveGame")
+      })
+  });
+
+  const snapshot = gameplayQuery.data || null;
+  const queryKey = gameplayStateQueryKey(gameId || "missing");
+  const authenticatedUser = state.status === "authenticated" ? state.user : null;
+
+  const playersById: Record<string, SnapshotPlayer> = {};
+  for (const player of snapshot?.players || []) {
+    playersById[player.id] = player;
+  }
+
+  const territoriesById: Record<string, SnapshotTerritory> = {};
+  for (const territory of snapshot?.map || []) {
+    territoriesById[territory.id] = territory;
+  }
+
+  const storedPlayerId = readCurrentPlayerId();
+  const myPlayerId = snapshot?.playerId || storedPlayerId || null;
+  const me = myPlayerId ? playersById[myPlayerId] || null : null;
+  const currentPlayer = snapshot?.currentPlayerId ? playersById[snapshot.currentPlayerId] || null : null;
+  const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
+  const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];
+  const localizedLog = translateGameLogEntries(snapshot);
+  const myTerritories = (snapshot?.map || []).filter((territory) => territory.ownerId === myPlayerId);
+  const currentVersion =
+    snapshot && Number.isInteger(snapshot.version) ? snapshot.version : undefined;
+  const isMyTurn = Boolean(
+    snapshot?.phase === "active" && myPlayerId && snapshot.currentPlayerId === myPlayerId
+  );
+  const mustTradeCards = Boolean(
+    isMyTurn && snapshot?.cardState?.currentPlayerMustTrade && playerHand.length
+  );
+  const showJoinLobby = snapshot?.phase === "lobby" && !myPlayerId;
+  const showStartGame = snapshot?.phase === "lobby" && Boolean(myPlayerId);
+  const showReinforceGroup = Boolean(
+    isMyTurn && snapshot?.turnPhase === "reinforcement" && Number(snapshot?.reinforcementPool || 0) > 0
+  );
+  const showAttackGroup = Boolean(
+    isMyTurn && snapshot?.turnPhase === "attack" && !snapshot?.pendingConquest
+  );
+  const showConquestGroup = Boolean(isMyTurn && snapshot?.pendingConquest);
+  const showFortifyGroup = Boolean(isMyTurn && snapshot?.turnPhase === "fortify");
+  const showEndTurn = Boolean(isMyTurn && snapshot?.phase === "active" && !snapshot?.pendingConquest);
+  const showSurrender = Boolean(myPlayerId && snapshot?.phase === "active");
+  const reinforceTerritoryId = selectOrFallback(
+    selectedReinforceTerritoryId,
+    myTerritories,
+    myTerritories[0]?.id || null
+  );
+  const attackFromId = selectOrFallback(
+    selectedAttackFromId,
+    myTerritories,
+    reinforceTerritoryId || null
+  );
+  const attackSource = attackFromId ? territoriesById[attackFromId] || null : null;
+  const attackTargets = (snapshot?.map || []).filter(
+    (territory) =>
+      Boolean(attackSource?.neighbors.includes(territory.id)) &&
+      Boolean(territory.ownerId) &&
+      territory.ownerId !== myPlayerId
+  );
+  const attackToId = selectOrFallback(selectedAttackToId, attackTargets);
+  const maxAttackDice = attackSource
+    ? Math.max(
+        0,
+        Math.min(Number(snapshot?.diceRuleSet?.attackerMaxDice || 3), attackSource.armies - 1)
+      )
+    : 0;
+  const attackDiceCount = maxAttackDice
+    ? normalizeSelectNumber(selectedAttackDiceCount, 1, maxAttackDice, maxAttackDice)
+    : "";
+  const fortifyFromId = selectOrFallback(
+    selectedFortifyFromId,
+    myTerritories,
+    reinforceTerritoryId || null
+  );
+  const fortifySource = fortifyFromId ? territoriesById[fortifyFromId] || null : null;
+  const fortifyTargets = myTerritories.filter(
+    (territory) =>
+      territory.id !== fortifyFromId && Boolean(fortifySource?.neighbors.includes(territory.id))
+  );
+  const fortifyToId = selectOrFallback(selectedFortifyToId, fortifyTargets);
+  const maxFortifyArmies = fortifySource ? Math.max(0, fortifySource.armies - 1) : 0;
+  const pendingConquestMin = Math.max(1, Number(snapshot?.pendingConquest?.minArmies || 1));
+  const pendingConquestMax = Math.max(
+    pendingConquestMin,
+    Number(snapshot?.pendingConquest?.maxArmies || snapshot?.pendingConquest?.minArmies || 1)
+  );
+  const endTurnLabel =
+    snapshot?.turnPhase === "fortify" ? t("game.actions.endTurn") : t("game.runtime.goToFortify");
+
+  useEffect(() => {
+    if (snapshot?.playerId) {
+      storeCurrentPlayerId(snapshot.playerId);
+    }
+  }, [snapshot?.playerId]);
+
+  useEffect(() => {
+    setSelectedTradeCardIds((current) =>
+      current.filter((cardId) => playerHand.some((card) => card.id === cardId)).slice(0, 3)
+    );
+  }, [playerHand]);
+
+  const applyMutationPayload = useEffectEvent(
+    (payload: GameMutationResponse, options: { feedback?: string } = {}) => {
+      if (payload.playerId) {
+        storeCurrentPlayerId(payload.playerId);
+      } else if (payload.state?.playerId) {
+        storeCurrentPlayerId(payload.state.playerId);
+      }
+
+      if (payload.state) {
+        queryClient.setQueryData(queryKey, payload.state);
+      }
+
+      setActionError("");
+      setFeedbackMessage(options.feedback || "");
+
+      if (!payload.state?.pendingConquest) {
+        setConquestArmies("");
+      }
+      if (!Array.isArray(payload.state?.playerHand) || !payload.state?.playerHand.length) {
+        setSelectedTradeCardIds([]);
+      }
+    }
+  );
+
+  const handleMutationError = useEffectEvent((error: unknown) => {
+    const versionConflict = extractGameVersionConflict(error);
+    if (versionConflict) {
+      queryClient.setQueryData(queryKey, versionConflict.state);
+      if (versionConflict.state.playerId) {
+        storeCurrentPlayerId(versionConflict.state.playerId);
+      }
+      setActionError("");
+      setFeedbackMessage(t("game.errors.versionConflict"));
+      return;
+    }
+
+    setFeedbackMessage("");
+    setActionError(translateGameplayError(error, t("errors.requestFailed")));
+  });
+
+  const handleEventMessage = useEffectEvent((event: MessageEvent<string>) => {
+    if (!gameId) {
+      return;
+    }
+
+    const nextPayload = parseGameEventPayload(JSON.parse(event.data));
+    queryClient.setQueryData(gameplayStateQueryKey(gameId), nextPayload);
+    if (nextPayload.playerId) {
+      storeCurrentPlayerId(nextPayload.playerId);
+    }
+    setStreamStatus("live");
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: () =>
+      joinGame(gameId || "", {
+        errorMessage: t("errors.requestFailed"),
+        fallbackMessage: t("errors.requestFailed")
+      }),
+    onSuccess: (payload) => applyMutationPayload(payload),
+    onError: handleMutationError
+  });
+
+  const startMutation = useMutation({
+    mutationFn: () => {
+      if (!gameId || !myPlayerId) {
+        throw new Error(t("game.invalidPlayer"));
+      }
+
+      return startGame(
+        {
+          gameId,
+          playerId: myPlayerId,
+          ...(currentVersion ? { expectedVersion: currentVersion } : {})
+        },
+        {
+          errorMessage: t("errors.requestFailed"),
+          fallbackMessage: t("errors.requestFailed")
+        }
+      );
+    },
+    onSuccess: (payload) => applyMutationPayload(payload),
+    onError: handleMutationError
+  });
+
+  const actionMutation = useMutation({
+    mutationFn: sendGameAction,
+    onSuccess: (payload) => applyMutationPayload(payload),
+    onError: handleMutationError
+  });
+
+  const tradeMutation = useMutation({
+    mutationFn: tradeCards,
+    onSuccess: (payload) =>
+      applyMutationPayload(payload, {
+        feedback:
+          typeof payload.bonus === "number"
+            ? t("game.runtime.tradeSuccess", { bonus: payload.bonus })
+            : ""
+      }),
+    onError: handleMutationError
+  });
+
+  useEffect(() => {
+    if (!gameId) {
+      return;
+    }
+
+    setStreamStatus("connecting");
+    const eventSource = new EventSource(`/api/events?gameId=${encodeURIComponent(gameId)}`, {
+      withCredentials: true
+    });
+
+    eventSource.onmessage = handleEventMessage;
+    eventSource.onerror = () => {
+      setStreamStatus((current) => (current === "live" ? "reconnecting" : current));
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [gameId, handleEventMessage]);
+
+  function submitGameAction(request: Parameters<typeof sendGameAction>[0]): Promise<void> {
+    return actionMutation.mutateAsync(request).then(() => undefined);
+  }
+
+  async function handleJoinLobby(): Promise<void> {
+    if (!gameId) {
+      return;
+    }
+
+    await joinMutation.mutateAsync();
+  }
+
+  async function handleStartGame(): Promise<void> {
+    await startMutation.mutateAsync();
+  }
+
+  async function handleReinforce(): Promise<void> {
+    if (!gameId || !myPlayerId || !reinforceTerritoryId) {
+      return;
+    }
+
+    const amount = clamp(
+      parsePositiveInteger(reinforceAmount, 1),
+      1,
+      Math.max(1, Number(snapshot?.reinforcementPool || 1))
+    );
+    await submitGameAction({
+      gameId,
+      playerId: myPlayerId,
+      type: "reinforce",
+      territoryId: reinforceTerritoryId,
+      amount,
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  async function handleAttack(type: "attack" | "attackBanzai"): Promise<void> {
+    if (!gameId || !myPlayerId || !attackFromId || !attackToId || !attackDiceCount) {
+      return;
+    }
+
+    await submitGameAction({
+      gameId,
+      playerId: myPlayerId,
+      type,
+      fromId: attackFromId,
+      toId: attackToId,
+      attackDice: Number(attackDiceCount),
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  async function handleMoveAfterConquest(): Promise<void> {
+    if (!gameId || !myPlayerId || !snapshot?.pendingConquest) {
+      return;
+    }
+
+    const armies = clamp(
+      parsePositiveInteger(conquestArmies, pendingConquestMin),
+      pendingConquestMin,
+      pendingConquestMax
+    );
+    await submitGameAction({
+      gameId,
+      playerId: myPlayerId,
+      type: "moveAfterConquest",
+      armies,
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  async function handleFortify(): Promise<void> {
+    if (!gameId || !myPlayerId || !fortifyFromId || !fortifyToId || maxFortifyArmies < 1) {
+      return;
+    }
+
+    const armies = clamp(parsePositiveInteger(fortifyArmies, 1), 1, maxFortifyArmies);
+    await submitGameAction({
+      gameId,
+      playerId: myPlayerId,
+      type: "fortify",
+      fromId: fortifyFromId,
+      toId: fortifyToId,
+      armies,
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  async function handleEndTurn(): Promise<void> {
+    if (!gameId || !myPlayerId) {
+      return;
+    }
+
+    await submitGameAction({
+      gameId,
+      playerId: myPlayerId,
+      type: "endTurn",
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  async function handleTradeCards(): Promise<void> {
+    if (!gameId || !myPlayerId || selectedTradeCardIds.length !== 3) {
+      return;
+    }
+
+    await tradeMutation.mutateAsync({
+      gameId,
+      playerId: myPlayerId,
+      cardIds: selectedTradeCardIds,
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  async function handleSurrender(): Promise<void> {
+    if (!gameId || !myPlayerId || !window.confirm(t("game.runtime.confirmSurrender"))) {
+      return;
+    }
+
+    await submitGameAction({
+      gameId,
+      playerId: myPlayerId,
+      type: "surrender",
+      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+    });
+  }
+
+  function toggleTradeCard(cardId: string): void {
+    setSelectedTradeCardIds((current) => {
+      if (current.includes(cardId)) {
+        return current.filter((entry) => entry !== cardId);
+      }
+
+      if (current.length >= 3) {
+        return [...current.slice(1), cardId];
+      }
+
+      return [...current, cardId];
+    });
+  }
+
+  function handleTerritorySelect(territoryId: string): void {
+    const territory = territoriesById[territoryId];
+    if (!territory) {
+      return;
+    }
+
+    if (
+      territory.ownerId === myPlayerId &&
+      fortifySource &&
+      territory.id !== fortifySource.id &&
+      fortifySource.neighbors.includes(territory.id)
+    ) {
+      setSelectedFortifyToId(territory.id);
+      return;
+    }
+
+    if (territory.ownerId === myPlayerId) {
+      setSelectedReinforceTerritoryId(territoryId);
+      setSelectedAttackFromId(territoryId);
+      setSelectedFortifyFromId(territoryId);
+      setSelectedAttackDiceCount("");
+      return;
+    }
+
+    if (
+      territory.ownerId &&
+      territory.ownerId !== myPlayerId &&
+      attackSource?.neighbors.includes(territoryId)
+    ) {
+      setSelectedAttackToId(territoryId);
+      return;
+    }
+
+    if (
+      territory.ownerId === myPlayerId &&
+      fortifySource &&
+      territory.id !== fortifySource.id &&
+      fortifySource.neighbors.includes(territory.id)
+    ) {
+      setSelectedFortifyToId(territory.id);
+    }
+  }
+
+  if (!gameId) {
+    return <GameEmptyRoute />;
+  }
+
+  if (gameplayQuery.isLoading && !snapshot) {
+    return (
+      <section className="status-panel" data-testid="react-shell-game-loading">
+        <p className="status-label">Game</p>
+        <h2>{t("game.runtime.loadingState")}</h2>
+        <p className="status-copy">{t("game.errors.loadActiveGame")}</p>
+      </section>
+    );
+  }
+
+  if (gameplayQuery.isError && !snapshot) {
+    return (
+      <section className="status-panel status-panel-error" data-testid="react-shell-game-error">
+        <p className="status-label">Game</p>
+        <h2>{t("game.errors.loadActiveGame")}</h2>
+        <p className="status-copy">
+          {translateGameplayError(gameplayQuery.error, t("game.errors.loadActiveGame"))}
+        </p>
+        <div className="shell-actions">
+          <button
+            type="button"
+            className="refresh-button"
+            onClick={() => void gameplayQuery.refetch()}
+          >
+            Retry game
+          </button>
+          <a className="ghost-action" href={buildLegacyGamePath(gameId)}>
+            Legacy fallback
+          </a>
+        </div>
+      </section>
+    );
+  }
+
+  if (!snapshot) {
+    return null;
+  }
+
+  const connectionBadge =
+    streamStatus === "live"
+      ? "Live"
+      : streamStatus === "reconnecting"
+        ? "Reconnecting"
+        : "Connecting";
+  const canTradeCards = selectedTradeCardIds.length === 3 && !tradeMutation.isPending;
+  const actionPending =
+    joinMutation.isPending ||
+    startMutation.isPending ||
+    actionMutation.isPending ||
+    tradeMutation.isPending;
+
+  return (
+    <section data-testid="react-shell-game-page">
+      <p className="status-label">{t("game.command.eyebrow")}</p>
+      <div className="card-header gameplay-page-header">
+        <div>
+          <h2>{snapshot.gameName || t("game.title")}</h2>
+          <p className="status-copy">
+            {snapshot.gameId || gameId} · {snapshot.gameConfig?.mapName || t("common.classicMini")}
+          </p>
+        </div>
+        <div className="shell-actions">
+          <span
+            className={`status-pill${streamStatus === "live" ? " success" : streamStatus === "reconnecting" ? " danger" : " muted"}`}
+          >
+            {connectionBadge}
+          </span>
+          <a className="ghost-action" href={buildLegacyGamePath(gameId)}>
+            Legacy fallback
+          </a>
+        </div>
+      </div>
+
+      {mustTradeCards ? (
+        <div
+          id="trade-alert"
+          className="game-trade-alert"
+          data-testid="react-shell-game-trade-alert"
+        >
+          <strong>{t("game.tradeAlert.title")}</strong>
+          <span>
+            {t("game.runtime.tradeAlert.mustTradeNow", {
+              cardCount: playerHand.length,
+              limit: snapshot.cardState?.maxHandBeforeForcedTrade || 5
+            })}
+          </span>
+        </div>
+      ) : null}
+
+      {actionError ? (
+        <div className="profile-query-state profile-query-state-error" data-testid="react-shell-game-action-error">
+          <p className="metric-copy">{actionError}</p>
+        </div>
+      ) : null}
+
+      {feedbackMessage ? (
+        <div className="profile-query-state" data-testid="react-shell-game-feedback">
+          <p className="metric-copy">{feedbackMessage}</p>
+        </div>
+      ) : null}
+
+      <div className="gameplay-shell">
+        <section className="placeholder-card gameplay-map-card">
+          <div className="card-header gameplay-section-header">
+            <div>
+              <p className="status-label">{t("game.meta.map")}</p>
+              <h3>{snapshot.gameConfig?.mapName || t("common.classicMini")}</h3>
+            </div>
+            <span className="status-pill" data-testid="phase-indicator">
+              {phaseLabel(snapshot.phase)} · {turnPhaseLabel(snapshot.turnPhase)}
+            </span>
+          </div>
+
+          <div className="game-status-banner" data-testid="status-summary">
+            <span>
+              {t("game.phaseBanner")} <strong>{phaseLabel(snapshot.phase)}</strong>
+            </span>
+            <span>
+              {t("game.reinforcementBanner")} <strong>{snapshot.reinforcementPool}</strong>
+            </span>
+            <span>
+              {t("game.runtime.winner")}:{" "}
+              <strong>{winner ? winner.name : t("game.runtime.noneLower")}</strong>
+            </span>
+          </div>
+
+          <div className="game-meta-grid">
+            <article className="game-meta-item">
+              <span>{t("game.meta.player")}</span>
+              <strong data-testid="current-player-indicator">
+                {me?.name || authenticatedUser?.username || t("game.runtime.accessRequired")}
+              </strong>
+            </article>
+            <article className="game-meta-item">
+              <span>{t("game.command.heading")}</span>
+              <strong>
+                {snapshot.phase === "finished"
+                  ? t("game.runtime.finished")
+                  : currentPlayer
+                    ? t("game.runtime.turnOf", { name: currentPlayer.name })
+                    : t("game.runtime.waiting")}
+              </strong>
+            </article>
+            <article className="game-meta-item">
+              <span>{t("game.meta.setup")}</span>
+              <strong>
+                {t("game.runtime.setupMeta", {
+                  totalPlayers: snapshot.gameConfig?.totalPlayers || snapshot.players.length,
+                  playerLabel:
+                    (snapshot.gameConfig?.totalPlayers || snapshot.players.length) === 1
+                      ? t("game.runtime.playerSingle")
+                      : t("game.runtime.playerPlural"),
+                  aiCount: snapshot.players.filter((player) => player.isAi).length
+                })}
+              </strong>
+            </article>
+          </div>
+
+          <div
+            id="map"
+            className={`game-map-board${snapshot.mapVisual?.imageUrl ? " has-image" : ""}`}
+            style={{
+              aspectRatio: mapAspectRatio(snapshot),
+              ...(snapshot.mapVisual?.imageUrl
+                ? { backgroundImage: `linear-gradient(rgba(15, 22, 36, 0.18), rgba(15, 22, 36, 0.18)), url(${snapshot.mapVisual.imageUrl})` }
+                : {})
+            }}
+          >
+            <svg className="game-map-connections" viewBox="0 0 1000 1000" aria-hidden="true">
+              {(snapshot.map || []).flatMap((territory) =>
+                territory.x == null || territory.y == null
+                  ? []
+                  : territory.neighbors
+                      .filter((neighborId) => territory.id < neighborId)
+                      .map((neighborId) => {
+                        const target = territoriesById[neighborId];
+                        if (!target || target.x == null || target.y == null) {
+                          return null;
+                        }
+
+                        return (
+                          <line
+                            key={`${territory.id}-${neighborId}`}
+                            x1={territory.x * 1000}
+                            y1={territory.y * 1000}
+                            x2={target.x * 1000}
+                            y2={target.y * 1000}
+                          />
+                        );
+                      })
+              )}
+            </svg>
+
+            {(snapshot.map || []).map((territory) => {
+              const isMine = territory.ownerId === myPlayerId;
+              const isAttackSource = territory.id === attackFromId;
+              const isAttackTarget = territory.id === attackToId;
+              const isReinforceTarget = territory.id === reinforceTerritoryId;
+              const isFortifySource = territory.id === fortifyFromId;
+              const isFortifyTarget = territory.id === fortifyToId;
+
+              return (
+                <button
+                  key={territory.id}
+                  type="button"
+                  className={`territory-node${isMine ? " is-mine" : ""}${isAttackSource ? " is-source" : ""}${isAttackTarget ? " is-target" : ""}${isReinforceTarget ? " is-reinforce" : ""}${isFortifySource ? " is-fortify-source" : ""}${isFortifyTarget ? " is-fortify-target" : ""}`}
+                  data-territory-id={territory.id}
+                  style={{
+                    left: `${(territory.x ?? 0.5) * 100}%`,
+                    top: `${(territory.y ?? 0.5) * 100}%`,
+                    ["--territory-player-color" as "--territory-player-color"]:
+                      territory.ownerId && playersById[territory.ownerId]?.color
+                        ? playersById[territory.ownerId].color
+                        : "rgba(22, 32, 51, 0.7)"
+                  }}
+                  onClick={() => handleTerritorySelect(territory.id)}
+                >
+                  <strong>{territory.name}</strong>
+                  <span>{territoryOwnerName(territory, playersById)}</span>
+                  <span className="territory-armies">{territory.armies}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="game-map-legend">
+            <span>Map picks drive the form selections below. Rule validation stays on the backend.</span>
+          </div>
+        </section>
+
+        <aside className="gameplay-sidebar">
+          <section className="placeholder-card gameplay-action-card">
+            <div className="card-header gameplay-section-header">
+              <div>
+                <p className="status-label">{t("game.command.eyebrow")}</p>
+                <h3>{t("game.command.heading")}</h3>
+              </div>
+              <span className="status-pill">{currentPlayer?.name || t("game.runtime.waiting")}</span>
+            </div>
+
+            {showJoinLobby ? (
+              <div className="game-action-group">
+                <p className="metric-copy">{t("game.meta.accessCopy")}</p>
+                <button
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleJoinLobby()}
+                  disabled={actionPending}
+                >
+                  {joinMutation.isPending ? "Joining..." : t("game.join")}
+                </button>
+              </div>
+            ) : null}
+
+            {showStartGame ? (
+              <div className="game-action-group">
+                <p className="metric-copy">
+                  {snapshot.players.length < 2
+                    ? t("server.game.notEnoughPlayers")
+                    : "The lobby is ready to be promoted into the active turn flow."}
+                </p>
+                <button
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleStartGame()}
+                  disabled={actionPending || snapshot.players.length < 2}
+                >
+                  {startMutation.isPending ? "Starting..." : t("game.start")}
+                </button>
+              </div>
+            ) : null}
+
+            <div className="game-action-stack">
+              <section id="card-trade-group" className="game-action-group">
+                <div className="card-header gameplay-subsection-header">
+                  <div>
+                    <p className="status-label">{t("game.actions.cards")}</p>
+                    <h4>{t("game.cards.summary")}</h4>
+                  </div>
+                  {snapshot.cardState?.nextTradeBonus != null ? (
+                    <span className="status-pill">+{snapshot.cardState.nextTradeBonus}</span>
+                  ) : null}
+                </div>
+
+                {mustTradeCards ? (
+                  <p id="card-trade-alert" className="metric-copy">
+                    {t("game.cards.alert")}
+                  </p>
+                ) : null}
+
+                <p id="card-trade-summary" className="metric-copy">
+                  {playerHand.length
+                    ? t("game.runtime.cardsInHand", { count: playerHand.length })
+                    : t("game.runtime.noCardsAvailable")}
+                </p>
+
+                {playerHand.length ? (
+                  <div id="card-trade-list" className="game-card-grid">
+                    {playerHand.map((card) => (
+                      <button
+                        key={card.id}
+                        type="button"
+                        className={`game-card-pill${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
+                        data-card-id={card.id}
+                        onClick={() => toggleTradeCard(card.id)}
+                      >
+                        <strong>{card.territoryId || card.id}</strong>
+                        <span>{cardTypeLabel(card)}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+
+                <p id="card-trade-help" className="metric-copy">
+                  {mustTradeCards
+                    ? t("game.runtime.tradeHelp.mustTrade", {
+                        limit: snapshot.cardState?.maxHandBeforeForcedTrade || 5
+                      })
+                    : t("game.runtime.tradeHelp.selected", {
+                        selected: selectedTradeCardIds.length
+                      })}
+                </p>
+
+                <button
+                  id="card-trade-button"
+                  type="button"
+                  className="ghost-action"
+                  onClick={() => void handleTradeCards()}
+                  disabled={!canTradeCards}
+                >
+                  {tradeMutation.isPending ? "Trading..." : t("game.cards.tradeSet")}
+                </button>
+              </section>
+
+              <section id="reinforce-group" className="game-action-group" hidden={!showReinforceGroup}>
+                <div className="card-header gameplay-subsection-header">
+                  <div>
+                    <p className="status-label">{t("game.actions.reinforce")}</p>
+                    <h4>{t("game.reinforcementBanner")}</h4>
+                  </div>
+                  <span className="status-pill">{snapshot.reinforcementPool}</span>
+                </div>
+
+                <label className="shell-field">
+                  <span>{t("game.actions.reinforce")}</span>
+                  <select
+                    id="reinforce-territory"
+                    value={reinforceTerritoryId}
+                    onChange={(event) => setSelectedReinforceTerritoryId(event.target.value)}
+                  >
+                    {myTerritories.map((territory) => (
+                      <option key={territory.id} value={territory.id}>
+                        {territoryOptionLabel(territory, playersById)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("game.actions.reinforceAmountAria")}</span>
+                  <input
+                    id="reinforce-amount"
+                    inputMode="numeric"
+                    value={reinforceAmount}
+                    onChange={(event) => setReinforceAmount(event.target.value)}
+                  />
+                </label>
+
+                <button
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleReinforce()}
+                  disabled={!reinforceTerritoryId || actionPending}
+                >
+                  {actionMutation.isPending ? "Applying..." : t("game.actions.add")}
+                </button>
+              </section>
+
+              <section id="attack-group" className="game-action-group" hidden={!showAttackGroup}>
+                <div className="card-header gameplay-subsection-header">
+                  <div>
+                    <p className="status-label">{t("game.actions.attack")}</p>
+                    <h4>{t("game.actions.launchAttack")}</h4>
+                  </div>
+                </div>
+
+                <label className="shell-field">
+                  <span>{t("game.runtime.hint.attack")}</span>
+                  <select
+                    id="attack-from"
+                    value={attackFromId}
+                    onChange={(event) => setSelectedAttackFromId(event.target.value)}
+                  >
+                    {myTerritories.map((territory) => (
+                      <option key={territory.id} value={territory.id}>
+                        {territoryOptionLabel(territory, playersById)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("game.runtime.noTarget")}</span>
+                  <select
+                    id="attack-to"
+                    value={attackToId}
+                    onChange={(event) => setSelectedAttackToId(event.target.value)}
+                  >
+                    <option value="">{t("game.runtime.noTarget")}</option>
+                    {attackTargets.map((territory) => (
+                      <option key={territory.id} value={territory.id}>
+                        {territoryOptionLabel(territory, playersById)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("game.runtime.noDiceAvailable")}</span>
+                  <select
+                    id="attack-dice"
+                    value={attackDiceCount}
+                    onChange={(event) => setSelectedAttackDiceCount(event.target.value)}
+                  >
+                    {!maxAttackDice ? <option value="">{t("game.runtime.noDiceAvailable")}</option> : null}
+                    {Array.from({ length: maxAttackDice }, (_, index) => index + 1).map((count) => (
+                      <option key={count} value={String(count)}>
+                        {t("game.runtime.attackDiceOption", {
+                          count,
+                          suffix: count === 1 ? "" : "i"
+                        })}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <div className="shell-actions">
+                  <button
+                    type="button"
+                    className="refresh-button"
+                    onClick={() => void handleAttack("attack")}
+                    disabled={!attackFromId || !attackToId || !attackDiceCount || actionPending}
+                  >
+                    {actionMutation.isPending ? "Attacking..." : t("game.actions.launchAttack")}
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost-action"
+                    onClick={() => void handleAttack("attackBanzai")}
+                    disabled={!attackFromId || !attackToId || !attackDiceCount || actionPending}
+                  >
+                    {actionMutation.isPending ? t("game.runtime.banzaiLoading") : t("game.actions.banzai")}
+                  </button>
+                </div>
+              </section>
+
+              <section id="conquest-group" className="game-action-group" hidden={!showConquestGroup}>
+                <div className="card-header gameplay-subsection-header">
+                  <div>
+                    <p className="status-label">{t("game.actions.afterConquest")}</p>
+                    <h4>{t("game.runtime.conquest")}</h4>
+                  </div>
+                  <span className="status-pill">
+                    {pendingConquestMin}-{pendingConquestMax}
+                  </span>
+                </div>
+
+                <label className="shell-field">
+                  <span>{t("game.actions.moveArmies")}</span>
+                  <input
+                    id="conquest-armies"
+                    inputMode="numeric"
+                    value={conquestArmies}
+                    onChange={(event) => setConquestArmies(event.target.value)}
+                    placeholder={String(pendingConquestMin)}
+                  />
+                </label>
+
+                <button
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleMoveAfterConquest()}
+                  disabled={actionPending}
+                >
+                  {actionMutation.isPending ? "Moving..." : t("game.actions.moveArmies")}
+                </button>
+              </section>
+
+              <section id="fortify-group" className="game-action-group" hidden={!showFortifyGroup}>
+                <div className="card-header gameplay-subsection-header">
+                  <div>
+                    <p className="status-label">{t("game.actions.fortify")}</p>
+                    <h4>{t("game.actions.fortify")}</h4>
+                  </div>
+                </div>
+
+                <label className="shell-field">
+                  <span>{t("game.actions.fortify")}</span>
+                  <select
+                    id="fortify-from"
+                    value={fortifyFromId}
+                    onChange={(event) => setSelectedFortifyFromId(event.target.value)}
+                  >
+                    {myTerritories.map((territory) => (
+                      <option key={territory.id} value={territory.id}>
+                        {territoryOptionLabel(territory, playersById)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("game.runtime.noAdjacentTerritory")}</span>
+                  <select
+                    id="fortify-to"
+                    value={fortifyToId}
+                    onChange={(event) => setSelectedFortifyToId(event.target.value)}
+                  >
+                    <option value="">{t("game.runtime.noAdjacentTerritory")}</option>
+                    {fortifyTargets.map((territory) => (
+                      <option key={territory.id} value={territory.id}>
+                        {territoryOptionLabel(territory, playersById)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="shell-field">
+                  <span>{t("game.actions.moveArmies")}</span>
+                  <input
+                    id="fortify-armies"
+                    inputMode="numeric"
+                    value={fortifyArmies}
+                    onChange={(event) => setFortifyArmies(event.target.value)}
+                    placeholder="1"
+                  />
+                </label>
+
+                <button
+                  id="fortify-button"
+                  type="button"
+                  className="refresh-button"
+                  onClick={() => void handleFortify()}
+                  disabled={
+                    !fortifyFromId ||
+                    !fortifyToId ||
+                    maxFortifyArmies < 1 ||
+                    actionPending ||
+                    Boolean(snapshot.fortifyUsed)
+                  }
+                >
+                  {actionMutation.isPending ? "Fortifying..." : t("game.actions.fortify")}
+                </button>
+              </section>
+            </div>
+
+            <div className="shell-actions gameplay-primary-actions">
+              <button
+                id="end-turn-button"
+                type="button"
+                className="refresh-button"
+                onClick={() => void handleEndTurn()}
+                hidden={!showEndTurn}
+                disabled={actionPending}
+              >
+                {actionMutation.isPending ? "Updating..." : endTurnLabel}
+              </button>
+
+              {showSurrender ? (
+                <button
+                  id="surrender-button"
+                  type="button"
+                  className="ghost-action"
+                  onClick={() => void handleSurrender()}
+                  disabled={actionPending}
+                >
+                  {t("game.surrender")}
+                </button>
+              ) : null}
+            </div>
+
+            <p className="metric-copy gameplay-fallback-note">
+              Advanced sidebars and secondary legacy affordances still fall back to the legacy
+              gameplay route when needed.
+            </p>
+          </section>
+
+          <section className="placeholder-card gameplay-side-card">
+            <div className="card-header gameplay-section-header">
+              <div>
+                <p className="status-label">{t("game.players.heading")}</p>
+                <h3>{t("game.players.badge")}</h3>
+              </div>
+            </div>
+
+            <div className="game-player-list" id="players">
+              {snapshot.players.map((player) => (
+                <article className="game-player-card" key={player.id}>
+                  <div className="game-player-head">
+                    <strong>{player.name}</strong>
+                    <span
+                      className="game-player-swatch"
+                      style={{ backgroundColor: player.color || "#162033" }}
+                    />
+                  </div>
+                  <span>
+                    {t("game.runtime.territories")}: {player.territoryCount || 0}
+                  </span>
+                  <span>
+                    {player.eliminated
+                      ? t("game.runtime.eliminated")
+                      : player.surrendered
+                        ? t("game.surrender")
+                        : t("game.runtime.active")}
+                  </span>
+                  <span>
+                    {typeof player.cardCount === "number"
+                      ? t("game.runtime.cardsInHand", { count: player.cardCount })
+                      : t("game.runtime.none")}
+                  </span>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="placeholder-card gameplay-side-card">
+            <div className="card-header gameplay-section-header">
+              <div>
+                <p className="status-label">{t("game.combat.heading")}</p>
+                <h3>{t("game.combat.badge")}</h3>
+              </div>
+            </div>
+
+            {snapshot.lastCombat ? (
+              <div className="game-combat-panel">
+                <div className="game-combat-row">
+                  <span>{t("game.combat.attacker")}</span>
+                  <strong>{snapshot.lastCombat.fromTerritoryId}</strong>
+                </div>
+                <div className="game-combat-row">
+                  <span>{t("game.combat.defender")}</span>
+                  <strong>{snapshot.lastCombat.toTerritoryId}</strong>
+                </div>
+                <div className="game-combat-row">
+                  <span>{t("game.combat.comparisons")}</span>
+                  <strong>{snapshot.lastCombat.comparisons?.length || 0}</strong>
+                </div>
+                <div className="game-combat-row">
+                  <span>{t("game.runtime.combat.resolved")}</span>
+                  <strong>
+                    {snapshot.lastCombat.conqueredTerritory
+                      ? t("game.runtime.combat.conquered")
+                      : snapshot.lastCombat.defenderReducedToZero
+                        ? t("game.runtime.combat.defenseBroken")
+                        : t("game.runtime.combat.resolved")}
+                  </strong>
+                </div>
+              </div>
+            ) : (
+              <p className="metric-copy">{t("game.runtime.hint.observation")}</p>
+            )}
+          </section>
+
+          <section className="placeholder-card gameplay-side-card">
+            <div className="card-header gameplay-section-header">
+              <div>
+                <p className="status-label">{t("game.log.heading")}</p>
+                <h3>{t("game.log.badge")}</h3>
+              </div>
+            </div>
+
+            <div className="game-log-list" id="log">
+              {localizedLog.length ? (
+                localizedLog.map((entry, index) => (
+                  <article className="game-log-entry" key={`${index}-${entry}`}>
+                    {entry}
+                  </article>
+                ))
+              ) : (
+                <p className="metric-copy">{t("game.log.lobbyCreated")}</p>
+              )}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -836,7 +836,7 @@ export function GameRoute() {
                   style={{
                     left: `${(territory.x ?? 0.5) * 100}%`,
                     top: `${(territory.y ?? 0.5) * 100}%`,
-                    ["--territory-player-color" as "--territory-player-color"]:
+                    ["--territory-player-color" as const]:
                       territory.ownerId && playersById[territory.ownerId]?.color
                         ? playersById[territory.ownerId].color
                         : "rgba(22, 32, 51, 0.7)"

--- a/frontend/react-shell/src/legacy-game-handoff.ts
+++ b/frontend/react-shell/src/legacy-game-handoff.ts
@@ -5,3 +5,11 @@ export function buildLegacyGamePath(gameId: string): string {
 export function openLegacyGame(gameId: string): void {
   window.location.assign(buildLegacyGamePath(gameId));
 }
+
+export function buildReactGamePath(gameId: string): string {
+  return `/react/game/${encodeURIComponent(gameId)}`;
+}
+
+export function openReactGame(gameId: string): void {
+  window.location.assign(buildReactGamePath(gameId));
+}

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -375,7 +375,7 @@ export function LobbyCreateRoute() {
 
     try {
       const payload = await createMutation.mutateAsync(request);
-      storeCurrentPlayerId(payload.playerId);
+      storeCurrentPlayerId(payload.playerId, payload.game.id);
       setLobbyGamesCache(queryClient, {
         games: payload.games || [],
         activeGameId: payload.activeGameId || payload.game.id

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -145,7 +145,9 @@ function filterProfilesForSelectedModules(
     return [];
   }
 
-  return profiles.filter((profile) => !profile.moduleId || selectedModuleIds.includes(profile.moduleId));
+  return profiles.filter(
+    (profile) => !profile.moduleId || selectedModuleIds.includes(profile.moduleId)
+  );
 }
 
 function sanitizeProfiles(
@@ -239,17 +241,29 @@ function applyGamePreset(
     contentProfileId: preset.contentProfileId || "",
     gameplayProfileId: preset.gameplayProfileId || "",
     uiProfileId: preset.uiProfileId || "",
-    contentPackId: pickPresetId(preset.defaults?.contentPackId, formState.contentPackId, options.contentPacks),
+    contentPackId: pickPresetId(
+      preset.defaults?.contentPackId,
+      formState.contentPackId,
+      options.contentPacks
+    ),
     ruleSetId: pickPresetId(preset.defaults?.ruleSetId, formState.ruleSetId, options.ruleSets),
     mapId: pickPresetId(preset.defaults?.mapId, formState.mapId, options.maps),
-    diceRuleSetId: pickPresetId(preset.defaults?.diceRuleSetId, formState.diceRuleSetId, options.diceRuleSets),
+    diceRuleSetId: pickPresetId(
+      preset.defaults?.diceRuleSetId,
+      formState.diceRuleSetId,
+      options.diceRuleSets
+    ),
     victoryRuleSetId: pickPresetId(
       preset.defaults?.victoryRuleSetId,
       formState.victoryRuleSetId,
       options.victoryRuleSets
     ),
     themeId: pickPresetId(preset.defaults?.themeId, formState.themeId, options.themes),
-    pieceSkinId: pickPresetId(preset.defaults?.pieceSkinId, formState.pieceSkinId, options.pieceSkins)
+    pieceSkinId: pickPresetId(
+      preset.defaults?.pieceSkinId,
+      formState.pieceSkinId,
+      options.pieceSkins
+    )
   };
 
   return sanitizeProfiles(nextState, options);
@@ -296,7 +310,8 @@ export function LobbyCreateRoute() {
   });
 
   const options = gameOptionsQuery.data;
-  const availableModules = options?.modules?.filter((moduleEntry) => moduleEntry.id !== "core.base") || [];
+  const availableModules =
+    options?.modules?.filter((moduleEntry) => moduleEntry.id !== "core.base") || [];
   const contentProfiles = filterProfilesForSelectedModules(
     options?.contentProfiles,
     formState?.selectedModuleIds || []
@@ -340,7 +355,9 @@ export function LobbyCreateRoute() {
       ...(formState.themeId ? { themeId: formState.themeId } : {}),
       ...(formState.pieceSkinId ? { pieceSkinId: formState.pieceSkinId } : {}),
       ...(formState.gamePresetId ? { gamePresetId: formState.gamePresetId } : {}),
-      ...(formState.selectedModuleIds.length ? { activeModuleIds: formState.selectedModuleIds } : {}),
+      ...(formState.selectedModuleIds.length
+        ? { activeModuleIds: formState.selectedModuleIds }
+        : {}),
       ...(formState.contentProfileId ? { contentProfileId: formState.contentProfileId } : {}),
       ...(formState.gameplayProfileId ? { gameplayProfileId: formState.gameplayProfileId } : {}),
       ...(formState.uiProfileId ? { uiProfileId: formState.uiProfileId } : {}),
@@ -348,10 +365,12 @@ export function LobbyCreateRoute() {
         ? { turnTimeoutHours: Number(formState.turnTimeoutHours) }
         : {}),
       totalPlayers: formState.totalPlayers,
-      players: ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map((type, index) => ({
-        slot: index + 1,
-        type
-      }))
+      players: ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map(
+        (type, index) => ({
+          slot: index + 1,
+          type
+        })
+      )
     };
 
     try {
@@ -450,7 +469,11 @@ export function LobbyCreateRoute() {
               <select
                 value={formState.contentPackId}
                 onChange={(event) => {
-                  const nextState = applyContentPackDefaults(formState, options, event.target.value);
+                  const nextState = applyContentPackDefaults(
+                    formState,
+                    options,
+                    event.target.value
+                  );
                   updateFormState({
                     ...nextState,
                     gamePresetId: ""
@@ -527,7 +550,10 @@ export function LobbyCreateRoute() {
                 >
                   {Array.from(
                     {
-                      length: Math.max((options.playerRange?.max || 4) - (options.playerRange?.min || 2) + 1, 1)
+                      length: Math.max(
+                        (options.playerRange?.max || 4) - (options.playerRange?.min || 2) + 1,
+                        1
+                      )
                     },
                     (_, index) => (options.playerRange?.min || 2) + index
                   ).map((playerCount) => (
@@ -672,7 +698,11 @@ export function LobbyCreateRoute() {
               <p className="metric-copy">{t("newGame.options.copy")}</p>
             )}
 
-            {(options.gamePresets?.length || availableModules.length || contentProfiles.length || gameplayProfiles.length || uiProfiles.length) ? (
+            {options.gamePresets?.length ||
+            availableModules.length ||
+            contentProfiles.length ||
+            gameplayProfiles.length ||
+            uiProfiles.length ? (
               <div className="new-game-modules-stack">
                 {options.gamePresets?.length ? (
                   <label className="shell-field">
@@ -706,7 +736,9 @@ export function LobbyCreateRoute() {
                             onChange={(event) => {
                               const nextSelectedModuleIds = event.target.checked
                                 ? [...formState.selectedModuleIds, moduleEntry.id]
-                                : formState.selectedModuleIds.filter((entry) => entry !== moduleEntry.id);
+                                : formState.selectedModuleIds.filter(
+                                    (entry) => entry !== moduleEntry.id
+                                  );
                               updateFormState({
                                 ...formState,
                                 selectedModuleIds: nextSelectedModuleIds,
@@ -717,7 +749,9 @@ export function LobbyCreateRoute() {
                           />
                           <span>
                             <strong>{moduleEntry.displayName}</strong>
-                            <small>{moduleEntry.description || moduleEntry.kind || moduleEntry.id}</small>
+                            <small>
+                              {moduleEntry.description || moduleEntry.kind || moduleEntry.id}
+                            </small>
                           </span>
                         </label>
                       );
@@ -807,46 +841,48 @@ export function LobbyCreateRoute() {
           </div>
 
           <div className="new-game-slot-grid">
-            {ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map((playerType, index) => (
-              <article className="new-game-slot-card" key={`slot-${index + 1}`}>
-                <div className="new-game-slot-head">
-                  <strong>{t("newGame.slot.playerLabel", { number: index + 1 })}</strong>
-                  {index === 0 ? (
-                    <span className="status-pill">{t("newGame.slot.creatorBadge")}</span>
-                  ) : null}
-                </div>
-
-                {index === 0 ? (
-                  <div className="new-game-slot-copy">
-                    <span>{t("newGame.slot.humanOption")}</span>
-                    <small>{playerSlotDescription(playerType, index)}</small>
+            {ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map(
+              (playerType, index) => (
+                <article className="new-game-slot-card" key={`slot-${index + 1}`}>
+                  <div className="new-game-slot-head">
+                    <strong>{t("newGame.slot.playerLabel", { number: index + 1 })}</strong>
+                    {index === 0 ? (
+                      <span className="status-pill">{t("newGame.slot.creatorBadge")}</span>
+                    ) : null}
                   </div>
-                ) : (
-                  <label className="shell-field">
-                    <span>{t("newGame.slot.typeLabel")}</span>
-                    <select
-                      value={playerType}
-                      onChange={(event) => {
-                        const nextPlayerTypes = ensurePlayerTypes(
-                          formState.playerTypes,
-                          formState.totalPlayers
-                        );
-                        nextPlayerTypes[index] = event.target.value;
-                        updateFormState({
-                          ...formState,
-                          playerTypes: nextPlayerTypes
-                        });
-                      }}
-                      data-testid={`react-shell-new-game-slot-${index + 1}`}
-                    >
-                      <option value="human">{t("newGame.slot.humanOption")}</option>
-                      <option value="ai">{t("newGame.slot.aiOption")}</option>
-                    </select>
-                    <small>{playerSlotDescription(playerType, index)}</small>
-                  </label>
-                )}
-              </article>
-            ))}
+
+                  {index === 0 ? (
+                    <div className="new-game-slot-copy">
+                      <span>{t("newGame.slot.humanOption")}</span>
+                      <small>{playerSlotDescription(playerType, index)}</small>
+                    </div>
+                  ) : (
+                    <label className="shell-field">
+                      <span>{t("newGame.slot.typeLabel")}</span>
+                      <select
+                        value={playerType}
+                        onChange={(event) => {
+                          const nextPlayerTypes = ensurePlayerTypes(
+                            formState.playerTypes,
+                            formState.totalPlayers
+                          );
+                          nextPlayerTypes[index] = event.target.value;
+                          updateFormState({
+                            ...formState,
+                            playerTypes: nextPlayerTypes
+                          });
+                        }}
+                        data-testid={`react-shell-new-game-slot-${index + 1}`}
+                      >
+                        <option value="human">{t("newGame.slot.humanOption")}</option>
+                        <option value="ai">{t("newGame.slot.aiOption")}</option>
+                      </select>
+                      <small>{playerSlotDescription(playerType, index)}</small>
+                    </label>
+                  )}
+                </article>
+              )
+            )}
           </div>
 
           <div className="shell-actions">

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -17,7 +17,7 @@ import { createGame, getGameOptions } from "@frontend-core/api/client.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
 import { t } from "@frontend-i18n";
 
-import { openLegacyGame } from "@react-shell/legacy-game-handoff";
+import { openReactGame } from "@react-shell/legacy-game-handoff";
 import { storeCurrentPlayerId } from "@react-shell/player-session";
 import { gameOptionsQueryKey, lobbyGamesQueryKey } from "@react-shell/react-query";
 
@@ -361,7 +361,7 @@ export function LobbyCreateRoute() {
         games: payload.games || [],
         activeGameId: payload.activeGameId || payload.game.id
       });
-      openLegacyGame(payload.game.id);
+      openReactGame(payload.game.id);
     } catch (error) {
       setSubmitError(messageFromError(error, t("errors.requestFailed")));
     }

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -3,7 +3,10 @@ import { Link } from "react-router-dom";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import type { GameListResponse, GameSummary } from "@frontend-generated/shared-runtime-validation.mts";
+import type {
+  GameListResponse,
+  GameSummary
+} from "@frontend-generated/shared-runtime-validation.mts";
 
 import { joinGame, listGames, openGame } from "@frontend-core/api/client.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
@@ -374,13 +377,18 @@ export function LobbyRoute() {
           )}
         </section>
 
-        <section className="placeholder-card lobby-detail-panel" data-testid="react-shell-lobby-details">
+        <section
+          className="placeholder-card lobby-detail-panel"
+          data-testid="react-shell-lobby-details"
+        >
           <div className="card-header lobby-panel-header">
             <div>
               <p className="status-label">{t("lobby.details.heading")}</p>
               <h3>{selectedGame?.name || t("lobby.details.emptyBadge")}</h3>
             </div>
-            {selectedGame ? <span className="status-pill">{phaseLabel(selectedGame.phase)}</span> : null}
+            {selectedGame ? (
+              <span className="status-pill">{phaseLabel(selectedGame.phase)}</span>
+            ) : null}
           </div>
 
           {!selectedGame ? (
@@ -399,7 +407,9 @@ export function LobbyRoute() {
               <div className="lobby-detail-grid">
                 <article className="lobby-detail-item">
                   <span>{t("lobby.details.map")}</span>
-                  <strong>{selectedGame.mapName || selectedGame.mapId || t("common.classicMini")}</strong>
+                  <strong>
+                    {selectedGame.mapName || selectedGame.mapId || t("common.classicMini")}
+                  </strong>
                 </article>
                 <article className="lobby-detail-item">
                   <span>{t("lobby.details.playersPresent")}</span>

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -223,7 +223,7 @@ export function LobbyRoute() {
 
     try {
       const payload = await openMutation.mutateAsync(selectedGame.id);
-      storeCurrentPlayerId(payload.playerId);
+      storeCurrentPlayerId(payload.playerId, selectedGame.id);
       if (payload.games) {
         setLobbyGamesCache(queryClient, {
           games: payload.games,
@@ -245,7 +245,7 @@ export function LobbyRoute() {
 
     try {
       const payload = await joinMutation.mutateAsync(selectedGame.id);
-      storeCurrentPlayerId(payload.playerId);
+      storeCurrentPlayerId(payload.playerId, selectedGame.id);
       await queryClient.invalidateQueries({ queryKey: lobbyGamesQueryKey() });
       openReactGame(selectedGame.id);
     } catch (error) {

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -9,7 +9,7 @@ import { joinGame, listGames, openGame } from "@frontend-core/api/client.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
 import { formatDate, t } from "@frontend-i18n";
 
-import { openLegacyGame } from "@react-shell/legacy-game-handoff";
+import { openReactGame } from "@react-shell/legacy-game-handoff";
 import { storeCurrentPlayerId } from "@react-shell/player-session";
 import { lobbyGamesQueryKey } from "@react-shell/react-query";
 
@@ -227,7 +227,7 @@ export function LobbyRoute() {
           activeGameId: payload.activeGameId || selectedGame.id
         });
       }
-      openLegacyGame(selectedGame.id);
+      openReactGame(selectedGame.id);
     } catch (error) {
       setActionError(messageFromError(error, t("errors.requestFailed")));
     }
@@ -244,7 +244,7 @@ export function LobbyRoute() {
       const payload = await joinMutation.mutateAsync(selectedGame.id);
       storeCurrentPlayerId(payload.playerId);
       await queryClient.invalidateQueries({ queryKey: lobbyGamesQueryKey() });
-      openLegacyGame(selectedGame.id);
+      openReactGame(selectedGame.id);
     } catch (error) {
       setActionError(messageFromError(error, t("errors.requestFailed")));
     }

--- a/frontend/react-shell/src/player-session.ts
+++ b/frontend/react-shell/src/player-session.ts
@@ -1,9 +1,22 @@
 const PLAYER_ID_STORAGE_KEY = "frontline-player-id";
+type StoredPlayerSession = {
+  gameId: string;
+  playerId: string;
+};
 
-export function storeCurrentPlayerId(playerId: string | null | undefined): void {
+export function storeCurrentPlayerId(
+  playerId: string | null | undefined,
+  gameId?: string | null
+): void {
   try {
-    if (playerId) {
-      window.localStorage.setItem(PLAYER_ID_STORAGE_KEY, playerId);
+    if (playerId && gameId) {
+      window.localStorage.setItem(
+        PLAYER_ID_STORAGE_KEY,
+        JSON.stringify({
+          gameId,
+          playerId
+        } satisfies StoredPlayerSession)
+      );
       return;
     }
 
@@ -13,9 +26,27 @@ export function storeCurrentPlayerId(playerId: string | null | undefined): void 
   }
 }
 
-export function readCurrentPlayerId(): string | null {
+export function readCurrentPlayerId(gameId?: string | null): string | null {
   try {
-    return window.localStorage.getItem(PLAYER_ID_STORAGE_KEY);
+    const rawValue = window.localStorage.getItem(PLAYER_ID_STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const parsedValue = JSON.parse(rawValue) as Partial<StoredPlayerSession> | null;
+    if (
+      !parsedValue ||
+      typeof parsedValue.playerId !== "string" ||
+      typeof parsedValue.gameId !== "string"
+    ) {
+      return null;
+    }
+
+    if (gameId && parsedValue.gameId !== gameId) {
+      return null;
+    }
+
+    return parsedValue.playerId;
   } catch {
     return null;
   }

--- a/frontend/react-shell/src/player-session.ts
+++ b/frontend/react-shell/src/player-session.ts
@@ -12,3 +12,15 @@ export function storeCurrentPlayerId(playerId: string | null | undefined): void 
     // Preserve navigation behavior even if storage is unavailable.
   }
 }
+
+export function readCurrentPlayerId(): string | null {
+  try {
+    return window.localStorage.getItem(PLAYER_ID_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearCurrentPlayerId(): void {
+  storeCurrentPlayerId(null);
+}

--- a/frontend/react-shell/src/profile-route.tsx
+++ b/frontend/react-shell/src/profile-route.tsx
@@ -9,7 +9,7 @@ import { formatDate, t } from "@frontend-i18n";
 
 import { useAuth } from "@react-shell/auth";
 import { updateAuthenticatedUser } from "@react-shell/auth-store";
-import { buildLegacyGamePath } from "@react-shell/legacy-game-handoff";
+import { buildReactGamePath } from "@react-shell/legacy-game-handoff";
 import { profileDetailQueryKey } from "@react-shell/react-query";
 import { applyShellTheme, shellThemes, themeLabel } from "@react-shell/theme";
 
@@ -280,7 +280,7 @@ export function ProfileRoute() {
 
                         <a
                           className="ghost-action"
-                          href={buildLegacyGamePath(game.id)}
+                          href={buildReactGamePath(game.id)}
                           data-testid={`react-shell-profile-open-${game.id}`}
                         >
                           {t("profile.runtime.directive.resume")}

--- a/frontend/react-shell/src/react-query.ts
+++ b/frontend/react-shell/src/react-query.ts
@@ -23,3 +23,7 @@ export function lobbyGamesQueryKey() {
 export function gameOptionsQueryKey() {
   return ["lobby", "game-options"] as const;
 }
+
+export function gameplayStateQueryKey(gameId: string) {
+  return ["gameplay", "state", gameId] as const;
+}

--- a/frontend/react-shell/src/routes.tsx
+++ b/frontend/react-shell/src/routes.tsx
@@ -9,11 +9,11 @@ import {
   Routes,
   useLocation,
   useNavigate,
-  useParams,
   useSearchParams
 } from "react-router-dom";
 
 import { useAuth, AuthProvider } from "@react-shell/auth";
+import { GameRoute } from "@react-shell/gameplay-route";
 import { LobbyCreateRoute } from "@react-shell/lobby-create-route";
 import { LobbyRoute } from "@react-shell/lobby-route";
 import { ProfileRoute } from "@react-shell/profile-route";
@@ -93,8 +93,8 @@ function ShellLayout() {
           <p className="eyebrow">NetRisk</p>
           <h1>Session-aware React shell</h1>
           <p className="hero-copy">
-            Client routing, route guards, and session bootstrap are now centralized under the
-            parallel React app without replacing the existing legacy flows yet.
+            Client routing, protected access, lobby flows, and the core gameplay turn loop now run
+            inside the React shell while the backend engine stays authoritative.
           </p>
         </div>
 
@@ -275,34 +275,6 @@ function PlaceholderPage({
   );
 }
 
-function GamePlaceholderPage() {
-  const params = useParams();
-
-  return (
-    <PlaceholderPage
-      eyebrow="Game"
-      title="React gameplay shell placeholder"
-      copy="This protected route reserves the shape for the future gameplay migration while keeping backend engine authority unchanged."
-      details={
-        <>
-          <div className="placeholder-card">
-            <strong>Game route</strong>
-            <span>
-              {params.gameId ? `Selected game id: ${params.gameId}` : "No game selected yet."}
-            </span>
-          </div>
-          <div className="placeholder-card">
-            <strong>Deep links supported</strong>
-            <span>
-              Refreshing a direct `/react/game/:gameId` URL now resolves through the SPA shell.
-            </span>
-          </div>
-        </>
-      }
-    />
-  );
-}
-
 function LoginPage() {
   const { state, signIn, refresh } = useAuth();
   const navigate = useNavigate();
@@ -468,8 +440,8 @@ export function AppRoutes() {
               </Route>
               <Route path="profile" element={<ProfileRoute />} />
               <Route path="game">
-                <Route index element={<GamePlaceholderPage />} />
-                <Route path=":gameId" element={<GamePlaceholderPage />} />
+                <Route index element={<GameRoute />} />
+                <Route path=":gameId" element={<GameRoute />} />
               </Route>
             </Route>
             <Route path="*" element={<NotFoundPage />} />

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -645,6 +645,265 @@ select {
   gap: 0.75rem;
 }
 
+.gameplay-page-header {
+  align-items: flex-start;
+  margin-top: 0.5rem;
+}
+
+.gameplay-page-header h2 {
+  margin: 0;
+}
+
+.gameplay-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.85fr);
+  gap: 1rem;
+  margin-top: 1.5rem;
+  align-items: start;
+}
+
+.gameplay-map-card,
+.gameplay-sidebar,
+.gameplay-action-card,
+.gameplay-side-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.gameplay-sidebar {
+  align-content: start;
+}
+
+.gameplay-section-header,
+.gameplay-subsection-header {
+  margin-bottom: 0;
+}
+
+.gameplay-section-header h3,
+.gameplay-subsection-header h4 {
+  margin: 0.2rem 0 0;
+  font-size: 1.1rem;
+}
+
+.game-trade-alert {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(173, 79, 31, 0.28);
+  background: rgba(255, 244, 233, 0.9);
+}
+
+.game-status-banner,
+.game-meta-grid,
+.game-action-stack,
+.game-player-list,
+.game-card-grid,
+.game-combat-panel,
+.game-log-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.game-status-banner {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.game-status-banner span,
+.game-meta-item span,
+.game-player-card span,
+.game-card-pill span,
+.game-combat-row span,
+.game-map-legend,
+.gameplay-fallback-note {
+  color: var(--shell-muted);
+}
+
+.game-meta-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.game-meta-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.game-map-board {
+  position: relative;
+  overflow: hidden;
+  min-height: 360px;
+  border-radius: 22px;
+  border: 1px solid var(--shell-border);
+  background:
+    radial-gradient(circle at top left, rgba(237, 120, 71, 0.18), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(233, 225, 214, 0.92));
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.game-map-board.has-image {
+  background-size: cover;
+}
+
+.game-map-connections {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.game-map-connections line {
+  stroke: rgba(22, 32, 51, 0.18);
+  stroke-width: 6;
+  stroke-linecap: round;
+}
+
+.territory-node {
+  --territory-player-color: rgba(22, 32, 51, 0.7);
+  position: absolute;
+  display: grid;
+  gap: 0.1rem;
+  min-width: 6.25rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.64);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--shell-heading);
+  transform: translate(-50%, -50%);
+  box-shadow: 0 10px 24px rgba(22, 32, 51, 0.12);
+  cursor: pointer;
+  text-align: left;
+}
+
+.territory-node strong {
+  font-size: 0.92rem;
+}
+
+.territory-node span {
+  color: var(--shell-muted);
+  font-size: 0.78rem;
+}
+
+.territory-node .territory-armies {
+  color: var(--shell-heading);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.territory-node::before {
+  content: "";
+  position: absolute;
+  inset: auto auto 0.55rem 0.55rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: var(--territory-player-color);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.88);
+}
+
+.territory-node:hover,
+.territory-node.is-source,
+.territory-node.is-target,
+.territory-node.is-reinforce,
+.territory-node.is-fortify-source,
+.territory-node.is-fortify-target {
+  border-color: var(--shell-accent);
+}
+
+.territory-node.is-mine {
+  background: rgba(255, 248, 241, 0.96);
+}
+
+.game-map-legend {
+  font-size: 0.9rem;
+}
+
+.game-action-group {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.game-card-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.game-card-pill {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.72);
+  text-align: left;
+  cursor: pointer;
+}
+
+.game-card-pill.is-selected {
+  border-color: var(--shell-accent);
+  background: rgba(255, 247, 240, 0.94);
+}
+
+.gameplay-primary-actions {
+  justify-content: flex-start;
+}
+
+.gameplay-fallback-note {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.game-player-card,
+.game-log-entry {
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.game-player-card {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.game-player-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.game-player-swatch {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.82);
+}
+
+.game-combat-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 0.95rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.game-log-list {
+  max-height: 320px;
+  overflow: auto;
+}
+
 @media (max-width: 760px) {
   .react-shell-page {
     width: min(100% - 1.25rem, 100%);
@@ -687,7 +946,16 @@ select {
   .new-game-advanced-grid,
   .new-game-inline-grid,
   .new-game-slot-grid,
-  .lobby-detail-grid {
+  .lobby-detail-grid,
+  .gameplay-shell,
+  .game-status-banner,
+  .game-meta-grid,
+  .game-card-grid {
     grid-template-columns: 1fr;
+  }
+
+  .territory-node {
+    min-width: 5.2rem;
+    padding: 0.45rem 0.5rem;
   }
 }

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -46,7 +46,8 @@ type ClientMessages = {
 
 export type { GameActionRequest, GameEventPayload, GameStateResponse, StartGameRequest };
 
-export type TradeCardsRequest = import("../../generated/shared-runtime-validation.mjs").TradeCardsRequest;
+export type TradeCardsRequest =
+  import("../../generated/shared-runtime-validation.mjs").TradeCardsRequest;
 
 export function getSession(messages: ClientMessages): Promise<AuthSessionResponse> {
   return requestJson({

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -2,35 +2,51 @@ import {
   authSessionResponseSchema,
   createGameRequestSchema,
   createGameResponseSchema,
+  gameActionRequestSchema,
+  gameEventPayloadSchema,
   gameIdRequestSchema,
   gameListResponseSchema,
   gameOptionsResponseSchema,
   gameMutationResponseSchema,
+  gameStateResponseSchema,
+  gameVersionConflictResponseSchema,
   loginRequestSchema,
   loginResponseSchema,
   logoutResponseSchema,
   profileResponseSchema,
+  startGameRequestSchema,
   themePreferenceRequestSchema,
-  themePreferenceResponseSchema
+  themePreferenceResponseSchema,
+  tradeCardsRequestSchema
 } from "../../generated/shared-runtime-validation.mjs";
 import type {
   AuthSessionResponse,
   CreateGameRequest,
   CreateGameResponse,
+  GameActionRequest,
+  GameEventPayload,
   GameOptionsResponse,
   GameListResponse,
   GameMutationResponse,
+  GameStateResponse,
+  GameVersionConflictResponse,
   LoginResponse,
   LogoutResponse,
   ProfileResponse,
+  StartGameRequest,
   ThemePreferenceResponse
 } from "../../generated/shared-runtime-validation.mjs";
+import type { ApiClientError } from "./http.mjs";
 import { requestJson } from "./http.mjs";
 
 type ClientMessages = {
   errorMessage: string;
   fallbackMessage?: string;
 };
+
+export type { GameActionRequest, GameEventPayload, GameStateResponse, StartGameRequest };
+
+export type TradeCardsRequest = import("../../generated/shared-runtime-validation.mjs").TradeCardsRequest;
 
 export function getSession(messages: ClientMessages): Promise<AuthSessionResponse> {
   return requestJson({
@@ -154,4 +170,79 @@ export function joinGame(gameId: string, messages: ClientMessages): Promise<Game
     responseSchemaName: "GameMutationResponse",
     ...messages
   });
+}
+
+export function getGameState(gameId: string, messages: ClientMessages): Promise<GameStateResponse> {
+  return requestJson({
+    path: `/api/state?gameId=${encodeURIComponent(gameId)}`,
+    responseSchema: gameStateResponseSchema,
+    responseSchemaName: "GameStateResponse",
+    ...messages
+  });
+}
+
+export function startGame(
+  request: StartGameRequest,
+  messages: ClientMessages
+): Promise<GameMutationResponse> {
+  return requestJson({
+    path: "/api/start",
+    method: "POST",
+    body: request,
+    requestSchema: startGameRequestSchema,
+    requestSchemaName: "StartGameRequest",
+    responseSchema: gameMutationResponseSchema,
+    responseSchemaName: "GameMutationResponse",
+    ...messages
+  });
+}
+
+export function sendGameAction(
+  request: GameActionRequest,
+  messages: ClientMessages
+): Promise<GameMutationResponse> {
+  return requestJson({
+    path: "/api/action",
+    method: "POST",
+    body: request,
+    requestSchema: gameActionRequestSchema,
+    requestSchemaName: "GameActionRequest",
+    responseSchema: gameMutationResponseSchema,
+    responseSchemaName: "GameMutationResponse",
+    ...messages
+  });
+}
+
+export function tradeCards(
+  request: TradeCardsRequest,
+  messages: ClientMessages
+): Promise<GameMutationResponse> {
+  return requestJson({
+    path: "/api/cards/trade",
+    method: "POST",
+    body: request,
+    requestSchema: tradeCardsRequestSchema,
+    requestSchemaName: "TradeCardsRequest",
+    responseSchema: gameMutationResponseSchema,
+    responseSchemaName: "GameMutationResponse",
+    ...messages
+  });
+}
+
+export function parseGameEventPayload(payload: unknown): GameEventPayload {
+  return gameEventPayloadSchema.parse(payload);
+}
+
+export function extractGameVersionConflict(error: unknown): GameVersionConflictResponse | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  const apiError = error as ApiClientError;
+  if (apiError.code !== "VERSION_CONFLICT" || !apiError.payload) {
+    return null;
+  }
+
+  const parsed = gameVersionConflictResponseSchema.safeParse(apiError.payload);
+  return parsed.success ? parsed.data : null;
 }

--- a/frontend/src/core/api/http.mts
+++ b/frontend/src/core/api/http.mts
@@ -8,6 +8,8 @@ type ValidationSchema<T> = {
 
 export type ApiClientError = Error & {
   code?: string | null;
+  payload?: unknown;
+  status?: number;
 };
 
 type JsonRequestOptions<TRequest, TResponse> = {
@@ -27,6 +29,8 @@ function toApiClientError(
   options: {
     cause?: unknown;
     code?: string | null;
+    payload?: unknown;
+    status?: number;
   } = {}
 ): ApiClientError {
   const error = new Error(message, {
@@ -35,6 +39,14 @@ function toApiClientError(
 
   if (options.code !== undefined) {
     error.code = options.code;
+  }
+
+  if (options.payload !== undefined) {
+    error.payload = options.payload;
+  }
+
+  if (options.status !== undefined) {
+    error.status = options.status;
   }
 
   return error;
@@ -95,7 +107,9 @@ export async function requestJson<TRequest, TResponse>({
   if (!response.ok) {
     const payload = await tryReadJson(response);
     throw toApiClientError(translateServerMessage(payload, errorMessage), {
-      code: extractErrorCode(payload)
+      code: extractErrorCode(payload),
+      payload,
+      status: response.status
     });
   }
 

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -422,9 +422,7 @@ export const gameActionAttackBanzaiRequestSchema = gameplayRequestBaseSchema.ext
   attackDice: z.number().int().min(1).nullable().optional()
 });
 
-export type GameActionAttackBanzaiRequest = z.infer<
-  typeof gameActionAttackBanzaiRequestSchema
->;
+export type GameActionAttackBanzaiRequest = z.infer<typeof gameActionAttackBanzaiRequestSchema>;
 
 export const gameActionMoveAfterConquestRequestSchema = gameplayRequestBaseSchema.extend({
   type: z.literal("moveAfterConquest"),

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -382,6 +382,98 @@ export const gameIdRequestSchema = objectSchema({
 
 export type GameIdRequest = z.infer<typeof gameIdRequestSchema>;
 
+const gameplayRequestBaseSchema = objectSchema({
+  gameId: z.string().min(1).nullable().optional(),
+  playerId: z.string().min(1),
+  expectedVersion: z.number().int().min(1).nullable().optional()
+});
+
+export const startGameRequestSchema = gameplayRequestBaseSchema;
+
+export type StartGameRequest = z.infer<typeof startGameRequestSchema>;
+
+export const gameActionReinforceRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("reinforce"),
+  territoryId: z.string().min(1),
+  amount: z.number().int().min(1).nullable().optional()
+});
+
+export type GameActionReinforceRequest = z.infer<typeof gameActionReinforceRequestSchema>;
+
+export const gameActionEnvelopeSchema = gameplayRequestBaseSchema.extend({
+  type: z.string().min(1)
+});
+
+export type GameActionEnvelope = z.infer<typeof gameActionEnvelopeSchema>;
+
+export const gameActionAttackRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("attack"),
+  fromId: z.string().min(1),
+  toId: z.string().min(1),
+  attackDice: z.number().int().min(1).nullable().optional()
+});
+
+export type GameActionAttackRequest = z.infer<typeof gameActionAttackRequestSchema>;
+
+export const gameActionAttackBanzaiRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("attackBanzai"),
+  fromId: z.string().min(1),
+  toId: z.string().min(1),
+  attackDice: z.number().int().min(1).nullable().optional()
+});
+
+export type GameActionAttackBanzaiRequest = z.infer<
+  typeof gameActionAttackBanzaiRequestSchema
+>;
+
+export const gameActionMoveAfterConquestRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("moveAfterConquest"),
+  armies: z.number().int().min(1)
+});
+
+export type GameActionMoveAfterConquestRequest = z.infer<
+  typeof gameActionMoveAfterConquestRequestSchema
+>;
+
+export const gameActionFortifyRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("fortify"),
+  fromId: z.string().min(1),
+  toId: z.string().min(1),
+  armies: z.number().int().min(1)
+});
+
+export type GameActionFortifyRequest = z.infer<typeof gameActionFortifyRequestSchema>;
+
+export const gameActionEndTurnRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("endTurn")
+});
+
+export type GameActionEndTurnRequest = z.infer<typeof gameActionEndTurnRequestSchema>;
+
+export const gameActionSurrenderRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("surrender")
+});
+
+export type GameActionSurrenderRequest = z.infer<typeof gameActionSurrenderRequestSchema>;
+
+export const gameActionRequestSchema = z.discriminatedUnion("type", [
+  gameActionReinforceRequestSchema,
+  gameActionAttackRequestSchema,
+  gameActionAttackBanzaiRequestSchema,
+  gameActionMoveAfterConquestRequestSchema,
+  gameActionFortifyRequestSchema,
+  gameActionEndTurnRequestSchema,
+  gameActionSurrenderRequestSchema
+]);
+
+export type GameActionRequest = z.infer<typeof gameActionRequestSchema>;
+
+export const tradeCardsRequestSchema = gameplayRequestBaseSchema.extend({
+  cardIds: z.array(z.string().min(1)).length(3)
+});
+
+export type TradeCardsRequest = z.infer<typeof tradeCardsRequestSchema>;
+
 export const gameListResponseSchema = objectSchema({
   games: z.array(gameSummarySchema),
   activeGameId: z.string().min(1).nullable().optional()
@@ -414,6 +506,231 @@ export const gameOptionsResponseSchema = objectSchema({
 
 export type GameOptionsResponse = z.infer<typeof gameOptionsResponseSchema>;
 
+export const gameConfigPieceSetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  paletteSize: z.number()
+});
+
+export type GameConfigPieceSet = z.infer<typeof gameConfigPieceSetSchema>;
+
+export const snapshotPlayerSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  color: z.string().min(1),
+  connected: z.boolean().optional(),
+  isAi: z.boolean().optional(),
+  surrendered: z.boolean().optional(),
+  territoryCount: z.number().optional(),
+  eliminated: z.boolean().optional(),
+  cardCount: z.number().optional()
+});
+
+export type SnapshotPlayer = z.infer<typeof snapshotPlayerSchema>;
+
+export const snapshotTerritorySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  neighbors: z.array(z.string().min(1)),
+  continentId: z.string().min(1).nullable().optional(),
+  ownerId: z.string().min(1).nullable(),
+  armies: z.number(),
+  x: z.number().nullable().optional(),
+  y: z.number().nullable().optional()
+});
+
+export type SnapshotTerritory = z.infer<typeof snapshotTerritorySchema>;
+
+export const snapshotCardSchema = objectSchema({
+  id: z.string().min(1),
+  territoryId: z.string().min(1).nullable().optional(),
+  type: z.string().min(1).nullable().optional()
+});
+
+export type SnapshotCard = z.infer<typeof snapshotCardSchema>;
+
+export const snapshotCombatComparisonSchema = objectSchema({
+  winner: z.string().min(1),
+  attackDie: z.number().optional(),
+  defendDie: z.number().optional(),
+  pair: z.number().optional()
+});
+
+export type SnapshotCombatComparison = z.infer<typeof snapshotCombatComparisonSchema>;
+
+export const snapshotLastCombatSchema = objectSchema({
+  fromTerritoryId: z.string().min(1),
+  toTerritoryId: z.string().min(1),
+  attackerPlayerId: z.string().min(1).optional(),
+  defenderPlayerId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).optional(),
+  attackDiceCount: z.number().optional(),
+  defendDiceCount: z.number().optional(),
+  attackerRolls: z.array(z.number()).optional(),
+  defenderRolls: z.array(z.number()).optional(),
+  comparisons: z.array(snapshotCombatComparisonSchema).optional(),
+  attackerArmiesBefore: z.number().optional(),
+  defenderArmiesBefore: z.number().optional(),
+  attackerArmiesRemaining: z.number().optional(),
+  defenderArmiesRemaining: z.number().optional(),
+  conqueredTerritory: z.boolean().optional(),
+  defenderReducedToZero: z.boolean().optional()
+});
+
+export type SnapshotLastCombat = z.infer<typeof snapshotLastCombatSchema>;
+
+export const pendingConquestSchema = objectSchema({
+  fromId: z.string().min(1).optional(),
+  toId: z.string().min(1).optional(),
+  minArmies: z.number().optional(),
+  maxArmies: z.number().optional()
+});
+
+export type PendingConquest = z.infer<typeof pendingConquestSchema>;
+
+export const snapshotCardStateSchema = objectSchema({
+  ruleSetId: z.string().min(1).optional(),
+  tradeCount: z.number().optional(),
+  deckCount: z.number().optional(),
+  discardCount: z.number().optional(),
+  nextTradeBonus: z.number().optional(),
+  maxHandBeforeForcedTrade: z.number().optional(),
+  currentPlayerMustTrade: z.boolean().optional()
+});
+
+export type SnapshotCardState = z.infer<typeof snapshotCardStateSchema>;
+
+export const snapshotMapAspectRatioSchema = objectSchema({
+  width: z.number().optional(),
+  height: z.number().optional()
+});
+
+export type SnapshotMapAspectRatio = z.infer<typeof snapshotMapAspectRatioSchema>;
+
+export const snapshotMapVisualSchema = objectSchema({
+  imageUrl: z.string().min(1).nullable().optional(),
+  aspectRatio: snapshotMapAspectRatioSchema.nullable().optional()
+});
+
+export type SnapshotMapVisual = z.infer<typeof snapshotMapVisualSchema>;
+
+export const snapshotDiceRuleSetSchema = objectSchema({
+  id: z.string().min(1).optional(),
+  attackerMaxDice: z.number().optional(),
+  defenderMaxDice: z.number().optional()
+});
+
+export type SnapshotDiceRuleSet = z.infer<typeof snapshotDiceRuleSetSchema>;
+
+export const snapshotLogEntrySchema = objectSchema({
+  message: z.string().min(1).optional(),
+  messageKey: z.string().min(1).nullable().optional(),
+  messageParams: z.record(z.string(), z.unknown()).optional(),
+  error: z.string().min(1).optional(),
+  errorKey: z.string().min(1).nullable().optional(),
+  errorParams: z.record(z.string(), z.unknown()).optional(),
+  reason: z.string().min(1).optional(),
+  reasonKey: z.string().min(1).nullable().optional(),
+  reasonParams: z.record(z.string(), z.unknown()).optional()
+});
+
+export type SnapshotLogEntry = z.infer<typeof snapshotLogEntrySchema>;
+
+export const gameConfigSummarySchema = objectSchema({
+  contentPackId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  extensionSchemaVersion: z.number().optional(),
+  moduleSchemaVersion: z.number().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  ruleSetName: z.string().min(1).nullable().optional(),
+  mapName: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional(),
+  activeModules: z.array(netRiskModuleReferenceSchema).optional(),
+  gamePresetId: z.string().min(1).nullable().optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  pieceSet: gameConfigPieceSetSchema.nullable().optional(),
+  pieceSkin: pieceSkinSchema.nullable().optional(),
+  turnTimeoutHours: z.number().int().nullable().optional(),
+  totalPlayers: z.number().int().optional(),
+  players: z.array(playerSlotConfigSchema).optional()
+});
+
+export type GameConfigSummary = z.infer<typeof gameConfigSummarySchema>;
+
+export const gameSnapshotSchema = objectSchema({
+  gameId: z.string().min(1).nullable().optional(),
+  gameName: z.string().min(1).nullable().optional(),
+  version: z.number().int().nullable().optional(),
+  playerId: z.string().min(1).nullable().optional(),
+  phase: z.string().min(1).optional(),
+  turnPhase: z.string().min(1).optional(),
+  currentPlayerId: z.string().min(1).nullable().optional(),
+  winnerId: z.string().min(1).nullable().optional(),
+  players: z.array(snapshotPlayerSchema),
+  map: z.array(snapshotTerritorySchema),
+  continents: z.array(z.record(z.string(), z.unknown())).optional(),
+  reinforcementPool: z.number(),
+  playerHand: z.array(snapshotCardSchema).optional(),
+  pendingConquest: pendingConquestSchema.nullable().optional(),
+  lastAction: z.record(z.string(), z.unknown()).nullable().optional(),
+  lastCombat: snapshotLastCombatSchema.nullable().optional(),
+  cardState: snapshotCardStateSchema.nullable().optional(),
+  gameConfig: gameConfigSummarySchema.nullable().optional(),
+  mapVisual: snapshotMapVisualSchema.nullable().optional(),
+  diceRuleSet: snapshotDiceRuleSetSchema.nullable().optional(),
+  fortifyUsed: z.boolean().optional(),
+  attacksThisTurn: z.number().optional(),
+  conqueredTerritoryThisTurn: z.boolean().optional(),
+  log: z.array(z.string()).optional(),
+  logEntries: z.array(snapshotLogEntrySchema).optional()
+});
+
+export type GameSnapshot = z.infer<typeof gameSnapshotSchema>;
+
+export const gameMutationStateSchema = objectSchema({
+  gameId: z.string().min(1).nullable().optional(),
+  gameName: z.string().min(1).nullable().optional(),
+  version: z.number().int().nullable().optional(),
+  playerId: z.string().min(1).nullable().optional(),
+  phase: z.string().min(1).optional(),
+  turnPhase: z.string().min(1).optional(),
+  currentPlayerId: z.string().min(1).nullable().optional(),
+  winnerId: z.string().min(1).nullable().optional(),
+  players: z.union([z.array(snapshotPlayerSchema), z.number()]).optional(),
+  map: z.union([z.array(snapshotTerritorySchema), z.number()]).optional(),
+  continents: z.array(z.record(z.string(), z.unknown())).optional(),
+  reinforcementPool: z.number().optional(),
+  playerHand: z.array(snapshotCardSchema).optional(),
+  pendingConquest: pendingConquestSchema.nullable().optional(),
+  lastAction: z.record(z.string(), z.unknown()).nullable().optional(),
+  lastCombat: snapshotLastCombatSchema.nullable().optional(),
+  cardState: snapshotCardStateSchema.nullable().optional(),
+  gameConfig: gameConfigSummarySchema.nullable().optional(),
+  mapVisual: snapshotMapVisualSchema.nullable().optional(),
+  diceRuleSet: snapshotDiceRuleSetSchema.nullable().optional(),
+  fortifyUsed: z.boolean().optional(),
+  attacksThisTurn: z.number().optional(),
+  conqueredTerritoryThisTurn: z.boolean().optional(),
+  log: z.array(z.string()).optional(),
+  logEntries: z.array(snapshotLogEntrySchema).optional()
+});
+
+export type GameMutationState = z.infer<typeof gameMutationStateSchema>;
+
+export const gameStateResponseSchema = gameSnapshotSchema;
+
+export type GameStateResponse = z.infer<typeof gameStateResponseSchema>;
+
+export const gameEventPayloadSchema = gameSnapshotSchema;
+
+export type GameEventPayload = z.infer<typeof gameEventPayloadSchema>;
+
 export const gameMutationGameSchema = objectSchema({
   id: z.string().min(1),
   name: z.string().min(1).nullable().optional()
@@ -423,14 +740,27 @@ export type GameMutationGame = z.infer<typeof gameMutationGameSchema>;
 
 export const gameMutationResponseSchema = objectSchema({
   ok: z.literal(true).optional(),
+  code: z.string().min(1).nullable().optional(),
+  currentVersion: z.number().int().nullable().optional(),
   user: publicUserSchema.optional(),
   playerId: z.string().min(1).nullable().optional(),
+  bonus: z.number().optional(),
+  validation: z.record(z.string(), z.unknown()).optional(),
   game: gameMutationGameSchema.optional(),
   games: z.array(gameSummarySchema).optional(),
-  activeGameId: z.string().min(1).nullable().optional()
+  activeGameId: z.string().min(1).nullable().optional(),
+  state: gameMutationStateSchema.optional()
 });
 
 export type GameMutationResponse = z.infer<typeof gameMutationResponseSchema>;
+
+export const gameVersionConflictResponseSchema = objectSchema({
+  code: z.literal("VERSION_CONFLICT"),
+  currentVersion: z.number().int().nullable().optional(),
+  state: gameMutationStateSchema
+});
+
+export type GameVersionConflictResponse = z.infer<typeof gameVersionConflictResponseSchema>;
 
 export const createGameResponseSchema = objectSchema({
   ok: z.literal(true),
@@ -438,7 +768,7 @@ export const createGameResponseSchema = objectSchema({
   game: gameMutationGameSchema,
   games: z.array(gameSummarySchema),
   activeGameId: z.string().min(1).nullable().optional(),
-  state: z.record(z.string(), z.unknown()).optional(),
+  state: gameMutationStateSchema.optional(),
   config: z.record(z.string(), z.unknown()).optional()
 });
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -2262,12 +2262,10 @@ register("game start route blocca l'avvio se la partita e gia iniziata", async (
       gameName: "Started Game"
     }),
     (body: Record<string, unknown>) => String(body.gameId || ""),
-    async () => {
-      throw new Error("getGame should not be called after phase guard");
-    },
-    () => {
-      throw new Error("authorize should not be called after phase guard");
-    },
+    async () => ({
+      game: { id: "game-1", creatorUserId: "user-1" }
+    }),
+    () => undefined,
     () => {
       throw new Error("getPlayer should not be called after phase guard");
     },
@@ -2296,6 +2294,144 @@ register("game start route blocca l'avvio se la partita e gia iniziata", async (
     code: null
   });
 });
+
+register("game start route rilegge la versione aggiornata dopo l'autorizzazione", async () => {
+  const res = makeMockResponse();
+
+  await handleStartRoute(
+    { method: "POST", headers: {} },
+    res,
+    { gameId: "game-1", playerId: "player-1", expectedVersion: 2 },
+    new URL("http://127.0.0.1/api/start"),
+    async () => ({ user: { id: "user-1", username: "Alice" } }),
+    async () => ({
+      state: {
+        phase: "lobby",
+        players: [{ id: "player-1" }, { id: "player-2" }, { id: "player-3" }]
+      },
+      gameId: "game-1",
+      version: 3,
+      gameName: "Reloaded Start Game"
+    }),
+    (body: Record<string, unknown>) => String(body.gameId || ""),
+    async () => ({
+      game: { id: "game-1", creatorUserId: "user-1" }
+    }),
+    () => undefined,
+    () => {
+      throw new Error("getPlayer should not be called on version conflict");
+    },
+    () => false,
+    () => {
+      throw new Error("startGame should not be called on version conflict");
+    },
+    async () => {
+      throw new Error("persistWithAiTurns should not be called on version conflict");
+    },
+    () => {
+      throw new Error("broadcastGame should not be called on version conflict");
+    },
+    (state: any, gameId: string, version: number, gameName: string) => ({
+      gameId,
+      version,
+      gameName,
+      playerCount: state.players.length
+    }),
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(res.statusCode, 409);
+  assert.deepEqual(JSON.parse(res.body), {
+    error: "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+    messageKey: "server.versionConflict",
+    messageParams: {},
+    code: "VERSION_CONFLICT",
+    currentVersion: 3,
+    state: {
+      gameId: "game-1",
+      version: 3,
+      gameName: "Reloaded Start Game",
+      playerCount: 3
+    }
+  });
+});
+
+register(
+  "game start route non muta lo stato condiviso se il salvataggio va in version conflict",
+  async () => {
+    const res = makeMockResponse();
+    const sharedState = {
+      phase: "lobby",
+      players: [{ id: "player-1" }, { id: "player-2" }]
+    };
+
+    await handleStartRoute(
+      { method: "POST", headers: {} },
+      res,
+      { gameId: "game-1", playerId: "player-1", expectedVersion: 2 },
+      new URL("http://127.0.0.1/api/start"),
+      async () => ({ user: { id: "user-1", username: "Alice" } }),
+      async () => ({
+        state: sharedState,
+        gameId: "game-1",
+        version: 2,
+        gameName: "Conflict Start Game"
+      }),
+      (body: Record<string, unknown>) => String(body.gameId || ""),
+      async () => ({
+        game: { id: "game-1", creatorUserId: "user-1" }
+      }),
+      () => undefined,
+      () => ({ id: "player-1", linkedUserId: "user-1" }),
+      () => true,
+      (state: any) => {
+        state.phase = "active";
+      },
+      async () => {
+        const error = new Error("Conflitto salvataggio");
+        Object.assign(error, {
+          code: "VERSION_CONFLICT",
+          currentVersion: 3,
+          currentState: {
+            phase: "lobby",
+            players: [{ id: "player-1" }, { id: "player-2" }]
+          },
+          game: { name: "Conflict Start Game" },
+          messageKey: "server.versionConflict"
+        });
+        throw error;
+      },
+      () => {
+        throw new Error("broadcastGame should not be called after persist conflict");
+      },
+      (state: any, gameId: string, version: number, gameName: string) => ({
+        phase: state.phase,
+        gameId,
+        version,
+        gameName
+      }),
+      sendJson,
+      sendLocalizedError
+    );
+
+    assert.equal(sharedState.phase, "lobby");
+    assert.equal(res.statusCode, 409);
+    assert.deepEqual(JSON.parse(res.body), {
+      error: "Conflitto salvataggio",
+      messageKey: "server.versionConflict",
+      messageParams: {},
+      code: "VERSION_CONFLICT",
+      currentVersion: 3,
+      state: {
+        phase: "lobby",
+        gameId: "game-1",
+        version: 3,
+        gameName: "Conflict Start Game"
+      }
+    });
+  }
+);
 
 register("game start route richiede almeno due giocatori", async () => {
   const res = makeMockResponse();

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -2619,6 +2619,262 @@ register("frontend API client invia body JSON tipizzati per join e logout", asyn
   assert.equal(requests[1]?.init?.body, JSON.stringify({}));
 });
 
+register(
+  "frontend API client copre i boundary gameplay e recupera i version conflict",
+  async () => {
+    const client = await getFrontendApiClientModule();
+    const requests: Array<{ input: string; init?: Record<string, unknown> }> = [];
+    const gameId = "game 1/alpha";
+    const gameplayState = {
+      gameId,
+      gameName: "React Match",
+      version: 4,
+      playerId: "player-1",
+      phase: "active",
+      turnPhase: "reinforcement",
+      currentPlayerId: "player-1",
+      winnerId: null,
+      players: [
+        {
+          id: "player-1",
+          name: "Alice",
+          color: "#e85d04",
+          connected: true,
+          isAi: false,
+          territoryCount: 1,
+          eliminated: false,
+          cardCount: 3
+        },
+        {
+          id: "player-2",
+          name: "Bob",
+          color: "#0f4c5c",
+          connected: true,
+          isAi: false,
+          territoryCount: 1,
+          eliminated: false,
+          cardCount: 0
+        }
+      ],
+      map: [
+        {
+          id: "aurora",
+          name: "Aurora",
+          neighbors: ["bastion"],
+          continentId: "north",
+          ownerId: "player-1",
+          armies: 3,
+          x: 0.2,
+          y: 0.3
+        },
+        {
+          id: "bastion",
+          name: "Bastion",
+          neighbors: ["aurora"],
+          continentId: "north",
+          ownerId: "player-2",
+          armies: 1,
+          x: 0.65,
+          y: 0.45
+        }
+      ],
+      continents: [],
+      reinforcementPool: 3,
+      playerHand: [
+        { id: "c1", type: "infantry", territoryId: "aurora" },
+        { id: "c2", type: "cavalry", territoryId: "bastion" },
+        { id: "c3", type: "wild" }
+      ],
+      pendingConquest: null,
+      lastAction: null,
+      lastCombat: null,
+      cardState: {
+        ruleSetId: "standard",
+        tradeCount: 0,
+        deckCount: 12,
+        discardCount: 0,
+        nextTradeBonus: 4,
+        maxHandBeforeForcedTrade: 5,
+        currentPlayerMustTrade: false
+      },
+      gameConfig: {
+        mapId: "classic-mini",
+        mapName: "Classic Mini",
+        totalPlayers: 2,
+        players: [{ type: "human" }, { type: "human" }]
+      },
+      fortifyUsed: false,
+      attacksThisTurn: 0,
+      conqueredTerritoryThisTurn: false,
+      log: ["Gameplay route ready"],
+      logEntries: [
+        {
+          message: "Gameplay route ready",
+          messageKey: "game.log.lobbyCreated",
+          messageParams: {}
+        }
+      ]
+    };
+    const mutationState = {
+      ...gameplayState,
+      version: 5,
+      turnPhase: "attack",
+      reinforcementPool: 0
+    };
+
+    await withMockFetch(
+      async (input: string, init?: Record<string, unknown>) => {
+        requests.push({ input, init });
+
+        if (input === `/api/state?gameId=${encodeURIComponent(gameId)}`) {
+          return {
+            ok: true,
+            async json() {
+              return gameplayState;
+            }
+          };
+        }
+
+        if (input === "/api/start") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                ok: true,
+                playerId: "player-1",
+                state: mutationState
+              };
+            }
+          };
+        }
+
+        if (input === "/api/action") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                ok: true,
+                state: mutationState
+              };
+            }
+          };
+        }
+
+        if (input === "/api/cards/trade") {
+          return {
+            ok: true,
+            async json() {
+              return {
+                ok: true,
+                bonus: 4,
+                state: mutationState
+              };
+            }
+          };
+        }
+
+        throw new Error(`Unexpected request: ${input}`);
+      },
+      async () => {
+        const state = await client.getGameState(gameId, {
+          errorMessage: "Stato partita non disponibile",
+          fallbackMessage: "Stato partita non valido"
+        });
+        const started = await client.startGame(
+          {
+            gameId,
+            playerId: "player-1",
+            expectedVersion: 4
+          },
+          {
+            errorMessage: "Avvio partita non disponibile",
+            fallbackMessage: "Avvio partita non valido"
+          }
+        );
+        const action = await client.sendGameAction(
+          {
+            gameId,
+            playerId: "player-1",
+            type: "reinforce",
+            territoryId: "aurora",
+            amount: 1,
+            expectedVersion: 5
+          },
+          {
+            errorMessage: "Azione non disponibile",
+            fallbackMessage: "Azione non valida"
+          }
+        );
+        const trade = await client.tradeCards(
+          {
+            gameId,
+            playerId: "player-1",
+            cardIds: ["c1", "c2", "c3"],
+            expectedVersion: 5
+          },
+          {
+            errorMessage: "Trade non disponibile",
+            fallbackMessage: "Trade non valido"
+          }
+        );
+        const eventPayload = client.parseGameEventPayload(gameplayState);
+        const versionConflictPayload = {
+          code: "VERSION_CONFLICT",
+          currentVersion: 5,
+          state: mutationState
+        };
+        const versionConflictError = Object.assign(new Error("Conflitto versione"), {
+          code: "VERSION_CONFLICT",
+          payload: versionConflictPayload
+        });
+
+        assert.equal(state.gameId, gameId);
+        assert.equal(started.state.version, 5);
+        assert.equal(action.state.turnPhase, "attack");
+        assert.equal(trade.bonus, 4);
+        assert.equal(eventPayload.currentPlayerId, "player-1");
+        assert.deepEqual(
+          client.extractGameVersionConflict(versionConflictError),
+          versionConflictPayload
+        );
+        assert.equal(client.extractGameVersionConflict(new Error("Other error")), null);
+      }
+    );
+
+    assert.deepEqual(
+      requests.map((entry) => entry.input),
+      [
+        `/api/state?gameId=${encodeURIComponent(gameId)}`,
+        "/api/start",
+        "/api/action",
+        "/api/cards/trade"
+      ]
+    );
+    assert.equal(requests[1]?.init?.method, "POST");
+    assert.equal(requests[2]?.init?.method, "POST");
+    assert.equal(requests[3]?.init?.method, "POST");
+    assert.deepEqual(JSON.parse(String(requests[1]?.init?.body)), {
+      gameId,
+      playerId: "player-1",
+      expectedVersion: 4
+    });
+    assert.deepEqual(JSON.parse(String(requests[2]?.init?.body)), {
+      gameId,
+      playerId: "player-1",
+      type: "reinforce",
+      territoryId: "aurora",
+      amount: 1,
+      expectedVersion: 5
+    });
+    assert.deepEqual(JSON.parse(String(requests[3]?.init?.body)), {
+      gameId,
+      playerId: "player-1",
+      cardIds: ["c1", "c2", "c3"],
+      expectedVersion: 5
+    });
+  }
+);
+
 register("game action route segnala il version conflict prima di eseguire mutazioni", async () => {
   const res = makeMockResponse();
 

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -421,9 +421,7 @@ export const gameActionAttackBanzaiRequestSchema = gameplayRequestBaseSchema.ext
   attackDice: z.number().int().min(1).nullable().optional()
 });
 
-export type GameActionAttackBanzaiRequest = z.infer<
-  typeof gameActionAttackBanzaiRequestSchema
->;
+export type GameActionAttackBanzaiRequest = z.infer<typeof gameActionAttackBanzaiRequestSchema>;
 
 export const gameActionMoveAfterConquestRequestSchema = gameplayRequestBaseSchema.extend({
   type: z.literal("moveAfterConquest"),

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -381,6 +381,98 @@ export const gameIdRequestSchema = objectSchema({
 
 export type GameIdRequest = z.infer<typeof gameIdRequestSchema>;
 
+const gameplayRequestBaseSchema = objectSchema({
+  gameId: z.string().min(1).nullable().optional(),
+  playerId: z.string().min(1),
+  expectedVersion: z.number().int().min(1).nullable().optional()
+});
+
+export const startGameRequestSchema = gameplayRequestBaseSchema;
+
+export type StartGameRequest = z.infer<typeof startGameRequestSchema>;
+
+export const gameActionReinforceRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("reinforce"),
+  territoryId: z.string().min(1),
+  amount: z.number().int().min(1).nullable().optional()
+});
+
+export type GameActionReinforceRequest = z.infer<typeof gameActionReinforceRequestSchema>;
+
+export const gameActionEnvelopeSchema = gameplayRequestBaseSchema.extend({
+  type: z.string().min(1)
+});
+
+export type GameActionEnvelope = z.infer<typeof gameActionEnvelopeSchema>;
+
+export const gameActionAttackRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("attack"),
+  fromId: z.string().min(1),
+  toId: z.string().min(1),
+  attackDice: z.number().int().min(1).nullable().optional()
+});
+
+export type GameActionAttackRequest = z.infer<typeof gameActionAttackRequestSchema>;
+
+export const gameActionAttackBanzaiRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("attackBanzai"),
+  fromId: z.string().min(1),
+  toId: z.string().min(1),
+  attackDice: z.number().int().min(1).nullable().optional()
+});
+
+export type GameActionAttackBanzaiRequest = z.infer<
+  typeof gameActionAttackBanzaiRequestSchema
+>;
+
+export const gameActionMoveAfterConquestRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("moveAfterConquest"),
+  armies: z.number().int().min(1)
+});
+
+export type GameActionMoveAfterConquestRequest = z.infer<
+  typeof gameActionMoveAfterConquestRequestSchema
+>;
+
+export const gameActionFortifyRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("fortify"),
+  fromId: z.string().min(1),
+  toId: z.string().min(1),
+  armies: z.number().int().min(1)
+});
+
+export type GameActionFortifyRequest = z.infer<typeof gameActionFortifyRequestSchema>;
+
+export const gameActionEndTurnRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("endTurn")
+});
+
+export type GameActionEndTurnRequest = z.infer<typeof gameActionEndTurnRequestSchema>;
+
+export const gameActionSurrenderRequestSchema = gameplayRequestBaseSchema.extend({
+  type: z.literal("surrender")
+});
+
+export type GameActionSurrenderRequest = z.infer<typeof gameActionSurrenderRequestSchema>;
+
+export const gameActionRequestSchema = z.discriminatedUnion("type", [
+  gameActionReinforceRequestSchema,
+  gameActionAttackRequestSchema,
+  gameActionAttackBanzaiRequestSchema,
+  gameActionMoveAfterConquestRequestSchema,
+  gameActionFortifyRequestSchema,
+  gameActionEndTurnRequestSchema,
+  gameActionSurrenderRequestSchema
+]);
+
+export type GameActionRequest = z.infer<typeof gameActionRequestSchema>;
+
+export const tradeCardsRequestSchema = gameplayRequestBaseSchema.extend({
+  cardIds: z.array(z.string().min(1)).length(3)
+});
+
+export type TradeCardsRequest = z.infer<typeof tradeCardsRequestSchema>;
+
 export const gameListResponseSchema = objectSchema({
   games: z.array(gameSummarySchema),
   activeGameId: z.string().min(1).nullable().optional()
@@ -413,6 +505,231 @@ export const gameOptionsResponseSchema = objectSchema({
 
 export type GameOptionsResponse = z.infer<typeof gameOptionsResponseSchema>;
 
+export const gameConfigPieceSetSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  paletteSize: z.number()
+});
+
+export type GameConfigPieceSet = z.infer<typeof gameConfigPieceSetSchema>;
+
+export const snapshotPlayerSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  color: z.string().min(1),
+  connected: z.boolean().optional(),
+  isAi: z.boolean().optional(),
+  surrendered: z.boolean().optional(),
+  territoryCount: z.number().optional(),
+  eliminated: z.boolean().optional(),
+  cardCount: z.number().optional()
+});
+
+export type SnapshotPlayer = z.infer<typeof snapshotPlayerSchema>;
+
+export const snapshotTerritorySchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  neighbors: z.array(z.string().min(1)),
+  continentId: z.string().min(1).nullable().optional(),
+  ownerId: z.string().min(1).nullable(),
+  armies: z.number(),
+  x: z.number().nullable().optional(),
+  y: z.number().nullable().optional()
+});
+
+export type SnapshotTerritory = z.infer<typeof snapshotTerritorySchema>;
+
+export const snapshotCardSchema = objectSchema({
+  id: z.string().min(1),
+  territoryId: z.string().min(1).nullable().optional(),
+  type: z.string().min(1).nullable().optional()
+});
+
+export type SnapshotCard = z.infer<typeof snapshotCardSchema>;
+
+export const snapshotCombatComparisonSchema = objectSchema({
+  winner: z.string().min(1),
+  attackDie: z.number().optional(),
+  defendDie: z.number().optional(),
+  pair: z.number().optional()
+});
+
+export type SnapshotCombatComparison = z.infer<typeof snapshotCombatComparisonSchema>;
+
+export const snapshotLastCombatSchema = objectSchema({
+  fromTerritoryId: z.string().min(1),
+  toTerritoryId: z.string().min(1),
+  attackerPlayerId: z.string().min(1).optional(),
+  defenderPlayerId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).optional(),
+  attackDiceCount: z.number().optional(),
+  defendDiceCount: z.number().optional(),
+  attackerRolls: z.array(z.number()).optional(),
+  defenderRolls: z.array(z.number()).optional(),
+  comparisons: z.array(snapshotCombatComparisonSchema).optional(),
+  attackerArmiesBefore: z.number().optional(),
+  defenderArmiesBefore: z.number().optional(),
+  attackerArmiesRemaining: z.number().optional(),
+  defenderArmiesRemaining: z.number().optional(),
+  conqueredTerritory: z.boolean().optional(),
+  defenderReducedToZero: z.boolean().optional()
+});
+
+export type SnapshotLastCombat = z.infer<typeof snapshotLastCombatSchema>;
+
+export const pendingConquestSchema = objectSchema({
+  fromId: z.string().min(1).optional(),
+  toId: z.string().min(1).optional(),
+  minArmies: z.number().optional(),
+  maxArmies: z.number().optional()
+});
+
+export type PendingConquest = z.infer<typeof pendingConquestSchema>;
+
+export const snapshotCardStateSchema = objectSchema({
+  ruleSetId: z.string().min(1).optional(),
+  tradeCount: z.number().optional(),
+  deckCount: z.number().optional(),
+  discardCount: z.number().optional(),
+  nextTradeBonus: z.number().optional(),
+  maxHandBeforeForcedTrade: z.number().optional(),
+  currentPlayerMustTrade: z.boolean().optional()
+});
+
+export type SnapshotCardState = z.infer<typeof snapshotCardStateSchema>;
+
+export const snapshotMapAspectRatioSchema = objectSchema({
+  width: z.number().optional(),
+  height: z.number().optional()
+});
+
+export type SnapshotMapAspectRatio = z.infer<typeof snapshotMapAspectRatioSchema>;
+
+export const snapshotMapVisualSchema = objectSchema({
+  imageUrl: z.string().min(1).nullable().optional(),
+  aspectRatio: snapshotMapAspectRatioSchema.nullable().optional()
+});
+
+export type SnapshotMapVisual = z.infer<typeof snapshotMapVisualSchema>;
+
+export const snapshotDiceRuleSetSchema = objectSchema({
+  id: z.string().min(1).optional(),
+  attackerMaxDice: z.number().optional(),
+  defenderMaxDice: z.number().optional()
+});
+
+export type SnapshotDiceRuleSet = z.infer<typeof snapshotDiceRuleSetSchema>;
+
+export const snapshotLogEntrySchema = objectSchema({
+  message: z.string().min(1).optional(),
+  messageKey: z.string().min(1).nullable().optional(),
+  messageParams: z.record(z.string(), z.unknown()).optional(),
+  error: z.string().min(1).optional(),
+  errorKey: z.string().min(1).nullable().optional(),
+  errorParams: z.record(z.string(), z.unknown()).optional(),
+  reason: z.string().min(1).optional(),
+  reasonKey: z.string().min(1).nullable().optional(),
+  reasonParams: z.record(z.string(), z.unknown()).optional()
+});
+
+export type SnapshotLogEntry = z.infer<typeof snapshotLogEntrySchema>;
+
+export const gameConfigSummarySchema = objectSchema({
+  contentPackId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  extensionSchemaVersion: z.number().optional(),
+  moduleSchemaVersion: z.number().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  ruleSetName: z.string().min(1).nullable().optional(),
+  mapName: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional(),
+  activeModules: z.array(netRiskModuleReferenceSchema).optional(),
+  gamePresetId: z.string().min(1).nullable().optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  pieceSet: gameConfigPieceSetSchema.nullable().optional(),
+  pieceSkin: pieceSkinSchema.nullable().optional(),
+  turnTimeoutHours: z.number().int().nullable().optional(),
+  totalPlayers: z.number().int().optional(),
+  players: z.array(playerSlotConfigSchema).optional()
+});
+
+export type GameConfigSummary = z.infer<typeof gameConfigSummarySchema>;
+
+export const gameSnapshotSchema = objectSchema({
+  gameId: z.string().min(1).nullable().optional(),
+  gameName: z.string().min(1).nullable().optional(),
+  version: z.number().int().nullable().optional(),
+  playerId: z.string().min(1).nullable().optional(),
+  phase: z.string().min(1).optional(),
+  turnPhase: z.string().min(1).optional(),
+  currentPlayerId: z.string().min(1).nullable().optional(),
+  winnerId: z.string().min(1).nullable().optional(),
+  players: z.array(snapshotPlayerSchema),
+  map: z.array(snapshotTerritorySchema),
+  continents: z.array(z.record(z.string(), z.unknown())).optional(),
+  reinforcementPool: z.number(),
+  playerHand: z.array(snapshotCardSchema).optional(),
+  pendingConquest: pendingConquestSchema.nullable().optional(),
+  lastAction: z.record(z.string(), z.unknown()).nullable().optional(),
+  lastCombat: snapshotLastCombatSchema.nullable().optional(),
+  cardState: snapshotCardStateSchema.nullable().optional(),
+  gameConfig: gameConfigSummarySchema.nullable().optional(),
+  mapVisual: snapshotMapVisualSchema.nullable().optional(),
+  diceRuleSet: snapshotDiceRuleSetSchema.nullable().optional(),
+  fortifyUsed: z.boolean().optional(),
+  attacksThisTurn: z.number().optional(),
+  conqueredTerritoryThisTurn: z.boolean().optional(),
+  log: z.array(z.string()).optional(),
+  logEntries: z.array(snapshotLogEntrySchema).optional()
+});
+
+export type GameSnapshot = z.infer<typeof gameSnapshotSchema>;
+
+export const gameMutationStateSchema = objectSchema({
+  gameId: z.string().min(1).nullable().optional(),
+  gameName: z.string().min(1).nullable().optional(),
+  version: z.number().int().nullable().optional(),
+  playerId: z.string().min(1).nullable().optional(),
+  phase: z.string().min(1).optional(),
+  turnPhase: z.string().min(1).optional(),
+  currentPlayerId: z.string().min(1).nullable().optional(),
+  winnerId: z.string().min(1).nullable().optional(),
+  players: z.union([z.array(snapshotPlayerSchema), z.number()]).optional(),
+  map: z.union([z.array(snapshotTerritorySchema), z.number()]).optional(),
+  continents: z.array(z.record(z.string(), z.unknown())).optional(),
+  reinforcementPool: z.number().optional(),
+  playerHand: z.array(snapshotCardSchema).optional(),
+  pendingConquest: pendingConquestSchema.nullable().optional(),
+  lastAction: z.record(z.string(), z.unknown()).nullable().optional(),
+  lastCombat: snapshotLastCombatSchema.nullable().optional(),
+  cardState: snapshotCardStateSchema.nullable().optional(),
+  gameConfig: gameConfigSummarySchema.nullable().optional(),
+  mapVisual: snapshotMapVisualSchema.nullable().optional(),
+  diceRuleSet: snapshotDiceRuleSetSchema.nullable().optional(),
+  fortifyUsed: z.boolean().optional(),
+  attacksThisTurn: z.number().optional(),
+  conqueredTerritoryThisTurn: z.boolean().optional(),
+  log: z.array(z.string()).optional(),
+  logEntries: z.array(snapshotLogEntrySchema).optional()
+});
+
+export type GameMutationState = z.infer<typeof gameMutationStateSchema>;
+
+export const gameStateResponseSchema = gameSnapshotSchema;
+
+export type GameStateResponse = z.infer<typeof gameStateResponseSchema>;
+
+export const gameEventPayloadSchema = gameSnapshotSchema;
+
+export type GameEventPayload = z.infer<typeof gameEventPayloadSchema>;
+
 export const gameMutationGameSchema = objectSchema({
   id: z.string().min(1),
   name: z.string().min(1).nullable().optional()
@@ -422,14 +739,27 @@ export type GameMutationGame = z.infer<typeof gameMutationGameSchema>;
 
 export const gameMutationResponseSchema = objectSchema({
   ok: z.literal(true).optional(),
+  code: z.string().min(1).nullable().optional(),
+  currentVersion: z.number().int().nullable().optional(),
   user: publicUserSchema.optional(),
   playerId: z.string().min(1).nullable().optional(),
+  bonus: z.number().optional(),
+  validation: z.record(z.string(), z.unknown()).optional(),
   game: gameMutationGameSchema.optional(),
   games: z.array(gameSummarySchema).optional(),
-  activeGameId: z.string().min(1).nullable().optional()
+  activeGameId: z.string().min(1).nullable().optional(),
+  state: gameMutationStateSchema.optional()
 });
 
 export type GameMutationResponse = z.infer<typeof gameMutationResponseSchema>;
+
+export const gameVersionConflictResponseSchema = objectSchema({
+  code: z.literal("VERSION_CONFLICT"),
+  currentVersion: z.number().int().nullable().optional(),
+  state: gameMutationStateSchema
+});
+
+export type GameVersionConflictResponse = z.infer<typeof gameVersionConflictResponseSchema>;
 
 export const createGameResponseSchema = objectSchema({
   ok: z.literal(true),
@@ -437,7 +767,7 @@ export const createGameResponseSchema = objectSchema({
   game: gameMutationGameSchema,
   games: z.array(gameSummarySchema),
   activeGameId: z.string().min(1).nullable().optional(),
-  state: z.record(z.string(), z.unknown()).optional(),
+  state: gameMutationStateSchema.optional(),
   config: z.record(z.string(), z.unknown()).optional()
 });
 

--- a/tests/gameplay/README.md
+++ b/tests/gameplay/README.md
@@ -26,3 +26,4 @@ The command builds the current TypeScript sources first and then runs the gamepl
 
 - Gameplay tests are registered explicitly by the harness, so adding a new test file also requires wiring it into `scripts/run-gameplay-tests.cts`.
 - This suite is the right place for engine rules, module-runtime regressions, and deterministic repository checks that do not need a browser.
+- Browser-independent frontend/backend contract tests for the typed HTTP client live in `scripts/run-tests.cts`, not in this gameplay harness.


### PR DESCRIPTION
Closes #102

## Summary
- add shared gameplay validation and typed client helpers for `/api/state`, `/api/events`, `/api/action`, `/api/cards/trade`, and `/api/start`
- implement the React gameplay route on `/react/game/:gameId` with snapshot query, SSE updates, action panels, map selections, and explicit legacy fallback
- switch React lobby/profile/new-game entry points to the new gameplay route and add smoke coverage for deep links, core turn flow, forced trade, and fallback

## Validation
- npm run typecheck
- npm run test:all
- npm run test:e2e -- e2e/smoke/react-shell-gameplay.spec.ts
- npm run test:e2e -- e2e/smoke/react-shell.spec.ts e2e/smoke/react-shell-lobby.spec.ts e2e/smoke/react-shell-new-game.spec.ts