### PR TITLE
docs: add issue 60 documentation pack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to NetRisk
+
+NetRisk grows best through small, well-bounded changes. Keep frontend rendering concerns, backend orchestration, and pure engine rules separate so new features stay easy to review and extend.
+
+## Local setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Optional local environment setup:
+
+```powershell
+Copy-Item .env.example .env.local
+```
+
+```bash
+cp .env.example .env.local
+```
+
+For local work without Supabase, you can omit `.env.local` or set:
+
+```bash
+DATASTORE_DRIVER=sqlite
+PORT=3000
+```
+
+Useful local commands:
+
+```bash
+npm start
+npm run dev:react-shell
+npm run format:check
+npm run lint
+npm run typecheck
+npm test
+npm run test:gameplay
+npm run test:e2e:smoke
+```
+
+## Change boundaries
+
+- `frontend` and `frontend/react-shell`: rendering, navigation, UI state, and client transport helpers
+- `backend`: HTTP routing, auth, persistence, orchestration, and module/runtime integration
+- `backend/engine`: pure turn logic and rules
+- `shared`: contracts, runtime validation, registries, map data, and shared domain types
+- `modules`: runtime-discoverable extensions, presets, UI slots, and optional server-side content
+
+Keep game rules out of React components and out of route handlers. The backend is the source of truth for state transitions.
+
+## Working style
+
+- Prefer small, reviewable commits and PRs.
+- Modify the minimum code required for the change.
+- Do not mix cosmetic refactors with feature work.
+- Reuse existing ids, registries, and validation helpers instead of introducing parallel patterns.
+- Keep new code in TypeScript.
+
+## Validation expectations
+
+Run the smallest relevant validation set for your change, then broaden when the edit crosses boundaries.
+
+- Documentation-only changes: `npm run format:check`
+- Shared types, routes, or engine logic: `npm run typecheck` and `npm test`
+- Turn rules, setup rules, or combat/reinforcement changes: `npm run test:gameplay`
+- UI, routing, or end-to-end behavior changes: `npm run test:e2e:smoke` or the most relevant Playwright subset
+
+If you change public API payloads or shared validation, verify the implementation against `shared/runtime-validation.cts` and `shared/api-contracts.cts`.
+
+## Adding maps
+
+Built-in maps live in `shared`, not in the frontend.
+
+1. Add typed territory and continent data under `shared/maps/data`.
+2. Add the map module under `shared/maps`.
+3. Register it in `shared/maps/index.cts`.
+4. Keep map-specific validation and topology inside shared helpers such as `shared/map-graph.cts` and `shared/map-loader.cts`.
+5. Cover the new map with gameplay and shared tests instead of UI-only checks.
+
+Do not hardcode map rules or adjacency in the browser.
+
+## Adding rules
+
+Rules should be selected by stable ids and resolved on the backend.
+
+1. Add or extend the shared registry that owns the rule family, such as dice, victory, reinforcement, or fortify rule sets.
+2. Persist only ids and metadata needed by the game config.
+3. Apply the rule in the appropriate engine module under `backend/engine`.
+4. Keep request/response validation separate from rule evaluation.
+5. Add focused tests under `tests/gameplay`.
+
+If a rule changes setup defaults or extension selection, update the shared extension/module selection flow rather than duplicating conditionals in the UI.
+
+## Adding runtime modules
+
+Runtime modules are the right choice for additive content, presets, UI slots, or optional gameplay packaging.
+
+1. Create a folder under `modules/<module-id>`.
+2. Add `module.json` with id, version, capabilities, dependencies, and entrypoints.
+3. Add `client-manifest.json` for UI slots, profiles, presets, and client-visible content declarations.
+4. Add a server entrypoint only when the module contributes runtime maps, content packs, piece sets, dice rule sets, or server-side profile defaults.
+5. Verify the module through the runtime catalog and add or extend regression coverage in `tests/gameplay/regression/module-runtime.test.cts`.
+
+Use the existing `modules/demo.command-center` fixture as the baseline shape for manifests and slot declarations.
+
+## API and validation guardrails
+
+- Shared request and response schemas belong in `shared` when both backend and frontend consume them.
+- Validate inbound route payloads and important outbound responses.
+- Treat opaque game snapshots as server-owned data structures.
+- Keep OpenAPI and Markdown API docs aligned with the code whenever a public route changes.
+
+## Pull requests
+
+A good PR for NetRisk is narrow, tested, and explicit about touched boundaries.
+
+- Summarize what changed and why.
+- List any public API or docs updates.
+- Mention the validation commands you ran.
+- Call out follow-up work separately instead of folding it into the same change.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Today the project includes:
 
 Currently supported maps are `classic-mini`, `middle-earth`, and `world-classic`.
 
+## Documentation
+
+- [OpenAPI reference](docs/openapi.json)
+- [API transport notes](docs/api.md)
+- [Gameplay flows](docs/gameplay-flows.md)
+- [Extending NetRisk](docs/extending-netrisk.md)
+- [Contributing](CONTRIBUTING.md)
+- [Architecture background](ARCHITECTURE.md)
+
 ## Quick Start
 
 Prerequisites:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,149 @@
+# NetRisk API Notes
+
+`docs/openapi.json` is the canonical reference for the stable JSON endpoints that are documented as schema-backed or interface-backed contracts.
+
+This companion guide covers public endpoints that are intentionally snapshot-driven, stream-based, or not yet modeled as first-class OpenAPI schemas.
+
+## Transport rules
+
+- Session auth uses the `netrisk_session` cookie.
+- Cron auth uses `Authorization: Bearer <CRON_SECRET>`.
+- Most game mutations accept `gameId` in the body. Read endpoints may also resolve `gameId` from the query string. If neither is present, the backend falls back to the active game in server memory.
+- Game snapshots are server-owned objects. Treat them as opaque documents and read only the fields your client actually needs.
+- Localized error responses use the same envelope shape across the backend:
+
+```json
+{
+  "error": "Human-readable fallback message.",
+  "messageKey": "server.example.key",
+  "messageParams": {},
+  "code": "OPTIONAL_CODE"
+}
+```
+
+- Request validation failures add `validationErrors` and use `code: "REQUEST_VALIDATION_FAILED"`.
+- Optimistic concurrency conflicts return `409` with `code: "VERSION_CONFLICT"`, `currentVersion`, and a fresh `state` snapshot.
+
+## Endpoints outside the OpenAPI artifact
+
+### `GET /api/state`
+
+- Returns the current game snapshot or the snapshot for `?gameId=<id>`.
+- Creator-bound games require a valid session; open games can be read without auth.
+- Before responding, the backend may resume pending AI work for the requested game.
+- The snapshot shape is intentionally broad and mirrors the state the frontend consumes.
+
+### `GET /api/events`
+
+- Server-Sent Events endpoint for game snapshots.
+- Response content type is `text/event-stream`.
+- Sends one snapshot immediately after the stream opens, then pushes later snapshots for the same game.
+- The stream is read-only. AI recovery happens on state/open reads, not because a client is subscribed.
+
+### `POST /api/action`
+
+Cookie-authenticated mutation endpoint for active-turn actions.
+
+Common fields:
+
+- `playerId`: required
+- `type`: required
+- `gameId`: optional when the active game is already selected
+- `expectedVersion`: optional but recommended for optimistic concurrency
+
+Supported action types:
+
+- `reinforce`: requires `territoryId`; accepts optional `amount`
+- `attack`: requires `fromId`, `toId`; accepts optional `attackDice`
+- `attackBanzai`: same request shape as `attack`
+- `moveAfterConquest`: requires `armies`
+- `fortify`: requires `fromId`, `toId`, `armies`
+- `endTurn`: no extra fields
+- `surrender`: no extra fields
+
+Success responses return:
+
+```json
+{
+  "ok": true,
+  "state": {},
+  "rounds": []
+}
+```
+
+`rounds` is present only for attack variants.
+
+### `POST /api/join`
+
+- Cookie-authenticated join for a human player.
+- Request body must resolve to a valid `gameId`.
+- Returns `200` for a rejoin and `201` for a new join.
+- Success payload includes `playerId`, `state`, and `user`.
+
+### `POST /api/ai/join`
+
+- Adds an AI player to a lobby.
+- Expects `gameId` and `name`.
+- Returns `200` for a rejoin and `201` for a new AI slot.
+- Success payload includes `playerId`, `state`, and the created `player`.
+
+### `POST /api/start`
+
+- Cookie-authenticated lobby mutation.
+- Expects `gameId` and `playerId`.
+- The authenticated user must be allowed to start the game and must own the supplied player slot.
+- Success payload is `{ "ok": true, "state": { ... } }`.
+
+### `POST /api/cards/trade`
+
+- Cookie-authenticated reinforcement-phase mutation.
+- Expects `gameId`, `playerId`, `cardIds`, and optional `expectedVersion`.
+- On success returns:
+
+```json
+{
+  "ok": true,
+  "bonus": 0,
+  "validation": {},
+  "state": {}
+}
+```
+
+- On version conflict returns the standard `409` snapshot reload envelope.
+
+## Public JSON endpoints not modeled in OpenAPI yet
+
+### `POST /api/auth/register`
+
+- Request body accepts `username`, `password`, and optional `email`.
+- On success the backend returns:
+
+```json
+{
+  "ok": true,
+  "user": {},
+  "nextAuthProviders": ["password", "email", "google", "discord"]
+}
+```
+
+- This route is public, but it is not yet backed by a shared runtime response schema, so it is documented here instead of in `docs/openapi.json`.
+
+### `GET /api/health`
+
+- Returns a lightweight backend snapshot:
+
+```json
+{
+  "ok": true,
+  "storage": {},
+  "activeGameId": "optional-id",
+  "activeGameVersion": 1,
+  "hasActiveGame": true
+}
+```
+
+- The route answers with `200` when `ok` is true and `503` otherwise.
+
+## Internal endpoints excluded from public docs
+
+`/api/test/reset` and `/api/test/next-attack-rolls` exist only for E2E support when `E2E=true`. They are intentionally excluded from the public API reference.

--- a/docs/extending-netrisk.md
+++ b/docs/extending-netrisk.md
@@ -1,0 +1,140 @@
+# Extending NetRisk
+
+NetRisk supports two extension paths:
+
+- built-in extensions under `shared` for core maps, registries, and engine-integrated rule families
+- runtime modules under `modules` for additive content, presets, UI slots, and optional server-side content packages
+
+Choose the built-in path when the feature becomes part of the main product baseline. Choose a runtime module when the feature should stay optional, discoverable, and enable/disable-friendly.
+
+## Path 1: built-in maps and rule registries
+
+Use this path for core content that should always ship with the base game.
+
+### Adding a built-in map
+
+1. Add typed territory and continent records under `shared/maps/data`.
+2. Add the exported map module under `shared/maps`.
+3. Register it in `shared/maps/index.cts`.
+4. Keep topology and validation inside shared utilities such as `shared/map-graph.cts`, `shared/map-loader.cts`, and `shared/typed-map-data.cts`.
+5. Cover the new map with shared and gameplay tests.
+
+The current built-in map registry is resolved through `shared/maps/index.cts`, which is the single source of truth for supported maps.
+
+### Adding a built-in rule family or rule variant
+
+Rule ids should remain stable and backend-resolved.
+
+1. Add the rule definition to the owning shared registry, for example:
+   - `shared/combat-rule-sets.cts`
+   - `shared/reinforcement-rule-sets.cts`
+   - `shared/fortify-rule-sets.cts`
+   - `shared/victory-rule-sets.cts`
+   - `shared/dice.cts`
+2. Make sure setup and extension selection continue to store rule ids instead of duplicated rule logic. The current selection flow is centered on `shared/extensions.cts`.
+3. Apply the rule in the matching engine module under `backend/engine`.
+4. Update validation and defaults only where the transport or configuration shape changes.
+5. Add focused gameplay tests.
+
+Good examples already in the repository:
+
+- dice rule selection flowing through `shared/dice.cts`, `shared/extensions.cts`, and `backend/new-game-config.cts`
+- victory rule selection resolved in `shared/victory-rule-sets.cts` and enforced in `backend/engine/victory-detection.cts`
+
+## Path 2: runtime modules
+
+Runtime modules are loaded from `modules` and validated by the backend runtime catalog.
+
+Use this path for:
+
+- optional maps or content packs
+- selectable presets and profiles
+- UI slot contributions
+- runtime piece sets, dice rule sets, or server-side gameplay defaults
+
+### Required files
+
+Every module starts with `module.json`. Client-visible contributions live in `client-manifest.json`. Add a server entrypoint only when the module contributes server-side content or defaults.
+
+Minimal structure:
+
+```text
+modules/<module-id>/
+  module.json
+  client-manifest.json
+  server-module.cts   # optional
+  assets/             # optional
+```
+
+### `module.json`
+
+Use `module.json` to declare:
+
+- stable `id`, `version`, and `engineVersion`
+- `kind` (`content`, `gameplay`, `ui`, or `hybrid`)
+- dependencies and conflicts
+- capabilities
+- entrypoints and optional assets directory
+
+The existing `modules/demo.command-center/module.json` is the best reference for a valid hybrid module manifest.
+
+### `client-manifest.json`
+
+Use the client manifest for declarations the backend can expose without running custom code:
+
+- `ui.slots`
+- `gamePresets`
+- `profiles.content`
+- `profiles.gameplay`
+- `profiles.ui`
+- client-visible `content` capability ids
+
+The demo module shows all three patterns:
+
+- slot contributions for lobby, new game, game sidebar, and admin modules
+- a game preset that activates the module and picks profiles
+- named profiles for content, gameplay, and UI
+
+### Optional server entrypoint
+
+Add a server entrypoint when the module contributes runtime content or defaults that the backend must resolve directly. The current runtime supports:
+
+- `maps`
+- `contentPacks`
+- `playerPieceSets`
+- `diceRuleSets`
+- server-side `profiles`
+
+The regression coverage in `tests/gameplay/regression/module-runtime.test.cts` contains concrete fixtures for runtime maps, content packs, piece sets, dice rule sets, and server-side default profiles.
+
+### Runtime module checklist
+
+1. Declare the module and its capabilities in `module.json`.
+2. Add `client-manifest.json` for presets, slots, and profiles.
+3. Add a server entrypoint only when backend-resolved content is needed.
+4. Enable the module through the modules API or admin tooling.
+5. Verify that `GET /api/modules/options` and `GET /api/game/options` expose the expected catalog changes.
+6. Add regression coverage for enable/disable behavior and selection rules.
+
+## Built-in vs runtime: which one should you pick?
+
+Use built-in extensions when:
+
+- the feature is part of the default NetRisk product
+- it must always be available
+- the engine should depend on it directly
+
+Use runtime modules when:
+
+- the feature is optional or experimental
+- you want enable/disable support
+- you need presets, profiles, or UI slot packaging
+- you want to ship content without rewriting the base registries
+
+## Guardrails
+
+- Keep game rules in `backend/engine`, not in React components.
+- Keep shared ids and transport contracts in `shared`.
+- Avoid duplicating validation in both frontend and backend.
+- Prefer additive modules and registries over broad refactors.
+- Back every new map, rule, or module path with focused tests.

--- a/docs/gameplay-flows.md
+++ b/docs/gameplay-flows.md
@@ -1,0 +1,95 @@
+# NetRisk Gameplay Flows
+
+These diagrams are derived from the current engine and regression tests in `tests/gameplay`. They describe the server-authoritative flow the UI has to follow.
+
+## Game lifecycle
+
+```mermaid
+flowchart LR
+    Create["POST /api/games"] --> Lobby["Lobby"]
+    Lobby --> JoinHuman["POST /api/join"]
+    JoinHuman --> Lobby
+    Lobby --> JoinAi["POST /api/ai/join"]
+    JoinAi --> Lobby
+    Lobby --> OpenLobby["POST /api/games/open"]
+    OpenLobby --> Lobby
+    Lobby --> Start["POST /api/start"]
+    Start --> Active["Active game"]
+    Active --> OpenActive["POST /api/games/open"]
+    OpenActive --> Active
+    Active --> Surrender["type=surrender"]
+    Surrender --> VictoryCheck{"Winner detected?"}
+    Active --> TurnLoop["Turn loop"]
+    TurnLoop --> VictoryCheck
+    VictoryCheck -- "No" --> TurnLoop
+    VictoryCheck -- "Yes" --> Ended["Ended"]
+```
+
+Notes:
+
+- The game remains in `lobby` until a valid start request succeeds.
+- `POST /api/games/open` does not mutate the rules flow; it rehydrates a saved snapshot and can resume pending AI work before replying.
+- Player surrender feeds the same victory detection path used by normal turn resolution.
+
+## Turn lifecycle
+
+```mermaid
+flowchart LR
+    Reinforcement["Reinforcement phase"] --> TradeGate{"Mandatory trade required?"}
+    TradeGate -- "Yes" --> Trade["POST /api/cards/trade"]
+    Trade --> Reinforcement
+    TradeGate -- "No" --> Place["type=reinforce"]
+    Place --> PoolEmpty{"Pool empty?"}
+    PoolEmpty -- "No" --> Reinforcement
+    PoolEmpty -- "Yes" --> Attack["Attack phase"]
+
+    Attack --> AttackAction["type=attack or type=attackBanzai"]
+    AttackAction --> Conquest{"Territory conquered?"}
+    Conquest -- "Yes" --> MoveAfter["type=moveAfterConquest"]
+    MoveAfter --> Attack
+    Conquest -- "No" --> Attack
+
+    Attack --> EndAttack["type=endTurn"]
+    EndAttack --> AttackGate{"Minimum attacks reached?"}
+    AttackGate -- "No, legal attacks remain" --> Attack
+    AttackGate -- "Yes or none available" --> Fortify["Fortify phase"]
+
+    Fortify --> FortifyAction["type=fortify"]
+    FortifyAction --> NextTurn["Next player turn"]
+    Fortify --> SkipFortify["type=endTurn"]
+    SkipFortify --> FortifyGate{"Required fortify available?"}
+    FortifyGate -- "Yes" --> Fortify
+    FortifyGate -- "No" --> NextTurn
+
+    NextTurn --> Reinforcement
+```
+
+Notes:
+
+- Reinforcements transition to attack only when the pool reaches zero.
+- A conquest can force a post-combat movement before more attacks are allowed.
+- `endTurn` from attack moves the game into `fortify` before advancing to the next player.
+- Optional gameplay effects can require a minimum number of attacks or force a fortify when one is legally available.
+
+## Mutation transport and version conflicts
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as Backend API
+    participant Stream as SSE listeners
+
+    Client->>API: Mutation with expectedVersion
+    alt Version matches
+        API-->>Client: 200 { ok, state }
+        API-->>Stream: fresh snapshot event
+    else Version conflict
+        API-->>Client: 409 { code: "VERSION_CONFLICT", currentVersion, state }
+        Client->>Client: replace local snapshot
+    end
+```
+
+Notes:
+
+- The backend owns the authoritative snapshot after every mutation.
+- When the client receives a version conflict, the correct recovery path is to replace local state with the returned snapshot and retry only if the action is still valid.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,2115 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "NetRisk Backend API",
+    "version": "0.1.0",
+    "description": "Static OpenAPI reference for the stable NetRisk JSON endpoints. Snapshot-driven and stream-based routes are documented in docs/api.md."
+  },
+  "jsonSchemaDialect": "https://spec.openapis.org/oas/3.1/dialect/base",
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "tags": [
+    {
+      "name": "auth"
+    },
+    {
+      "name": "profile"
+    },
+    {
+      "name": "games"
+    },
+    {
+      "name": "modules"
+    },
+    {
+      "name": "cron"
+    }
+  ],
+  "paths": {
+    "/api/auth/login": {
+      "post": {
+        "tags": ["auth"],
+        "operationId": "loginWithPassword",
+        "summary": "Create a password-authenticated session",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login succeeded.",
+            "headers": {
+              "Set-Cookie": {
+                "description": "Session cookie for subsequent authenticated requests.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationFailure"
+          },
+          "401": {
+            "$ref": "#/components/responses/LocalizedError"
+          }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "tags": ["auth"],
+        "operationId": "logout",
+        "summary": "Clear the current session cookie",
+        "responses": {
+          "200": {
+            "description": "Logout succeeded.",
+            "headers": {
+              "Set-Cookie": {
+                "description": "Clears the session cookie.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogoutResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/session": {
+      "get": {
+        "tags": ["auth"],
+        "operationId": "getAuthSession",
+        "summary": "Read the authenticated session user",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current authenticated user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSessionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          }
+        }
+      }
+    },
+    "/api/profile": {
+      "get": {
+        "tags": ["profile"],
+        "operationId": "getProfile",
+        "summary": "Read the profile for the authenticated user",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile summary and participating games.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/LocalizedError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          }
+        }
+      }
+    },
+    "/api/profile/preferences/theme": {
+      "put": {
+        "tags": ["profile"],
+        "operationId": "updateThemePreference",
+        "summary": "Update the authenticated user's theme preference",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThemePreferenceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Theme preference persisted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThemePreferenceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request validation failed or the requested theme is unsupported.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ValidationFailure"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LocalizedError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          }
+        }
+      }
+    },
+    "/api/games": {
+      "get": {
+        "tags": ["games"],
+        "operationId": "listGames",
+        "summary": "List known games",
+        "parameters": [
+          {
+            "name": "gameId",
+            "in": "query",
+            "required": false,
+            "description": "Optional game context override used to populate activeGameId in the response.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Game summaries currently known to the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GameListResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["games"],
+        "operationId": "createGame",
+        "summary": "Create a new game",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGameRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Game created and initial snapshot returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateGameResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or creation failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ValidationFailure"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LocalizedError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          }
+        }
+      }
+    },
+    "/api/games/open": {
+      "post": {
+        "tags": ["games"],
+        "operationId": "openGame",
+        "summary": "Open an existing game and return a fresh snapshot",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GameIdRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Game opened successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GameMutationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or open failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ValidationFailure"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LocalizedError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          }
+        }
+      }
+    },
+    "/api/game/options": {
+      "get": {
+        "tags": ["games"],
+        "operationId": "getGameOptions",
+        "summary": "Read the selectable setup catalog",
+        "responses": {
+          "200": {
+            "description": "Catalog used to configure new games.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GameOptionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/game-options": {
+      "get": {
+        "tags": ["games"],
+        "operationId": "getGameOptionsLegacyAlias",
+        "summary": "Legacy alias for the game options catalog",
+        "description": "Returns the same payload as GET /api/game/options.",
+        "responses": {
+          "200": {
+            "description": "Catalog used to configure new games.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GameOptionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/modules/options": {
+      "get": {
+        "tags": ["modules"],
+        "operationId": "getModuleOptions",
+        "summary": "Read the runtime module option snapshot",
+        "responses": {
+          "200": {
+            "description": "Runtime module selection data and enabled content restrictions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModuleOptionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/modules": {
+      "get": {
+        "tags": ["modules"],
+        "operationId": "listInstalledModules",
+        "summary": "Read the installed module catalog",
+        "description": "Requires an authenticated user with module management permissions.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Installed modules and enabled references.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModulesCatalogResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/LocalizedError"
+          }
+        }
+      }
+    },
+    "/api/modules/rescan": {
+      "post": {
+        "tags": ["modules"],
+        "operationId": "rescanModules",
+        "summary": "Rescan the module directory and rebuild the catalog",
+        "description": "Requires an authenticated user with module management permissions.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Catalog rescan completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModuleCatalogMutationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/LocalizedError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/LocalizedError"
+          }
+        }
+      }
+    },
+    "/api/modules/{moduleId}/enable": {
+      "post": {
+        "tags": ["modules"],
+        "operationId": "enableModule",
+        "summary": "Enable a runtime module",
+        "description": "Requires an authenticated user with module management permissions.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "moduleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Module enabled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModuleCatalogMutationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/LocalizedError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/LocalizedError"
+          }
+        }
+      }
+    },
+    "/api/modules/{moduleId}/disable": {
+      "post": {
+        "tags": ["modules"],
+        "operationId": "disableModule",
+        "summary": "Disable a runtime module",
+        "description": "Requires an authenticated user with module management permissions.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "moduleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Module disabled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModuleCatalogMutationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/LocalizedError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthRequired"
+          },
+          "403": {
+            "$ref": "#/components/responses/LocalizedError"
+          },
+          "409": {
+            "$ref": "#/components/responses/LocalizedError"
+          }
+        }
+      }
+    },
+    "/api/cron/scheduled-jobs": {
+      "get": {
+        "tags": ["cron"],
+        "operationId": "runScheduledJobs",
+        "summary": "Run the scheduled turn timeout and AI recovery jobs",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scheduled jobs executed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduledJobsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/LocalizedError"
+          },
+          "500": {
+            "$ref": "#/components/responses/LocalizedError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "netrisk_session"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "responses": {
+      "LocalizedError": {
+        "description": "Localized backend error envelope.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LocalizedError"
+            }
+          }
+        }
+      },
+      "ValidationFailure": {
+        "description": "Request payload validation failed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ValidationFailure"
+            }
+          }
+        }
+      },
+      "AuthRequired": {
+        "description": "A valid session cookie is required.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LocalizedError"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "LocalizedParams": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "ValidationErrorItem": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["code", "path", "message"],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "LocalizedError": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["error", "messageKey", "messageParams", "code"],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "messageKey": {
+            "type": ["string", "null"]
+          },
+          "messageParams": {
+            "$ref": "#/components/schemas/LocalizedParams"
+          },
+          "code": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "ValidationFailure": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LocalizedError"
+          },
+          {
+            "type": "object",
+            "required": ["validationErrors"],
+            "properties": {
+              "validationErrors": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ValidationErrorItem"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GameStateSnapshot": {
+        "type": "object",
+        "description": "Opaque server-owned game snapshot.",
+        "additionalProperties": true
+      },
+      "ThemePreferences": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "theme": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "PublicUser": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "username"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "authMethods": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hasEmail": {
+            "type": "boolean"
+          },
+          "preferences": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ThemePreferences"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "AuthSessionResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["user"],
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/PublicUser"
+          }
+        }
+      },
+      "LoginRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["username", "password"],
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 1
+          },
+          "password": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "LoginResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ok", "user"],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/PublicUser"
+          },
+          "availableAuthProviders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "nextAuthProviders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LogoutResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ok"],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          }
+        }
+      },
+      "ThemePreferenceRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["theme"],
+        "properties": {
+          "theme": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "ThemePreferenceResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ok", "user", "preferences"],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/PublicUser"
+          },
+          "preferences": {
+            "$ref": "#/components/schemas/ThemePreferences"
+          }
+        }
+      },
+      "VictoryRuleSet": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "description"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "VisualTheme": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "description"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "PieceSkin": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "description", "renderStyleId", "usesPlayerColor"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "renderStyleId": {
+            "type": "string"
+          },
+          "usesPlayerColor": {
+            "type": "boolean"
+          },
+          "assetBaseUrl": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "NetRiskModuleReference": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "version"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "NetRiskModuleProfile": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "moduleId": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "NetRiskGamePresetDefaults": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "contentPackId": {
+            "type": ["string", "null"]
+          },
+          "ruleSetId": {
+            "type": ["string", "null"]
+          },
+          "pieceSetId": {
+            "type": ["string", "null"]
+          },
+          "mapId": {
+            "type": ["string", "null"]
+          },
+          "diceRuleSetId": {
+            "type": ["string", "null"]
+          },
+          "victoryRuleSetId": {
+            "type": ["string", "null"]
+          },
+          "themeId": {
+            "type": ["string", "null"]
+          },
+          "pieceSkinId": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "NetRiskGamePreset": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "moduleId": {
+            "type": ["string", "null"]
+          },
+          "activeModuleIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "contentProfileId": {
+            "type": ["string", "null"]
+          },
+          "gameplayProfileId": {
+            "type": ["string", "null"]
+          },
+          "uiProfileId": {
+            "type": ["string", "null"]
+          },
+          "defaults": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NetRiskGamePresetDefaults"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "NetRiskUiSlotContribution": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["slotId", "itemId", "title", "kind"],
+        "properties": {
+          "slotId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "order": {
+            "type": "number"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "route": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "NetRiskContentContribution": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "mapIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "siteThemeIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pieceSkinIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "playerPieceSetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "contentPackIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "diceRuleSetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cardRuleSetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "victoryRuleSetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "fortifyRuleSetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "reinforcementRuleSetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "NetRiskModuleCapability": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["kind"],
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": ["string", "null"]
+          },
+          "hook": {
+            "type": ["string", "null"]
+          },
+          "scope": {
+            "type": ["string", "null"]
+          },
+          "description": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "InstalledModuleSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "id",
+          "version",
+          "displayName",
+          "kind",
+          "sourcePath",
+          "status",
+          "enabled",
+          "compatible",
+          "warnings",
+          "errors",
+          "capabilities"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "version": {
+            "type": ["string", "null"]
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "kind": {
+            "type": ["string", "null"]
+          },
+          "sourcePath": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "compatible": {
+            "type": "boolean"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleCapability"
+            }
+          }
+        }
+      },
+      "PlayerPieceSetSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "paletteSize"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "paletteSize": {
+            "type": "number"
+          }
+        }
+      },
+      "ContentPackSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "id",
+          "name",
+          "description",
+          "defaultSiteThemeId",
+          "defaultMapId",
+          "defaultDiceRuleSetId",
+          "defaultCardRuleSetId",
+          "defaultVictoryRuleSetId",
+          "defaultPieceSetId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "defaultSiteThemeId": {
+            "type": "string"
+          },
+          "defaultMapId": {
+            "type": "string"
+          },
+          "defaultDiceRuleSetId": {
+            "type": "string"
+          },
+          "defaultCardRuleSetId": {
+            "type": "string"
+          },
+          "defaultVictoryRuleSetId": {
+            "type": "string"
+          },
+          "defaultPieceSetId": {
+            "type": "string"
+          }
+        }
+      },
+      "ContinentBonusSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["name", "bonus", "territoryCount"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "bonus": {
+            "type": "number"
+          },
+          "territoryCount": {
+            "type": "number"
+          }
+        }
+      },
+      "MapSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "territoryCount", "continentCount"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "territoryCount": {
+            "type": "number"
+          },
+          "continentCount": {
+            "type": "number"
+          },
+          "continentBonuses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContinentBonusSummary"
+            }
+          }
+        }
+      },
+      "RuleSetDefaults": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "extensionSchemaVersion",
+          "mapId",
+          "diceRuleSetId",
+          "victoryRuleSetId",
+          "themeId",
+          "pieceSkinId"
+        ],
+        "properties": {
+          "extensionSchemaVersion": {
+            "type": "number"
+          },
+          "mapId": {
+            "type": "string"
+          },
+          "diceRuleSetId": {
+            "type": "string"
+          },
+          "victoryRuleSetId": {
+            "type": "string"
+          },
+          "themeId": {
+            "type": "string"
+          },
+          "pieceSkinId": {
+            "type": "string"
+          }
+        }
+      },
+      "RuleSetSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "defaults"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "defaults": {
+            "$ref": "#/components/schemas/RuleSetDefaults"
+          },
+          "defaultDiceRuleSetId": {
+            "type": "string"
+          },
+          "defaultVictoryRuleSetId": {
+            "type": "string"
+          }
+        }
+      },
+      "DiceRuleSet": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "attackerMaxDice", "defenderMaxDice"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "attackerMaxDice": {
+            "type": "number"
+          },
+          "defenderMaxDice": {
+            "type": "number"
+          }
+        }
+      },
+      "PlayerSlotConfig": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "slot": {
+            "type": ["integer", "null"]
+          },
+          "type": {
+            "type": ["string", "null"]
+          },
+          "name": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "CreateGameRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": ["string", "null"]
+          },
+          "totalPlayers": {
+            "type": ["integer", "null"]
+          },
+          "contentPackId": {
+            "type": ["string", "null"]
+          },
+          "ruleSetId": {
+            "type": ["string", "null"]
+          },
+          "mapId": {
+            "type": ["string", "null"]
+          },
+          "diceRuleSetId": {
+            "type": ["string", "null"]
+          },
+          "victoryRuleSetId": {
+            "type": ["string", "null"]
+          },
+          "pieceSetId": {
+            "type": ["string", "null"]
+          },
+          "themeId": {
+            "type": ["string", "null"]
+          },
+          "pieceSkinId": {
+            "type": ["string", "null"]
+          },
+          "gamePresetId": {
+            "type": ["string", "null"]
+          },
+          "activeModuleIds": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "contentProfileId": {
+            "type": ["string", "null"]
+          },
+          "gameplayProfileId": {
+            "type": ["string", "null"]
+          },
+          "uiProfileId": {
+            "type": ["string", "null"]
+          },
+          "turnTimeoutHours": {
+            "type": ["integer", "null"]
+          },
+          "players": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/PlayerSlotConfig"
+            }
+          }
+        }
+      },
+      "GameSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "name", "phase", "playerCount", "updatedAt"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "playerCount": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "contentPackId": {
+            "type": ["string", "null"]
+          },
+          "diceRuleSetId": {
+            "type": ["string", "null"]
+          },
+          "totalPlayers": {
+            "type": ["number", "null"]
+          },
+          "mapName": {
+            "type": ["string", "null"]
+          },
+          "mapId": {
+            "type": ["string", "null"]
+          },
+          "aiCount": {
+            "type": "number"
+          },
+          "creatorUserId": {
+            "type": ["string", "null"]
+          },
+          "activeModules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleReference"
+            }
+          },
+          "gamePresetId": {
+            "type": ["string", "null"]
+          },
+          "contentProfileId": {
+            "type": ["string", "null"]
+          },
+          "gameplayProfileId": {
+            "type": ["string", "null"]
+          },
+          "uiProfileId": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "GameIdRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["gameId"],
+        "properties": {
+          "gameId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "GameListResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["games"],
+        "properties": {
+          "games": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GameSummary"
+            }
+          },
+          "activeGameId": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "GameOptionsResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ruleSets",
+          "maps",
+          "diceRuleSets",
+          "victoryRuleSets",
+          "themes",
+          "pieceSkins",
+          "turnTimeoutHoursOptions",
+          "playerRange"
+        ],
+        "properties": {
+          "ruleSets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleSetSummary"
+            }
+          },
+          "maps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MapSummary"
+            }
+          },
+          "diceRuleSets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiceRuleSet"
+            }
+          },
+          "victoryRuleSets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VictoryRuleSet"
+            }
+          },
+          "themes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisualTheme"
+            }
+          },
+          "pieceSkins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PieceSkin"
+            }
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstalledModuleSummary"
+            }
+          },
+          "enabledModules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleReference"
+            }
+          },
+          "gamePresets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskGamePreset"
+            }
+          },
+          "contentProfiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleProfile"
+            }
+          },
+          "gameplayProfiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleProfile"
+            }
+          },
+          "uiProfiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleProfile"
+            }
+          },
+          "uiSlots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskUiSlotContribution"
+            }
+          },
+          "playerPieceSets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlayerPieceSetSummary"
+            }
+          },
+          "contentPacks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentPackSummary"
+            }
+          },
+          "turnTimeoutHoursOptions": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "playerRange": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["min", "max"],
+            "properties": {
+              "min": {
+                "type": "integer"
+              },
+              "max": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "GameMutationGame": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "GameMutationResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/PublicUser"
+          },
+          "playerId": {
+            "type": ["string", "null"]
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameMutationGame"
+          },
+          "games": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GameSummary"
+            }
+          },
+          "activeGameId": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "CreateGameResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ok", "game", "games"],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "playerId": {
+            "type": ["string", "null"]
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameMutationGame"
+          },
+          "games": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GameSummary"
+            }
+          },
+          "activeGameId": {
+            "type": ["string", "null"]
+          },
+          "state": {
+            "$ref": "#/components/schemas/GameStateSnapshot"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "ParticipatingGameLobby": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "playerName",
+          "statusLabel",
+          "focusLabel",
+          "turnPhaseLabel",
+          "territoryCount",
+          "cardCount"
+        ],
+        "properties": {
+          "playerName": {
+            "type": "string"
+          },
+          "statusLabel": {
+            "type": "string"
+          },
+          "focusLabel": {
+            "type": "string"
+          },
+          "turnPhaseLabel": {
+            "type": "string"
+          },
+          "territoryCount": {
+            "type": "number"
+          },
+          "cardCount": {
+            "type": "number"
+          }
+        }
+      },
+      "ParticipatingGame": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GameSummary"
+          },
+          {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["totalPlayers", "mapName", "myLobby"],
+            "properties": {
+              "totalPlayers": {
+                "type": ["number", "null"]
+              },
+              "mapName": {
+                "type": ["string", "null"]
+              },
+              "myLobby": {
+                "$ref": "#/components/schemas/ParticipatingGameLobby"
+              }
+            }
+          }
+        ]
+      },
+      "ProfileContract": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "playerName",
+          "gamesPlayed",
+          "wins",
+          "losses",
+          "gamesInProgress",
+          "participatingGames",
+          "winRate",
+          "hasHistory",
+          "placeholders"
+        ],
+        "properties": {
+          "playerName": {
+            "type": "string"
+          },
+          "gamesPlayed": {
+            "type": "number"
+          },
+          "wins": {
+            "type": "number"
+          },
+          "losses": {
+            "type": "number"
+          },
+          "gamesInProgress": {
+            "type": "number"
+          },
+          "participatingGames": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipatingGame"
+            }
+          },
+          "winRate": {
+            "type": ["number", "null"]
+          },
+          "hasHistory": {
+            "type": "boolean"
+          },
+          "placeholders": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["recentGames", "ranking"],
+            "properties": {
+              "recentGames": {
+                "type": "boolean"
+              },
+              "ranking": {
+                "type": "boolean"
+              }
+            }
+          },
+          "preferences": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ThemePreferences"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "ProfileResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["profile"],
+        "properties": {
+          "profile": {
+            "$ref": "#/components/schemas/ProfileContract"
+          }
+        }
+      },
+      "ModulesCatalogResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["modules", "engineVersion", "enabledModules"],
+        "properties": {
+          "modules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstalledModuleSummary"
+            }
+          },
+          "engineVersion": {
+            "type": "string"
+          },
+          "enabledModules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleReference"
+            }
+          }
+        }
+      },
+      "ModuleOptionsResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "modules",
+          "enabledModules",
+          "gameModules",
+          "content",
+          "maps",
+          "playerPieceSets",
+          "diceRuleSets",
+          "contentPacks",
+          "gamePresets",
+          "uiSlots",
+          "contentProfiles",
+          "gameplayProfiles",
+          "uiProfiles"
+        ],
+        "properties": {
+          "modules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstalledModuleSummary"
+            }
+          },
+          "enabledModules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleReference"
+            }
+          },
+          "gameModules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstalledModuleSummary"
+            }
+          },
+          "content": {
+            "$ref": "#/components/schemas/NetRiskContentContribution"
+          },
+          "maps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MapSummary"
+            }
+          },
+          "playerPieceSets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlayerPieceSetSummary"
+            }
+          },
+          "diceRuleSets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiceRuleSet"
+            }
+          },
+          "contentPacks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentPackSummary"
+            }
+          },
+          "gamePresets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskGamePreset"
+            }
+          },
+          "uiSlots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskUiSlotContribution"
+            }
+          },
+          "contentProfiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleProfile"
+            }
+          },
+          "gameplayProfiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleProfile"
+            }
+          },
+          "uiProfiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleProfile"
+            }
+          }
+        }
+      },
+      "ModuleCatalogMutationResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ok", "modules", "enabledModules", "engineVersion"],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstalledModuleSummary"
+            }
+          },
+          "enabledModules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetRiskModuleReference"
+            }
+          },
+          "engineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TurnTimeoutEnforcementResult": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "scannedGames",
+          "eligibleGames",
+          "expiredGames",
+          "forcedTurns",
+          "skippedConflicts"
+        ],
+        "properties": {
+          "scannedGames": {
+            "type": "number"
+          },
+          "eligibleGames": {
+            "type": "number"
+          },
+          "expiredGames": {
+            "type": "number"
+          },
+          "forcedTurns": {
+            "type": "number"
+          },
+          "skippedConflicts": {
+            "type": "number"
+          }
+        }
+      },
+      "AiTurnRecoveryJobResult": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "scannedGames",
+          "eligibleGames",
+          "recoveryAttempts",
+          "recoveredGames",
+          "forcedTurns",
+          "interceptedErrors",
+          "skippedConflicts"
+        ],
+        "properties": {
+          "scannedGames": {
+            "type": "number"
+          },
+          "eligibleGames": {
+            "type": "number"
+          },
+          "recoveryAttempts": {
+            "type": "number"
+          },
+          "recoveredGames": {
+            "type": "number"
+          },
+          "forcedTurns": {
+            "type": "number"
+          },
+          "interceptedErrors": {
+            "type": "number"
+          },
+          "skippedConflicts": {
+            "type": "number"
+          }
+        }
+      },
+      "TurnTimeoutJobReport": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["name", "result"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "turn-timeout-enforcement"
+          },
+          "result": {
+            "$ref": "#/components/schemas/TurnTimeoutEnforcementResult"
+          }
+        }
+      },
+      "AiTurnRecoveryJobReport": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["name", "result"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "ai-turn-recovery"
+          },
+          "result": {
+            "$ref": "#/components/schemas/AiTurnRecoveryJobResult"
+          }
+        }
+      },
+      "ScheduledJobsResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ok", "jobs"],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TurnTimeoutJobReport"
+                },
+                {
+                  "$ref": "#/components/schemas/AiTurnRecoveryJobReport"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -145,7 +145,9 @@ function filterProfilesForSelectedModules(
     return [];
   }
 
-  return profiles.filter((profile) => !profile.moduleId || selectedModuleIds.includes(profile.moduleId));
+  return profiles.filter(
+    (profile) => !profile.moduleId || selectedModuleIds.includes(profile.moduleId)
+  );
 }
 
 function sanitizeProfiles(
@@ -239,17 +241,29 @@ function applyGamePreset(
     contentProfileId: preset.contentProfileId || "",
     gameplayProfileId: preset.gameplayProfileId || "",
     uiProfileId: preset.uiProfileId || "",
-    contentPackId: pickPresetId(preset.defaults?.contentPackId, formState.contentPackId, options.contentPacks),
+    contentPackId: pickPresetId(
+      preset.defaults?.contentPackId,
+      formState.contentPackId,
+      options.contentPacks
+    ),
     ruleSetId: pickPresetId(preset.defaults?.ruleSetId, formState.ruleSetId, options.ruleSets),
     mapId: pickPresetId(preset.defaults?.mapId, formState.mapId, options.maps),
-    diceRuleSetId: pickPresetId(preset.defaults?.diceRuleSetId, formState.diceRuleSetId, options.diceRuleSets),
+    diceRuleSetId: pickPresetId(
+      preset.defaults?.diceRuleSetId,
+      formState.diceRuleSetId,
+      options.diceRuleSets
+    ),
     victoryRuleSetId: pickPresetId(
       preset.defaults?.victoryRuleSetId,
       formState.victoryRuleSetId,
       options.victoryRuleSets
     ),
     themeId: pickPresetId(preset.defaults?.themeId, formState.themeId, options.themes),
-    pieceSkinId: pickPresetId(preset.defaults?.pieceSkinId, formState.pieceSkinId, options.pieceSkins)
+    pieceSkinId: pickPresetId(
+      preset.defaults?.pieceSkinId,
+      formState.pieceSkinId,
+      options.pieceSkins
+    )
   };
 
   return sanitizeProfiles(nextState, options);
@@ -296,7 +310,8 @@ export function LobbyCreateRoute() {
   });
 
   const options = gameOptionsQuery.data;
-  const availableModules = options?.modules?.filter((moduleEntry) => moduleEntry.id !== "core.base") || [];
+  const availableModules =
+    options?.modules?.filter((moduleEntry) => moduleEntry.id !== "core.base") || [];
   const contentProfiles = filterProfilesForSelectedModules(
     options?.contentProfiles,
     formState?.selectedModuleIds || []
@@ -340,7 +355,9 @@ export function LobbyCreateRoute() {
       ...(formState.themeId ? { themeId: formState.themeId } : {}),
       ...(formState.pieceSkinId ? { pieceSkinId: formState.pieceSkinId } : {}),
       ...(formState.gamePresetId ? { gamePresetId: formState.gamePresetId } : {}),
-      ...(formState.selectedModuleIds.length ? { activeModuleIds: formState.selectedModuleIds } : {}),
+      ...(formState.selectedModuleIds.length
+        ? { activeModuleIds: formState.selectedModuleIds }
+        : {}),
       ...(formState.contentProfileId ? { contentProfileId: formState.contentProfileId } : {}),
       ...(formState.gameplayProfileId ? { gameplayProfileId: formState.gameplayProfileId } : {}),
       ...(formState.uiProfileId ? { uiProfileId: formState.uiProfileId } : {}),
@@ -348,10 +365,12 @@ export function LobbyCreateRoute() {
         ? { turnTimeoutHours: Number(formState.turnTimeoutHours) }
         : {}),
       totalPlayers: formState.totalPlayers,
-      players: ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map((type, index) => ({
-        slot: index + 1,
-        type
-      }))
+      players: ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map(
+        (type, index) => ({
+          slot: index + 1,
+          type
+        })
+      )
     };
 
     try {
@@ -450,7 +469,11 @@ export function LobbyCreateRoute() {
               <select
                 value={formState.contentPackId}
                 onChange={(event) => {
-                  const nextState = applyContentPackDefaults(formState, options, event.target.value);
+                  const nextState = applyContentPackDefaults(
+                    formState,
+                    options,
+                    event.target.value
+                  );
                   updateFormState({
                     ...nextState,
                     gamePresetId: ""
@@ -527,7 +550,10 @@ export function LobbyCreateRoute() {
                 >
                   {Array.from(
                     {
-                      length: Math.max((options.playerRange?.max || 4) - (options.playerRange?.min || 2) + 1, 1)
+                      length: Math.max(
+                        (options.playerRange?.max || 4) - (options.playerRange?.min || 2) + 1,
+                        1
+                      )
                     },
                     (_, index) => (options.playerRange?.min || 2) + index
                   ).map((playerCount) => (
@@ -672,7 +698,11 @@ export function LobbyCreateRoute() {
               <p className="metric-copy">{t("newGame.options.copy")}</p>
             )}
 
-            {(options.gamePresets?.length || availableModules.length || contentProfiles.length || gameplayProfiles.length || uiProfiles.length) ? (
+            {options.gamePresets?.length ||
+            availableModules.length ||
+            contentProfiles.length ||
+            gameplayProfiles.length ||
+            uiProfiles.length ? (
               <div className="new-game-modules-stack">
                 {options.gamePresets?.length ? (
                   <label className="shell-field">
@@ -706,7 +736,9 @@ export function LobbyCreateRoute() {
                             onChange={(event) => {
                               const nextSelectedModuleIds = event.target.checked
                                 ? [...formState.selectedModuleIds, moduleEntry.id]
-                                : formState.selectedModuleIds.filter((entry) => entry !== moduleEntry.id);
+                                : formState.selectedModuleIds.filter(
+                                    (entry) => entry !== moduleEntry.id
+                                  );
                               updateFormState({
                                 ...formState,
                                 selectedModuleIds: nextSelectedModuleIds,
@@ -717,7 +749,9 @@ export function LobbyCreateRoute() {
                           />
                           <span>
                             <strong>{moduleEntry.displayName}</strong>
-                            <small>{moduleEntry.description || moduleEntry.kind || moduleEntry.id}</small>
+                            <small>
+                              {moduleEntry.description || moduleEntry.kind || moduleEntry.id}
+                            </small>
                           </span>
                         </label>
                       );
@@ -807,46 +841,48 @@ export function LobbyCreateRoute() {
           </div>
 
           <div className="new-game-slot-grid">
-            {ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map((playerType, index) => (
-              <article className="new-game-slot-card" key={`slot-${index + 1}`}>
-                <div className="new-game-slot-head">
-                  <strong>{t("newGame.slot.playerLabel", { number: index + 1 })}</strong>
-                  {index === 0 ? (
-                    <span className="status-pill">{t("newGame.slot.creatorBadge")}</span>
-                  ) : null}
-                </div>
-
-                {index === 0 ? (
-                  <div className="new-game-slot-copy">
-                    <span>{t("newGame.slot.humanOption")}</span>
-                    <small>{playerSlotDescription(playerType, index)}</small>
+            {ensurePlayerTypes(formState.playerTypes, formState.totalPlayers).map(
+              (playerType, index) => (
+                <article className="new-game-slot-card" key={`slot-${index + 1}`}>
+                  <div className="new-game-slot-head">
+                    <strong>{t("newGame.slot.playerLabel", { number: index + 1 })}</strong>
+                    {index === 0 ? (
+                      <span className="status-pill">{t("newGame.slot.creatorBadge")}</span>
+                    ) : null}
                   </div>
-                ) : (
-                  <label className="shell-field">
-                    <span>{t("newGame.slot.typeLabel")}</span>
-                    <select
-                      value={playerType}
-                      onChange={(event) => {
-                        const nextPlayerTypes = ensurePlayerTypes(
-                          formState.playerTypes,
-                          formState.totalPlayers
-                        );
-                        nextPlayerTypes[index] = event.target.value;
-                        updateFormState({
-                          ...formState,
-                          playerTypes: nextPlayerTypes
-                        });
-                      }}
-                      data-testid={`react-shell-new-game-slot-${index + 1}`}
-                    >
-                      <option value="human">{t("newGame.slot.humanOption")}</option>
-                      <option value="ai">{t("newGame.slot.aiOption")}</option>
-                    </select>
-                    <small>{playerSlotDescription(playerType, index)}</small>
-                  </label>
-                )}
-              </article>
-            ))}
+
+                  {index === 0 ? (
+                    <div className="new-game-slot-copy">
+                      <span>{t("newGame.slot.humanOption")}</span>
+                      <small>{playerSlotDescription(playerType, index)}</small>
+                    </div>
+                  ) : (
+                    <label className="shell-field">
+                      <span>{t("newGame.slot.typeLabel")}</span>
+                      <select
+                        value={playerType}
+                        onChange={(event) => {
+                          const nextPlayerTypes = ensurePlayerTypes(
+                            formState.playerTypes,
+                            formState.totalPlayers
+                          );
+                          nextPlayerTypes[index] = event.target.value;
+                          updateFormState({
+                            ...formState,
+                            playerTypes: nextPlayerTypes
+                          });
+                        }}
+                        data-testid={`react-shell-new-game-slot-${index + 1}`}
+                      >
+                        <option value="human">{t("newGame.slot.humanOption")}</option>
+                        <option value="ai">{t("newGame.slot.aiOption")}</option>
+                      </select>
+                      <small>{playerSlotDescription(playerType, index)}</small>
+                    </label>
+                  )}
+                </article>
+              )
+            )}
           </div>
 
           <div className="shell-actions">

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -3,7 +3,10 @@ import { Link } from "react-router-dom";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import type { GameListResponse, GameSummary } from "@frontend-generated/shared-runtime-validation.mts";
+import type {
+  GameListResponse,
+  GameSummary
+} from "@frontend-generated/shared-runtime-validation.mts";
 
 import { joinGame, listGames, openGame } from "@frontend-core/api/client.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
@@ -374,13 +377,18 @@ export function LobbyRoute() {
           )}
         </section>
 
-        <section className="placeholder-card lobby-detail-panel" data-testid="react-shell-lobby-details">
+        <section
+          className="placeholder-card lobby-detail-panel"
+          data-testid="react-shell-lobby-details"
+        >
           <div className="card-header lobby-panel-header">
             <div>
               <p className="status-label">{t("lobby.details.heading")}</p>
               <h3>{selectedGame?.name || t("lobby.details.emptyBadge")}</h3>
             </div>
-            {selectedGame ? <span className="status-pill">{phaseLabel(selectedGame.phase)}</span> : null}
+            {selectedGame ? (
+              <span className="status-pill">{phaseLabel(selectedGame.phase)}</span>
+            ) : null}
           </div>
 
           {!selectedGame ? (
@@ -399,7 +407,9 @@ export function LobbyRoute() {
               <div className="lobby-detail-grid">
                 <article className="lobby-detail-item">
                   <span>{t("lobby.details.map")}</span>
-                  <strong>{selectedGame.mapName || selectedGame.mapId || t("common.classicMini")}</strong>
+                  <strong>
+                    {selectedGame.mapName || selectedGame.mapId || t("common.classicMini")}
+                  </strong>
                 </article>
                 <article className="lobby-detail-item">
                   <span>{t("lobby.details.playersPresent")}</span>

--- a/scripts/check-no-js-sources.cts
+++ b/scripts/check-no-js-sources.cts
@@ -42,6 +42,7 @@ const allowedPathPatterns = [
   /^modules\/.+\.(json|css|png|jpg|jpeg|svg|webp)$/i,
   /^frontend\/assets\/.+\.(png|jpg|jpeg|svg|webp)$/i,
   /^frontend\/react-shell\/.+\.(html|css)$/i,
+  /^docs\/openapi\.json$/i,
   /^e2e\/.+-snapshots\/.+\.png$/i,
   /(^|\/)[^/]+\.md$/i
 ];

--- a/tests/gameplay/regression/check-no-js-sources.test.cts
+++ b/tests/gameplay/regression/check-no-js-sources.test.cts
@@ -60,6 +60,36 @@ register("check-no-js-sources consente la react shell e i file tsx nel repo trac
   });
 });
 
+register("check-no-js-sources consente docs/openapi.json nel repo tracciato", () => {
+  withTrackedTempRepo((repoDir) => {
+    writeFile(
+      repoDir,
+      "package.json",
+      JSON.stringify({
+        name: "allowlist-openapi",
+        private: true
+      })
+    );
+    writeFile(
+      repoDir,
+      "docs/openapi.json",
+      JSON.stringify({
+        openapi: "3.1.0",
+        info: { title: "NetRisk", version: "0.1.0" },
+        paths: {}
+      })
+    );
+    runGit(["add", "."], repoDir);
+
+    const output = execFileSync(process.execPath, [builtScriptPath], {
+      cwd: repoDir,
+      encoding: "utf8"
+    });
+
+    assert.match(output, /Tracked repository sources satisfy the TS-complete allowlist\./);
+  });
+});
+
 register("check-no-js-sources rifiuta file js tracciati fuori allowlist", () => {
   withTrackedTempRepo((repoDir) => {
     writeFile(


### PR DESCRIPTION
## Summary
- add a static documentation hub and contributor guide
- add OpenAPI and companion docs for stable JSON routes, snapshots, and gameplay flows
- document built-in and runtime extension paths for maps, rules, and modules

Closes #60.

## Validation
- npm run format:check

## Notes
- includes Prettier-only updates for frontend/react-shell/src/lobby-create-route.tsx and frontend/react-shell/src/lobby-route.tsx so the repository formatting gate passes on this branch
