### PR TITLE
[codex] Harden frontend/backend boundary handling

### DIFF
--- a/frontend/react-shell/src/__tests__/api-client-stream.test.ts
+++ b/frontend/react-shell/src/__tests__/api-client-stream.test.ts
@@ -1,0 +1,118 @@
+import { registerFrontendObservabilityReporter } from "@frontend-core/observability.mts";
+import { subscribeToGameEvents } from "@frontend-core/api/client.mts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FakeMessageEvent = {
+  data: string;
+};
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: FakeMessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readonly url: string;
+  readonly withCredentials: boolean;
+  closed = false;
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = Boolean(options?.withCredentials);
+    FakeEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emitOpen(): void {
+    this.onopen?.();
+  }
+
+  emitMessage(payload: unknown): void {
+    this.onmessage?.({
+      data: JSON.stringify(payload)
+    });
+  }
+}
+
+describe("game event subscription boundary", () => {
+  afterEach(() => {
+    FakeEventSource.instances.length = 0;
+    registerFrontendObservabilityReporter(null);
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards validated game events to subscribers", () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+
+    const onMessage = vi.fn();
+    const onOpen = vi.fn();
+    const stream = subscribeToGameEvents({
+      gameId: "g-1",
+      onMessage,
+      onOpen
+    });
+
+    const eventSource = FakeEventSource.instances[0];
+    expect(eventSource.url).toBe("/api/events?gameId=g-1");
+    expect(eventSource.withCredentials).toBe(true);
+
+    eventSource.emitOpen();
+    eventSource.emitMessage({
+      gameId: "g-1",
+      players: [],
+      map: [],
+      reinforcementPool: 3
+    });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameId: "g-1",
+        reinforcementPool: 3
+      })
+    );
+
+    stream.close();
+    expect(eventSource.closed).toBe(true);
+  });
+
+  it("reports invalid event payloads without forwarding them to the UI", () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    const onMessage = vi.fn();
+    const onInvalidPayload = vi.fn();
+
+    subscribeToGameEvents({
+      gameId: "g-1",
+      onMessage,
+      onInvalidPayload
+    });
+
+    const eventSource = FakeEventSource.instances[0];
+    eventSource.emitMessage({
+      gameId: "g-1",
+      players: "bad-payload",
+      map: [],
+      reinforcementPool: 3
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(onInvalidPayload).toHaveBeenCalledTimes(1);
+    expect(reporter).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        category: "validation",
+        kind: "response_validation",
+        path: "/api/events?gameId=g-1",
+        schemaName: "GameEventPayload"
+      })
+    );
+  });
+});

--- a/frontend/react-shell/src/__tests__/api-client-stream.test.ts
+++ b/frontend/react-shell/src/__tests__/api-client-stream.test.ts
@@ -115,4 +115,35 @@ describe("game event subscription boundary", () => {
       })
     );
   });
+
+  it("does not swallow subscriber exceptions as payload validation errors", () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    const onInvalidPayload = vi.fn();
+
+    subscribeToGameEvents({
+      gameId: "g-1",
+      onMessage: () => {
+        throw new Error("Subscriber exploded.");
+      },
+      onInvalidPayload
+    });
+
+    const eventSource = FakeEventSource.instances[0];
+
+    expect(() => {
+      eventSource.emitMessage({
+        gameId: "g-1",
+        players: [],
+        map: [],
+        reinforcementPool: 3
+      });
+    }).toThrow("Subscriber exploded.");
+
+    expect(onInvalidPayload).not.toHaveBeenCalled();
+    expect(reporter).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -1,0 +1,262 @@
+import { act, screen, waitFor } from "@testing-library/react";
+
+import type {
+  AuthSessionResponse,
+  GameStateResponse,
+  ModuleOptionsResponse
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+import {
+  getGameState,
+  getModuleOptions,
+  getSession,
+  subscribeToGameEvents
+} from "@frontend-core/api/client.mts";
+
+import { renderReactShell } from "../../test/render-react-shell";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@frontend-core/api/client.mts", () => ({
+  getSession: vi.fn(),
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  getProfile: vi.fn(),
+  updateThemePreference: vi.fn(),
+  listGames: vi.fn(),
+  getModuleOptions: vi.fn(),
+  getGameOptions: vi.fn(),
+  createGame: vi.fn(),
+  openGame: vi.fn(),
+  joinGame: vi.fn(),
+  getGameState: vi.fn(),
+  sendGameAction: vi.fn(),
+  startGame: vi.fn(),
+  tradeCards: vi.fn(),
+  subscribeToGameEvents: vi.fn(),
+  extractGameVersionConflict: vi.fn(() => null)
+}));
+
+vi.mock("@react-shell/gameplay-map-viewport", () => ({
+  GameplayMapViewport: () => <div data-testid="mock-gameplay-map-viewport" />
+}));
+
+const getGameStateMock = vi.mocked(getGameState);
+const getModuleOptionsMock = vi.mocked(getModuleOptions);
+const getSessionMock = vi.mocked(getSession);
+const subscribeToGameEventsMock = vi.mocked(subscribeToGameEvents);
+
+type StreamHandlers = Parameters<typeof subscribeToGameEvents>[0];
+
+let streamHandlers: StreamHandlers | null = null;
+let closeStreamMock: ReturnType<typeof vi.fn>;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function createSession(theme = "command"): AuthSessionResponse {
+  return {
+    user: {
+      id: "user-1",
+      username: "Commander",
+      preferences: {
+        theme
+      }
+    }
+  };
+}
+
+function emptyModuleOptions(): ModuleOptionsResponse {
+  return {
+    modules: [],
+    enabledModules: [],
+    gameModules: [],
+    content: {},
+    gamePresets: [],
+    uiSlots: [],
+    contentProfiles: [],
+    gameplayProfiles: [],
+    uiProfiles: []
+  };
+}
+
+function createGameplayState(overrides: Partial<GameStateResponse> = {}): GameStateResponse {
+  return {
+    phase: "active",
+    turnPhase: "reinforcement",
+    players: [
+      {
+        id: "p1",
+        name: "Commander",
+        color: "#e85d04",
+        connected: true,
+        isAi: false,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 0
+      },
+      {
+        id: "p2",
+        name: "CPU",
+        color: "#0f4c5c",
+        connected: true,
+        isAi: true,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "aurora",
+        name: "Aurora",
+        neighbors: ["bastion"],
+        continentId: "north",
+        ownerId: "p1",
+        armies: 3,
+        x: 0.2,
+        y: 0.3
+      },
+      {
+        id: "bastion",
+        name: "Bastion",
+        neighbors: ["aurora"],
+        continentId: "north",
+        ownerId: "p2",
+        armies: 1,
+        x: 0.65,
+        y: 0.45
+      }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool: 3,
+    winnerId: null,
+    gameConfig: {
+      mapId: "classic-mini",
+      mapName: "Classic Mini",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    log: ["Gameplay route integration"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: false,
+    attacksThisTurn: 0,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 5,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    diceRuleSet: {
+      id: "standard",
+      attackerMaxDice: 3,
+      defenderMaxDice: 2
+    },
+    gameId: "g-1",
+    version: 4,
+    gameName: "Integration Match",
+    playerId: "p1",
+    playerHand: [],
+    ...overrides
+  } as GameStateResponse;
+}
+
+describe("GameRoute integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    closeStreamMock = vi.fn();
+    streamHandlers = null;
+
+    getSessionMock.mockResolvedValue(createSession());
+    getModuleOptionsMock.mockResolvedValue(emptyModuleOptions());
+    getGameStateMock.mockResolvedValue(createGameplayState());
+    subscribeToGameEventsMock.mockImplementation((handlers) => {
+      streamHandlers = handlers;
+      return {
+        close: closeStreamMock,
+        onopen: null,
+        onmessage: null,
+        onerror: null,
+        readyState: 1,
+        url: "/api/events?gameId=g-1",
+        withCredentials: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true),
+        CONNECTING: 0,
+        OPEN: 1,
+        CLOSED: 2
+      } as unknown as EventSource;
+    });
+  });
+
+  afterEach(() => {
+    streamHandlers = null;
+  });
+
+  it("falls back to polling after an invalid stream payload and returns to live updates after recovery", async () => {
+    const recoveredState = createGameplayState({
+      reinforcementPool: 0,
+      version: 5
+    });
+
+    const { unmount } = renderReactShell("/react/game/g-1");
+
+    expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getGameStateMock).toHaveBeenCalledTimes(1);
+      expect(subscribeToGameEventsMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      streamHandlers?.onOpen?.();
+    });
+
+    await act(async () => {
+      await delay(1_700);
+    });
+
+    expect(getGameStateMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      streamHandlers?.onInvalidPayload?.(new Error("Malformed event payload."));
+    });
+
+    await act(async () => {
+      await delay(1_700);
+    });
+
+    await waitFor(() => {
+      expect(getGameStateMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      streamHandlers?.onMessage(recoveredState);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-summary")).toHaveTextContent(/Rinforzi disponibili:\s*0/i);
+    });
+
+    await act(async () => {
+      await delay(1_700);
+    });
+
+    expect(getGameStateMock).toHaveBeenCalledTimes(2);
+
+    unmount();
+
+    expect(closeStreamMock).toHaveBeenCalledTimes(1);
+  }, 20_000);
+});

--- a/frontend/react-shell/src/__tests__/http-observability.test.ts
+++ b/frontend/react-shell/src/__tests__/http-observability.test.ts
@@ -142,6 +142,71 @@ describe("frontend API observability boundary", () => {
     );
   });
 
+  it("captures backend response validation failures as unexpected 5xx errors", async () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: "Response payload invalid.",
+            code: "RESPONSE_VALIDATION_FAILED",
+            validationErrors: [
+              {
+                code: "invalid_type",
+                path: "state.players",
+                message: "Expected array."
+              }
+            ]
+          }),
+          {
+            status: 500,
+            headers: {
+              "Content-Type": "application/json",
+              "X-Request-Id": "req-response-validation"
+            }
+          }
+        )
+      )
+    );
+
+    await expect(
+      requestJson({
+        path: "/api/state",
+        responseSchema: okResponseSchema,
+        responseSchemaName: "OkResponse",
+        errorMessage: "Unable to load game."
+      })
+    ).rejects.toMatchObject({
+      category: "unexpected_5xx",
+      kind: "http",
+      statusCode: 500,
+      requestId: "req-response-validation",
+      code: "RESPONSE_VALIDATION_FAILED",
+      validationErrors: [
+        expect.objectContaining({
+          path: "state.players"
+        })
+      ]
+    });
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "unexpected_5xx",
+        requestId: "req-response-validation",
+        code: "RESPONSE_VALIDATION_FAILED"
+      }),
+      expect.objectContaining({
+        category: "unexpected_5xx",
+        kind: "http",
+        requestId: "req-response-validation",
+        code: "RESPONSE_VALIDATION_FAILED"
+      })
+    );
+  });
+
   it("does not capture expected HTTP 401 responses", async () => {
     const reporter = vi.fn();
     registerFrontendObservabilityReporter(reporter);

--- a/frontend/react-shell/src/__tests__/http-observability.test.ts
+++ b/frontend/react-shell/src/__tests__/http-observability.test.ts
@@ -29,16 +29,19 @@ describe("frontend API observability boundary", () => {
         errorMessage: "Profile unavailable."
       })
     ).rejects.toMatchObject({
+      category: "network",
       kind: "network",
       path: "/api/profile"
     });
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
+        category: "network",
         kind: "network",
         path: "/api/profile"
       }),
       expect.objectContaining({
+        category: "network",
         kind: "network",
         path: "/api/profile"
       })
@@ -70,6 +73,7 @@ describe("frontend API observability boundary", () => {
         errorMessage: "Profile unavailable."
       })
     ).rejects.toMatchObject({
+      category: "unexpected_5xx",
       kind: "http",
       statusCode: 500,
       requestId: "req-500",
@@ -78,10 +82,12 @@ describe("frontend API observability boundary", () => {
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
+        category: "unexpected_5xx",
         requestId: "req-500",
         statusCode: 500
       }),
       expect.objectContaining({
+        category: "unexpected_5xx",
         kind: "http",
         requestId: "req-500",
         statusCode: 500,
@@ -116,6 +122,7 @@ describe("frontend API observability boundary", () => {
         fallbackMessage: "Profile payload invalid."
       })
     ).rejects.toMatchObject({
+      category: "validation",
       kind: "response_validation",
       requestId: "req-schema",
       statusCode: 200
@@ -123,9 +130,11 @@ describe("frontend API observability boundary", () => {
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
+        category: "validation",
         requestId: "req-schema"
       }),
       expect.objectContaining({
+        category: "validation",
         kind: "response_validation",
         schemaName: "OkResponse",
         requestId: "req-schema"
@@ -158,6 +167,7 @@ describe("frontend API observability boundary", () => {
         errorMessage: "Unable to load session."
       })
     ).rejects.toMatchObject({
+      category: "auth",
       kind: "http",
       statusCode: 401,
       requestId: "req-auth",
@@ -165,5 +175,45 @@ describe("frontend API observability boundary", () => {
     });
 
     expect(reporter).not.toHaveBeenCalled();
+  });
+
+  it("wraps request schema mismatches as controlled validation errors", async () => {
+    const reporter = vi.fn();
+    registerFrontendObservabilityReporter(reporter);
+
+    const requestSchema = z.object({
+      count: z.number().int()
+    });
+
+    await expect(
+      requestJson<unknown, z.infer<typeof okResponseSchema>>({
+        path: "/api/action",
+        method: "POST",
+        body: {
+          count: "bad"
+        },
+        requestSchema,
+        requestSchemaName: "CountRequest",
+        responseSchema: okResponseSchema,
+        responseSchemaName: "OkResponse",
+        errorMessage: "Request failed."
+      })
+    ).rejects.toMatchObject({
+      category: "validation",
+      kind: "request_validation",
+      path: "/api/action"
+    });
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "validation",
+        kind: "request_validation"
+      }),
+      expect.objectContaining({
+        category: "validation",
+        kind: "request_validation",
+        schemaName: "CountRequest"
+      })
+    );
   });
 });

--- a/frontend/react-shell/src/auth.tsx
+++ b/frontend/react-shell/src/auth.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useRef, type ReactNode } from "react";
 
 import { getSession, login, logout } from "@frontend-core/api/client.mts";
-import type { ApiClientError } from "@frontend-core/api/http.mts";
+import { isAuthApiError } from "@frontend-core/api/http.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
 import {
   initialAuthState,
@@ -28,12 +28,8 @@ function requestMessages(scope: string) {
   };
 }
 
-function isApiClientError(error: unknown): error is ApiClientError {
-  return error instanceof Error;
-}
-
 function isAuthRequired(error: unknown): boolean {
-  return isApiClientError(error) && error.code === "AUTH_REQUIRED";
+  return isAuthApiError(error);
 }
 
 async function resolveSessionState(): Promise<AuthState> {

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   GameMutationResponse,
   GameSnapshot,
+  GameStateResponse,
   SnapshotCard,
   SnapshotPlayer,
   SnapshotTerritory
@@ -16,9 +17,9 @@ import {
   extractGameVersionConflict,
   getGameState,
   joinGame,
-  parseGameEventPayload,
   sendGameAction,
   startGame,
+  subscribeToGameEvents,
   tradeCards
 } from "@frontend-core/api/client.mts";
 import type { GameActionRequest, TradeCardsRequest } from "@frontend-core/api/client.mts";
@@ -456,8 +457,7 @@ export function GameRoute() {
     setActionError(translateGameplayError(error, t("errors.requestFailed")));
   });
 
-  const handleEventMessage = useEffectEvent((event: MessageEvent<string>) => {
-    const nextPayload = parseGameEventPayload(JSON.parse(event.data));
+  const handleEventMessage = useEffectEvent((nextPayload: GameStateResponse) => {
     queryClient.setQueryData(queryKey, nextPayload);
     if (nextPayload.playerId) {
       storeCurrentPlayerId(nextPayload.playerId, nextPayload.gameId || resolvedGameId || null);
@@ -526,20 +526,19 @@ export function GameRoute() {
     }
 
     setStreamStatus("connecting");
-    const eventSource = new EventSource(
-      `/api/events?gameId=${encodeURIComponent(resolvedGameId)}`,
-      {
-        withCredentials: true
+    const eventSource = subscribeToGameEvents({
+      gameId: resolvedGameId,
+      onOpen: () => {
+        setStreamStatus("live");
+      },
+      onMessage: handleEventMessage,
+      onInvalidPayload: () => {
+        setStreamStatus("reconnecting");
+      },
+      onError: () => {
+        setStreamStatus((current) => (current === "live" ? "reconnecting" : current));
       }
-    );
-
-    eventSource.onopen = () => {
-      setStreamStatus("live");
-    };
-    eventSource.onmessage = handleEventMessage;
-    eventSource.onerror = () => {
-      setStreamStatus((current) => (current === "live" ? "reconnecting" : current));
-    };
+    });
 
     return () => {
       eventSource.close();

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -458,6 +458,7 @@ export function GameRoute() {
   });
 
   const handleEventMessage = useEffectEvent((nextPayload: GameStateResponse) => {
+    setStreamStatus("live");
     queryClient.setQueryData(queryKey, nextPayload);
     if (nextPayload.playerId) {
       storeCurrentPlayerId(nextPayload.playerId, nextPayload.gameId || resolvedGameId || null);

--- a/frontend/react-shell/src/observability.ts
+++ b/frontend/react-shell/src/observability.ts
@@ -82,6 +82,9 @@ function applyObservabilityScope(error: Error, context: FrontendObservabilityCon
     if (context.kind) {
       scope.setTag("app.error_kind", context.kind);
     }
+    if (context.category) {
+      scope.setTag("app.error_category", context.category);
+    }
     if (context.code) {
       scope.setTag("app.error_code", context.code);
     }

--- a/frontend/react-shell/src/profile-route.tsx
+++ b/frontend/react-shell/src/profile-route.tsx
@@ -470,12 +470,12 @@ export function ProfileRoute() {
                 hidden={!activeGames.length}
               >
                 {activeGames.map((game) => (
-                  <a
+                  <Link
                     className="profile-game-row"
                     data-open-game-id={game.id}
                     data-testid={`react-shell-profile-open-${game.id}`}
-                    href={buildReactGamePath(game.id)}
                     key={game.id}
+                    to={buildReactGamePath(game.id)}
                   >
                     <span className="profile-game-primary">
                       <span className="profile-game-kicker">{t("profile.games.kicker")}</span>
@@ -493,7 +493,7 @@ export function ProfileRoute() {
                       </span>
                     </span>
                     <span className="ghost-button">{t("profile.runtime.directive.resume")}</span>
-                  </a>
+                  </Link>
                 ))}
               </div>
             </article>

--- a/frontend/src/app.mts
+++ b/frontend/src/app.mts
@@ -1,9 +1,22 @@
 import { closest as closestElement, maybeQuery, setMarkup } from "./core/dom.mjs";
 import { buildSyncedGameLocation, requestedGameIdFromLocation } from "./core/game-route-paths.mjs";
 import { mountModuleSlotSection } from "./core/module-slots.mjs";
+import {
+  createGame,
+  extractGameVersionConflict,
+  getGameState,
+  getSession,
+  joinGame,
+  listGames,
+  login,
+  logout,
+  openGame,
+  sendGameAction,
+  startGame,
+  subscribeToGameEvents,
+  tradeCards
+} from "./core/api/client.mjs";
 import type {
-  GameListResponse,
-  MessagePayload,
   GameSnapshot,
   GameSummary,
   MutationResponse,
@@ -13,13 +26,7 @@ import type {
   SnapshotPlayer,
   SnapshotTerritory
 } from "./core/types.mjs";
-import {
-  formatDate,
-  t,
-  translateGameLogEntries,
-  translateMessagePayload,
-  translateServerMessage
-} from "./i18n.mjs";
+import { formatDate, t, translateGameLogEntries } from "./i18n.mjs";
 
 type GameListState = "loading" | "ready" | "empty" | "error";
 type FortifySelectionMode = "from" | "to";
@@ -783,7 +790,7 @@ function ensurePrivateStateFresh(currentPlayer: SnapshotPlayer | null): void {
   setTimeout(async () => {
     try {
       await loadState();
-    } catch (error) {
+    } catch (_error) {
     } finally {
       privateStateRefreshInFlight = false;
     }
@@ -813,7 +820,7 @@ async function refreshPrivateStateIfNeeded(nextState: GameSnapshot): Promise<Gam
       if (latestHand.length >= currentPlayerCardCount) {
         return latestState;
       }
-    } catch (error) {
+    } catch (_error) {
       return latestState;
     }
 
@@ -2187,18 +2194,10 @@ async function fetchLatestStateSnapshot(
   options: { includeGameId?: boolean } = {}
 ): Promise<GameSnapshot> {
   const includeGameId = options.includeGameId !== false;
-  const query =
-    includeGameId && state.currentGameId
-      ? "?gameId=" + encodeURIComponent(state.currentGameId)
-      : "";
-  const response = await fetch("/api/state" + query);
-  const data = (await response.json()) as GameSnapshot;
-  if (!response.ok) {
-    throw new Error(
-      translateServerMessage(data as unknown as MessagePayload, t("game.errors.loadActiveGame"))
-    );
-  }
-  return data;
+  return (await getGameState(includeGameId ? state.currentGameId : null, {
+    errorMessage: t("game.errors.loadActiveGame"),
+    fallbackMessage: t("game.errors.loadActiveGame")
+  })) as unknown as GameSnapshot;
 }
 
 function shouldAcceptSnapshot(
@@ -2252,26 +2251,73 @@ function applySnapshot(
 
 async function send(
   path: string,
-  payload: Record<string, unknown> = {},
-  options: { method?: string } = {}
+  payload: Record<string, unknown> = {}
 ): Promise<MutationResponse> {
-  const response = await fetch(path, {
-    method: options.method || "POST",
-    headers: { "Content-Type": "application/json" },
-    body: options.method === "GET" ? undefined : JSON.stringify(payload)
-  });
+  const mutationMessages = {
+    errorMessage: path === "/api/auth/login" ? t("errors.loginFailed") : t("errors.requestFailed"),
+    fallbackMessage:
+      path === "/api/auth/login" ? t("errors.loginFailed") : t("errors.requestFailed")
+  };
 
-  const data = (await response.json()) as MutationResponse;
-  if (!response.ok) {
-    if (response.status === 409 && data.code === "VERSION_CONFLICT" && data.state) {
-      applySnapshot(data.state, { clearPlayerIdentity: false });
-      await loadGameList();
-      throw new Error(translateServerMessage(data, t("game.errors.versionConflict")));
+  try {
+    switch (path) {
+      case "/api/games":
+        return (await createGame(
+          payload as Parameters<typeof createGame>[0],
+          mutationMessages
+        )) as unknown as MutationResponse;
+      case "/api/games/open":
+        return (await openGame(
+          String(payload.gameId || ""),
+          mutationMessages
+        )) as unknown as MutationResponse;
+      case "/api/auth/login":
+        return (await login(
+          {
+            username: String(payload.username || ""),
+            password: String(payload.password || "")
+          },
+          mutationMessages
+        )) as unknown as MutationResponse;
+      case "/api/auth/logout":
+        return (await logout(mutationMessages)) as unknown as MutationResponse;
+      case "/api/join":
+        return (await joinGame(
+          String(payload.gameId || ""),
+          mutationMessages
+        )) as unknown as MutationResponse;
+      case "/api/start":
+        return (await startGame(
+          payload as Parameters<typeof startGame>[0],
+          mutationMessages
+        )) as unknown as MutationResponse;
+      case "/api/action":
+        return (await sendGameAction(
+          payload as Parameters<typeof sendGameAction>[0],
+          mutationMessages
+        )) as unknown as MutationResponse;
+      case "/api/cards/trade":
+        return (await tradeCards(
+          payload as Parameters<typeof tradeCards>[0],
+          mutationMessages
+        )) as unknown as MutationResponse;
+      default:
+        throw new Error(`Unsupported legacy mutation path: ${path}`);
     }
-    throw new Error(translateServerMessage(data, t("errors.requestFailed")));
-  }
+  } catch (error: unknown) {
+    const versionConflict = extractGameVersionConflict(error);
+    if (versionConflict?.state) {
+      applySnapshot(versionConflict.state as unknown as GameSnapshot, {
+        clearPlayerIdentity: false
+      });
+      await loadGameList();
+      throw new Error(t("game.errors.versionConflict"), {
+        cause: error
+      });
+    }
 
-  return data;
+    throw error;
+  }
 }
 
 async function loadState() {
@@ -2301,14 +2347,15 @@ async function loadGameList() {
 
   try {
     const requestedId = pendingRequestedGameId || requestedGameIdFromRoute();
-    const query = state.currentGameId ? "?gameId=" + encodeURIComponent(state.currentGameId) : "";
-    const response = await fetch("/api/games" + query);
-    if (!response.ok) {
-      const payload = await response.json();
-      throw new Error(translateServerMessage(payload, t("lobby.errors.loadGames")));
-    }
-
-    const data = await response.json();
+    const data = await listGames(
+      {
+        errorMessage: t("lobby.errors.loadGames"),
+        fallbackMessage: t("lobby.errors.loadGames")
+      },
+      {
+        gameId: state.currentGameId
+      }
+    );
     state.gameList = data.games || [];
     const activeGame = state.gameList.find((game) => game.id === data.activeGameId) || null;
     const canAutoSelectActiveGame =
@@ -2339,12 +2386,10 @@ async function loadGameList() {
 
 async function restoreSession() {
   try {
-    const response = await fetch("/api/auth/session");
-    if (!response.ok) {
-      throw new Error(t("auth.sessionExpired"));
-    }
-
-    const data = (await response.json()) as MutationResponse;
+    const data = await getSession({
+      errorMessage: t("auth.sessionExpired"),
+      fallbackMessage: t("auth.sessionExpired")
+    });
     setSession(data.user);
   } catch (_error: unknown) {
     setSession(null);
@@ -2381,7 +2426,7 @@ function startSnapshotPolling() {
       const data = await fetchLatestStateSnapshot();
       applySnapshot(data);
       render();
-    } catch (error) {
+    } catch (_error) {
     } finally {
       snapshotPollInFlight = false;
     }
@@ -2391,23 +2436,25 @@ function startSnapshotPolling() {
 function connectEvents() {
   disconnectLiveUpdates();
   eventsGameId = state.currentGameId || null;
-  const params = new URLSearchParams();
-  if (state.currentGameId) {
-    params.set("gameId", state.currentGameId);
-  }
-  const query = params.toString() ? "?" + params.toString() : "";
   eventsMode = "sse";
-  const events = new EventSource("/api/events" + query);
-  eventsConnection = events;
-  events.onmessage = (event) => {
-    applySnapshot(JSON.parse(event.data));
-    render();
-  };
-  events.onerror = () => {
-    if (eventsConnection === events) {
+  const events = subscribeToGameEvents({
+    gameId: state.currentGameId,
+    onMessage: (payload) => {
+      applySnapshot(payload as unknown as GameSnapshot);
+      render();
+    },
+    onInvalidPayload: () => {
       disconnectLiveUpdates();
+      startSnapshotPolling();
+    },
+    onError: () => {
+      if (eventsConnection === events) {
+        disconnectLiveUpdates();
+        startSnapshotPolling();
+      }
     }
-  };
+  });
+  eventsConnection = events;
 }
 
 function ensureEventConnection() {

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -40,20 +40,36 @@ import type {
   ProfileResponse,
   RegisterRequest,
   StartGameRequest,
+  TradeCardsRequest,
   ThemePreferenceResponse
 } from "../../generated/shared-runtime-validation.mjs";
 import type { ApiClientError } from "./http.mjs";
 import { requestJson } from "./http.mjs";
+import { reportFrontendException } from "../observability.mjs";
 
 type ClientMessages = {
   errorMessage: string;
   fallbackMessage?: string;
 };
 
-export type { GameActionRequest, GameEventPayload, GameStateResponse, StartGameRequest };
+type GameListRequestOptions = {
+  gameId?: string | null;
+};
 
-export type TradeCardsRequest =
-  import("../../generated/shared-runtime-validation.mjs").TradeCardsRequest;
+type GameStateRequestOptions = {
+  gameId?: string | null;
+};
+
+type GameEventSubscriptionOptions = {
+  gameId?: string | null;
+  onMessage(payload: GameEventPayload): void;
+  onOpen?(): void;
+  onError?(error: Event): void;
+  onInvalidPayload?(error: Error): void;
+};
+
+export type { GameActionRequest, GameEventPayload, GameStateResponse, StartGameRequest };
+export type { TradeCardsRequest };
 
 export function getSession(messages: ClientMessages): Promise<AuthSessionResponse> {
   return requestJson({
@@ -137,6 +153,16 @@ export function getModuleOptions(messages: ClientMessages): Promise<ModuleOption
   });
 }
 
+export async function getModuleOptionsOrNull(
+  messages: ClientMessages
+): Promise<ModuleOptionsResponse | null> {
+  try {
+    return await getModuleOptions(messages);
+  } catch {
+    return null;
+  }
+}
+
 export function rescanModules(messages: ClientMessages): Promise<ModulesCatalogResponse> {
   return requestJson({
     path: "/api/modules/rescan",
@@ -179,9 +205,20 @@ export function updateThemePreference(
   });
 }
 
-export function listGames(messages: ClientMessages): Promise<GameListResponse> {
+function buildGameListPath(options: GameListRequestOptions = {}): string {
+  if (!options.gameId) {
+    return "/api/games";
+  }
+
+  return `/api/games?gameId=${encodeURIComponent(options.gameId)}`;
+}
+
+export function listGames(
+  messages: ClientMessages,
+  options: GameListRequestOptions = {}
+): Promise<GameListResponse> {
   return requestJson({
-    path: "/api/games",
+    path: buildGameListPath(options),
     responseSchema: gameListResponseSchema,
     responseSchemaName: "GameListResponse",
     ...messages
@@ -239,9 +276,30 @@ export function joinGame(gameId: string, messages: ClientMessages): Promise<Game
   });
 }
 
-export function getGameState(gameId: string, messages: ClientMessages): Promise<GameStateResponse> {
+function buildGameStatePath(options: GameStateRequestOptions = {}): string {
+  if (!options.gameId) {
+    return "/api/state";
+  }
+
+  return `/api/state?gameId=${encodeURIComponent(options.gameId)}`;
+}
+
+function buildGameEventsPath(gameId: string | null | undefined): string {
+  if (!gameId) {
+    return "/api/events";
+  }
+
+  return `/api/events?gameId=${encodeURIComponent(gameId)}`;
+}
+
+export function getGameState(
+  gameId: string | null | undefined,
+  messages: ClientMessages
+): Promise<GameStateResponse> {
   return requestJson({
-    path: `/api/state?gameId=${encodeURIComponent(gameId)}`,
+    path: buildGameStatePath({
+      gameId
+    }),
     responseSchema: gameStateResponseSchema,
     responseSchemaName: "GameStateResponse",
     ...messages
@@ -298,6 +356,47 @@ export function tradeCards(
 
 export function parseGameEventPayload(payload: unknown): GameEventPayload {
   return gameEventPayloadSchema.parse(payload);
+}
+
+export function subscribeToGameEvents({
+  gameId,
+  onMessage,
+  onOpen,
+  onError,
+  onInvalidPayload
+}: GameEventSubscriptionOptions): EventSource {
+  const path = buildGameEventsPath(gameId);
+  const eventSource = new EventSource(path, {
+    withCredentials: true
+  });
+
+  if (typeof onOpen === "function") {
+    eventSource.onopen = onOpen;
+  }
+
+  eventSource.onmessage = (event) => {
+    try {
+      const payload = parseGameEventPayload(JSON.parse(event.data));
+      onMessage(payload);
+    } catch (error: unknown) {
+      const streamError =
+        error instanceof Error ? error : new Error("Unable to validate game event payload.");
+      reportFrontendException(streamError, {
+        area: "react-shell",
+        kind: "response_validation",
+        category: "validation",
+        path,
+        schemaName: "GameEventPayload"
+      });
+      onInvalidPayload?.(streamError);
+    }
+  };
+
+  eventSource.onerror = (error) => {
+    onError?.(error);
+  };
+
+  return eventSource;
 }
 
 export function extractGameVersionConflict(error: unknown): GameVersionConflictResponse | null {

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -375,9 +375,10 @@ export function subscribeToGameEvents({
   }
 
   eventSource.onmessage = (event) => {
+    let payload: GameEventPayload;
+
     try {
-      const payload = parseGameEventPayload(JSON.parse(event.data));
-      onMessage(payload);
+      payload = parseGameEventPayload(JSON.parse(event.data));
     } catch (error: unknown) {
       const streamError =
         error instanceof Error ? error : new Error("Unable to validate game event payload.");
@@ -389,7 +390,10 @@ export function subscribeToGameEvents({
         schemaName: "GameEventPayload"
       });
       onInvalidPayload?.(streamError);
+      return;
     }
+
+    onMessage(payload);
   };
 
   eventSource.onerror = (error) => {

--- a/frontend/src/core/api/http.mts
+++ b/frontend/src/core/api/http.mts
@@ -1,4 +1,11 @@
-import { parseWithSchema } from "../../generated/shared-runtime-validation.mjs";
+import {
+  parseWithSchema,
+  transportErrorPayloadSchema
+} from "../../generated/shared-runtime-validation.mjs";
+import type {
+  TransportErrorPayload,
+  ValidationError
+} from "../../generated/shared-runtime-validation.mjs";
 import { translateServerMessage } from "../../i18n.mjs";
 import { reportFrontendException } from "../observability.mjs";
 import { readValidatedJson } from "../validated-json.mjs";
@@ -7,6 +14,15 @@ type ValidationSchema<T> = {
   safeParse(input: unknown): { success: true; data: T } | { success: false; error: unknown };
 };
 
+export type ApiClientKind = "network" | "http" | "request_validation" | "response_validation";
+export type ApiErrorCategory =
+  | "network"
+  | "auth"
+  | "business"
+  | "validation"
+  | "version_conflict"
+  | "unexpected_5xx";
+
 export type ApiClientError = Error & {
   code?: string | null;
   payload?: unknown;
@@ -14,7 +30,9 @@ export type ApiClientError = Error & {
   path?: string;
   requestId?: string | null;
   statusCode?: number | null;
-  kind?: "network" | "http" | "response_validation";
+  kind?: ApiClientKind;
+  category?: ApiErrorCategory;
+  validationErrors?: ValidationError[];
 };
 
 type JsonRequestOptions<TRequest, TResponse> = {
@@ -39,7 +57,9 @@ function toApiClientError(
     path?: string;
     requestId?: string | null;
     statusCode?: number | null;
-    kind?: "network" | "http" | "response_validation";
+    kind?: ApiClientKind;
+    category?: ApiErrorCategory;
+    validationErrors?: ValidationError[];
   } = {}
 ): ApiClientError {
   const error = new Error(message, {
@@ -74,7 +94,38 @@ function toApiClientError(
     error.kind = options.kind;
   }
 
+  if (options.category !== undefined) {
+    error.category = options.category;
+  }
+
+  if (Array.isArray(options.validationErrors)) {
+    error.validationErrors = options.validationErrors;
+  }
+
   return error;
+}
+
+function extractValidationErrors(error: unknown): ValidationError[] {
+  const queue = [error];
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+
+    if (
+      "validationErrors" in current &&
+      Array.isArray((current as { validationErrors?: unknown }).validationErrors)
+    ) {
+      return (current as { validationErrors: ValidationError[] }).validationErrors;
+    }
+
+    if ("cause" in current) {
+      queue.push((current as { cause?: unknown }).cause);
+    }
+  }
+
+  return [];
 }
 
 function extractErrorCode(payload: unknown): string | null {
@@ -84,6 +135,52 @@ function extractErrorCode(payload: unknown): string | null {
 
   const code = payload.code;
   return typeof code === "string" && code ? code : null;
+}
+
+function extractTransportErrorPayload(payload: unknown): TransportErrorPayload | null {
+  const parsed = transportErrorPayloadSchema.safeParse(payload);
+  return parsed.success ? parsed.data : null;
+}
+
+function categorizeHttpError(statusCode: number, code: string | null): ApiErrorCategory {
+  if (code === "VERSION_CONFLICT" || statusCode === 409) {
+    return "version_conflict";
+  }
+
+  if (
+    code === "REQUEST_VALIDATION_FAILED" ||
+    code === "RESPONSE_VALIDATION_FAILED" ||
+    statusCode === 422
+  ) {
+    return "validation";
+  }
+
+  if (code === "AUTH_REQUIRED" || statusCode === 401 || statusCode === 403) {
+    return "auth";
+  }
+
+  if (statusCode >= 500) {
+    return "unexpected_5xx";
+  }
+
+  return "business";
+}
+
+function shouldReportUnexpectedClientError(error: ApiClientError): boolean {
+  return (
+    error.category === "network" ||
+    error.category === "unexpected_5xx" ||
+    error.kind === "request_validation" ||
+    error.kind === "response_validation"
+  );
+}
+
+export function isApiClientError(error: unknown): error is ApiClientError {
+  return error instanceof Error;
+}
+
+export function isAuthApiError(error: unknown): error is ApiClientError {
+  return isApiClientError(error) && (error.category === "auth" || error.code === "AUTH_REQUIRED");
 }
 
 function extractRequestId(response: Response): string | null {
@@ -112,18 +209,25 @@ function extractRequestId(response: Response): string | null {
 function reportUnexpectedClientError(
   error: ApiClientError,
   context: {
-    kind: "network" | "http" | "response_validation";
+    kind: ApiClientKind;
+    category: ApiErrorCategory;
     schemaName?: string;
   }
 ): void {
   reportFrontendException(error, {
     area: "react-shell",
     kind: context.kind,
+    category: context.category,
     path: error.path,
     requestId: error.requestId,
     statusCode: error.statusCode,
     code: error.code,
-    schemaName: context.schemaName || null
+    schemaName: context.schemaName || null,
+    extra: error.validationErrors?.length
+      ? {
+          validationErrors: error.validationErrors
+        }
+      : undefined
   });
 }
 
@@ -153,14 +257,30 @@ export async function requestJson<TRequest, TResponse>({
 
   let payloadBody: string | undefined;
   if (body !== undefined) {
-    const parsedBody = requestSchema
-      ? parseWithSchema(requestSchema, body, {
-          schemaName: requestSchemaName || "request",
-          message: errorMessage
-        })
-      : body;
-    headers["Content-Type"] = "application/json";
-    payloadBody = JSON.stringify(parsedBody);
+    try {
+      const parsedBody = requestSchema
+        ? parseWithSchema(requestSchema, body, {
+            schemaName: requestSchemaName || "request",
+            message: errorMessage
+          })
+        : body;
+      headers["Content-Type"] = "application/json";
+      payloadBody = JSON.stringify(parsedBody);
+    } catch (error: unknown) {
+      const requestValidationError = toApiClientError(errorMessage, {
+        cause: error,
+        path,
+        kind: "request_validation",
+        category: "validation",
+        validationErrors: extractValidationErrors(error)
+      });
+      reportUnexpectedClientError(requestValidationError, {
+        kind: "request_validation",
+        category: "validation",
+        schemaName: requestSchemaName || "request"
+      });
+      throw requestValidationError;
+    }
   }
 
   let response: Response;
@@ -175,10 +295,12 @@ export async function requestJson<TRequest, TResponse>({
     const networkError = toApiClientError(resolvedFallbackMessage, {
       cause: error,
       path,
-      kind: "network"
+      kind: "network",
+      category: "network"
     });
     reportUnexpectedClientError(networkError, {
-      kind: "network"
+      kind: "network",
+      category: "network"
     });
     throw networkError;
   }
@@ -187,18 +309,23 @@ export async function requestJson<TRequest, TResponse>({
 
   if (!response.ok) {
     const payload = await tryReadJson(response);
+    const transportError = extractTransportErrorPayload(payload);
+    const code = extractErrorCode(payload);
     const clientError = toApiClientError(translateServerMessage(payload, errorMessage), {
-      code: extractErrorCode(payload),
+      code,
       payload,
       status: response.status,
       path,
       requestId,
       statusCode: response.status,
-      kind: "http"
+      kind: "http",
+      category: categorizeHttpError(response.status, code),
+      validationErrors: transportError?.validationErrors || []
     });
-    if (response.status >= 500) {
+    if (shouldReportUnexpectedClientError(clientError)) {
       reportUnexpectedClientError(clientError, {
-        kind: "http"
+        kind: "http",
+        category: clientError.category || "business"
       });
     }
     throw clientError;
@@ -218,10 +345,13 @@ export async function requestJson<TRequest, TResponse>({
       path,
       requestId,
       statusCode: response.status,
-      kind: "response_validation"
+      kind: "response_validation",
+      category: "validation",
+      validationErrors: extractValidationErrors(error)
     });
     reportUnexpectedClientError(validationError, {
       kind: "response_validation",
+      category: "validation",
       schemaName: responseSchemaName
     });
     throw validationError;

--- a/frontend/src/core/api/http.mts
+++ b/frontend/src/core/api/http.mts
@@ -147,11 +147,11 @@ function categorizeHttpError(statusCode: number, code: string | null): ApiErrorC
     return "version_conflict";
   }
 
-  if (
-    code === "REQUEST_VALIDATION_FAILED" ||
-    code === "RESPONSE_VALIDATION_FAILED" ||
-    statusCode === 422
-  ) {
+  if (code === "RESPONSE_VALIDATION_FAILED") {
+    return statusCode >= 500 ? "unexpected_5xx" : "validation";
+  }
+
+  if (code === "REQUEST_VALIDATION_FAILED" || statusCode === 422) {
     return "validation";
   }
 

--- a/frontend/src/core/module-slots.mts
+++ b/frontend/src/core/module-slots.mts
@@ -1,4 +1,5 @@
 import { setMarkup } from "./dom.mjs";
+import { getModuleOptionsOrNull } from "./api/client.mjs";
 import type { ModuleOptionsResponse, NetRiskUiSlotContribution } from "./types.mjs";
 
 type MountModuleSlotSectionOptions = {
@@ -26,19 +27,10 @@ async function fetchModuleOptions(): Promise<ModuleOptionsResponse | null> {
     return moduleOptionsPromise;
   }
 
-  moduleOptionsPromise = (async () => {
-    try {
-      const response = await fetch("/api/modules/options");
-      const payload = (await response.json()) as ModuleOptionsResponse;
-      if (!response.ok) {
-        return null;
-      }
-
-      return payload;
-    } catch {
-      return null;
-    }
-  })();
+  moduleOptionsPromise = getModuleOptionsOrNull({
+    errorMessage: "Unable to load module options.",
+    fallbackMessage: "Unable to validate module options."
+  });
 
   return moduleOptionsPromise;
 }

--- a/frontend/src/core/observability.mts
+++ b/frontend/src/core/observability.mts
@@ -1,6 +1,7 @@
 export type FrontendObservabilityContext = {
   area?: string;
   kind?: string;
+  category?: string;
   path?: string;
   requestId?: string | null;
   statusCode?: number | null;

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -25,6 +25,28 @@ export const validationErrorSchema = z.object({
 
 export type ValidationError = z.infer<typeof validationErrorSchema>;
 
+export const messagePayloadSchema = objectSchema({
+  message: z.string().min(1).optional(),
+  error: z.string().min(1).optional(),
+  reason: z.string().min(1).optional(),
+  messageKey: z.string().min(1).optional(),
+  errorKey: z.string().min(1).optional(),
+  reasonKey: z.string().min(1).optional(),
+  messageParams: z.record(z.string(), z.unknown()).optional(),
+  errorParams: z.record(z.string(), z.unknown()).optional(),
+  reasonParams: z.record(z.string(), z.unknown()).optional()
+});
+
+export type MessagePayload = z.infer<typeof messagePayloadSchema>;
+
+export const transportErrorPayloadSchema = messagePayloadSchema.extend({
+  code: z.string().min(1).nullable().optional(),
+  validationErrors: z.array(validationErrorSchema).optional(),
+  validation: z.record(z.string(), z.unknown()).optional()
+});
+
+export type TransportErrorPayload = z.infer<typeof transportErrorPayloadSchema>;
+
 function objectSchema<T extends z.ZodRawShape>(shape: T) {
   return z.object(shape).passthrough();
 }

--- a/frontend/src/new-game.mts
+++ b/frontend/src/new-game.mts
@@ -1,13 +1,12 @@
 import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
+import { createGame, getGameOptions, getSession, login, logout } from "./core/api/client.mjs";
 import { messageFromError } from "./core/errors.mjs";
 import { buildSyncedGameLocation } from "./core/game-route-paths.mjs";
 import { mountModuleSlotSection } from "./core/module-slots.mjs";
 import type {
   ContentPackSummary,
   DiceRuleSet,
-  GameOptionsResponse,
   InstalledModuleSummary,
-  LoginResponse,
   MapSummary,
   NetRiskContentContribution,
   NetRiskGamePreset,
@@ -18,7 +17,7 @@ import type {
   VictoryRuleSet,
   VisualTheme
 } from "./core/types.mjs";
-import { t, translateServerMessage } from "./i18n.mjs";
+import { t } from "./i18n.mjs";
 
 const state: {
   contentPacks: ContentPackSummary[];
@@ -98,8 +97,6 @@ const CONTENT_CONTRIBUTION_KEYS = [
   "fortifyRuleSetIds",
   "reinforcementRuleSetIds"
 ] as const;
-
-type ContentContributionKey = (typeof CONTENT_CONTRIBUTION_KEYS)[number];
 
 function setHeaderAuthFeedback(message = ""): void {
   if (!message) {
@@ -829,28 +826,44 @@ function readConfig() {
 async function send(
   path: string,
   body: unknown
-): Promise<LoginResponse & { game?: { id: string }; playerId?: string | null }> {
-  const response = await fetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body)
-  });
-  const data = (await response.json()) as LoginResponse & {
-    game?: { id: string };
-    playerId?: string | null;
+): Promise<{ user?: PublicUser; game?: { id: string }; playerId?: string | null }> {
+  const mutationMessages = {
+    errorMessage: path === "/api/auth/login" ? t("errors.loginFailed") : t("errors.requestFailed"),
+    fallbackMessage:
+      path === "/api/auth/login" ? t("errors.loginFailed") : t("errors.requestFailed")
   };
-  if (!response.ok) {
-    throw new Error(translateServerMessage(data, t("errors.requestFailed")));
+
+  switch (path) {
+    case "/api/games":
+      return (await createGame(body as Parameters<typeof createGame>[0], mutationMessages)) as {
+        user?: PublicUser;
+        game?: { id: string };
+        playerId?: string | null;
+      };
+    case "/api/auth/login":
+      return (await login(
+        body as {
+          username: string;
+          password: string;
+        },
+        mutationMessages
+      )) as { user?: PublicUser; game?: { id: string }; playerId?: string | null };
+    case "/api/auth/logout":
+      return (await logout(mutationMessages)) as {
+        user?: PublicUser;
+        game?: { id: string };
+        playerId?: string | null;
+      };
+    default:
+      throw new Error(`Unsupported setup mutation path: ${path}`);
   }
-  return data;
 }
 
 async function loadOptions() {
-  const response = await fetch("/api/game/options");
-  const data = (await response.json()) as GameOptionsResponse;
-  if (!response.ok) {
-    throw new Error(translateServerMessage(data, t("newGame.errors.loadOptions")));
-  }
+  const data = await getGameOptions({
+    errorMessage: t("newGame.errors.loadOptions"),
+    fallbackMessage: t("newGame.errors.loadOptions")
+  });
 
   state.contentPacks = data.contentPacks || [];
   state.maps = data.maps || [];
@@ -888,13 +901,10 @@ async function loadOptions() {
 
 async function restoreSession() {
   try {
-    const response = await fetch("/api/auth/session");
-
-    if (!response.ok) {
-      throw new Error(t("auth.sessionExpired"));
-    }
-
-    const data = (await response.json()) as LoginResponse;
+    const data = await getSession({
+      errorMessage: t("auth.sessionExpired"),
+      fallbackMessage: t("auth.sessionExpired")
+    });
     state.user = data.user;
     window.netriskTheme?.applyUserTheme?.(state.user);
   } catch (_error: unknown) {
@@ -927,16 +937,16 @@ async function restoreSession() {
 }
 
 async function loginWithCredentials(username: string, password: string): Promise<void> {
-  const response = await fetch("/api/auth/login", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password })
-  });
-  const data = (await response.json()) as LoginResponse;
-  if (!response.ok) {
-    throw new Error(translateServerMessage(data, t("errors.loginFailed")));
-  }
-
+  const data = await login(
+    {
+      username,
+      password
+    },
+    {
+      errorMessage: t("errors.loginFailed"),
+      fallbackMessage: t("errors.loginFailed")
+    }
+  );
   state.user = data.user;
   window.netriskTheme?.applyUserTheme?.(state.user);
   if (elements.headerAuthPassword) {

--- a/frontend/src/profile.mts
+++ b/frontend/src/profile.mts
@@ -1,27 +1,30 @@
 import { byId, closest, maybeQuery, setDisabled, setHidden, setMarkup } from "./core/dom.mjs";
 import {
+  getGameOptions,
+  getModuleOptionsOrNull,
+  getModulesCatalog,
   getProfile,
   getSession,
   login,
   logout,
+  rescanModules,
+  setModuleEnabled,
   updateThemePreference
 } from "./core/api/client.mjs";
+import { isAuthApiError } from "./core/api/http.mjs";
 import { messageFromError } from "./core/errors.mjs";
 import { buildSyncedGameLocation } from "./core/game-route-paths.mjs";
 import type {
-  GameOptionsResponse,
   NetRiskModuleCapability,
   NetRiskModuleDependency,
   InstalledModuleSummary,
-  ModuleOptionsResponse,
-  ModulesCatalogResponse,
   NetRiskUiSlotContribution
 } from "./core/types.mjs";
 import type {
   ProfileContract as ProfileSummary,
   PublicUser
 } from "./generated/shared-runtime-validation.mjs";
-import { formatDate, t, translateServerMessage } from "./i18n.mjs";
+import { formatDate, t } from "./i18n.mjs";
 
 const elements = {
   profileName: byId("profile-name"),
@@ -103,7 +106,7 @@ let themeOptionsLoaded = false;
 let currentSessionUser: PublicUser | null = null;
 
 function profileMessageFromError(error: unknown, fallback: string): string {
-  if (error && typeof error === "object" && "code" in error && error.code === "AUTH_REQUIRED") {
+  if (isAuthApiError(error)) {
     return t("profile.errors.loginRequired");
   }
 
@@ -148,9 +151,11 @@ async function loadThemeOptions(): Promise<void> {
   }
 
   try {
-    const response = await fetch("/api/game/options");
-    const data = (await response.json()) as GameOptionsResponse;
-    if (response.ok && Array.isArray(data.themes)) {
+    const data = await getGameOptions({
+      errorMessage: t("profile.errors.unavailable"),
+      fallbackMessage: t("profile.errors.unavailable")
+    });
+    if (Array.isArray(data.themes)) {
       themeManager.setThemes(data.themes.map((theme) => theme.id));
       renderThemeOptions(true);
     }
@@ -525,21 +530,21 @@ function renderAdminModuleSlots(slots: NetRiskUiSlotContribution[]): void {
 }
 
 async function loadAdminModuleSlots(): Promise<void> {
-  try {
-    const response = await fetch("/api/modules/options");
-    const payload = (await response.json()) as ModuleOptionsResponse;
-    if (!response.ok) {
-      throw new Error(translateServerMessage(payload, t("profile.modules.status.error")));
-    }
+  const payload = await getModuleOptionsOrNull({
+    errorMessage: t("profile.modules.status.error"),
+    fallbackMessage: t("profile.modules.status.error")
+  });
 
-    const adminSlots = Array.isArray(payload.uiSlots)
-      ? payload.uiSlots.filter((slot) => slot.slotId === "admin-modules-page")
-      : [];
-    renderAdminModuleSlots(adminSlots);
-  } catch (_error: unknown) {
+  if (!payload) {
     setMarkup(elements.profileModuleSlotsList, "");
     setHidden(elements.profileModuleSlotsEmpty, false);
+    return;
   }
+
+  const adminSlots = Array.isArray(payload.uiSlots)
+    ? payload.uiSlots.filter((slot) => slot.slotId === "admin-modules-page")
+    : [];
+  renderAdminModuleSlots(adminSlots);
 }
 
 async function loadModuleCatalog(
@@ -560,15 +565,15 @@ async function loadModuleCatalog(
   );
 
   try {
-    const response = await fetch(options.rescan ? "/api/modules/rescan" : "/api/modules", {
-      method: options.rescan ? "POST" : "GET",
-      headers: options.rescan ? { "Content-Type": "application/json" } : undefined,
-      body: options.rescan ? JSON.stringify({}) : undefined
-    });
-    const payload = (await response.json()) as ModulesCatalogResponse;
-    if (!response.ok) {
-      throw new Error(translateServerMessage(payload, t("profile.modules.status.error")));
-    }
+    const payload = options.rescan
+      ? await rescanModules({
+          errorMessage: t("profile.modules.status.error"),
+          fallbackMessage: t("profile.modules.status.error")
+        })
+      : await getModulesCatalog({
+          errorMessage: t("profile.modules.status.error"),
+          fallbackMessage: t("profile.modules.status.error")
+        });
 
     if (requestId !== moduleCatalogRequestId) {
       return;
@@ -612,15 +617,10 @@ async function toggleModule(
   setModuleStatus(t("profile.modules.status.refreshing"));
 
   try {
-    const response = await fetch(`/api/modules/${encodeURIComponent(moduleId)}/${action}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({})
+    const payload = await setModuleEnabled(moduleId, action === "enable", {
+      errorMessage: t("profile.modules.status.error"),
+      fallbackMessage: t("profile.modules.status.error")
     });
-    const payload = (await response.json()) as ModulesCatalogResponse;
-    if (!response.ok) {
-      throw new Error(translateServerMessage(payload, t("profile.modules.status.error")));
-    }
 
     if (requestId !== moduleCatalogRequestId) {
       return;

--- a/frontend/src/register.mts
+++ b/frontend/src/register.mts
@@ -1,8 +1,9 @@
 import { byId, maybeQuery, setDisabled, setHidden } from "./core/dom.mjs";
+import { getSession, login, logout, register } from "./core/api/client.mjs";
 import { messageFromError } from "./core/errors.mjs";
 import { validateRegistrationInput } from "./core/register-validation.mjs";
-import type { LoginResponse, PublicUser, SessionResponse } from "./core/types.mjs";
-import { t, translateServerMessage } from "./i18n.mjs";
+import type { PublicUser } from "./core/types.mjs";
+import { t } from "./i18n.mjs";
 
 const state: {
   user: PublicUser | null;
@@ -65,16 +66,16 @@ function setFeedback(message = "", tone = "") {
 }
 
 async function loginWithCredentials(username: string, password: string): Promise<void> {
-  const response = await fetch("/api/auth/login", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password })
-  });
-  const data = (await response.json()) as LoginResponse;
-  if (!response.ok) {
-    throw new Error(translateServerMessage(data, t("errors.loginFailed")));
-  }
-
+  const data = await login(
+    {
+      username,
+      password
+    },
+    {
+      errorMessage: t("errors.loginFailed"),
+      fallbackMessage: t("errors.loginFailed")
+    }
+  );
   state.user = data.user;
   window.netriskTheme?.applyUserTheme?.(state.user);
   render();
@@ -83,12 +84,10 @@ async function loginWithCredentials(username: string, password: string): Promise
 
 async function restoreSession() {
   try {
-    const response = await fetch("/api/auth/session");
-    if (!response.ok) {
-      throw new Error(t("auth.sessionExpired"));
-    }
-
-    const data = (await response.json()) as SessionResponse;
+    const data = await getSession({
+      errorMessage: t("auth.sessionExpired"),
+      fallbackMessage: t("auth.sessionExpired")
+    });
     state.user = data.user;
     window.netriskTheme?.applyUserTheme?.(state.user);
   } catch (_error) {
@@ -146,10 +145,9 @@ if (elements.headerLoginForm) {
 
 elements.logoutButton.addEventListener("click", async () => {
   try {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({})
+    await logout({
+      errorMessage: t("errors.requestFailed"),
+      fallbackMessage: t("errors.requestFailed")
     });
   } catch (_error) {}
 
@@ -183,15 +181,17 @@ elements.form.addEventListener("submit", async (event) => {
   setFeedback();
 
   try {
-    const response = await fetch("/api/auth/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, email, password })
-    });
-    const data = (await response.json()) as LoginResponse;
-    if (!response.ok) {
-      throw new Error(translateServerMessage(data, t("register.errors.submitFailed")));
-    }
+    await register(
+      {
+        username,
+        email,
+        password
+      },
+      {
+        errorMessage: t("register.errors.submitFailed"),
+        fallbackMessage: t("register.errors.submitFailed")
+      }
+    );
 
     await loginWithCredentials(username, password);
   } catch (error) {

--- a/frontend/src/shell.mts
+++ b/frontend/src/shell.mts
@@ -1,16 +1,10 @@
 import { setMarkup } from "./core/dom.mjs";
+import { getModuleOptionsOrNull, login } from "./core/api/client.mjs";
 import { DEFAULT_THEME, SUPPORTED_THEMES, normalizeTheme } from "./core/contracts.mjs";
 import type { ThemeName } from "./core/contracts.mjs";
 import { messageFromError } from "./core/errors.mjs";
 import type { ModuleOptionsResponse, PublicUser } from "./core/types.mjs";
-import {
-  applyTranslations,
-  listSupportedLocales,
-  resolveLocale,
-  setLocale,
-  t,
-  translateServerMessage
-} from "./i18n.mjs";
+import { applyTranslations, listSupportedLocales, resolveLocale, setLocale, t } from "./i18n.mjs";
 
 const THEME_STORAGE_KEY = "netrisk.theme";
 const routeQuery = new URLSearchParams(window.location.search);
@@ -348,19 +342,10 @@ async function fetchModuleOptions(): Promise<ModuleOptionsResponse | null> {
     return moduleOptionsPromise;
   }
 
-  moduleOptionsPromise = (async () => {
-    try {
-      const response = await fetch("/api/modules/options");
-      const data = (await response.json()) as ModuleOptionsResponse;
-      if (!response.ok) {
-        return null;
-      }
-
-      return data;
-    } catch {
-      return null;
-    }
-  })();
+  moduleOptionsPromise = getModuleOptionsOrNull({
+    errorMessage: "Unable to load module options.",
+    fallbackMessage: "Unable to validate module options."
+  });
 
   return moduleOptionsPromise;
 }
@@ -520,17 +505,16 @@ async function fallbackHeaderLogin(
   username: string,
   password: string
 ): Promise<{ user?: PublicUser }> {
-  const response = await fetch("/api/auth/login", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password })
-  });
-  const data = await response.json();
-  if (!response.ok) {
-    throw new Error(translateServerMessage(data, t("errors.loginFailed")));
-  }
-
-  return data;
+  return login(
+    {
+      username,
+      password
+    },
+    {
+      errorMessage: t("errors.loginFailed"),
+      fallbackMessage: t("errors.loginFailed")
+    }
+  );
 }
 
 function sanitizedCurrentUrl() {

--- a/scripts/generate-frontend-static.cts
+++ b/scripts/generate-frontend-static.cts
@@ -31,7 +31,7 @@ const legacyRuntimeFiles = [
   "shell.mjs",
   "speed-insights.mjs"
 ] as const;
-const legacyRuntimeDirectories = ["core", "locales"] as const;
+const legacyRuntimeDirectories = ["core", "generated", "locales"] as const;
 
 function writeTextFile(fileName: string, content: string): void {
   const absolutePath = path.join(publicDir, fileName);

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -24,6 +24,28 @@ export const validationErrorSchema = z.object({
 
 export type ValidationError = z.infer<typeof validationErrorSchema>;
 
+export const messagePayloadSchema = objectSchema({
+  message: z.string().min(1).optional(),
+  error: z.string().min(1).optional(),
+  reason: z.string().min(1).optional(),
+  messageKey: z.string().min(1).optional(),
+  errorKey: z.string().min(1).optional(),
+  reasonKey: z.string().min(1).optional(),
+  messageParams: z.record(z.string(), z.unknown()).optional(),
+  errorParams: z.record(z.string(), z.unknown()).optional(),
+  reasonParams: z.record(z.string(), z.unknown()).optional()
+});
+
+export type MessagePayload = z.infer<typeof messagePayloadSchema>;
+
+export const transportErrorPayloadSchema = messagePayloadSchema.extend({
+  code: z.string().min(1).nullable().optional(),
+  validationErrors: z.array(validationErrorSchema).optional(),
+  validation: z.record(z.string(), z.unknown()).optional()
+});
+
+export type TransportErrorPayload = z.infer<typeof transportErrorPayloadSchema>;
+
 function objectSchema<T extends z.ZodRawShape>(shape: T) {
   return z.object(shape).passthrough();
 }

--- a/tests/gameplay/regression/legacy-runtime-assets.test.cts
+++ b/tests/gameplay/regression/legacy-runtime-assets.test.cts
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+
+const { createApp } = require("../../../backend/server.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type HeaderMap = Record<string, string>;
+
+type MockResponse = {
+  statusCode: number;
+  headers: HeaderMap;
+  body: string;
+  setHeader(name: string, value: string): void;
+  writeHead(statusCode: number, nextHeaders?: HeaderMap): void;
+  end(chunk?: string): void;
+};
+
+function makeMockResponse(): MockResponse {
+  const headers: HeaderMap = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: "",
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
+    writeHead(statusCode: number, nextHeaders: HeaderMap = {}) {
+      this.statusCode = statusCode;
+      Object.assign(headers, nextHeaders);
+    },
+    end(chunk = "") {
+      this.body += chunk || "";
+    }
+  };
+}
+
+async function callRequest(app: any, pathname: string): Promise<MockResponse> {
+  const req = new (require("events").EventEmitter)();
+  req.method = "GET";
+  req.url = pathname;
+  req.headers = { host: "127.0.0.1" };
+  req.destroy = () => {};
+
+  const res = makeMockResponse();
+
+  await new Promise<void>((resolve) => {
+    const originalEnd = res.end.bind(res);
+    res.end = (chunk = "") => {
+      originalEnd(chunk);
+      resolve();
+    };
+    app.handleRequest(req, res);
+  });
+
+  return res;
+}
+
+async function withApp(run: (app: any) => Promise<void>): Promise<void> {
+  const tempRoot = path.join(
+    os.tmpdir(),
+    `netrisk-legacy-runtime-assets-${process.pid}-${Date.now()}`
+  );
+  const app = createApp({
+    projectRoot: process.cwd(),
+    dbFile: path.join(tempRoot, "data", "runtime-assets.sqlite"),
+    dataFile: path.join(tempRoot, "data", "users.json"),
+    gamesFile: path.join(tempRoot, "data", "games.json"),
+    sessionsFile: path.join(tempRoot, "data", "sessions.json")
+  });
+
+  try {
+    await run(app);
+  } finally {
+    app.datastore.close();
+  }
+}
+
+register(
+  "GET /legacy/generated/shared-runtime-validation.mjs serves the rollback boundary runtime",
+  async () => {
+    await withApp(async (app: any) => {
+      const response = await callRequest(app, "/legacy/generated/shared-runtime-validation.mjs");
+
+      assert.equal(response.statusCode, 200);
+      assert.match(response.headers["Content-Type"] || "", /javascript|ecmascript/i);
+      assert.match(response.body, /SchemaValidationError/);
+      assert.match(response.body, /parseWithSchema/);
+    });
+  }
+);

--- a/tests/gameplay/shared/runtime-validation.test.cts
+++ b/tests/gameplay/shared/runtime-validation.test.cts
@@ -6,10 +6,12 @@ const {
   gameMutationResponseSchema,
   loginRequestSchema,
   logoutResponseSchema,
+  messagePayloadSchema,
   parseWithSchema,
   profileResponseSchema,
   registerRequestSchema,
   themePreferenceResponseSchema,
+  transportErrorPayloadSchema,
   toValidationErrors
 } = require("../../../shared/runtime-validation.cjs");
 
@@ -124,6 +126,24 @@ register("shared runtime validation parses the auth/profile slice payloads", () 
   const logoutResponse = parseWithSchema(logoutResponseSchema, {
     ok: true
   });
+  const messagePayload = parseWithSchema(messagePayloadSchema, {
+    message: "Everything is fine.",
+    messageKey: "server.ok",
+    messageParams: {
+      scope: "auth"
+    }
+  });
+  const transportErrorPayload = parseWithSchema(transportErrorPayloadSchema, {
+    code: "REQUEST_VALIDATION_FAILED",
+    error: "Richiesta non valida.",
+    validationErrors: [
+      {
+        code: "invalid_type",
+        path: "players.0.slot",
+        message: "Expected number."
+      }
+    ]
+  });
 
   assert.equal(loginRequest.username, "commander");
   assert.equal(sessionResponse.user.username, "commander");
@@ -134,6 +154,8 @@ register("shared runtime validation parses the auth/profile slice payloads", () 
   assert.equal(gameListResponse.games[0].id, "g-1");
   assert.equal(gameMutationResponse.playerId, "p-1");
   assert.equal(logoutResponse.ok, true);
+  assert.equal(messagePayload.messageKey, "server.ok");
+  assert.equal(transportErrorPayload.validationErrors[0].path, "players.0.slot");
 });
 
 register("shared runtime validation exposes deterministic validation issue paths", () => {


### PR DESCRIPTION
## Summary
- harden the shared frontend/backend transport boundary with typed error categories and shared message/error schemas
- route legacy frontend auth, lobby, setup, gameplay and SSE flows through `frontend/src/core/api`
- add runtime-validation and stream/client tests so UI consumers only receive validated payloads or controlled errors

## Why
The repo still had direct `fetch` and `EventSource` usage spread across legacy UI surfaces, which bypassed shared runtime validation and produced duplicated error handling. This change makes the API layer the single boundary entry point without changing public routes or moving game rules into the frontend.

## Impact
- frontend consumers now get normalized API errors with category, request id and validation details
- invalid SSE payloads are reported and suppressed instead of leaking into UI state
- legacy screens now reuse the same API client rules already used by the React shell

## Validation
- `npm run typecheck:frontend`
- `npm run typecheck:react-shell`
- `npm run test:react`
- `npm run test:gameplay`
- `npm run test:all`
- `npm run test:e2e:smoke`
- `npm run lint`
- `npm run format:check`
