### PR TITLE
[codex] Add React shell production observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key
 SUPABASE_DB_SCHEMA=public
 PORT=3000
+VITE_SENTRY_DSN=https://public@example.ingest.sentry.io/0
+SENTRY_AUTH_TOKEN=your-sentry-auth-token
+SENTRY_ORG=your-sentry-org
+SENTRY_PROJECT=your-sentry-project

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,8 +12,9 @@ L'applicazione include già:
 - validazione runtime condivisa dei payload auth/profile, lobby e gameplay tra backend e frontend
 - layer client API frontend tipizzato per auth, profile, lobby, setup e gameplay
 - shell React + Vite parallela servita su `/react/` senza sostituire la UI legacy
-- convenzioni React shell con TanStack Query per route state remoto e Zustand limitato a shell/session UI
+- convenzioni React shell con TanStack Query per route/server state remoto e Zustand limitato a shell/session UI
 - route React protette per login, lobby, new game, profile e gameplay core-playable su `/react/game/:gameId`
+- osservabilita minima della React shell con Sentry lato browser, release tagging e correlazione request-id verso il backend
 - lobby, creazione partita, join player umani e bot AI
 - setup partita 2-4 giocatori con mappe supportate
 - ciclo turno completo (`reinforcement` -> `attack` -> `fortify` -> `finished`)
@@ -166,12 +167,14 @@ Categorie future da trattare con lo stesso modello:
 - Pipeline React shell: `frontend/react-shell` viene buildata con Vite in `public/react/`, con `base=/react/` e proxy dev `/api` verso `VITE_BACKEND_TARGET`.
 - Boundary validation frontend: `frontend/src/core/validated-json.mts` valida le risposte condivise prima del consumo UI.
 - Boundary transport frontend: `frontend/src/core/api/http.mts` e `frontend/src/core/api/client.mts` centralizzano `fetch`, body JSON, validazione runtime, session handling, SSE payload parsing ed error translation per auth, profile, lobby, setup e gameplay.
+- Frontend observability boundary: il transport layer puo segnalare solo errori inattesi (`network`, `5xx`, payload validi ma fuori schema) tramite il reporter registrato dalla React shell, senza trasformare il frontend legacy in source of truth del monitoraggio.
 - React server-state ownership: nella shell React le query remote e le mutazioni stanno in TanStack Query; Zustand non sostituisce il backend e resta confinato a stato locale/sessione della shell.
 - Datastore supportati:
   - SQLite locale (default sviluppo)
   - Supabase (quando configurato via env)
 - La logica datastore è incapsulata dietro `backend/datastore.cts`.
 - Event stream partita via endpoint dedicato e broadcast server-side.
+- Correlazione runtime: le risposte `/api/*` espongono `X-Request-Id`; gli errori backend inattesi vengono loggati con `requestId`, route e `release` per facilitare la diagnosi dei problemi emersi dalla shell React.
 - Routing statico: `backend/server.cts` risolve `/`, `/game/*`, le pagine legacy e `/react/` senza sovrapporre i due frontend.
 - Guardrail repository/deploy: controllo env richieste, fallback senza `.git` per i check repository, `outputDirectory: public` su Vercel, `.vercelignore` per evitare upload di artefatti locali e `check-no-js-sources` per la TS-complete allowlist.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Today the project includes:
 - typed frontend API client helpers for auth, profile, lobby, setup, and gameplay flows
 - parallel React + Vite shell served at `/react/`, isolated from the legacy pages
 - TanStack Query + Zustand conventions in the React shell, with protected login, lobby, new game, profile, and gameplay routes
+- minimal React shell production observability with Sentry, release tagging, and API request-id correlation
 - initial lobby and reopening saved games
 - creation of a new game with supported map, selectable dice ruleset, and configurable turn time limit
 - joining with human players and adding AI bots
@@ -136,6 +137,15 @@ Required deploy/runtime variables are:
 
 For scheduled jobs, `CRON_SECRET` is required as well.
 
+Optional React shell observability variables are:
+
+- `VITE_SENTRY_DSN`
+- `SENTRY_AUTH_TOKEN`
+- `SENTRY_ORG`
+- `SENTRY_PROJECT`
+
+When `VITE_SENTRY_DSN` is enabled for Vercel `preview` or `production`, the React shell build also requires the three `SENTRY_*` upload variables so source maps can be uploaded and removed from the final public output.
+
 Before a Vercel deploy, you can validate environment coverage with:
 
 ```bash
@@ -152,6 +162,28 @@ That check verifies:
 The preview check accepts both globally-scoped preview variables and branch-specific preview overrides, matching the effective configuration used by Vercel deploys.
 
 Repository uploads are also filtered by `.vercelignore` so local artifacts such as temporary logs, coverage output, SQLite files, and generated local junk do not pollute preview builds.
+
+## React shell observability
+
+The migrated `/react/` shell now includes a minimal, reversible production observability layer:
+
+- Sentry is initialized only when `VITE_SENTRY_DSN` is present and the resolved environment is `preview` or `production`
+- the React shell reports unexpected render crashes, network failures, backend `5xx` responses, and invalid successful payloads
+- expected business/auth `4xx` responses stay out of Sentry unless they escalate into an unhandled render error
+- API responses include `X-Request-Id` so browser errors can be correlated with backend runtime logs
+- the backend keeps release correlation internal and uses structured `api_unexpected_error` log events for unexpected `5xx` responses
+
+For local development, observability stays off by default.
+
+## Analytics / PWA gate
+
+Before opening a separate analytics or PWA issue, verify all of the following:
+
+- React shell errors are visible in both preview and production
+- uploaded source maps/debug ids resolve readable stack traces in Sentry
+- Sentry events include a release and can be correlated with backend `X-Request-Id` logs
+- no unnecessary PII is being sent from the browser integration
+- error volume is stable enough that new analytics or PWA work will not hide unresolved migration regressions
 
 ## Useful commands
 

--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -12,6 +12,84 @@ interface LocalizedPayloadInput {
   code?: string | null;
 }
 
+type ResponseRequestContext = {
+  requestId: string;
+  method: string;
+  path: string;
+  release: string;
+  errorLogged?: boolean;
+};
+
+type ObservedResponse = import("node:http").ServerResponse & {
+  __netriskRequestContext?: ResponseRequestContext;
+  headers?: Record<string, string>;
+  setHeader?: (name: string, value: string) => void;
+};
+
+function setResponseHeader(res: ObservedResponse, name: string, value: string): void {
+  if (typeof res.setHeader === "function") {
+    res.setHeader(name, value);
+    return;
+  }
+
+  if (res.headers && typeof res.headers === "object") {
+    res.headers[name] = value;
+  }
+}
+
+export function setResponseRequestContext(
+  res: import("node:http").ServerResponse,
+  context: ResponseRequestContext
+): void {
+  const observedResponse = res as ObservedResponse;
+  observedResponse.__netriskRequestContext = context;
+  setResponseHeader(observedResponse, "X-Request-Id", context.requestId);
+}
+
+function getResponseRequestContext(
+  res: import("node:http").ServerResponse
+): ResponseRequestContext | null {
+  const observedResponse = res as ObservedResponse;
+  return observedResponse.__netriskRequestContext || null;
+}
+
+function logUnexpectedServerError(
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  payload: {
+    error: string;
+  },
+  code: string | null,
+  input: LocalizedPayloadInput | null | undefined
+): void {
+  if (statusCode < 500) {
+    return;
+  }
+
+  const context = getResponseRequestContext(res);
+  if (!context || context.errorLogged) {
+    return;
+  }
+
+  context.errorLogged = true;
+
+  const inputError = input instanceof Error ? input : null;
+  console.error(
+    JSON.stringify({
+      event: "api_unexpected_error",
+      requestId: context.requestId,
+      method: context.method,
+      path: context.path,
+      release: context.release,
+      statusCode,
+      code,
+      message: payload.error,
+      errorName: inputError?.name || null,
+      stack: inputError?.stack || null
+    })
+  );
+}
+
 export function sendJson(
   res: import("node:http").ServerResponse,
   statusCode: number,
@@ -68,9 +146,11 @@ export function sendLocalizedError(
   extra: Record<string, unknown> = {}
 ): void {
   const payload = localizedPayload(input, fallbackMessage, fallbackKey, fallbackParams);
+  const resolvedCode = code || input?.code || null;
+  logUnexpectedServerError(res, statusCode, payload, resolvedCode, input);
   sendJson(res, statusCode, {
     ...payload,
-    code: code || input?.code || null,
+    code: resolvedCode,
     ...extra
   });
 }

--- a/backend/observability.cts
+++ b/backend/observability.cts
@@ -1,0 +1,50 @@
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+export function resolveObservabilityEnvironment(env: NodeJS.ProcessEnv = process.env): string {
+  return firstNonEmpty(env.NETRISK_APP_ENVIRONMENT, env.VERCEL_ENV, env.NODE_ENV) || "development";
+}
+
+export function resolveObservabilityRelease(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    firstNonEmpty(
+      env.NETRISK_RELEASE,
+      env.SENTRY_RELEASE,
+      env.VERCEL_GIT_COMMIT_SHA,
+      env.GITHUB_SHA,
+      env.COMMIT_SHA,
+      env.npm_package_version
+    ) || "local-dev"
+  );
+}
+
+export function parseSentryOrigin(dsn: unknown): string | null {
+  const value = firstNonEmpty(dsn);
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  parseSentryOrigin,
+  resolveObservabilityEnvironment,
+  resolveObservabilityRelease
+};

--- a/backend/required-runtime-env.cts
+++ b/backend/required-runtime-env.cts
@@ -6,6 +6,7 @@ const REQUIRED_DEPLOY_ENV_KEYS = [
 ];
 
 const REQUIRED_CRON_ENV_KEYS = ["CRON_SECRET"];
+const OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS = ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"];
 
 function hasValue(value: unknown): boolean {
   return typeof value === "string" ? value.trim() !== "" : Boolean(value);
@@ -20,8 +21,17 @@ function shouldValidateDeployEnv(env: NodeJS.ProcessEnv = process.env): boolean 
   return targetEnv === "preview" || targetEnv === "production";
 }
 
+function hasObservabilityClientEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return hasValue(env.VITE_SENTRY_DSN);
+}
+
 function missingRequiredDeployEnv(env: NodeJS.ProcessEnv = process.env): string[] {
-  return REQUIRED_DEPLOY_ENV_KEYS.filter((key) => !hasValue(env[key]));
+  const requiredKeys = REQUIRED_DEPLOY_ENV_KEYS.slice();
+  if (hasObservabilityClientEnv(env)) {
+    requiredKeys.push(...OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS);
+  }
+
+  return requiredKeys.filter((key) => !hasValue(env[key]));
 }
 
 function missingRequiredCronEnv(env: NodeJS.ProcessEnv = process.env): string[] {
@@ -29,8 +39,10 @@ function missingRequiredCronEnv(env: NodeJS.ProcessEnv = process.env): string[] 
 }
 
 module.exports = {
+  OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS,
   REQUIRED_DEPLOY_ENV_KEYS,
   REQUIRED_CRON_ENV_KEYS,
+  hasObservabilityClientEnv,
   missingRequiredCronEnv,
   missingRequiredDeployEnv,
   shouldValidateDeployEnv

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1,4 +1,5 @@
 const http = require("http");
+const crypto = require("node:crypto");
 const fs = require("fs");
 const path = require("path");
 const { loadLocalEnv } = require("./load-local-env.cjs");
@@ -19,6 +20,7 @@ const {
 const { secureRandom } = require("./random.cjs");
 const { isPromiseLike } = require("./maybe-async.cjs");
 const { missingRequiredDeployEnv, shouldValidateDeployEnv } = require("./required-runtime-env.cjs");
+const { parseSentryOrigin, resolveObservabilityRelease } = require("./observability.cjs");
 const {
   addPlayer,
   createInitialState,
@@ -34,7 +36,12 @@ const { runAiTurnsIfNeeded } = require("./engine/ai-turn-resume.cjs");
 const { recoverAiTurnState } = require("./services/ai-turn-recovery.cjs");
 const { runScheduledJobs } = require("./scheduler/index.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
-const { sendJson, sendLocalizedError, localizedPayload } = require("./http-response.cjs");
+const {
+  localizedPayload,
+  sendJson,
+  sendLocalizedError,
+  setResponseRequestContext
+} = require("./http-response.cjs");
 const { broadcastEventPayload } = require("./event-broadcast.cjs");
 const {
   handleAuthSessionRoute,
@@ -95,6 +102,9 @@ type GameContext = {
 type EventClient = {
   res: Response;
   user: unknown;
+};
+type RequestWithId = Request & {
+  __netriskRequestId?: string;
 };
 
 loadLocalEnv();
@@ -257,6 +267,8 @@ function createApp(options: CreateAppOptions = {}) {
   const runtimeProjectRoot = options.projectRoot || projectRoot;
   const runtimePublicDir = path.join(runtimeProjectRoot, "public");
   const runtimeModulesDir = path.join(runtimeProjectRoot, "modules");
+  const runtimeRelease = resolveObservabilityRelease(process.env);
+  const sentryConnectOrigin = parseSentryOrigin(process.env.VITE_SENTRY_DSN);
 
   if (shouldValidateDeployEnv(process.env)) {
     const missingEnvKeys = missingRequiredDeployEnv(process.env);
@@ -644,7 +656,31 @@ function createApp(options: CreateAppOptions = {}) {
     };
   }
 
+  function ensureApiRequestContext(req: Request, res: Response, url: URL): { requestId: string } {
+    const requestWithId = req as RequestWithId;
+    const existingRequestId = requestWithId.__netriskRequestId;
+    if (existingRequestId) {
+      return {
+        requestId: existingRequestId
+      };
+    }
+
+    const requestId = crypto.randomUUID();
+    requestWithId.__netriskRequestId = requestId;
+    setResponseRequestContext(res, {
+      requestId,
+      method: String(req.method || "GET").toUpperCase(),
+      path: url.pathname,
+      release: runtimeRelease
+    });
+
+    return {
+      requestId
+    };
+  }
+
   async function handleApi(req: Request, res: Response, url: URL) {
+    ensureApiRequestContext(req, res, url);
     await initializeActiveGame();
 
     if (req.method === "GET" && url.pathname === "/api/health") {
@@ -1270,12 +1306,17 @@ function createApp(options: CreateAppOptions = {}) {
   }
 
   function addSecurityHeaders(res: Response) {
+    const connectSources = ["'self'"];
+    if (sentryConnectOrigin) {
+      connectSources.push(sentryConnectOrigin);
+    }
+
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("X-Frame-Options", "DENY");
     res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
     res.setHeader(
       "Content-Security-Policy",
-      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+      `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ${connectSources.join(" ")}`
     );
   }
 

--- a/frontend/react-shell/src/App.tsx
+++ b/frontend/react-shell/src/App.tsx
@@ -2,11 +2,14 @@ import { QueryClientProvider } from "@tanstack/react-query";
 
 import { AppRoutes } from "@react-shell/routes";
 import { queryClient } from "@react-shell/react-query";
+import { ShellErrorBoundary } from "@react-shell/shell-error-boundary";
 
 export function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AppRoutes />
-    </QueryClientProvider>
+    <ShellErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AppRoutes />
+      </QueryClientProvider>
+    </ShellErrorBoundary>
   );
 }

--- a/frontend/react-shell/src/__tests__/http-observability.test.ts
+++ b/frontend/react-shell/src/__tests__/http-observability.test.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+import { registerFrontendObservabilityReporter } from "@frontend-core/observability.mts";
+import { requestJson } from "@frontend-core/api/http.mts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const okResponseSchema = z.object({
+  ok: z.literal(true)
+});
+
+describe("frontend API observability boundary", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    registerFrontendObservabilityReporter(null);
+  });
+
+  it("captures network failures as unexpected frontend errors", async () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(
+      requestJson({
+        path: "/api/profile",
+        responseSchema: okResponseSchema,
+        responseSchemaName: "OkResponse",
+        errorMessage: "Profile unavailable."
+      })
+    ).rejects.toMatchObject({
+      kind: "network",
+      path: "/api/profile"
+    });
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "network",
+        path: "/api/profile"
+      }),
+      expect.objectContaining({
+        kind: "network",
+        path: "/api/profile"
+      })
+    );
+  });
+
+  it("captures HTTP 5xx responses with the request id header", async () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Server exploded.", code: "SERVER_FAILURE" }), {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Request-Id": "req-500"
+          }
+        })
+      )
+    );
+
+    await expect(
+      requestJson({
+        path: "/api/profile",
+        responseSchema: okResponseSchema,
+        responseSchemaName: "OkResponse",
+        errorMessage: "Profile unavailable."
+      })
+    ).rejects.toMatchObject({
+      kind: "http",
+      statusCode: 500,
+      requestId: "req-500",
+      code: "SERVER_FAILURE"
+    });
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "req-500",
+        statusCode: 500
+      }),
+      expect.objectContaining({
+        kind: "http",
+        requestId: "req-500",
+        statusCode: 500,
+        code: "SERVER_FAILURE"
+      })
+    );
+  });
+
+  it("captures invalid successful payloads as response validation failures", async () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: false }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Request-Id": "req-schema"
+          }
+        })
+      )
+    );
+
+    await expect(
+      requestJson({
+        path: "/api/profile",
+        responseSchema: okResponseSchema,
+        responseSchemaName: "OkResponse",
+        errorMessage: "Profile unavailable.",
+        fallbackMessage: "Profile payload invalid."
+      })
+    ).rejects.toMatchObject({
+      kind: "response_validation",
+      requestId: "req-schema",
+      statusCode: 200
+    });
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "req-schema"
+      }),
+      expect.objectContaining({
+        kind: "response_validation",
+        schemaName: "OkResponse",
+        requestId: "req-schema"
+      })
+    );
+  });
+
+  it("does not capture expected HTTP 401 responses", async () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Sign in to continue.", code: "AUTH_REQUIRED" }), {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Request-Id": "req-auth"
+          }
+        })
+      )
+    );
+
+    await expect(
+      requestJson({
+        path: "/api/auth/session",
+        responseSchema: okResponseSchema,
+        responseSchemaName: "OkResponse",
+        errorMessage: "Unable to load session."
+      })
+    ).rejects.toMatchObject({
+      kind: "http",
+      statusCode: 401,
+      requestId: "req-auth",
+      code: "AUTH_REQUIRED"
+    });
+
+    expect(reporter).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/react-shell/src/__tests__/observability.test.tsx
+++ b/frontend/react-shell/src/__tests__/observability.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+
+import {
+  registerFrontendObservabilityReporter,
+  reportFrontendException
+} from "@frontend-core/observability.mts";
+import {
+  createReactShellRootOptions,
+  initReactShellObservability,
+  resetReactShellObservabilityForTests,
+  resolveReactShellObservabilityConfig
+} from "@react-shell/observability";
+import { ShellErrorBoundary } from "@react-shell/shell-error-boundary";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentryMocks = vi.hoisted(() => {
+  const scope = {
+    setContext: vi.fn(),
+    setExtra: vi.fn(),
+    setLevel: vi.fn(),
+    setTag: vi.fn()
+  };
+
+  return {
+    captureException: vi.fn(),
+    init: vi.fn(),
+    scope,
+    withScope: vi.fn((callback: (value: typeof scope) => void) => callback(scope))
+  };
+});
+
+vi.mock("@sentry/react", () => ({
+  captureException: sentryMocks.captureException,
+  init: sentryMocks.init,
+  withScope: sentryMocks.withScope
+}));
+
+describe("react shell observability", () => {
+  beforeEach(() => {
+    resetReactShellObservabilityForTests();
+    sentryMocks.captureException.mockReset();
+    sentryMocks.init.mockReset();
+    sentryMocks.scope.setContext.mockReset();
+    sentryMocks.scope.setExtra.mockReset();
+    sentryMocks.scope.setLevel.mockReset();
+    sentryMocks.scope.setTag.mockReset();
+    sentryMocks.withScope.mockClear();
+  });
+
+  afterEach(() => {
+    resetReactShellObservabilityForTests();
+  });
+
+  it("keeps observability disabled without a DSN or deploy environment", () => {
+    expect(
+      resolveReactShellObservabilityConfig({
+        dsn: null,
+        environment: "development",
+        release: "rel-dev"
+      })
+    ).toEqual({
+      enabled: false,
+      dsn: null,
+      environment: "development",
+      release: "rel-dev"
+    });
+  });
+
+  it("initializes Sentry only for preview and production when the DSN is configured", () => {
+    const config = resolveReactShellObservabilityConfig({
+      dsn: "https://public@example.ingest.sentry.io/123",
+      environment: "preview",
+      release: "sha-preview"
+    });
+
+    const resolved = initReactShellObservability(config);
+
+    expect(resolved.enabled).toBe(true);
+    expect(sentryMocks.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: "https://public@example.ingest.sentry.io/123",
+        environment: "preview",
+        release: "sha-preview",
+        sendDefaultPii: false
+      })
+    );
+  });
+
+  it("forwards registered frontend errors to Sentry with request correlation context", () => {
+    initReactShellObservability({
+      enabled: true,
+      dsn: "https://public@example.ingest.sentry.io/123",
+      environment: "production",
+      release: "sha-prod"
+    });
+
+    const error = new Error("Unexpected HTTP failure.");
+    reportFrontendException(error, {
+      area: "react-shell",
+      kind: "http",
+      path: "/api/profile",
+      requestId: "req-42",
+      statusCode: 500,
+      code: "SERVER_FAILURE",
+      schemaName: "ProfileResponse"
+    });
+
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
+    expect(sentryMocks.scope.setTag).toHaveBeenCalledWith("app.request_id", "req-42");
+    expect(sentryMocks.scope.setExtra).toHaveBeenCalledWith("statusCode", 500);
+    expect(sentryMocks.scope.setExtra).toHaveBeenCalledWith("schemaName", "ProfileResponse");
+  });
+
+  it("reports React root errors through the shared frontend reporter", () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    createReactShellRootOptions().onUncaughtError(new Error("Root crash."), {
+      componentStack: "\n in BrokenRoute"
+    });
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Root crash."
+      }),
+      expect.objectContaining({
+        area: "react-shell",
+        kind: "react_uncaught",
+        componentStack: "\n in BrokenRoute"
+      })
+    );
+  });
+
+  it("renders a fallback panel when the shell crashes during render", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    function BrokenRoute() {
+      throw new Error("Render failure.");
+      return null;
+    }
+
+    render(
+      <ShellErrorBoundary>
+        <BrokenRoute />
+      </ShellErrorBoundary>
+    );
+
+    expect(screen.getByTestId("react-shell-crash-fallback")).toBeInTheDocument();
+    expect(screen.getByText("React shell unavailable")).toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/react-shell/src/__tests__/observability.test.tsx
+++ b/frontend/react-shell/src/__tests__/observability.test.tsx
@@ -67,6 +67,19 @@ describe("react shell observability", () => {
     });
   });
 
+  it("reads Vite build constants when runtime overrides are omitted", () => {
+    expect(
+      resolveReactShellObservabilityConfig({
+        dsn: "https://public@example.ingest.sentry.io/123"
+      })
+    ).toEqual({
+      enabled: true,
+      dsn: "https://public@example.ingest.sentry.io/123",
+      environment: "preview",
+      release: "vitest-build"
+    });
+  });
+
   it("initializes Sentry only for preview and production when the DSN is configured", () => {
     const config = resolveReactShellObservabilityConfig({
       dsn: "https://public@example.ingest.sentry.io/123",

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useState, type CSSProperties } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -21,6 +21,7 @@ import {
   startGame,
   tradeCards
 } from "@frontend-core/api/client.mts";
+import type { GameActionRequest, TradeCardsRequest } from "@frontend-core/api/client.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
 import { t, translateGameLogEntries, translateServerMessage } from "@frontend-i18n";
 
@@ -414,14 +415,19 @@ export function GameRoute() {
     onError: handleMutationError
   });
 
+  const actionClientMessages = {
+    errorMessage: t("errors.requestFailed"),
+    fallbackMessage: t("errors.requestFailed")
+  };
+
   const actionMutation = useMutation({
-    mutationFn: sendGameAction,
+    mutationFn: (request: GameActionRequest) => sendGameAction(request, actionClientMessages),
     onSuccess: (payload) => applyMutationPayload(payload),
     onError: handleMutationError
   });
 
   const tradeMutation = useMutation({
-    mutationFn: tradeCards,
+    mutationFn: (request: TradeCardsRequest) => tradeCards(request, actionClientMessages),
     onSuccess: (payload) =>
       applyMutationPayload(payload, {
         feedback:
@@ -814,28 +820,32 @@ export function GameRoute() {
             }}
           >
             <svg className="game-map-connections" viewBox="0 0 1000 1000" aria-hidden="true">
-              {(snapshot.map || []).flatMap((territory) =>
-                territory.x == null || territory.y == null
-                  ? []
-                  : territory.neighbors
-                      .filter((neighborId) => territory.id < neighborId)
-                      .map((neighborId) => {
-                        const target = territoriesById[neighborId];
-                        if (!target || target.x == null || target.y == null) {
-                          return null;
-                        }
+              {(snapshot.map || []).flatMap((territory) => {
+                const territoryX = territory.x;
+                const territoryY = territory.y;
+                if (territoryX == null || territoryY == null) {
+                  return [];
+                }
 
-                        return (
-                          <line
-                            key={`${territory.id}-${neighborId}`}
-                            x1={territory.x * 1000}
-                            y1={territory.y * 1000}
-                            x2={target.x * 1000}
-                            y2={target.y * 1000}
-                          />
-                        );
-                      })
-              )}
+                return territory.neighbors
+                  .filter((neighborId) => territory.id < neighborId)
+                  .map((neighborId) => {
+                    const target = territoriesById[neighborId];
+                    if (!target || target.x == null || target.y == null) {
+                      return null;
+                    }
+
+                    return (
+                      <line
+                        key={`${territory.id}-${neighborId}`}
+                        x1={territoryX * 1000}
+                        y1={territoryY * 1000}
+                        x2={target.x * 1000}
+                        y2={target.y * 1000}
+                      />
+                    );
+                  });
+              })}
             </svg>
 
             {(snapshot.map || []).map((territory) => {
@@ -845,6 +855,16 @@ export function GameRoute() {
               const isReinforceTarget = territory.id === reinforceTerritoryId;
               const isFortifySource = territory.id === fortifyFromId;
               const isFortifyTarget = territory.id === fortifyToId;
+              const territoryStyle: CSSProperties & {
+                "--territory-player-color": string;
+              } = {
+                left: `${(territory.x ?? 0.5) * 100}%`,
+                top: `${(territory.y ?? 0.5) * 100}%`,
+                "--territory-player-color":
+                  territory.ownerId && playersById[territory.ownerId]?.color
+                    ? playersById[territory.ownerId].color
+                    : "rgba(22, 32, 51, 0.7)"
+              };
 
               return (
                 <button
@@ -852,14 +872,7 @@ export function GameRoute() {
                   type="button"
                   className={`territory-node${isMine ? " is-mine" : ""}${isAttackSource ? " is-source" : ""}${isAttackTarget ? " is-target" : ""}${isReinforceTarget ? " is-reinforce" : ""}${isFortifySource ? " is-fortify-source" : ""}${isFortifyTarget ? " is-fortify-target" : ""}`}
                   data-territory-id={territory.id}
-                  style={{
-                    left: `${(territory.x ?? 0.5) * 100}%`,
-                    top: `${(territory.y ?? 0.5) * 100}%`,
-                    ["--territory-player-color" as const]:
-                      territory.ownerId && playersById[territory.ownerId]?.color
-                        ? playersById[territory.ownerId].color
-                        : "rgba(22, 32, 51, 0.7)"
-                  }}
+                  style={territoryStyle}
                   onClick={() => handleTerritorySelect(territory.id)}
                 >
                   <strong>{territory.name}</strong>

--- a/frontend/react-shell/src/instrument.ts
+++ b/frontend/react-shell/src/instrument.ts
@@ -1,0 +1,3 @@
+import { initReactShellObservability } from "@react-shell/observability";
+
+initReactShellObservability();

--- a/frontend/react-shell/src/main.tsx
+++ b/frontend/react-shell/src/main.tsx
@@ -1,8 +1,11 @@
+import "./instrument";
+
 import ReactDOM from "react-dom/client";
 
 import { resolveLocale, setLocale } from "@frontend-i18n";
 
 import { App } from "@react-shell/App";
+import { createReactShellRootOptions } from "@react-shell/observability";
 import { applyShellTheme } from "@react-shell/theme";
 
 import "./styles.css";
@@ -15,4 +18,4 @@ if (!rootElement) {
   throw new Error("React shell root element not found.");
 }
 
-ReactDOM.createRoot(rootElement).render(<App />);
+ReactDOM.createRoot(rootElement, createReactShellRootOptions()).render(<App />);

--- a/frontend/react-shell/src/observability.ts
+++ b/frontend/react-shell/src/observability.ts
@@ -42,11 +42,16 @@ function toError(error: unknown): Error {
   return new Error(typeof error === "string" && error ? error : "Unknown frontend error.");
 }
 
-function readBuildConstant(
-  name: "__NETRISK_APP_ENVIRONMENT__" | "__NETRISK_APP_RELEASE__"
-): string | null {
-  const globalValue = (globalThis as Record<string, unknown>)[name];
-  return typeof globalValue === "string" && globalValue ? globalValue : null;
+function readEnvironmentBuildConstant(): string | null {
+  return typeof __NETRISK_APP_ENVIRONMENT__ !== "undefined"
+    ? firstNonEmpty(__NETRISK_APP_ENVIRONMENT__)
+    : null;
+}
+
+function readReleaseBuildConstant(): string | null {
+  return typeof __NETRISK_APP_RELEASE__ !== "undefined"
+    ? firstNonEmpty(__NETRISK_APP_RELEASE__)
+    : null;
 }
 
 export function resolveReactShellObservabilityConfig(
@@ -57,10 +62,8 @@ export function resolveReactShellObservabilityConfig(
   } = {}
 ): ReactShellObservabilityConfig {
   const environment =
-    firstNonEmpty(input.environment, readBuildConstant("__NETRISK_APP_ENVIRONMENT__")) ||
-    "development";
-  const release =
-    firstNonEmpty(input.release, readBuildConstant("__NETRISK_APP_RELEASE__")) || "local-dev";
+    firstNonEmpty(input.environment, readEnvironmentBuildConstant()) || "development";
+  const release = firstNonEmpty(input.release, readReleaseBuildConstant()) || "local-dev";
   const dsn = firstNonEmpty(input.dsn, import.meta.env.VITE_SENTRY_DSN) || null;
   const enabled = Boolean(dsn) && (environment === "preview" || environment === "production");
 

--- a/frontend/react-shell/src/observability.ts
+++ b/frontend/react-shell/src/observability.ts
@@ -1,0 +1,176 @@
+import * as Sentry from "@sentry/react";
+
+import {
+  registerFrontendObservabilityReporter,
+  reportFrontendException,
+  type FrontendObservabilityContext
+} from "@frontend-core/observability.mts";
+
+export type ReactShellObservabilityConfig = {
+  enabled: boolean;
+  dsn: string | null;
+  environment: string;
+  release: string;
+};
+
+type ReactRootErrorInfo = {
+  componentStack?: string | null;
+};
+
+let initialized = false;
+
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(typeof error === "string" && error ? error : "Unknown frontend error.");
+}
+
+function readBuildConstant(
+  name: "__NETRISK_APP_ENVIRONMENT__" | "__NETRISK_APP_RELEASE__"
+): string | null {
+  const globalValue = (globalThis as Record<string, unknown>)[name];
+  return typeof globalValue === "string" && globalValue ? globalValue : null;
+}
+
+export function resolveReactShellObservabilityConfig(
+  input: {
+    dsn?: string | null;
+    environment?: string | null;
+    release?: string | null;
+  } = {}
+): ReactShellObservabilityConfig {
+  const environment =
+    firstNonEmpty(input.environment, readBuildConstant("__NETRISK_APP_ENVIRONMENT__")) ||
+    "development";
+  const release =
+    firstNonEmpty(input.release, readBuildConstant("__NETRISK_APP_RELEASE__")) || "local-dev";
+  const dsn = firstNonEmpty(input.dsn, import.meta.env.VITE_SENTRY_DSN) || null;
+  const enabled = Boolean(dsn) && (environment === "preview" || environment === "production");
+
+  return {
+    enabled,
+    dsn,
+    environment,
+    release
+  };
+}
+
+function applyObservabilityScope(error: Error, context: FrontendObservabilityContext = {}): void {
+  Sentry.withScope((scope) => {
+    scope.setLevel("error");
+    scope.setTag("app.area", context.area || "react-shell");
+    if (context.kind) {
+      scope.setTag("app.error_kind", context.kind);
+    }
+    if (context.code) {
+      scope.setTag("app.error_code", context.code);
+    }
+    if (context.path) {
+      scope.setTag("app.path", context.path);
+    }
+    if (context.requestId) {
+      scope.setTag("app.request_id", context.requestId);
+      scope.setExtra("requestId", context.requestId);
+    }
+    if (context.statusCode != null) {
+      scope.setExtra("statusCode", context.statusCode);
+    }
+    if (context.componentStack) {
+      scope.setContext("react", {
+        componentStack: context.componentStack
+      });
+    }
+    if (context.schemaName) {
+      scope.setExtra("schemaName", context.schemaName);
+    }
+    if (context.extra && typeof context.extra === "object") {
+      Object.entries(context.extra).forEach(([key, value]) => {
+        scope.setExtra(key, value);
+      });
+    }
+
+    Sentry.captureException(error);
+  });
+}
+
+export function initReactShellObservability(
+  config: ReactShellObservabilityConfig = resolveReactShellObservabilityConfig()
+): ReactShellObservabilityConfig {
+  registerFrontendObservabilityReporter((error, context) => {
+    if (!config.enabled) {
+      return;
+    }
+
+    applyObservabilityScope(toError(error), context);
+  });
+
+  if (!config.enabled || initialized) {
+    return config;
+  }
+
+  Sentry.init({
+    dsn: config.dsn || undefined,
+    environment: config.environment,
+    release: config.release,
+    sendDefaultPii: false
+  });
+
+  initialized = true;
+  return config;
+}
+
+function captureReactShellException(
+  error: unknown,
+  kind: "react_uncaught" | "react_caught" | "react_recoverable",
+  errorInfo?: ReactRootErrorInfo
+): void {
+  reportFrontendException(toError(error), {
+    area: "react-shell",
+    kind,
+    path: typeof window !== "undefined" ? window.location.pathname : "/react/",
+    componentStack:
+      typeof errorInfo?.componentStack === "string" && errorInfo.componentStack
+        ? errorInfo.componentStack
+        : undefined
+  });
+}
+
+export function createReactShellRootOptions(): {
+  onUncaughtError(error: unknown, errorInfo: ReactRootErrorInfo): void;
+  onCaughtError(error: unknown, errorInfo: ReactRootErrorInfo): void;
+  onRecoverableError(error: unknown, errorInfo: ReactRootErrorInfo): void;
+} {
+  return {
+    onUncaughtError(error: unknown, errorInfo: ReactRootErrorInfo): void {
+      captureReactShellException(error, "react_uncaught", errorInfo);
+    },
+    onCaughtError(error: unknown, errorInfo: ReactRootErrorInfo): void {
+      captureReactShellException(error, "react_caught", errorInfo);
+    },
+    onRecoverableError(error: unknown, errorInfo: ReactRootErrorInfo): void {
+      captureReactShellException(error, "react_recoverable", errorInfo);
+    }
+  };
+}
+
+export function resetReactShellObservabilityForTests(): void {
+  initialized = false;
+  registerFrontendObservabilityReporter(null);
+}

--- a/frontend/react-shell/src/shell-error-boundary.tsx
+++ b/frontend/react-shell/src/shell-error-boundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type ShellErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ShellErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class ShellErrorBoundary extends Component<
+  ShellErrorBoundaryProps,
+  ShellErrorBoundaryState
+> {
+  state: ShellErrorBoundaryState = {
+    hasError: false
+  };
+
+  static getDerivedStateFromError(): ShellErrorBoundaryState {
+    return {
+      hasError: true
+    };
+  }
+
+  componentDidCatch(_error: Error, _errorInfo: ErrorInfo): void {}
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <section
+          className="status-panel status-panel-error"
+          data-testid="react-shell-crash-fallback"
+        >
+          <p className="status-label">Error</p>
+          <h2>React shell unavailable</h2>
+          <p className="status-copy">
+            An unexpected render error interrupted the migrated shell. Reload the page or retry from
+            the previous screen.
+          </p>
+        </section>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/react-shell/src/vite-env.d.ts
+++ b/frontend/react-shell/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+declare const __NETRISK_APP_ENVIRONMENT__: string;
+declare const __NETRISK_APP_RELEASE__: string;
+
+interface ImportMetaEnv {
+  readonly VITE_SENTRY_DSN?: string;
+}

--- a/frontend/react-shell/test/setup.ts
+++ b/frontend/react-shell/test/setup.ts
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 
 import { DEFAULT_LOCALE, setLocale } from "@frontend-i18n";
+import { resetFrontendObservabilityReporter } from "@frontend-core/observability.mts";
 
 import { resetAuthState } from "@react-shell/auth-store";
 
@@ -11,6 +12,7 @@ import { afterEach, beforeEach, vi } from "vitest";
 function resetBrowserState(): void {
   window.localStorage.clear();
   resetAuthState();
+  resetFrontendObservabilityReporter();
 
   document.documentElement.removeAttribute("data-theme");
   document.body?.removeAttribute("data-theme");

--- a/frontend/react-shell/vite.config.ts
+++ b/frontend/react-shell/vite.config.ts
@@ -1,18 +1,101 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 const reactShellRoot = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(reactShellRoot, "..", "..");
 const backendTarget = process.env.VITE_BACKEND_TARGET || "http://127.0.0.1:3000";
+const reactShellOutDir = path.resolve(projectRoot, "public", "react");
+
+function firstNonEmpty(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+function resolveObservabilityEnvironment(): string {
+  return (
+    firstNonEmpty(
+      process.env.NETRISK_APP_ENVIRONMENT,
+      process.env.VERCEL_ENV,
+      process.env.NODE_ENV
+    ) || "development"
+  );
+}
+
+function resolveObservabilityRelease(): string {
+  return (
+    firstNonEmpty(
+      process.env.NETRISK_RELEASE,
+      process.env.SENTRY_RELEASE,
+      process.env.VERCEL_GIT_COMMIT_SHA,
+      process.env.GITHUB_SHA,
+      process.env.COMMIT_SHA,
+      process.env.npm_package_version
+    ) || "local-dev"
+  );
+}
+
+const reactShellEnvironment = resolveObservabilityEnvironment();
+const reactShellRelease = resolveObservabilityRelease();
+const reactShellSentryDsn = firstNonEmpty(process.env.VITE_SENTRY_DSN);
+const reactShellObservabilityEnabled =
+  Boolean(reactShellSentryDsn) &&
+  (reactShellEnvironment === "preview" || reactShellEnvironment === "production");
+const sentryOrg = firstNonEmpty(process.env.SENTRY_ORG);
+const sentryProject = firstNonEmpty(process.env.SENTRY_PROJECT);
+const sentryAuthToken = firstNonEmpty(process.env.SENTRY_AUTH_TOKEN);
+const hasSentryUploadCredentials = Boolean(sentryOrg && sentryProject && sentryAuthToken);
+const shouldValidateDeployEnv =
+  Boolean(process.env.VERCEL) &&
+  (reactShellEnvironment === "preview" || reactShellEnvironment === "production");
+
+if (shouldValidateDeployEnv && reactShellObservabilityEnabled && !hasSentryUploadCredentials) {
+  throw new Error(
+    "React shell observability requires SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT when VITE_SENTRY_DSN is enabled for preview or production."
+  );
+}
+
+const shouldUploadSentryArtifacts = reactShellObservabilityEnabled && hasSentryUploadCredentials;
+const reactShellPlugins = [react()];
+if (shouldUploadSentryArtifacts) {
+  reactShellPlugins.push(
+    sentryVitePlugin({
+      authToken: sentryAuthToken || undefined,
+      org: sentryOrg || undefined,
+      project: sentryProject || undefined,
+      release: {
+        name: reactShellRelease
+      },
+      sourcemaps: {
+        filesToDeleteAfterUpload: [path.join(reactShellOutDir, "**", "*.map")]
+      },
+      telemetry: false
+    })
+  );
+}
 
 export default defineConfig({
   root: reactShellRoot,
   base: "/react/",
   publicDir: false,
-  plugins: [react()],
+  define: {
+    __NETRISK_APP_ENVIRONMENT__: JSON.stringify(reactShellEnvironment),
+    __NETRISK_APP_RELEASE__: JSON.stringify(reactShellRelease)
+  },
+  plugins: reactShellPlugins,
   resolve: {
     alias: {
       "@react-shell": path.resolve(reactShellRoot, "src"),
@@ -34,7 +117,8 @@ export default defineConfig({
     }
   },
   build: {
-    outDir: path.resolve(projectRoot, "public", "react"),
-    emptyOutDir: true
+    outDir: reactShellOutDir,
+    emptyOutDir: true,
+    sourcemap: shouldUploadSentryArtifacts
   }
 });

--- a/frontend/react-shell/vitest.config.ts
+++ b/frontend/react-shell/vitest.config.ts
@@ -10,6 +10,10 @@ const projectRoot = path.resolve(reactShellRoot, "..", "..");
 export default defineConfig({
   root: reactShellRoot,
   plugins: [react()],
+  define: {
+    __NETRISK_APP_ENVIRONMENT__: JSON.stringify("preview"),
+    __NETRISK_APP_RELEASE__: JSON.stringify("vitest-build")
+  },
   resolve: {
     alias: {
       "@react-shell": path.resolve(reactShellRoot, "src"),

--- a/frontend/src/core/api/http.mts
+++ b/frontend/src/core/api/http.mts
@@ -1,5 +1,6 @@
 import { parseWithSchema } from "../../generated/shared-runtime-validation.mjs";
 import { translateServerMessage } from "../../i18n.mjs";
+import { reportFrontendException } from "../observability.mjs";
 import { readValidatedJson } from "../validated-json.mjs";
 
 type ValidationSchema<T> = {
@@ -10,6 +11,10 @@ export type ApiClientError = Error & {
   code?: string | null;
   payload?: unknown;
   status?: number;
+  path?: string;
+  requestId?: string | null;
+  statusCode?: number | null;
+  kind?: "network" | "http" | "response_validation";
 };
 
 type JsonRequestOptions<TRequest, TResponse> = {
@@ -31,6 +36,10 @@ function toApiClientError(
     code?: string | null;
     payload?: unknown;
     status?: number;
+    path?: string;
+    requestId?: string | null;
+    statusCode?: number | null;
+    kind?: "network" | "http" | "response_validation";
   } = {}
 ): ApiClientError {
   const error = new Error(message, {
@@ -49,6 +58,22 @@ function toApiClientError(
     error.status = options.status;
   }
 
+  if (options.path !== undefined) {
+    error.path = options.path;
+  }
+
+  if (options.requestId !== undefined) {
+    error.requestId = options.requestId;
+  }
+
+  if (options.statusCode !== undefined) {
+    error.statusCode = options.statusCode;
+  }
+
+  if (options.kind !== undefined) {
+    error.kind = options.kind;
+  }
+
   return error;
 }
 
@@ -59,6 +84,47 @@ function extractErrorCode(payload: unknown): string | null {
 
   const code = payload.code;
   return typeof code === "string" && code ? code : null;
+}
+
+function extractRequestId(response: Response): string | null {
+  const headers = response?.headers as
+    | Headers
+    | {
+        get?(name: string): string | null | undefined;
+        [key: string]: unknown;
+      }
+    | undefined;
+
+  if (!headers) {
+    return null;
+  }
+
+  if (typeof headers.get === "function") {
+    const requestId = headers.get("x-request-id");
+    return typeof requestId === "string" && requestId ? requestId : null;
+  }
+
+  const rawHeaders = headers as Record<string, unknown>;
+  const rawRequestId = rawHeaders["x-request-id"] || rawHeaders["X-Request-Id"];
+  return typeof rawRequestId === "string" && rawRequestId ? rawRequestId : null;
+}
+
+function reportUnexpectedClientError(
+  error: ApiClientError,
+  context: {
+    kind: "network" | "http" | "response_validation";
+    schemaName?: string;
+  }
+): void {
+  reportFrontendException(error, {
+    area: "react-shell",
+    kind: context.kind,
+    path: error.path,
+    requestId: error.requestId,
+    statusCode: error.statusCode,
+    code: error.code,
+    schemaName: context.schemaName || null
+  });
 }
 
 async function tryReadJson(response: Response): Promise<unknown> {
@@ -97,20 +163,45 @@ export async function requestJson<TRequest, TResponse>({
     payloadBody = JSON.stringify(parsedBody);
   }
 
-  const response = await fetch(path, {
-    method,
-    credentials: "same-origin",
-    headers,
-    ...(payloadBody ? { body: payloadBody } : {})
-  });
+  let response: Response;
+  try {
+    response = await fetch(path, {
+      method,
+      credentials: "same-origin",
+      headers,
+      ...(payloadBody ? { body: payloadBody } : {})
+    });
+  } catch (error: unknown) {
+    const networkError = toApiClientError(resolvedFallbackMessage, {
+      cause: error,
+      path,
+      kind: "network"
+    });
+    reportUnexpectedClientError(networkError, {
+      kind: "network"
+    });
+    throw networkError;
+  }
+
+  const requestId = extractRequestId(response);
 
   if (!response.ok) {
     const payload = await tryReadJson(response);
-    throw toApiClientError(translateServerMessage(payload, errorMessage), {
+    const clientError = toApiClientError(translateServerMessage(payload, errorMessage), {
       code: extractErrorCode(payload),
       payload,
-      status: response.status
+      status: response.status,
+      path,
+      requestId,
+      statusCode: response.status,
+      kind: "http"
     });
+    if (response.status >= 500) {
+      reportUnexpectedClientError(clientError, {
+        kind: "http"
+      });
+    }
+    throw clientError;
   }
 
   try {
@@ -121,8 +212,18 @@ export async function requestJson<TRequest, TResponse>({
       responseSchemaName
     );
   } catch (error: unknown) {
-    throw toApiClientError(resolvedFallbackMessage, {
-      cause: error
+    const validationError = toApiClientError(resolvedFallbackMessage, {
+      cause: error,
+      status: response.status,
+      path,
+      requestId,
+      statusCode: response.status,
+      kind: "response_validation"
     });
+    reportUnexpectedClientError(validationError, {
+      kind: "response_validation",
+      schemaName: responseSchemaName
+    });
+    throw validationError;
   }
 }

--- a/frontend/src/core/observability.mts
+++ b/frontend/src/core/observability.mts
@@ -1,0 +1,39 @@
+export type FrontendObservabilityContext = {
+  area?: string;
+  kind?: string;
+  path?: string;
+  requestId?: string | null;
+  statusCode?: number | null;
+  code?: string | null;
+  componentStack?: string | null;
+  schemaName?: string | null;
+  extra?: Record<string, unknown>;
+};
+
+export type FrontendObservabilityReporter = (
+  error: unknown,
+  context?: FrontendObservabilityContext
+) => void;
+
+let reporter: FrontendObservabilityReporter | null = null;
+
+export function registerFrontendObservabilityReporter(
+  nextReporter: FrontendObservabilityReporter | null
+): void {
+  reporter = typeof nextReporter === "function" ? nextReporter : null;
+}
+
+export function resetFrontendObservabilityReporter(): void {
+  reporter = null;
+}
+
+export function reportFrontendException(
+  error: unknown,
+  context: FrontendObservabilityContext = {}
+): void {
+  if (!reporter) {
+    return;
+  }
+
+  reporter(error, context);
+}

--- a/frontend/src/i18n.mts
+++ b/frontend/src/i18n.mts
@@ -196,9 +196,7 @@ export function translateServerMessage(payload: unknown, fallback = ""): string 
   return translateMessagePayload(payload, fallback);
 }
 
-export function translateGameLogEntries(
-  snapshot: unknown
-): string[] {
+export function translateGameLogEntries(snapshot: unknown): string[] {
   const snapshotRecord =
     snapshot && typeof snapshot === "object" ? (snapshot as Record<string, unknown>) : null;
   const logEntries = snapshotRecord?.logEntries;

--- a/frontend/src/i18n.mts
+++ b/frontend/src/i18n.mts
@@ -1,5 +1,5 @@
 import { setMarkup } from "./core/dom.mjs";
-import type { GameSnapshot, MessagePayload, TranslationParams } from "./core/types.mjs";
+import type { MessagePayload, TranslationParams } from "./core/types.mjs";
 import { it } from "./locales/it.mjs";
 import { en } from "./locales/en.mjs";
 
@@ -197,20 +197,21 @@ export function translateServerMessage(payload: unknown, fallback = ""): string 
 }
 
 export function translateGameLogEntries(
-  snapshot:
-    | (Pick<GameSnapshot, "playerHand"> & {
-        logEntries?: MessagePayload[];
-        log?: string[];
-      })
-    | null
-    | undefined
+  snapshot: unknown
 ): string[] {
-  const localizedEntries = Array.isArray(snapshot?.logEntries)
-    ? snapshot.logEntries
+  const snapshotRecord =
+    snapshot && typeof snapshot === "object" ? (snapshot as Record<string, unknown>) : null;
+  const logEntries = snapshotRecord?.logEntries;
+  const legacyLog = snapshotRecord?.log;
+
+  const localizedEntries = Array.isArray(logEntries)
+    ? logEntries
         .map((entry) => translateMessagePayload(entry, entry?.message || ""))
         .filter(Boolean)
     : [];
-  const legacyEntries = Array.isArray(snapshot?.log) ? snapshot.log.filter(Boolean) : [];
+  const legacyEntries = Array.isArray(legacyLog)
+    ? legacyLog.filter((entry): entry is string => typeof entry === "string" && Boolean(entry))
+    : [];
 
   if (!localizedEntries.length) {
     return legacyEntries;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "netrisk",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.22.0",
         "@tanstack/react-query": "^5.99.0",
         "@vercel/speed-insights": "^2.0.0",
         "react": "^19.2.5",
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.59.1",
+        "@sentry/vite-plugin": "^4.5.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -102,12 +104,168 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -118,9 +276,48 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -129,6 +326,54 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -528,6 +773,109 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -536,6 +884,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -593,6 +963,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -874,6 +1255,407 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.49.0.tgz",
+      "integrity": "sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.49.0.tgz",
+      "integrity": "sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.49.0.tgz",
+      "integrity": "sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.49.0.tgz",
+      "integrity": "sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.9.1.tgz",
+      "integrity": "sha512-0gEoi2Lb54MFYPOmdTfxlNKxI7kCOvNV7gP8lxMXJ7nCazF5OqOOZIVshfWjDLrc0QrSV6XdVvwPV9GDn4wBMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.49.0.tgz",
+      "integrity": "sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.49.0",
+        "@sentry-internal/feedback": "10.49.0",
+        "@sentry-internal/replay": "10.49.0",
+        "@sentry-internal/replay-canvas": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-4.9.1.tgz",
+      "integrity": "sha512-moii+w7N8k8WdvkX7qCDY9iRBlhgHlhTHTUQwF2FNMhBHuqlNpVcSJJqJMjFUQcjYMBDrZgxhfKV18bt5ixwlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "4.9.1",
+        "@sentry/cli": "^2.57.0",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^10.5.0",
+        "magic-string": "0.30.8",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
+      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.5",
+        "@sentry/cli-linux-arm": "2.58.5",
+        "@sentry/cli-linux-arm64": "2.58.5",
+        "@sentry/cli-linux-i686": "2.58.5",
+        "@sentry/cli-linux-x64": "2.58.5",
+        "@sentry/cli-win32-arm64": "2.58.5",
+        "@sentry/cli-win32-i686": "2.58.5",
+        "@sentry/cli-win32-x64": "2.58.5"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
+      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
+      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
+      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
+      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
+      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
+      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
+      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
+      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.49.0.tgz",
+      "integrity": "sha512-WdfJve0orTiumr25Ozgs2p2KaJR9xV82Z5V9IYBi0TadsurSWK6xI6SAFjw84tQht9Fp8q4UCn3QYCnApF4BfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.49.0",
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-4.9.1.tgz",
+      "integrity": "sha512-Tlyg2cyFYp/icX58GWvfpvZr9NLdLs2/xyFVyS8pQ0faZWmoXic3FMzoXYHV1gsdMbL1Yy5WQvGJy8j1rS8LGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "4.9.1",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1523,6 +2305,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1566,6 +2361,33 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1596,6 +2418,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1604,6 +2439,19 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -1617,6 +2465,53 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/c8": {
@@ -1653,6 +2548,27 @@
         }
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1661,6 +2577,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cliui": {
@@ -1834,6 +2788,33 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2125,6 +3106,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2193,6 +3187,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -2279,6 +3283,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2305,6 +3323,19 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -2340,6 +3371,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2395,13 +3436,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.0.2",
@@ -2444,6 +3500,19 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2464,6 +3533,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2889,6 +3971,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2949,6 +4094,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -3144,6 +4296,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3219,6 +4388,32 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -3416,7 +4611,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3541,6 +4766,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -3655,6 +4893,50 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unplugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.8.1",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3887,6 +5169,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/webpack-sources": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -3973,6 +5272,25 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -3999,6 +5317,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:all:e2e": "npm run build:ts && npm run test:react && node .tsbuild/scripts/run-tests.cjs && node .tsbuild/scripts/run-gameplay-tests.cjs && node .tsbuild/scripts/run-e2e.cjs"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "^4.5.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
@@ -59,6 +60,7 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
+    "@sentry/react": "^10.22.0",
     "@tanstack/react-query": "^5.99.0",
     "@vercel/speed-insights": "^2.0.0",
     "react": "^19.2.5",

--- a/scripts/check-vercel-env-parity.cts
+++ b/scripts/check-vercel-env-parity.cts
@@ -1,5 +1,6 @@
 const { spawnSync } = require("child_process");
 const {
+  OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS,
   REQUIRED_CRON_ENV_KEYS,
   REQUIRED_DEPLOY_ENV_KEYS
 } = require("../backend/required-runtime-env.cjs");
@@ -74,15 +75,36 @@ function summarizeMissing(
   return keys.filter((key) => source[key] && !target[key]);
 }
 
+function requiredDeployKeysFor(envKeys: Record<string, unknown>): string[] {
+  const keys = REQUIRED_DEPLOY_ENV_KEYS.slice();
+  if (envKeys.VITE_SENTRY_DSN) {
+    keys.push(...OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS);
+  }
+  return keys;
+}
+
+function parityDeployKeys(source: Record<string, unknown>): string[] {
+  const keys = REQUIRED_DEPLOY_ENV_KEYS.slice();
+  if (source.VITE_SENTRY_DSN) {
+    keys.push("VITE_SENTRY_DSN", ...OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS);
+  }
+  return keys;
+}
+
 function main(): void {
   const branch = process.env.VERCEL_ENV_CHECK_BRANCH || currentBranch();
   const production = listEnvKeys("production");
   const preview = mergeEnvKeys(listEnvKeys("preview"), listEnvKeys("preview", branch));
+  const requiredProductionDeployKeys = requiredDeployKeysFor(production);
+  const requiredPreviewDeployKeys = requiredDeployKeysFor(preview);
+  const deployParityKeys = parityDeployKeys(production);
 
-  const missingInProduction = REQUIRED_DEPLOY_ENV_KEYS.filter((key: string) => !production[key]);
-  const missingInPreview = REQUIRED_DEPLOY_ENV_KEYS.filter((key: string) => !preview[key]);
+  const missingInProduction = requiredProductionDeployKeys.filter(
+    (key: string) => !production[key]
+  );
+  const missingInPreview = requiredPreviewDeployKeys.filter((key: string) => !preview[key]);
   const missingFromPreviewComparedToProduction = summarizeMissing(
-    REQUIRED_DEPLOY_ENV_KEYS,
+    deployParityKeys,
     production,
     preview
   );

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -63,6 +63,7 @@ const { createGameSessionStore } = require("../backend/game-session-store.cjs");
 const { readJsonFile, writeJsonFile } = require("../backend/json-file-store.cjs");
 const { createPlayerProfileStore } = require("../backend/player-profile-store.cjs");
 const {
+  OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS,
   missingRequiredDeployEnv,
   shouldValidateDeployEnv
 } = require("../backend/required-runtime-env.cjs");
@@ -225,6 +226,37 @@ async function withMockFetch<T>(
     return await fn();
   } finally {
     global.fetch = previousFetch;
+  }
+}
+
+async function withEnvironment<T>(
+  overrides: Record<string, string | null | undefined>,
+  fn: () => Promise<T> | T
+): Promise<T> {
+  const keys = Object.keys(overrides);
+  const previousValues = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+
+  try {
+    keys.forEach((key) => {
+      const value = overrides[key];
+      if (value == null || value === "") {
+        delete process.env[key];
+        return;
+      }
+
+      process.env[key] = value;
+    });
+
+    return await fn();
+  } finally {
+    keys.forEach((key) => {
+      if (typeof previousValues[key] === "undefined") {
+        delete process.env[key];
+        return;
+      }
+
+      process.env[key] = previousValues[key];
+    });
   }
 }
 
@@ -787,6 +819,17 @@ register("required runtime env valida solo preview e production su Vercel", () =
       DATASTORE_DRIVER: "supabase"
     }),
     ["SUPABASE_SERVICE_ROLE_KEY"]
+  );
+
+  assert.deepEqual(
+    missingRequiredDeployEnv({
+      AUTH_ENCRYPTION_KEY: "enc",
+      SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role",
+      DATASTORE_DRIVER: "supabase",
+      VITE_SENTRY_DSN: "https://public@example.ingest.sentry.io/0"
+    }),
+    OPTIONAL_OBSERVABILITY_BUILD_ENV_KEYS
   );
 });
 
@@ -6451,6 +6494,69 @@ register("GET /api/health espone lo stato del datastore sqlite", async () => {
     assert.equal(typeof payload.storage.counts.games, "number");
     assert.equal(typeof payload.storage.counts.sessions, "number");
     assert.equal(payload.hasActiveGame, true);
+  });
+});
+
+register("API responses espongono X-Request-Id per la correlazione", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/health`);
+    assert.equal(response.status, 200);
+    assert.equal(typeof response.headers.get("x-request-id"), "string");
+    assert.equal(Boolean(response.headers.get("x-request-id")), true);
+  });
+});
+
+register("API unexpected 5xx logga requestId, path e release in modo strutturato", async () => {
+  await withServer(async (baseUrl, context) => {
+    const originalConsoleError = console.error;
+    const originalGetUserFromSession = context.app.auth.getUserFromSession;
+    const errorLogs: string[] = [];
+
+    context.app.auth.getUserFromSession = async () => {
+      throw new Error("Session storage exploded.");
+    };
+    (console as any).error = (value: unknown) => {
+      errorLogs.push(String(value));
+    };
+
+    try {
+      const response = await fetch(`${baseUrl}/api/auth/session`);
+      assert.equal(response.status, 500);
+
+      const requestId = response.headers.get("x-request-id");
+      assert.equal(Boolean(requestId), true);
+      assert.equal(errorLogs.length > 0, true);
+
+      const logPayload = JSON.parse(errorLogs[0]);
+      assert.equal(logPayload.event, "api_unexpected_error");
+      assert.equal(logPayload.path, "/api/auth/session");
+      assert.equal(logPayload.statusCode, 500);
+      assert.equal(logPayload.requestId, requestId);
+      assert.equal(typeof logPayload.release, "string");
+      assert.equal(logPayload.message, "Session storage exploded.");
+    } finally {
+      context.app.auth.getUserFromSession = originalGetUserFromSession;
+      (console as any).error = originalConsoleError;
+    }
+  });
+});
+
+register("CSP aggiunge l'origin Sentry solo quando il DSN frontend e configurato", async () => {
+  await withEnvironment({ VITE_SENTRY_DSN: null }, async () => {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/health`);
+      const csp = response.headers.get("content-security-policy") || "";
+      assert.equal(csp.includes("connect-src 'self'"), true);
+      assert.equal(csp.includes("ingest.sentry.io"), false);
+    });
+  });
+
+  await withEnvironment({ VITE_SENTRY_DSN: "https://public@o0.ingest.sentry.io/0" }, async () => {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/health`);
+      const csp = response.headers.get("content-security-policy") || "";
+      assert.equal(csp.includes("connect-src 'self' https://o0.ingest.sentry.io"), true);
+    });
   });
 });
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -6546,8 +6546,13 @@ register("CSP aggiunge l'origin Sentry solo quando il DSN frontend e configurato
     await withServer(async (baseUrl) => {
       const response = await fetch(`${baseUrl}/api/health`);
       const csp = response.headers.get("content-security-policy") || "";
+      const connectSrcDirective = csp
+        .split(";")
+        .map((directive) => directive.trim())
+        .find((directive) => directive.startsWith("connect-src "));
+      const connectSrcSources = new Set((connectSrcDirective || "").split(/\s+/).slice(1));
       assert.equal(csp.includes("connect-src 'self'"), true);
-      assert.equal(csp.includes("ingest.sentry.io"), false);
+      assert.equal(connectSrcSources.has("https://o0.ingest.sentry.io"), false);
     });
   });
 
@@ -6555,7 +6560,12 @@ register("CSP aggiunge l'origin Sentry solo quando il DSN frontend e configurato
     await withServer(async (baseUrl) => {
       const response = await fetch(`${baseUrl}/api/health`);
       const csp = response.headers.get("content-security-policy") || "";
-      assert.equal(csp.includes("connect-src 'self' https://o0.ingest.sentry.io"), true);
+      const connectSrcDirective = csp
+        .split(";")
+        .map((directive) => directive.trim())
+        .find((directive) => directive.startsWith("connect-src "));
+      const connectSrcSources = new Set((connectSrcDirective || "").split(/\s+/).slice(1));
+      assert.equal(connectSrcSources.has("https://o0.ingest.sentry.io"), true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add minimal Sentry-backed observability for the migrated React shell with a dedicated bootstrap, root error handlers, and a shell crash fallback
- capture only unexpected client failures at the API boundary, add backend request-id/release correlation, and extend CSP/env handling for deploy-time Sentry setup
- document the observability rollout and add frontend/backend coverage for init toggles, API capture filtering, request-id headers, structured 5xx logs, and Sentry CSP wiring

## Why
Issue #104 asks for production visibility on the migrated React shell before analytics or PWA work expands the surface area.

## Linked issue
Closes #104.

## Stacked PR note
This branch is intentionally based on codex/issue-103-vitest-react-shell so the diff stays scoped to issue 104 while #124 is still open. Once #124 lands, this PR can be retargeted to main. Until then, the closing keyword is only there to keep the issue linkage explicit.

## Validation
- npm run typecheck:react-shell
- npm run test:react
- npm run lint
- npm run build:ts
- npm run vercel:env:check
- npm test
