### PR TITLE
[codex] Fix Vercel canonical route rewrites

### DIFF
--- a/tests/gameplay/regression/vercel-routing-config.test.cts
+++ b/tests/gameplay/regression/vercel-routing-config.test.cts
@@ -43,7 +43,27 @@ register("vercel preview rewrites React shell deep links to the shell entry docu
     "Expected /register to rewrite to /react/index.html for the React auth flow."
   );
   assert.ok(
+    hasRewriteRule(rewrites, "/register.html", "/react/index.html"),
+    "Expected /register.html to rewrite to /react/index.html for the canonical auth alias."
+  );
+  assert.ok(
     hasRewriteRule(rewrites, "/unauthorized", "/react/index.html"),
     "Expected /unauthorized to rewrite to /react/index.html for the React auth flow."
+  );
+  assert.ok(
+    hasRewriteRule(rewrites, "/lobby.html", "/react/index.html"),
+    "Expected /lobby.html to rewrite to /react/index.html for the canonical lobby route."
+  );
+  assert.ok(
+    hasRewriteRule(rewrites, "/new-game.html", "/react/index.html"),
+    "Expected /new-game.html to rewrite to /react/index.html for the canonical new-game route."
+  );
+  assert.ok(
+    hasRewriteRule(rewrites, "/profile.html", "/react/index.html"),
+    "Expected /profile.html to rewrite to /react/index.html for the canonical profile route."
+  );
+  assert.ok(
+    hasRewriteRule(rewrites, "/game.html", "/react/index.html"),
+    "Expected /game.html to rewrite to /react/index.html for the canonical gameplay document alias."
   );
 });

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,27 @@
       "destination": "/react/index.html"
     },
     {
+      "source": "/register.html",
+      "destination": "/react/index.html"
+    },
+    {
       "source": "/unauthorized",
+      "destination": "/react/index.html"
+    },
+    {
+      "source": "/lobby.html",
+      "destination": "/react/index.html"
+    },
+    {
+      "source": "/new-game.html",
+      "destination": "/react/index.html"
+    },
+    {
+      "source": "/profile.html",
+      "destination": "/react/index.html"
+    },
+    {
+      "source": "/game.html",
       "destination": "/react/index.html"
     },
     {


### PR DESCRIPTION
## What changed
- add Vercel rewrites for the canonical React-shell document aliases: `/register.html`, `/lobby.html`, `/new-game.html`, `/profile.html`, and `/game.html`
- extend the Vercel routing regression test so those aliases stay covered

## Why
Recent routing commits moved these canonical `.html` routes into the React shell on the Node server, but `vercel.json` still rewrote only `/react/*`, `/login`, `/register`, `/unauthorized`, `/game`, and `/game/:path*`.
That left Vercel preview traffic serving the legacy static documents for the canonical aliases instead of the React shell.

## Impact
- Vercel previews now match the server-side route handling for canonical React-shell entry points
- canonical deep links no longer fall back to legacy static pages in preview deployments

## Validation
- `npm run build:ts`
- `npm run test:gameplay`
