### PR TITLE
[codex] Build admin console

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Currently supported maps are `classic-mini`, `middle-earth`, and `world-classic`
 - [API transport notes](docs/api.md)
 - [Gameplay flows](docs/gameplay-flows.md)
 - [Admin console guide](docs/admin-console.md)
+- [Admin console execution plan](docs/admin-console-plan.md)
 - [Admin console handoff](docs/admin-console-handoff.md)
 - [React migration matrix](docs/react-migration-matrix.md)
 - [Extending NetRisk](docs/extending-netrisk.md)
@@ -106,6 +107,13 @@ Application available at `http://localhost:3000`.
 After `npm start`, the same built React shell serves the canonical user-facing clean routes and the supported `/react/*` aliases from `http://localhost:3000`.
 The rollback static UI remains available only under `http://localhost:3000/legacy/*` during the transition period.
 Authenticated administrators can access the operational console at `http://localhost:3000/admin`.
+Grant a local admin account with:
+
+```bash
+npm run admin:grant -- --username your_username
+```
+
+Refresh the session after the role change, then reopen `/admin`.
 
 React shell preview:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Today the project includes:
 - shared runtime validation for auth/profile, lobby, and gameplay payloads at backend and frontend boundaries
 - typed frontend API client helpers for auth, profile, lobby, setup, and gameplay flows
 - canonical React + Vite UI served on clean routes `/`, `/login`, `/register`, `/lobby`, `/lobby/new`, `/profile`, `/game`, and `/game/:gameId`, with `/react/*` kept as a supported alias, root `.html` routes kept as compatibility redirects, and the legacy rollback UI isolated under `/legacy/*`
+- admin-only operational console on `/admin` and `/react/admin` with overview, users, games, configuration, maintenance, runtime modules, and audit log sections
 - TanStack Query + Zustand conventions in the React shell, with protected login, lobby, new game, profile, and gameplay routes shared by the canonical URLs and their `/react/*` aliases
 - minimal React shell production observability with Sentry, release tagging, and API request-id correlation
 - initial lobby and reopening saved games
@@ -50,6 +51,8 @@ Currently supported maps are `classic-mini`, `middle-earth`, and `world-classic`
 - [OpenAPI reference](docs/openapi.json)
 - [API transport notes](docs/api.md)
 - [Gameplay flows](docs/gameplay-flows.md)
+- [Admin console guide](docs/admin-console.md)
+- [Admin console handoff](docs/admin-console-handoff.md)
 - [React migration matrix](docs/react-migration-matrix.md)
 - [Extending NetRisk](docs/extending-netrisk.md)
 - [Contributing](CONTRIBUTING.md)
@@ -102,6 +105,7 @@ npm start
 Application available at `http://localhost:3000`.
 After `npm start`, the same built React shell serves the canonical user-facing clean routes and the supported `/react/*` aliases from `http://localhost:3000`.
 The rollback static UI remains available only under `http://localhost:3000/legacy/*` during the transition period.
+Authenticated administrators can access the operational console at `http://localhost:3000/admin`.
 
 React shell preview:
 
@@ -125,6 +129,12 @@ The example configuration in `.env.example` is intended for a Supabase/Vercel en
 ```bash
 DATASTORE_DRIVER=sqlite
 PORT=3000
+```
+
+To promote a locally registered user to admin:
+
+```bash
+npm run admin:grant -- --username your_username
 ```
 
 ## Scheduled jobs
@@ -210,6 +220,7 @@ Before opening a separate analytics or PWA issue, verify all of the following:
 
 ```bash
 npm start
+npm run admin:grant -- --username your_username
 npm run backup:data
 npm run backup:check -- --file data/backups/netrisk-YYYYMMDD-HHMMSS.sqlite
 npm run build:react-shell

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -1063,6 +1063,10 @@ function createAdminConsole(options: AdminConsoleOptions) {
         continue;
       }
 
+      if (String(context.state?.phase || "") !== "lobby") {
+        continue;
+      }
+
       const nextState = safeClone(context.state);
       nextState.phase = "finished";
       nextState.adminMeta = {

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -131,9 +131,7 @@ type AdminConsoleOptions = {
   };
   gameSessions: {
     listGames(): Promise<GameSummary[]> | GameSummary[];
-    getGame(
-      gameId: string
-    ):
+    getGame(gameId: string):
       | Promise<{ game: GameSummary; state: GameState }>
       | {
           game: GameSummary;
@@ -149,10 +147,12 @@ type AdminConsoleOptions = {
   createConfiguredInitialState(
     configInput?: Record<string, unknown>,
     options?: Record<string, unknown>
-  ): Promise<{ state: GameState; config: Record<string, unknown> }> | {
-    state: GameState;
-    config: Record<string, unknown>;
-  };
+  ):
+    | Promise<{ state: GameState; config: Record<string, unknown> }>
+    | {
+        state: GameState;
+        config: Record<string, unknown>;
+      };
   moduleRuntime: {
     listInstalledModules(): Promise<Array<Record<string, unknown>>>;
     getEnabledModules(): Promise<Array<{ id: string; version: string }>>;
@@ -188,7 +188,10 @@ function publicUserRole(user: PublicUser | null | undefined): "admin" | "user" {
   return user?.role === "admin" ? "admin" : "user";
 }
 
-function toPublicUser(auth: AdminConsoleOptions["auth"], user: StoredUser | null | undefined): PublicUser {
+function toPublicUser(
+  auth: AdminConsoleOptions["auth"],
+  user: StoredUser | null | undefined
+): PublicUser {
   return (
     auth.publicUser(user) || {
       id: String(user?.id || ""),
@@ -197,7 +200,10 @@ function toPublicUser(auth: AdminConsoleOptions["auth"], user: StoredUser | null
       hasEmail: false,
       authMethods: [],
       preferences: {
-        theme: typeof user?.profile?.preferences?.theme === "string" ? user.profile.preferences.theme : null
+        theme:
+          typeof user?.profile?.preferences?.theme === "string"
+            ? user.profile.preferences.theme
+            : null
       }
     }
   );
@@ -226,7 +232,9 @@ function normalizeAuditEntries(raw: unknown): AdminAuditEntry[] {
   }
 
   return raw
-    .filter((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === "object"))
+    .filter((entry): entry is Record<string, unknown> =>
+      Boolean(entry && typeof entry === "object")
+    )
     .map((entry) => ({
       id: asNonEmptyString(entry.id) || crypto.randomBytes(8).toString("hex"),
       actorId: asNonEmptyString(entry.actorId) || "unknown",
@@ -343,9 +351,12 @@ function createAdminConsole(options: AdminConsoleOptions) {
   async function resolveAdminDefaults(input: Record<string, unknown> = {}) {
     const configured = await maybeResolve(
       options.createConfiguredInitialState(input, {
-        resolveContentPack: (contentPackId: string) => options.moduleRuntime.findContentPack(contentPackId),
-        resolveDiceRuleSet: (diceRuleSetId: string) => options.moduleRuntime.findDiceRuleSet(diceRuleSetId),
-        resolvePlayerPieceSet: (pieceSetId: string) => options.moduleRuntime.findPlayerPieceSet(pieceSetId),
+        resolveContentPack: (contentPackId: string) =>
+          options.moduleRuntime.findContentPack(contentPackId),
+        resolveDiceRuleSet: (diceRuleSetId: string) =>
+          options.moduleRuntime.findDiceRuleSet(diceRuleSetId),
+        resolvePlayerPieceSet: (pieceSetId: string) =>
+          options.moduleRuntime.findPlayerPieceSet(pieceSetId),
         resolveSupportedMap: (mapId: string) => options.moduleRuntime.findSupportedMap(mapId),
         resolveGamePreset: (presetInput: Record<string, unknown>) =>
           options.moduleRuntime.resolveGamePreset(presetInput),
@@ -358,11 +369,13 @@ function createAdminConsole(options: AdminConsoleOptions) {
 
     const gameConfig = ensureGameConfig(configured.state);
     const activeModules = asArray(gameConfig.activeModules as Array<{ id?: string }> | null);
-    const players = asArray(gameConfig.players as Array<Record<string, unknown>> | null).map((player) => ({
-      slot: typeof player.slot === "number" ? player.slot : null,
-      type: typeof player.type === "string" ? player.type : null,
-      name: typeof player.name === "string" ? player.name : null
-    }));
+    const players = asArray(gameConfig.players as Array<Record<string, unknown>> | null).map(
+      (player) => ({
+        slot: typeof player.slot === "number" ? player.slot : null,
+        type: typeof player.type === "string" ? player.type : null,
+        name: typeof player.name === "string" ? player.name : null
+      })
+    );
 
     return {
       totalPlayers:
@@ -580,10 +593,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
       });
     }
 
-    if (
-      summary.phase === "active" &&
-      (!Array.isArray(state.players) || !state.players.length)
-    ) {
+    if (summary.phase === "active" && (!Array.isArray(state.players) || !state.players.length)) {
       issues.push({
         code: "active-game-without-players",
         severity: "error",
@@ -707,7 +717,9 @@ function createAdminConsole(options: AdminConsoleOptions) {
     const summaries = asArray(users)
       .map((user) => {
         const participatingGames = asArray(rawGames).filter((game) => gameUsesUser(game, user));
-        const completedGames = participatingGames.filter((game) => game?.state?.phase === "finished");
+        const completedGames = participatingGames.filter(
+          (game) => game?.state?.phase === "finished"
+        );
         const wins = completedGames.filter((game) => gameWonByUser(game, user)).length;
         const publicUser = toPublicUser(options.auth, user);
         const role = publicUserRole(publicUser);
@@ -755,7 +767,10 @@ function createAdminConsole(options: AdminConsoleOptions) {
     };
   }
 
-  async function updateUserRole(actor: PublicUser, input: { userId: string; role: "admin" | "user" }) {
+  async function updateUserRole(
+    actor: PublicUser,
+    input: { userId: string; role: "admin" | "user" }
+  ) {
     const targetUser = await maybeResolve(options.datastore.findUserById(input.userId));
     if (!targetUser) {
       throw new Error(`Utente "${input.userId}" non trovato.`);
@@ -1009,8 +1024,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
         invalidGames: enrichedGames.filter((game) => game.health === "error").length,
         orphanedModuleReferences: issues.filter(
           (issue) =>
-            issue.code === "orphaned-module-reference" ||
-            issue.code === "disabled-module-reference"
+            issue.code === "orphaned-module-reference" || issue.code === "disabled-module-reference"
         ).length
       },
       issues
@@ -1052,8 +1066,8 @@ function createAdminConsole(options: AdminConsoleOptions) {
 
     const config = await loadConfigRecord();
     const games = await listGames({ status: "lobby" });
-    const staleGames = games.games.filter((game) =>
-      game.stale || game.issues.some((issue) => issue.code === "stale-lobby")
+    const staleGames = games.games.filter(
+      (game) => game.stale || game.issues.some((issue) => issue.code === "stale-lobby")
     );
     const affectedGameIds: string[] = [];
 

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -1,0 +1,1153 @@
+const crypto = require("node:crypto");
+const {
+  findPieceSkin,
+  findVictoryRuleSet,
+  findVisualTheme,
+  migrateGameStateExtensions
+} = require("../shared/extensions.cjs");
+
+type PublicUser = {
+  id: string;
+  username: string;
+  role?: string;
+  authMethods?: string[];
+  hasEmail?: boolean;
+  preferences?: {
+    theme?: string | null;
+  } | null;
+};
+
+type StoredUser = {
+  id: string;
+  username: string;
+  role?: string;
+  profile?: {
+    preferences?: {
+      theme?: string | null;
+    } | null;
+  } | null;
+  createdAt?: string;
+};
+
+type GamePlayer = {
+  id?: string;
+  name?: string;
+  linkedUserId?: string | null;
+  isAi?: boolean;
+  surrendered?: boolean;
+};
+
+type GameState = {
+  phase?: string;
+  currentTurnIndex?: number;
+  winnerId?: string | null;
+  turnPhase?: string | null;
+  players?: GamePlayer[];
+  territories?: Record<string, { ownerId?: string | null }>;
+  hands?: Record<string, unknown[]>;
+  gameConfig?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+type GameSummary = {
+  id: string;
+  name: string;
+  version?: number;
+  phase: string;
+  playerCount: number;
+  totalPlayers?: number | null;
+  creatorUserId?: string | null;
+  contentPackId?: string | null;
+  mapId?: string | null;
+  mapName?: string | null;
+  diceRuleSetId?: string | null;
+  activeModules?: Array<{ id: string; version: string }>;
+  gamePresetId?: string | null;
+  contentProfileId?: string | null;
+  gameplayProfileId?: string | null;
+  uiProfileId?: string | null;
+  updatedAt: string;
+  createdAt?: string;
+};
+
+type RawGameRecord = {
+  id: string;
+  name: string;
+  version?: number;
+  creatorUserId?: string | null;
+  state: GameState;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type GameContext = {
+  gameId: string | null;
+  gameName: string | null;
+  version: number | null;
+  state: GameState;
+};
+
+type AdminConfigRecord = {
+  defaults: Record<string, unknown>;
+  maintenance: {
+    staleLobbyDays: number;
+    auditLogLimit: number;
+  };
+  updatedAt: string | null;
+  updatedBy: PublicUser | null;
+};
+
+type AdminAuditEntry = {
+  id: string;
+  actorId: string;
+  actorUsername: string;
+  action: string;
+  targetType: string;
+  targetId: string | null;
+  targetLabel: string | null;
+  result: "success" | "failure";
+  createdAt: string;
+  details: Record<string, unknown> | null;
+};
+
+type AdminIssue = {
+  code: string;
+  severity: "info" | "warning" | "error";
+  message: string;
+  gameId?: string | null;
+  actionId?: string | null;
+};
+
+type AdminConsoleOptions = {
+  datastore: {
+    listUsers(): Promise<StoredUser[]> | StoredUser[];
+    findUserById(userId: string): Promise<StoredUser | null> | StoredUser | null;
+    updateUserRoleByUsername(username: string, role: string): Promise<void> | void;
+    getAppState(key: string): Promise<unknown> | unknown;
+    setAppState(key: string, value: unknown): Promise<unknown> | unknown;
+  };
+  auth: {
+    publicUser(user: StoredUser | null | undefined): PublicUser | null;
+  };
+  gameSessions: {
+    listGames(): Promise<GameSummary[]> | GameSummary[];
+    getGame(
+      gameId: string
+    ):
+      | Promise<{ game: GameSummary; state: GameState }>
+      | {
+          game: GameSummary;
+          state: GameState;
+        };
+    datastore: {
+      listGames(): Promise<RawGameRecord[]> | RawGameRecord[];
+    };
+  };
+  loadGameContext(gameId: string | null): Promise<GameContext>;
+  persistGameContext(gameContext: GameContext, expectedVersion?: number | null): Promise<unknown>;
+  broadcastGame(gameContext: GameContext): void;
+  createConfiguredInitialState(
+    configInput?: Record<string, unknown>,
+    options?: Record<string, unknown>
+  ): Promise<{ state: GameState; config: Record<string, unknown> }> | {
+    state: GameState;
+    config: Record<string, unknown>;
+  };
+  moduleRuntime: {
+    listInstalledModules(): Promise<Array<Record<string, unknown>>>;
+    getEnabledModules(): Promise<Array<{ id: string; version: string }>>;
+    findSupportedMap(mapId: string): Record<string, unknown> | null;
+    findContentPack(contentPackId: string): Record<string, unknown> | null;
+    findPlayerPieceSet(pieceSetId: string): Record<string, unknown> | null;
+    findDiceRuleSet(diceRuleSetId: string): Record<string, unknown> | null;
+    resolveGamePreset(input?: Record<string, unknown>): Promise<Record<string, unknown> | null>;
+    resolveGameConfigDefaults(input?: Record<string, unknown>): Promise<Record<string, unknown>>;
+    resolveGameSelection(input?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  };
+};
+
+const ADMIN_CONFIG_STATE_KEY = "adminConsoleConfig";
+const ADMIN_AUDIT_LOG_STATE_KEY = "adminAuditLog";
+const DEFAULT_STALE_LOBBY_DAYS = 7;
+const DEFAULT_AUDIT_LOG_LIMIT = 120;
+
+function safeClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized ? normalized : null;
+}
+
+function publicUserRole(user: PublicUser | null | undefined): "admin" | "user" {
+  return user?.role === "admin" ? "admin" : "user";
+}
+
+function toPublicUser(auth: AdminConsoleOptions["auth"], user: StoredUser | null | undefined): PublicUser {
+  return (
+    auth.publicUser(user) || {
+      id: String(user?.id || ""),
+      username: String(user?.username || ""),
+      role: user?.role === "admin" ? "admin" : "user",
+      hasEmail: false,
+      authMethods: [],
+      preferences: {
+        theme: typeof user?.profile?.preferences?.theme === "string" ? user.profile.preferences.theme : null
+      }
+    }
+  );
+}
+
+function normalizeMaintenanceConfig(input: unknown): AdminConfigRecord["maintenance"] {
+  const source = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const staleLobbyDays = Number(source.staleLobbyDays);
+  const auditLogLimit = Number(source.auditLogLimit);
+
+  return {
+    staleLobbyDays:
+      Number.isInteger(staleLobbyDays) && staleLobbyDays >= 1 && staleLobbyDays <= 365
+        ? staleLobbyDays
+        : DEFAULT_STALE_LOBBY_DAYS,
+    auditLogLimit:
+      Number.isInteger(auditLogLimit) && auditLogLimit >= 10 && auditLogLimit <= 500
+        ? auditLogLimit
+        : DEFAULT_AUDIT_LOG_LIMIT
+  };
+}
+
+function normalizeAuditEntries(raw: unknown): AdminAuditEntry[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === "object"))
+    .map((entry) => ({
+      id: asNonEmptyString(entry.id) || crypto.randomBytes(8).toString("hex"),
+      actorId: asNonEmptyString(entry.actorId) || "unknown",
+      actorUsername: asNonEmptyString(entry.actorUsername) || "unknown",
+      action: asNonEmptyString(entry.action) || "unknown",
+      targetType: asNonEmptyString(entry.targetType) || "unknown",
+      targetId: asNonEmptyString(entry.targetId),
+      targetLabel: asNonEmptyString(entry.targetLabel),
+      result: entry.result === "failure" ? ("failure" as const) : ("success" as const),
+      createdAt: asNonEmptyString(entry.createdAt) || new Date().toISOString(),
+      details:
+        entry.details && typeof entry.details === "object"
+          ? (safeClone(entry.details) as Record<string, unknown>)
+          : null
+    }))
+    .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)));
+}
+
+function gameUsesUser(game: RawGameRecord, user: StoredUser): boolean {
+  return asArray(game?.state?.players).some((player) => {
+    if (!player || player.isAi) {
+      return false;
+    }
+
+    if (player.linkedUserId) {
+      return player.linkedUserId === user.id;
+    }
+
+    return player.name === user.username;
+  });
+}
+
+function gameWonByUser(game: RawGameRecord, user: StoredUser): boolean {
+  const winnerId = asNonEmptyString(game?.state?.winnerId);
+  if (!winnerId) {
+    return false;
+  }
+
+  return asArray(game?.state?.players).some(
+    (player) => player?.id === winnerId && player?.name === user.username
+  );
+}
+
+function territoryCountForPlayer(state: GameState, playerId: string | null | undefined): number {
+  if (!playerId) {
+    return 0;
+  }
+
+  return Object.values(state?.territories || {}).filter(
+    (territory) => territory?.ownerId === playerId
+  ).length;
+}
+
+function cardCountForPlayer(state: GameState, playerId: string | null | undefined): number {
+  if (!playerId) {
+    return 0;
+  }
+
+  return Array.isArray(state?.hands?.[playerId]) ? state.hands[playerId].length : 0;
+}
+
+function isStale(updatedAt: string | null | undefined, staleLobbyDays: number): boolean {
+  const parsed = new Date(String(updatedAt || ""));
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+
+  const ageMs = Date.now() - parsed.getTime();
+  return ageMs > staleLobbyDays * 24 * 60 * 60 * 1000;
+}
+
+function ensureGameConfig(state: GameState): Record<string, unknown> {
+  return state?.gameConfig && typeof state.gameConfig === "object"
+    ? (state.gameConfig as Record<string, unknown>)
+    : {};
+}
+
+function normalizeGameStateForRepair(state: GameState): GameState {
+  migrateGameStateExtensions(state);
+  const gameConfig = ensureGameConfig(state);
+
+  if (asNonEmptyString(gameConfig.contentPackId)) {
+    state.contentPackId = gameConfig.contentPackId;
+  }
+
+  if (asNonEmptyString(gameConfig.diceRuleSetId)) {
+    state.diceRuleSetId = gameConfig.diceRuleSetId;
+  }
+
+  if (asNonEmptyString(gameConfig.victoryRuleSetId)) {
+    state.victoryRuleSetId = gameConfig.victoryRuleSetId;
+  }
+
+  if (asNonEmptyString(gameConfig.pieceSetId)) {
+    state.pieceSetId = gameConfig.pieceSetId;
+  }
+
+  if (asNonEmptyString(gameConfig.mapId)) {
+    state.mapId = gameConfig.mapId;
+  }
+
+  if (asNonEmptyString(gameConfig.mapName)) {
+    state.mapName = gameConfig.mapName;
+  }
+
+  return state;
+}
+
+async function maybeResolve<T>(value: Promise<T> | T): Promise<T> {
+  return value;
+}
+
+function createAdminConsole(options: AdminConsoleOptions) {
+  async function resolveAdminDefaults(input: Record<string, unknown> = {}) {
+    const configured = await maybeResolve(
+      options.createConfiguredInitialState(input, {
+        resolveContentPack: (contentPackId: string) => options.moduleRuntime.findContentPack(contentPackId),
+        resolveDiceRuleSet: (diceRuleSetId: string) => options.moduleRuntime.findDiceRuleSet(diceRuleSetId),
+        resolvePlayerPieceSet: (pieceSetId: string) => options.moduleRuntime.findPlayerPieceSet(pieceSetId),
+        resolveSupportedMap: (mapId: string) => options.moduleRuntime.findSupportedMap(mapId),
+        resolveGamePreset: (presetInput: Record<string, unknown>) =>
+          options.moduleRuntime.resolveGamePreset(presetInput),
+        resolveGameModuleConfigDefaults: (selectionInput: Record<string, unknown>) =>
+          options.moduleRuntime.resolveGameConfigDefaults(selectionInput),
+        resolveGameModuleSelection: (selectionInput: Record<string, unknown>) =>
+          options.moduleRuntime.resolveGameSelection(selectionInput)
+      })
+    );
+
+    const gameConfig = ensureGameConfig(configured.state);
+    const activeModules = asArray(gameConfig.activeModules as Array<{ id?: string }> | null);
+    const players = asArray(gameConfig.players as Array<Record<string, unknown>> | null).map((player) => ({
+      slot: typeof player.slot === "number" ? player.slot : null,
+      type: typeof player.type === "string" ? player.type : null,
+      name: typeof player.name === "string" ? player.name : null
+    }));
+
+    return {
+      totalPlayers:
+        typeof gameConfig.totalPlayers === "number" && Number.isInteger(gameConfig.totalPlayers)
+          ? Number(gameConfig.totalPlayers)
+          : null,
+      contentPackId: asNonEmptyString(gameConfig.contentPackId),
+      ruleSetId: asNonEmptyString(gameConfig.ruleSetId),
+      mapId: asNonEmptyString(gameConfig.mapId),
+      diceRuleSetId: asNonEmptyString(gameConfig.diceRuleSetId),
+      victoryRuleSetId: asNonEmptyString(gameConfig.victoryRuleSetId),
+      pieceSetId: asNonEmptyString(gameConfig.pieceSetId),
+      themeId: asNonEmptyString(gameConfig.themeId),
+      pieceSkinId: asNonEmptyString(gameConfig.pieceSkinId),
+      gamePresetId: asNonEmptyString(gameConfig.gamePresetId),
+      activeModuleIds: activeModules
+        .map((entry) => asNonEmptyString(entry?.id))
+        .filter((value): value is string => Boolean(value)),
+      contentProfileId: asNonEmptyString(gameConfig.contentProfileId),
+      gameplayProfileId: asNonEmptyString(gameConfig.gameplayProfileId),
+      uiProfileId: asNonEmptyString(gameConfig.uiProfileId),
+      turnTimeoutHours:
+        typeof gameConfig.turnTimeoutHours === "number" &&
+        Number.isInteger(gameConfig.turnTimeoutHours)
+          ? Number(gameConfig.turnTimeoutHours)
+          : null,
+      players
+    };
+  }
+
+  async function loadConfigRecord(): Promise<AdminConfigRecord> {
+    const raw = await maybeResolve(options.datastore.getAppState(ADMIN_CONFIG_STATE_KEY));
+    const source = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+    const defaults = await resolveAdminDefaults(
+      source.defaults && typeof source.defaults === "object"
+        ? (source.defaults as Record<string, unknown>)
+        : {}
+    );
+    const updatedBySource =
+      source.updatedBy && typeof source.updatedBy === "object"
+        ? (source.updatedBy as StoredUser | PublicUser)
+        : null;
+
+    return {
+      defaults,
+      maintenance: normalizeMaintenanceConfig(source.maintenance),
+      updatedAt: asNonEmptyString(source.updatedAt),
+      updatedBy: updatedBySource ? toPublicUser(options.auth, updatedBySource as StoredUser) : null
+    };
+  }
+
+  async function saveConfigRecord(record: AdminConfigRecord): Promise<AdminConfigRecord> {
+    await maybeResolve(
+      options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, {
+        defaults: safeClone(record.defaults),
+        maintenance: safeClone(record.maintenance),
+        updatedAt: record.updatedAt,
+        updatedBy: record.updatedBy
+      })
+    );
+
+    return loadConfigRecord();
+  }
+
+  async function listAuditEntries(limit?: number): Promise<AdminAuditEntry[]> {
+    const config = await loadConfigRecord();
+    const entries = normalizeAuditEntries(
+      await maybeResolve(options.datastore.getAppState(ADMIN_AUDIT_LOG_STATE_KEY))
+    );
+    const maxItems =
+      Number.isInteger(limit) && Number(limit) > 0
+        ? Number(limit)
+        : config.maintenance.auditLogLimit;
+    return entries.slice(0, maxItems);
+  }
+
+  async function recordAudit(input: {
+    actor: PublicUser;
+    action: string;
+    targetType: string;
+    targetId?: string | null;
+    targetLabel?: string | null;
+    result: "success" | "failure";
+    details?: Record<string, unknown> | null;
+  }): Promise<AdminAuditEntry> {
+    const config = await loadConfigRecord();
+    const entries = normalizeAuditEntries(
+      await maybeResolve(options.datastore.getAppState(ADMIN_AUDIT_LOG_STATE_KEY))
+    );
+    const entry: AdminAuditEntry = {
+      id: crypto.randomBytes(8).toString("hex"),
+      actorId: input.actor.id,
+      actorUsername: input.actor.username,
+      action: input.action,
+      targetType: input.targetType,
+      targetId: input.targetId || null,
+      targetLabel: input.targetLabel || null,
+      result: input.result,
+      createdAt: new Date().toISOString(),
+      details: input.details ? safeClone(input.details) : null
+    };
+    const nextEntries = [entry, ...entries].slice(0, config.maintenance.auditLogLimit);
+    await maybeResolve(options.datastore.setAppState(ADMIN_AUDIT_LOG_STATE_KEY, nextEntries));
+    return entry;
+  }
+
+  async function rawGamesById(): Promise<Map<string, RawGameRecord>> {
+    const entries = asArray(await maybeResolve(options.gameSessions.datastore.listGames()));
+    return new Map(entries.map((entry) => [entry.id, entry]));
+  }
+
+  async function collectGameIssues(
+    summary: GameSummary,
+    rawGame: RawGameRecord | null,
+    staleLobbyDays: number
+  ): Promise<AdminIssue[]> {
+    const issues: AdminIssue[] = [];
+    const state = rawGame?.state || ({ players: [], territories: {}, hands: {} } as GameState);
+    const config = ensureGameConfig(state);
+    const installedModules = await options.moduleRuntime.listInstalledModules();
+    const installedById = new Map(
+      installedModules.map((moduleEntry) => [String(moduleEntry.id || ""), moduleEntry])
+    );
+    const activeModules = asArray(summary.activeModules);
+
+    if (summary.phase === "lobby" && isStale(summary.updatedAt, staleLobbyDays)) {
+      issues.push({
+        code: "stale-lobby",
+        severity: "warning",
+        message: `Lobby "${summary.name}" inattiva da oltre ${staleLobbyDays} giorni.`,
+        gameId: summary.id,
+        actionId: "cleanup-stale-lobbies"
+      });
+    }
+
+    activeModules.forEach((moduleRef) => {
+      const moduleEntry = installedById.get(moduleRef.id);
+      if (!moduleEntry) {
+        issues.push({
+          code: "orphaned-module-reference",
+          severity: "error",
+          message: `La partita riferisce il modulo mancante "${moduleRef.id}".`,
+          gameId: summary.id
+        });
+        return;
+      }
+
+      if (!moduleEntry.enabled || !moduleEntry.compatible) {
+        issues.push({
+          code: "disabled-module-reference",
+          severity: "error",
+          message: `La partita dipende dal modulo non disponibile "${moduleRef.id}".`,
+          gameId: summary.id
+        });
+      }
+    });
+
+    const mapId = asNonEmptyString(config.mapId);
+    if (mapId && !options.moduleRuntime.findSupportedMap(mapId)) {
+      issues.push({
+        code: "missing-map",
+        severity: "error",
+        message: `La configurazione usa la mappa non risolta "${mapId}".`,
+        gameId: summary.id
+      });
+    }
+
+    const contentPackId = asNonEmptyString(config.contentPackId);
+    if (contentPackId && !options.moduleRuntime.findContentPack(contentPackId)) {
+      issues.push({
+        code: "missing-content-pack",
+        severity: "error",
+        message: `La configurazione usa il content pack non risolto "${contentPackId}".`,
+        gameId: summary.id
+      });
+    }
+
+    const diceRuleSetId = asNonEmptyString(config.diceRuleSetId);
+    if (diceRuleSetId && !options.moduleRuntime.findDiceRuleSet(diceRuleSetId)) {
+      issues.push({
+        code: "missing-dice-rule-set",
+        severity: asNonEmptyString(config.diceRuleSetName) ? "warning" : "error",
+        message: `La configurazione usa il rule set dadi non risolto "${diceRuleSetId}".`,
+        gameId: summary.id
+      });
+    }
+
+    const themeId = asNonEmptyString(config.themeId);
+    if (themeId && !findVisualTheme(themeId)) {
+      issues.push({
+        code: "missing-theme",
+        severity: "error",
+        message: `La configurazione usa il tema non supportato "${themeId}".`,
+        gameId: summary.id
+      });
+    }
+
+    const pieceSkinId = asNonEmptyString(config.pieceSkinId);
+    if (pieceSkinId && !findPieceSkin(pieceSkinId)) {
+      issues.push({
+        code: "missing-piece-skin",
+        severity: "error",
+        message: `La configurazione usa la skin pedine non supportata "${pieceSkinId}".`,
+        gameId: summary.id
+      });
+    }
+
+    const victoryRuleSetId = asNonEmptyString(config.victoryRuleSetId);
+    if (victoryRuleSetId && !findVictoryRuleSet(victoryRuleSetId)) {
+      issues.push({
+        code: "missing-victory-rule-set",
+        severity: "error",
+        message: `La configurazione usa la regola vittoria non supportata "${victoryRuleSetId}".`,
+        gameId: summary.id
+      });
+    }
+
+    if (
+      summary.phase === "active" &&
+      (!Array.isArray(state.players) || !state.players.length)
+    ) {
+      issues.push({
+        code: "active-game-without-players",
+        severity: "error",
+        message: `La partita attiva "${summary.name}" non ha giocatori validi.`,
+        gameId: summary.id
+      });
+    }
+
+    if (
+      summary.phase === "active" &&
+      Array.isArray(state.players) &&
+      state.players.length > 0 &&
+      (!Number.isInteger(state.currentTurnIndex) ||
+        Number(state.currentTurnIndex) < 0 ||
+        Number(state.currentTurnIndex) >= state.players.length)
+    ) {
+      issues.push({
+        code: "invalid-turn-index",
+        severity: "warning",
+        message: `La partita attiva "${summary.name}" ha un currentTurnIndex non valido.`,
+        gameId: summary.id
+      });
+    }
+
+    if (
+      typeof summary.totalPlayers === "number" &&
+      Number.isInteger(summary.totalPlayers) &&
+      summary.totalPlayers > 0 &&
+      summary.playerCount > summary.totalPlayers
+    ) {
+      issues.push({
+        code: "player-count-exceeds-config",
+        severity: "warning",
+        message: `La lobby "${summary.name}" ha piu giocatori dello slot configurato.`,
+        gameId: summary.id
+      });
+    }
+
+    return issues;
+  }
+
+  async function summarizeAdminGame(
+    summary: GameSummary,
+    rawGame: RawGameRecord | null,
+    staleLobbyDays: number
+  ) {
+    const issues = await collectGameIssues(summary, rawGame, staleLobbyDays);
+    return {
+      ...summary,
+      stale: summary.phase === "lobby" && isStale(summary.updatedAt, staleLobbyDays),
+      health: issues.some((issue) => issue.severity === "error")
+        ? "error"
+        : issues.some((issue) => issue.severity === "warning")
+          ? "warning"
+          : "ok",
+      issueCount: issues.length,
+      issues
+    };
+  }
+
+  function buildPlayerSummaries(state: GameState) {
+    return asArray(state.players).map((player) => ({
+      id: String(player?.id || ""),
+      name: String(player?.name || "Unknown"),
+      linkedUserId: asNonEmptyString(player?.linkedUserId),
+      isAi: Boolean(player?.isAi),
+      surrendered: Boolean(player?.surrendered),
+      territoryCount: territoryCountForPlayer(state, player?.id),
+      cardCount: cardCountForPlayer(state, player?.id)
+    }));
+  }
+
+  async function getOverview() {
+    const [users, games, config, enabledModules, audit] = await Promise.all([
+      maybeResolve(options.datastore.listUsers()),
+      maybeResolve(options.gameSessions.listGames()),
+      loadConfigRecord(),
+      options.moduleRuntime.getEnabledModules(),
+      listAuditEntries(8)
+    ]);
+    const rawById = await rawGamesById();
+    const enrichedGames = await Promise.all(
+      asArray(games).map((game) =>
+        summarizeAdminGame(game, rawById.get(game.id) || null, config.maintenance.staleLobbyDays)
+      )
+    );
+
+    return {
+      summary: {
+        totalUsers: asArray(users).length,
+        adminUsers: asArray(users).filter((user) => user?.role === "admin").length,
+        activeGames: enrichedGames.filter((game) => game.phase === "active").length,
+        lobbyGames: enrichedGames.filter((game) => game.phase === "lobby").length,
+        finishedGames: enrichedGames.filter((game) => game.phase === "finished").length,
+        staleLobbies: enrichedGames.filter((game) => game.stale).length,
+        invalidGames: enrichedGames.filter((game) => game.health === "error").length,
+        enabledModules: enabledModules.length
+      },
+      config,
+      recentGames: enrichedGames.slice(0, 6),
+      issues: enrichedGames
+        .flatMap((game) => game.issues)
+        .sort((left, right) => left.severity.localeCompare(right.severity))
+        .slice(0, 8),
+      audit
+    };
+  }
+
+  async function listUsers(filters: { query?: string | null; role?: string | null } = {}) {
+    const [users, rawGames] = await Promise.all([
+      maybeResolve(options.datastore.listUsers()),
+      maybeResolve(options.gameSessions.datastore.listGames())
+    ]);
+    const total = asArray(users).length;
+    const normalizedQuery = String(filters.query || "")
+      .trim()
+      .toLowerCase();
+    const requestedRole = asNonEmptyString(filters.role);
+    const adminCount = asArray(users).filter((user) => user?.role === "admin").length;
+
+    const summaries = asArray(users)
+      .map((user) => {
+        const participatingGames = asArray(rawGames).filter((game) => gameUsesUser(game, user));
+        const completedGames = participatingGames.filter((game) => game?.state?.phase === "finished");
+        const wins = completedGames.filter((game) => gameWonByUser(game, user)).length;
+        const publicUser = toPublicUser(options.auth, user);
+        const role = publicUserRole(publicUser);
+        const canPromote = role !== "admin";
+        const canDemote = role === "admin" && adminCount > 1;
+
+        return {
+          ...publicUser,
+          role,
+          createdAt: String(user?.createdAt || new Date().toISOString()),
+          gamesPlayed: completedGames.length,
+          gamesInProgress: participatingGames.filter(
+            (game) => game?.state?.phase === "active" || game?.state?.phase === "lobby"
+          ).length,
+          wins,
+          canPromote,
+          canDemote
+        };
+      })
+      .filter((user) => {
+        if (requestedRole && user.role !== requestedRole) {
+          return false;
+        }
+
+        if (normalizedQuery) {
+          return user.username.toLowerCase().includes(normalizedQuery);
+        }
+
+        return true;
+      })
+      .sort((left, right) => {
+        if (left.role !== right.role) {
+          return left.role === "admin" ? -1 : 1;
+        }
+
+        return left.username.localeCompare(right.username);
+      });
+
+    return {
+      users: summaries,
+      total,
+      filteredTotal: summaries.length,
+      query: String(filters.query || ""),
+      role: requestedRole
+    };
+  }
+
+  async function updateUserRole(actor: PublicUser, input: { userId: string; role: "admin" | "user" }) {
+    const targetUser = await maybeResolve(options.datastore.findUserById(input.userId));
+    if (!targetUser) {
+      throw new Error(`Utente "${input.userId}" non trovato.`);
+    }
+
+    const users = asArray(await maybeResolve(options.datastore.listUsers()));
+    const adminUsers = users.filter((user) => user?.role === "admin");
+    if (targetUser.role === "admin" && input.role === "user" && adminUsers.length <= 1) {
+      throw new Error("Impossibile rimuovere l'ultimo amministratore disponibile.");
+    }
+
+    await maybeResolve(options.datastore.updateUserRoleByUsername(targetUser.username, input.role));
+    const refreshedUsers = await listUsers();
+    const updatedUser = refreshedUsers.users.find((user) => user.id === input.userId);
+    if (!updatedUser) {
+      throw new Error(`Utente "${input.userId}" aggiornato ma non ricaricabile.`);
+    }
+
+    const audit = await recordAudit({
+      actor,
+      action: "user.role.update",
+      targetType: "user",
+      targetId: updatedUser.id,
+      targetLabel: updatedUser.username,
+      result: "success",
+      details: {
+        role: updatedUser.role
+      }
+    });
+
+    return {
+      ok: true,
+      user: updatedUser,
+      audit
+    };
+  }
+
+  async function listGames(filters: { query?: string | null; status?: string | null } = {}) {
+    const config = await loadConfigRecord();
+    const [games, rawById] = await Promise.all([
+      maybeResolve(options.gameSessions.listGames()),
+      rawGamesById()
+    ]);
+    const requestedStatus = asNonEmptyString(filters.status);
+    const normalizedQuery = String(filters.query || "")
+      .trim()
+      .toLowerCase();
+    const total = asArray(games).length;
+
+    const enrichedGames = (
+      await Promise.all(
+        asArray(games).map((game) =>
+          summarizeAdminGame(game, rawById.get(game.id) || null, config.maintenance.staleLobbyDays)
+        )
+      )
+    ).filter((game) => {
+      if (requestedStatus && game.phase !== requestedStatus) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      return (
+        game.name.toLowerCase().includes(normalizedQuery) ||
+        String(game.id).toLowerCase().includes(normalizedQuery)
+      );
+    });
+
+    return {
+      games: enrichedGames,
+      total,
+      filteredTotal: enrichedGames.length,
+      status: requestedStatus,
+      query: String(filters.query || "")
+    };
+  }
+
+  async function getGameDetails(gameId: string) {
+    const config = await loadConfigRecord();
+    const record = await maybeResolve(options.gameSessions.getGame(gameId));
+    const summary = await summarizeAdminGame(
+      record.game,
+      {
+        id: record.game.id,
+        name: record.game.name,
+        version: record.game.version,
+        creatorUserId: record.game.creatorUserId || null,
+        state: safeClone(record.state),
+        createdAt: record.game.createdAt || new Date().toISOString(),
+        updatedAt: record.game.updatedAt
+      },
+      config.maintenance.staleLobbyDays
+    );
+
+    return {
+      game: summary,
+      players: buildPlayerSummaries(record.state),
+      rawState: safeClone(record.state)
+    };
+  }
+
+  function requireConfirmation(gameId: string, confirmation: string | null | undefined) {
+    if (String(confirmation || "").trim() !== String(gameId || "").trim()) {
+      throw new Error(`Conferma richiesta: inserisci ${gameId} per procedere.`);
+    }
+  }
+
+  async function performGameAction(
+    actor: PublicUser,
+    input: {
+      gameId: string;
+      action: "close-lobby" | "terminate-game" | "repair-game-config";
+      confirmation?: string | null;
+    }
+  ) {
+    const gameContext = await options.loadGameContext(input.gameId);
+    if (!gameContext?.gameId) {
+      throw new Error(`Partita "${input.gameId}" non trovata.`);
+    }
+
+    const nextState = safeClone(gameContext.state);
+    const beforeState = JSON.stringify(nextState);
+    const now = new Date().toISOString();
+
+    if (input.action === "close-lobby") {
+      requireConfirmation(input.gameId, input.confirmation);
+      if (nextState.phase !== "lobby") {
+        throw new Error("Solo le lobby possono essere chiuse manualmente.");
+      }
+      nextState.phase = "finished";
+    } else if (input.action === "terminate-game") {
+      requireConfirmation(input.gameId, input.confirmation);
+      if (nextState.phase !== "active") {
+        throw new Error("Solo le partite attive possono essere terminate.");
+      }
+      nextState.phase = "finished";
+    } else {
+      normalizeGameStateForRepair(nextState);
+    }
+
+    nextState.adminMeta = {
+      ...(nextState.adminMeta && typeof nextState.adminMeta === "object"
+        ? (nextState.adminMeta as Record<string, unknown>)
+        : {}),
+      lastAction: input.action,
+      actedAt: now,
+      actedBy: {
+        id: actor.id,
+        username: actor.username
+      }
+    };
+
+    const changed = JSON.stringify(nextState) !== beforeState;
+    const nextContext: GameContext = {
+      ...gameContext,
+      state: nextState
+    };
+
+    if (changed) {
+      await options.persistGameContext(nextContext, gameContext.version);
+      options.broadcastGame(nextContext);
+    }
+
+    const detail = await getGameDetails(input.gameId);
+    const audit = await recordAudit({
+      actor,
+      action: `game.${input.action}`,
+      targetType: "game",
+      targetId: detail.game.id,
+      targetLabel: detail.game.name,
+      result: "success",
+      details: {
+        changed
+      }
+    });
+
+    return {
+      ok: true,
+      ...detail,
+      audit
+    };
+  }
+
+  async function getConfig() {
+    return {
+      config: await loadConfigRecord()
+    };
+  }
+
+  async function updateConfig(
+    actor: PublicUser,
+    input: {
+      defaults?: Record<string, unknown>;
+      maintenance?: Record<string, unknown>;
+    }
+  ) {
+    const currentConfig = await loadConfigRecord();
+    const defaults = await resolveAdminDefaults(
+      input.defaults && typeof input.defaults === "object"
+        ? (input.defaults as Record<string, unknown>)
+        : currentConfig.defaults
+    );
+    const maintenance = input.maintenance
+      ? normalizeMaintenanceConfig(input.maintenance)
+      : currentConfig.maintenance;
+    const savedConfig = await saveConfigRecord({
+      defaults,
+      maintenance,
+      updatedAt: new Date().toISOString(),
+      updatedBy: actor
+    });
+    const audit = await recordAudit({
+      actor,
+      action: "config.update",
+      targetType: "config",
+      targetId: "global",
+      targetLabel: "Global defaults",
+      result: "success",
+      details: {
+        defaults,
+        maintenance
+      }
+    });
+
+    return {
+      ok: true,
+      config: savedConfig,
+      audit
+    };
+  }
+
+  async function getMaintenanceReport() {
+    const config = await loadConfigRecord();
+    const [games, rawById] = await Promise.all([
+      maybeResolve(options.gameSessions.listGames()),
+      rawGamesById()
+    ]);
+    const enrichedGames = await Promise.all(
+      asArray(games).map((game) =>
+        summarizeAdminGame(game, rawById.get(game.id) || null, config.maintenance.staleLobbyDays)
+      )
+    );
+    const issues = enrichedGames.flatMap((game) => game.issues);
+
+    return {
+      summary: {
+        totalGames: enrichedGames.length,
+        staleLobbies: enrichedGames.filter((game) => game.stale).length,
+        invalidGames: enrichedGames.filter((game) => game.health === "error").length,
+        orphanedModuleReferences: issues.filter(
+          (issue) =>
+            issue.code === "orphaned-module-reference" ||
+            issue.code === "disabled-module-reference"
+        ).length
+      },
+      issues
+    };
+  }
+
+  async function runMaintenanceAction(
+    actor: PublicUser,
+    input: {
+      action: "validate-all" | "cleanup-stale-lobbies";
+      confirmation?: string | null;
+    }
+  ) {
+    if (input.action === "validate-all") {
+      const report = await getMaintenanceReport();
+      const audit = await recordAudit({
+        actor,
+        action: "maintenance.validate-all",
+        targetType: "maintenance",
+        targetId: "validate-all",
+        targetLabel: "Validation report",
+        result: "success",
+        details: {
+          issues: report.issues.length
+        }
+      });
+
+      return {
+        ok: true,
+        report,
+        affectedGameIds: [],
+        audit
+      };
+    }
+
+    if (String(input.confirmation || "").trim() !== "cleanup-stale-lobbies") {
+      throw new Error("Conferma richiesta: inserisci cleanup-stale-lobbies per procedere.");
+    }
+
+    const config = await loadConfigRecord();
+    const games = await listGames({ status: "lobby" });
+    const staleGames = games.games.filter((game) =>
+      game.stale || game.issues.some((issue) => issue.code === "stale-lobby")
+    );
+    const affectedGameIds: string[] = [];
+
+    for (const game of staleGames) {
+      const context = await options.loadGameContext(game.id);
+      if (!context?.gameId) {
+        continue;
+      }
+
+      const nextState = safeClone(context.state);
+      nextState.phase = "finished";
+      nextState.adminMeta = {
+        ...(nextState.adminMeta && typeof nextState.adminMeta === "object"
+          ? (nextState.adminMeta as Record<string, unknown>)
+          : {}),
+        lastAction: "cleanup-stale-lobbies",
+        actedAt: new Date().toISOString(),
+        actedBy: {
+          id: actor.id,
+          username: actor.username
+        }
+      };
+
+      await options.persistGameContext(
+        {
+          ...context,
+          state: nextState
+        },
+        context.version
+      );
+      options.broadcastGame({
+        ...context,
+        state: nextState
+      });
+      affectedGameIds.push(game.id);
+    }
+
+    const report = await getMaintenanceReport();
+    const audit = await recordAudit({
+      actor,
+      action: "maintenance.cleanup-stale-lobbies",
+      targetType: "maintenance",
+      targetId: "cleanup-stale-lobbies",
+      targetLabel: "Stale lobby cleanup",
+      result: "success",
+      details: {
+        staleLobbyDays: config.maintenance.staleLobbyDays,
+        affectedGameIds
+      }
+    });
+
+    return {
+      ok: true,
+      report,
+      affectedGameIds,
+      audit
+    };
+  }
+
+  async function listAudit() {
+    return {
+      entries: await listAuditEntries()
+    };
+  }
+
+  async function assertModuleSafeToDisable(moduleId: string) {
+    const config = await loadConfigRecord();
+    const activeModuleIds = asArray(config.defaults.activeModuleIds as string[] | undefined);
+    if (activeModuleIds.includes(moduleId)) {
+      throw new Error(`Module "${moduleId}" is still referenced by admin defaults.`);
+    }
+  }
+
+  return {
+    getOverview,
+    listUsers,
+    updateUserRole,
+    listGames,
+    getGameDetails,
+    performGameAction,
+    getConfig,
+    updateConfig,
+    getMaintenanceReport,
+    runMaintenanceAction,
+    listAudit,
+    recordAudit,
+    assertModuleSafeToDisable,
+    loadConfigRecord
+  };
+}
+
+module.exports = {
+  ADMIN_AUDIT_LOG_STATE_KEY,
+  ADMIN_CONFIG_STATE_KEY,
+  createAdminConsole,
+  normalizeGameStateForRepair
+};

--- a/backend/authorization.cts
+++ b/backend/authorization.cts
@@ -149,6 +149,10 @@ function canManageModules(actor: Actor | null): boolean {
   return Boolean(actor && actor.id && actor.role === Roles.ADMIN);
 }
 
+function canManageAdmin(actor: Actor | null): boolean {
+  return Boolean(actor && actor.id && actor.role === Roles.ADMIN);
+}
+
 function authorize(action: string, context: AuthorizationContext = {}) {
   const actor = actorForUser(context.user);
 
@@ -217,6 +221,22 @@ function authorize(action: string, context: AuthorizationContext = {}) {
     return { ok: true, actor };
   }
 
+  if (action === "admin:manage") {
+    if (!actor) {
+      throw createAuthorizationError("Sessione non valida.", 401, "AUTH_REQUIRED");
+    }
+
+    if (!canManageAdmin(actor)) {
+      throw createAuthorizationError(
+        "Solo gli admin possono accedere alla console amministrativa.",
+        403,
+        "ADMIN_ONLY"
+      );
+    }
+
+    return { ok: true, actor };
+  }
+
   throw createAuthorizationError("Policy non supportata: " + action, 500, "POLICY_NOT_IMPLEMENTED");
 }
 
@@ -226,6 +246,7 @@ module.exports = {
   authorize,
   canReadGame,
   canCreateGame,
+  canManageAdmin,
   canManageModules,
   canOpenGame,
   canStartGame

--- a/backend/new-game-config.cts
+++ b/backend/new-game-config.cts
@@ -279,7 +279,8 @@ export function validateNewGameConfig(
   } = {}
 ): ValidatedNewGameConfig {
   const fallbackConfigInput = options.fallbackConfigInput || {};
-  const hasExplicitContentPackId = typeof input.contentPackId === "string" && input.contentPackId !== "";
+  const hasExplicitContentPackId =
+    typeof input.contentPackId === "string" && input.contentPackId !== "";
   const hasExplicitRuleSetId = typeof input.ruleSetId === "string" && input.ruleSetId !== "";
   const canPreferFallbackPresentationDefaults = !hasExplicitContentPackId && !hasExplicitRuleSetId;
   const totalPlayersSource =
@@ -651,6 +652,18 @@ export function createConfiguredInitialState(
     ) => {
       const resolvedDefaults = resolvedSetup?.defaults || null;
       const hydratedConfigInput: NewGameConfigInput = {
+        ...(Array.isArray(moduleDefaultsResolutionInput.activeModuleIds)
+          ? { activeModuleIds: moduleDefaultsResolutionInput.activeModuleIds }
+          : {}),
+        ...(typeof moduleDefaultsResolutionInput.contentProfileId === "string"
+          ? { contentProfileId: moduleDefaultsResolutionInput.contentProfileId }
+          : {}),
+        ...(typeof moduleDefaultsResolutionInput.gameplayProfileId === "string"
+          ? { gameplayProfileId: moduleDefaultsResolutionInput.gameplayProfileId }
+          : {}),
+        ...(typeof moduleDefaultsResolutionInput.uiProfileId === "string"
+          ? { uiProfileId: moduleDefaultsResolutionInput.uiProfileId }
+          : {}),
         ...(typeof resolvedDefaults?.contentPackId === "string"
           ? { contentPackId: resolvedDefaults.contentPackId }
           : {}),

--- a/backend/new-game-config.cts
+++ b/backend/new-game-config.cts
@@ -288,6 +288,7 @@ export function validateNewGameConfig(
     typeof presentationDefaultsInput.ruleSetId === "string" &&
     presentationDefaultsInput.ruleSetId !== "";
   const canPreferFallbackPresentationDefaults = !hasExplicitContentPackId && !hasExplicitRuleSetId;
+  const canPreferFallbackPieceSetDefaults = !hasExplicitContentPackId;
   const totalPlayersSource =
     input.totalPlayers == null ? fallbackConfigInput.totalPlayers : input.totalPlayers;
   const totalPlayers = totalPlayersSource == null ? 2 : Number(totalPlayersSource);
@@ -381,7 +382,7 @@ export function validateNewGameConfig(
 
   const requestedPieceSetId = String(
     input.pieceSetId ||
-      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.pieceSetId : null) ||
+      (canPreferFallbackPieceSetDefaults ? fallbackConfigInput.pieceSetId : null) ||
       selectedContentPack.defaultPieceSetId ||
       fallbackConfigInput.pieceSetId ||
       DEFAULT_PLAYER_PIECE_SET_ID

--- a/backend/new-game-config.cts
+++ b/backend/new-game-config.cts
@@ -268,6 +268,7 @@ export function validateNewGameConfig(
   options: {
     random?: () => number;
     resolveRuleSet?: (ruleSetId: string) => NewGameRuleSet | null;
+    fallbackConfigInput?: NewGameConfigInput;
     resolveContentPack?: (contentPackId: string) => ContentPackSummary | null;
     resolveDiceRuleSet?: (diceRuleSetId: string) => DiceRuleSet | null;
     resolvePlayerPieceSet?: (pieceSetId: string) => PlayerPieceSet | null;
@@ -277,7 +278,13 @@ export function validateNewGameConfig(
     resolvePieceSkin?: (pieceSkinId: string) => PieceSkin | null;
   } = {}
 ): ValidatedNewGameConfig {
-  const totalPlayers = input.totalPlayers == null ? 2 : Number(input.totalPlayers);
+  const fallbackConfigInput = options.fallbackConfigInput || {};
+  const hasExplicitContentPackId = typeof input.contentPackId === "string" && input.contentPackId !== "";
+  const hasExplicitRuleSetId = typeof input.ruleSetId === "string" && input.ruleSetId !== "";
+  const canPreferFallbackPresentationDefaults = !hasExplicitContentPackId && !hasExplicitRuleSetId;
+  const totalPlayersSource =
+    input.totalPlayers == null ? fallbackConfigInput.totalPlayers : input.totalPlayers;
+  const totalPlayers = totalPlayersSource == null ? 2 : Number(totalPlayersSource);
   if (!Number.isInteger(totalPlayers) || totalPlayers < 2 || totalPlayers > 4) {
     throw createLocalizedError(
       "Il numero totale di giocatori deve essere compreso tra 2 e 4.",
@@ -285,7 +292,9 @@ export function validateNewGameConfig(
     );
   }
 
-  const requestedContentPackId = String(input.contentPackId || DEFAULT_CONTENT_PACK_ID);
+  const requestedContentPackId = String(
+    input.contentPackId || fallbackConfigInput.contentPackId || DEFAULT_CONTENT_PACK_ID
+  );
   const resolveContentPack =
     typeof options.resolveContentPack === "function" ? options.resolveContentPack : findContentPack;
   const selectedContentPack = resolveContentPack(requestedContentPackId);
@@ -296,9 +305,11 @@ export function validateNewGameConfig(
     );
   }
 
-  const requestedRuleSetId = String(input.ruleSetId || STANDARD_NEW_GAME_RULE_SET_ID);
   const resolveRuleSet =
     typeof options.resolveRuleSet === "function" ? options.resolveRuleSet : findNewGameRuleSet;
+  const requestedRuleSetId = String(
+    input.ruleSetId || fallbackConfigInput.ruleSetId || STANDARD_NEW_GAME_RULE_SET_ID
+  );
   const selectedRuleSet = resolveRuleSet(requestedRuleSetId);
   if (!selectedRuleSet) {
     throw createLocalizedError(
@@ -309,8 +320,10 @@ export function validateNewGameConfig(
 
   const mapId = String(
     input.mapId ||
+      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.mapId : null) ||
       selectedContentPack.defaultMapId ||
       selectedRuleSet.defaults.mapId ||
+      fallbackConfigInput.mapId ||
       "classic-mini"
   );
   const resolveSupportedMap =
@@ -324,8 +337,10 @@ export function validateNewGameConfig(
 
   const requestedDiceRuleSetId = String(
     input.diceRuleSetId ||
+      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.diceRuleSetId : null) ||
       selectedRuleSet.defaults.diceRuleSetId ||
       selectedContentPack.defaultDiceRuleSetId ||
+      fallbackConfigInput.diceRuleSetId ||
       STANDARD_DICE_RULE_SET_ID
   );
   const resolveDiceRuleSet =
@@ -340,8 +355,10 @@ export function validateNewGameConfig(
 
   const requestedVictoryRuleSetId = String(
     input.victoryRuleSetId ||
+      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.victoryRuleSetId : null) ||
       selectedRuleSet.defaults.victoryRuleSetId ||
       selectedContentPack.defaultVictoryRuleSetId ||
+      fallbackConfigInput.victoryRuleSetId ||
       DEFAULT_VICTORY_RULE_SET_ID
   );
   const resolveVictoryRuleSet =
@@ -357,7 +374,10 @@ export function validateNewGameConfig(
   }
 
   const requestedPieceSetId = String(
-    input.pieceSetId || selectedContentPack.defaultPieceSetId || DEFAULT_PLAYER_PIECE_SET_ID
+    input.pieceSetId ||
+      selectedContentPack.defaultPieceSetId ||
+      fallbackConfigInput.pieceSetId ||
+      DEFAULT_PLAYER_PIECE_SET_ID
   );
   const resolvePlayerPieceSet =
     typeof options.resolvePlayerPieceSet === "function"
@@ -373,8 +393,10 @@ export function validateNewGameConfig(
 
   const requestedThemeId = String(
     input.themeId ||
+      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.themeId : null) ||
       selectedRuleSet.defaults.themeId ||
       selectedContentPack.defaultSiteThemeId ||
+      fallbackConfigInput.themeId ||
       DEFAULT_THEME_ID
   );
   const resolveTheme =
@@ -385,7 +407,11 @@ export function validateNewGameConfig(
   }
 
   const requestedPieceSkinId = String(
-    input.pieceSkinId || selectedRuleSet.defaults.pieceSkinId || DEFAULT_PIECE_SKIN_ID
+    input.pieceSkinId ||
+      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.pieceSkinId : null) ||
+      selectedRuleSet.defaults.pieceSkinId ||
+      fallbackConfigInput.pieceSkinId ||
+      DEFAULT_PIECE_SKIN_ID
   );
   const resolvePieceSkin =
     typeof options.resolvePieceSkin === "function" ? options.resolvePieceSkin : findPieceSkin;
@@ -397,9 +423,11 @@ export function validateNewGameConfig(
     );
   }
 
+  const turnTimeoutSource =
+    input.turnTimeoutHours == null ? fallbackConfigInput.turnTimeoutHours : input.turnTimeoutHours;
   const turnTimeoutHours =
-    input.turnTimeoutHours == null ? null : normalizeTurnTimeoutHours(input.turnTimeoutHours);
-  if (input.turnTimeoutHours != null && turnTimeoutHours == null) {
+    turnTimeoutSource == null ? null : normalizeTurnTimeoutHours(turnTimeoutSource);
+  if (turnTimeoutSource != null && turnTimeoutHours == null) {
     throw createLocalizedError(
       "Il limite tempo turno selezionato non e supportato.",
       "newGame.invalidTurnTimeoutHours",
@@ -474,6 +502,7 @@ export function createConfiguredInitialState(
   options: {
     random?: () => number;
     resolveRuleSet?: (ruleSetId: string) => NewGameRuleSet | null;
+    defaultConfigInput?: NewGameConfigInput;
     resolveContentPack?: (contentPackId: string) => ContentPackSummary | null;
     resolveDiceRuleSet?: (diceRuleSetId: string) => DiceRuleSet | null;
     resolvePlayerPieceSet?: (pieceSetId: string) => PlayerPieceSet | null;
@@ -528,13 +557,20 @@ export function createConfiguredInitialState(
       gameInput: { name: string | undefined };
       config: ValidatedNewGameConfig;
     }> {
+  const defaultConfigInput = options.defaultConfigInput || {};
+  const presetResolutionInput: NewGameConfigInput = {
+    ...defaultConfigInput,
+    ...configInput
+  };
   const resolvedPreset =
     typeof options.resolveGamePreset === "function"
       ? options.resolveGamePreset({
           gamePresetId:
-            typeof configInput.gamePresetId === "string" ? configInput.gamePresetId : null,
-          activeModuleIds: Array.isArray(configInput.activeModuleIds)
-            ? configInput.activeModuleIds
+            typeof presetResolutionInput.gamePresetId === "string"
+              ? presetResolutionInput.gamePresetId
+              : null,
+          activeModuleIds: Array.isArray(presetResolutionInput.activeModuleIds)
+            ? presetResolutionInput.activeModuleIds
             : []
         })
       : null;
@@ -584,24 +620,28 @@ export function createConfiguredInitialState(
         : {}),
       ...configInput
     };
+    const moduleDefaultsResolutionInput: NewGameConfigInput = {
+      ...defaultConfigInput,
+      ...hydratedPresetInput
+    };
 
     const resolvedProfileDefaults =
       typeof options.resolveGameModuleConfigDefaults === "function"
         ? options.resolveGameModuleConfigDefaults({
-            activeModuleIds: Array.isArray(hydratedPresetInput.activeModuleIds)
-              ? hydratedPresetInput.activeModuleIds
+            activeModuleIds: Array.isArray(moduleDefaultsResolutionInput.activeModuleIds)
+              ? moduleDefaultsResolutionInput.activeModuleIds
               : [],
             contentProfileId:
-              typeof hydratedPresetInput.contentProfileId === "string"
-                ? hydratedPresetInput.contentProfileId
+              typeof moduleDefaultsResolutionInput.contentProfileId === "string"
+                ? moduleDefaultsResolutionInput.contentProfileId
                 : null,
             gameplayProfileId:
-              typeof hydratedPresetInput.gameplayProfileId === "string"
-                ? hydratedPresetInput.gameplayProfileId
+              typeof moduleDefaultsResolutionInput.gameplayProfileId === "string"
+                ? moduleDefaultsResolutionInput.gameplayProfileId
                 : null,
             uiProfileId:
-              typeof hydratedPresetInput.uiProfileId === "string"
-                ? hydratedPresetInput.uiProfileId
+              typeof moduleDefaultsResolutionInput.uiProfileId === "string"
+                ? moduleDefaultsResolutionInput.uiProfileId
                 : null
           })
         : null;
@@ -638,6 +678,7 @@ export function createConfiguredInitialState(
       const config = validateNewGameConfig(hydratedConfigInput, {
         random: options.random,
         resolveRuleSet: options.resolveRuleSet,
+        fallbackConfigInput: defaultConfigInput,
         resolveContentPack: options.resolveContentPack,
         resolveDiceRuleSet: options.resolveDiceRuleSet,
         resolvePlayerPieceSet: options.resolvePlayerPieceSet,

--- a/backend/new-game-config.cts
+++ b/backend/new-game-config.cts
@@ -269,6 +269,7 @@ export function validateNewGameConfig(
     random?: () => number;
     resolveRuleSet?: (ruleSetId: string) => NewGameRuleSet | null;
     fallbackConfigInput?: NewGameConfigInput;
+    presentationDefaultsInput?: NewGameConfigInput;
     resolveContentPack?: (contentPackId: string) => ContentPackSummary | null;
     resolveDiceRuleSet?: (diceRuleSetId: string) => DiceRuleSet | null;
     resolvePlayerPieceSet?: (pieceSetId: string) => PlayerPieceSet | null;
@@ -279,9 +280,13 @@ export function validateNewGameConfig(
   } = {}
 ): ValidatedNewGameConfig {
   const fallbackConfigInput = options.fallbackConfigInput || {};
+  const presentationDefaultsInput = options.presentationDefaultsInput || input;
   const hasExplicitContentPackId =
-    typeof input.contentPackId === "string" && input.contentPackId !== "";
-  const hasExplicitRuleSetId = typeof input.ruleSetId === "string" && input.ruleSetId !== "";
+    typeof presentationDefaultsInput.contentPackId === "string" &&
+    presentationDefaultsInput.contentPackId !== "";
+  const hasExplicitRuleSetId =
+    typeof presentationDefaultsInput.ruleSetId === "string" &&
+    presentationDefaultsInput.ruleSetId !== "";
   const canPreferFallbackPresentationDefaults = !hasExplicitContentPackId && !hasExplicitRuleSetId;
   const totalPlayersSource =
     input.totalPlayers == null ? fallbackConfigInput.totalPlayers : input.totalPlayers;
@@ -376,6 +381,7 @@ export function validateNewGameConfig(
 
   const requestedPieceSetId = String(
     input.pieceSetId ||
+      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.pieceSetId : null) ||
       selectedContentPack.defaultPieceSetId ||
       fallbackConfigInput.pieceSetId ||
       DEFAULT_PLAYER_PIECE_SET_ID
@@ -692,6 +698,7 @@ export function createConfiguredInitialState(
         random: options.random,
         resolveRuleSet: options.resolveRuleSet,
         fallbackConfigInput: defaultConfigInput,
+        presentationDefaultsInput: configInput,
         resolveContentPack: options.resolveContentPack,
         resolveDiceRuleSet: options.resolveDiceRuleSet,
         resolvePlayerPieceSet: options.resolvePlayerPieceSet,

--- a/backend/routes/admin.cts
+++ b/backend/routes/admin.cts
@@ -1,0 +1,619 @@
+const {
+  adminAuditResponseSchema,
+  adminConfigResponseSchema,
+  adminConfigUpdateRequestSchema,
+  adminConfigUpdateResponseSchema,
+  adminGameActionRequestSchema,
+  adminGameActionResponseSchema,
+  adminGameDetailsResponseSchema,
+  adminGamesResponseSchema,
+  adminMaintenanceActionRequestSchema,
+  adminMaintenanceActionResponseSchema,
+  adminMaintenanceReportSchema,
+  adminOverviewResponseSchema,
+  adminUserRoleUpdateRequestSchema,
+  adminUserRoleUpdateResponseSchema,
+  adminUsersResponseSchema
+} = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+
+type SendJson = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  payload: unknown,
+  headers?: Record<string, string>
+) => void;
+
+type SendLocalizedError = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  input: Record<string, unknown> | null,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams?: Record<string, unknown>,
+  code?: string | null,
+  extra?: Record<string, unknown>
+) => void;
+
+type RequireAuth = (
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  url?: URL | null
+) => Promise<{ user: { id: string; username: string; role?: string } } | null>;
+
+type Authorize = (action: string, context: Record<string, unknown>) => unknown;
+
+type AdminConsole = {
+  getOverview(): Promise<unknown>;
+  listUsers(filters?: { query?: string | null; role?: string | null }): Promise<unknown>;
+  updateUserRole(
+    actor: { id: string; username: string; role?: string },
+    input: { userId: string; role: "admin" | "user" }
+  ): Promise<unknown>;
+  listGames(filters?: { query?: string | null; status?: string | null }): Promise<unknown>;
+  getGameDetails(gameId: string): Promise<unknown>;
+  performGameAction(
+    actor: { id: string; username: string; role?: string },
+    input: {
+      gameId: string;
+      action: "close-lobby" | "terminate-game" | "repair-game-config";
+      confirmation?: string | null;
+    }
+  ): Promise<unknown>;
+  getConfig(): Promise<unknown>;
+  updateConfig(
+    actor: { id: string; username: string; role?: string },
+    input: { defaults?: Record<string, unknown>; maintenance?: Record<string, unknown> }
+  ): Promise<unknown>;
+  getMaintenanceReport(): Promise<unknown>;
+  runMaintenanceAction(
+    actor: { id: string; username: string; role?: string },
+    input: { action: "validate-all" | "cleanup-stale-lobbies"; confirmation?: string | null }
+  ): Promise<unknown>;
+  listAudit(): Promise<unknown>;
+  recordAudit?(input: {
+    actor: { id: string; username: string; role?: string };
+    action: string;
+    targetType: string;
+    targetId?: string | null;
+    targetLabel?: string | null;
+    result: "success" | "failure";
+    details?: Record<string, unknown> | null;
+  }): Promise<unknown>;
+};
+
+async function requireAdminAccess(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  url?: URL | null
+) {
+  const authContext = await requireAuth(req, res, body, url);
+  if (!authContext) {
+    return null;
+  }
+
+  authorize("admin:manage", { user: authContext.user });
+  return authContext;
+}
+
+async function tryRecordFailureAudit(
+  adminConsole: AdminConsole,
+  authContext: { user: { id: string; username: string; role?: string } } | null,
+  action: string,
+  targetType: string,
+  targetId: string | null,
+  targetLabel: string | null,
+  error: unknown
+) {
+  if (!authContext || typeof adminConsole.recordAudit !== "function") {
+    return;
+  }
+
+  try {
+    await adminConsole.recordAudit({
+      actor: authContext.user,
+      action,
+      targetType,
+      targetId,
+      targetLabel,
+      result: "failure",
+      details: {
+        error:
+          error && typeof error === "object" && "message" in error
+            ? String((error as { message?: unknown }).message || "")
+            : "unknown"
+      }
+    });
+  } catch {
+    // Audit failures must not hide the primary route error.
+  }
+}
+
+async function handleAdminOverviewRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.getOverview(),
+      adminOverviewResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Accesso overview admin non autorizzato.",
+      "server.admin.overviewUnauthorized"
+    );
+  }
+}
+
+async function handleAdminUsersRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  url: URL,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize, url);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.listUsers({
+        query: url.searchParams.get("q"),
+        role: url.searchParams.get("role")
+      }),
+      adminUsersResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Accesso utenti admin non autorizzato.",
+      "server.admin.usersUnauthorized"
+    );
+  }
+}
+
+async function handleAdminUserRoleRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminUserRoleUpdateRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.updateUserRole(authContext.user, parsedBody),
+      adminUserRoleUpdateResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "user.role.update",
+      "user",
+      typeof body.userId === "string" ? body.userId : null,
+      null,
+      error
+    );
+    sendLocalizedError(
+      res,
+      error?.statusCode || 400,
+      error,
+      "Aggiornamento ruolo utente non riuscito.",
+      "server.admin.userRoleUpdateFailed"
+    );
+  }
+}
+
+async function handleAdminGamesRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  url: URL,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize, url);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.listGames({
+        query: url.searchParams.get("q"),
+        status: url.searchParams.get("status")
+      }),
+      adminGamesResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Accesso partite admin non autorizzato.",
+      "server.admin.gamesUnauthorized"
+    );
+  }
+}
+
+async function handleAdminGameDetailRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  gameId: string,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.getGameDetails(gameId),
+      adminGameDetailsResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 404,
+      error,
+      "Dettaglio partita admin non disponibile.",
+      "server.admin.gameDetailUnavailable"
+    );
+  }
+}
+
+async function handleAdminGameActionRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminGameActionRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.performGameAction(authContext.user, parsedBody),
+      adminGameActionResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      typeof body.action === "string" ? `game.${body.action}` : "game.action",
+      "game",
+      typeof body.gameId === "string" ? body.gameId : null,
+      null,
+      error
+    );
+    sendLocalizedError(
+      res,
+      error?.statusCode || 400,
+      error,
+      "Operazione admin sulla partita non riuscita.",
+      "server.admin.gameActionFailed"
+    );
+  }
+}
+
+async function handleAdminConfigRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.getConfig(),
+      adminConfigResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Configurazione admin non disponibile.",
+      "server.admin.configUnavailable"
+    );
+  }
+}
+
+async function handleAdminConfigUpdateRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminConfigUpdateRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.updateConfig(authContext.user, parsedBody),
+      adminConfigUpdateResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "config.update",
+      "config",
+      "global",
+      "Global defaults",
+      error
+    );
+    sendLocalizedError(
+      res,
+      error?.statusCode || 400,
+      error,
+      "Aggiornamento configurazione admin non riuscito.",
+      "server.admin.configUpdateFailed"
+    );
+  }
+}
+
+async function handleAdminMaintenanceRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.getMaintenanceReport(),
+      adminMaintenanceReportSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Report manutenzione admin non disponibile.",
+      "server.admin.maintenanceUnavailable"
+    );
+  }
+}
+
+async function handleAdminMaintenanceActionRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminMaintenanceActionRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.runMaintenanceAction(authContext.user, parsedBody),
+      adminMaintenanceActionResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      typeof body.action === "string" ? `maintenance.${body.action}` : "maintenance.action",
+      "maintenance",
+      typeof body.action === "string" ? body.action : null,
+      null,
+      error
+    );
+    sendLocalizedError(
+      res,
+      error?.statusCode || 400,
+      error,
+      "Operazione manutenzione admin non riuscita.",
+      "server.admin.maintenanceActionFailed"
+    );
+  }
+}
+
+async function handleAdminAuditRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.listAudit(),
+      adminAuditResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Audit log admin non disponibile.",
+      "server.admin.auditUnavailable"
+    );
+  }
+}
+
+module.exports = {
+  handleAdminAuditRoute,
+  handleAdminConfigRoute,
+  handleAdminConfigUpdateRoute,
+  handleAdminGameActionRoute,
+  handleAdminGameDetailRoute,
+  handleAdminGamesRoute,
+  handleAdminMaintenanceActionRoute,
+  handleAdminMaintenanceRoute,
+  handleAdminOverviewRoute,
+  handleAdminUserRoleRoute,
+  handleAdminUsersRoute
+};

--- a/backend/routes/modules.cts
+++ b/backend/routes/modules.cts
@@ -189,18 +189,22 @@ async function handleDisableModuleRoute(
       engineVersion
     });
   } catch (error: any) {
-    const message =
-      typeof error?.message === "string" && error.message.indexOf("active game") !== -1
-        ? "Il modulo e ancora usato da una partita attiva."
+    const isActiveGameConflict =
+      typeof error?.message === "string" && error.message.indexOf("active game") !== -1;
+    const isAdminDefaultsConflict =
+      typeof error?.message === "string" && error.message.indexOf("admin defaults") !== -1;
+    const message = isActiveGameConflict
+      ? "Il modulo e ancora usato da una partita attiva."
+      : isAdminDefaultsConflict
+        ? "Il modulo e ancora usato dalla configurazione admin."
         : "Disabilitazione modulo non riuscita.";
-    const key =
-      typeof error?.message === "string" && error.message.indexOf("active game") !== -1
-        ? "server.modules.disableInUse"
+    const key = isActiveGameConflict
+      ? "server.modules.disableInUse"
+      : isAdminDefaultsConflict
+        ? "server.modules.disableAdminConfigInUse"
         : "server.modules.disableFailed";
     const statusCode =
-      typeof error?.message === "string" && error.message.indexOf("active game") !== -1
-        ? 409
-        : error?.statusCode || 400;
+      isActiveGameConflict || isAdminDefaultsConflict ? 409 : error?.statusCode || 400;
     sendLocalizedError(res, statusCode, error, message, key);
   }
 }

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -213,9 +213,9 @@ function parseBody(req: Request): Promise<Record<string, any>> {
   });
 }
 
-  function deepClone<T>(value: T): T {
-    return JSON.parse(JSON.stringify(value ?? null)) as T;
-  }
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
 
 function parseCookies(req: Request): CookieMap {
   const rawCookies = String(req.headers.cookie || "");

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -2,6 +2,7 @@ const http = require("http");
 const crypto = require("node:crypto");
 const fs = require("fs");
 const path = require("path");
+const { createAdminConsole } = require("./admin-console.cjs");
 const { loadLocalEnv } = require("./load-local-env.cjs");
 const { createDatastore } = require("./datastore.cjs");
 const { createModuleRuntime } = require("./module-runtime.cjs");
@@ -58,6 +59,19 @@ const {
   handleModuleOptionsRoute,
   handleRescanModulesRoute
 } = require("./routes/modules.cjs");
+const {
+  handleAdminAuditRoute,
+  handleAdminConfigRoute,
+  handleAdminConfigUpdateRoute,
+  handleAdminGameActionRoute,
+  handleAdminGameDetailRoute,
+  handleAdminGamesRoute,
+  handleAdminMaintenanceActionRoute,
+  handleAdminMaintenanceRoute,
+  handleAdminOverviewRoute,
+  handleAdminUserRoleRoute,
+  handleAdminUsersRoute
+} = require("./routes/admin.cjs");
 const {
   handleLoginRoute,
   handleLogoutRoute,
@@ -199,6 +213,10 @@ function parseBody(req: Request): Promise<Record<string, any>> {
   });
 }
 
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
+
 function parseCookies(req: Request): CookieMap {
   const rawCookies = String(req.headers.cookie || "");
   if (!rawCookies) {
@@ -306,6 +324,25 @@ function createApp(options: CreateAppOptions = {}) {
     dataFile: options.dataFile || path.join(runtimeProjectRoot, "data", "users.json"),
     sessionsFile: options.sessionsFile || path.join(runtimeProjectRoot, "data", "sessions.json")
   });
+  const adminConsole = createAdminConsole({
+    datastore,
+    auth,
+    gameSessions,
+    loadGameContext,
+    persistGameContext,
+    broadcastGame,
+    createConfiguredInitialState,
+    moduleRuntime
+  });
+
+  async function getSafeAdminDefaults() {
+    try {
+      const adminConfig = await adminConsole.getConfig();
+      return adminConfig.config.defaults;
+    } catch (error) {
+      return undefined;
+    }
+  }
   const clientsByGameId = new Map<string, Set<EventClient>>();
   let initPromise: Promise<void> | null = null;
 
@@ -771,12 +808,15 @@ function createApp(options: CreateAppOptions = {}) {
       (url.pathname === "/api/game-options" || url.pathname === "/api/game/options")
     ) {
       const moduleOptions = await moduleRuntime.getModuleOptions();
+      const adminDefaults = await getSafeAdminDefaults();
       await handleGameOptionsRoute(
         res,
         () => moduleOptions.resolvedCatalog || moduleOptions,
         listTurnTimeoutHoursOptions,
         sendJson,
-        undefined,
+        async () => ({
+          ...(adminDefaults ? { adminDefaults } : {})
+        }),
         sendLocalizedError
       );
       return;
@@ -844,11 +884,170 @@ function createApp(options: CreateAppOptions = {}) {
         decodeURIComponent(disableModuleMatch[1] || ""),
         requireAuth,
         authorize,
-        (moduleId: string) => moduleRuntime.disableModule(moduleId),
+        async (moduleId: string) => {
+          await adminConsole.assertModuleSafeToDisable(moduleId);
+          return moduleRuntime.disableModule(moduleId);
+        },
         () => moduleRuntime.getEnabledModules(),
         sendJson,
         sendLocalizedError,
         NETRISK_ENGINE_VERSION
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/overview") {
+      await handleAdminOverviewRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/users") {
+      await handleAdminUsersRoute(
+        req,
+        res,
+        url,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/admin/users/role") {
+      const body = await parseBody(req);
+      await handleAdminUserRoleRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/games") {
+      await handleAdminGamesRoute(
+        req,
+        res,
+        url,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    const adminGameDetailMatch =
+      req.method === "GET" ? url.pathname.match(/^\/api\/admin\/games\/([^/]+)$/) : null;
+    if (adminGameDetailMatch) {
+      await handleAdminGameDetailRoute(
+        req,
+        res,
+        decodeURIComponent(adminGameDetailMatch[1] || ""),
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/admin/games/action") {
+      const body = await parseBody(req);
+      await handleAdminGameActionRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/config") {
+      await handleAdminConfigRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "PUT" && url.pathname === "/api/admin/config") {
+      const body = await parseBody(req);
+      await handleAdminConfigUpdateRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/maintenance") {
+      await handleAdminMaintenanceRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/admin/maintenance") {
+      const body = await parseBody(req);
+      await handleAdminMaintenanceActionRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/audit") {
+      await handleAdminAuditRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
       );
       return;
     }
@@ -913,6 +1112,7 @@ function createApp(options: CreateAppOptions = {}) {
       const body = await parseBody(req);
       const moduleOptions = await moduleRuntime.getModuleOptions();
       const resolvedCatalog = moduleOptions.resolvedCatalog || moduleOptions;
+      const adminDefaults = await getSafeAdminDefaults();
       await handleCreateGameRoute(
         req,
         res,
@@ -921,6 +1121,7 @@ function createApp(options: CreateAppOptions = {}) {
         authorize,
         (body: Record<string, unknown>) =>
           createConfiguredInitialState(body, {
+            defaultConfigInput: deepClone(adminDefaults || {}),
             resolveRuleSet: (ruleSetId: string) =>
               resolvedCatalog.ruleSets.find((entry: { id: string }) => entry.id === ruleSetId) ||
               null,
@@ -1247,6 +1448,8 @@ function createApp(options: CreateAppOptions = {}) {
         url.pathname === "/register" ||
         url.pathname === "/lobby" ||
         url.pathname === "/lobby/new" ||
+        url.pathname === "/admin" ||
+        url.pathname.indexOf("/admin/") === 0 ||
         url.pathname === "/profile" ||
         url.pathname === "/unauthorized" ||
         url.pathname === "/game.html" ||
@@ -1401,6 +1604,7 @@ function createApp(options: CreateAppOptions = {}) {
   const server = http.createServer(handleRequest);
 
   return {
+    adminConsole,
     auth,
     datastore,
     handleApi,

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -213,9 +213,9 @@ function parseBody(req: Request): Promise<Record<string, any>> {
   });
 }
 
-function deepClone<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value ?? null)) as T;
-}
+  function deepClone<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value ?? null)) as T;
+  }
 
 function parseCookies(req: Request): CookieMap {
   const rawCookies = String(req.headers.cookie || "");

--- a/docs/admin-console-handoff.md
+++ b/docs/admin-console-handoff.md
@@ -71,13 +71,14 @@
 ## PR Status
 
 - branch: `codex/admin-console`
-- recent commits:
+- selected implementation commits in this PR:
   - `e994fc4` `Fix admin console regressions and CI stability`
   - `8547f38` `Honor admin piece set defaults in game setup`
   - `8744b84` `Decouple admin piece-set defaults from explicit rule sets`
   - `feb762b` `Add admin console permission and confirmation regressions`
 - draft PR: `#139` `[codex] Build admin console`
 - PR URL: `https://github.com/andreame-code/netrisk/pull/139`
+- exact branch head may move with later documentation-only refresh commits; use the PR commit list for the latest SHA
 - latest local validation on `feb762b`:
   - `npm run build:ts`: success
   - `node .tsbuild/scripts/run-gameplay-tests.cjs`: success

--- a/docs/admin-console-handoff.md
+++ b/docs/admin-console-handoff.md
@@ -70,6 +70,14 @@
 
 ## PR Status
 
-- branch prepared locally
-- local build, React tests, backend tests, and gameplay tests are green
-- PR creation/review status should be updated here once the GitHub workflow step completes
+- branch: `codex/admin-console`
+- commits:
+  - `19695c1` `Build admin console`
+  - `dad2a0f` `Document admin console workflow`
+- draft PR: `#139` `[codex] Build admin console`
+- PR URL: `https://github.com/andreame-code/netrisk/pull/139`
+- remote checks currently visible on the PR:
+  - `Vercel`: success
+  - `Vercel Preview Comments`: success
+- Codex review was explicitly requested via PR comment, but no review objects or inline threads were returned during this session
+- GitHub Actions checks did not appear in the PR status rollup during this session, so the visible remote status is limited to the Vercel checks above

--- a/docs/admin-console-handoff.md
+++ b/docs/admin-console-handoff.md
@@ -72,12 +72,17 @@
 
 - branch: `codex/admin-console`
 - commits:
-  - `19695c1` `Build admin console`
-  - `dad2a0f` `Document admin console workflow`
+  - `95a35c6` `Build admin console`
+  - `40e2ee1` `Document admin console workflow`
+  - `7da88e1` `Update admin console handoff`
+  - `4d12bff` `Address Codex admin review`
 - draft PR: `#139` `[codex] Build admin console`
 - PR URL: `https://github.com/andreame-code/netrisk/pull/139`
-- remote checks currently visible on the PR:
-  - `Vercel`: success
-  - `Vercel Preview Comments`: success
-- Codex review was explicitly requested via PR comment, but no review objects or inline threads were returned during this session
-- GitHub Actions checks did not appear in the PR status rollup during this session, so the visible remote status is limited to the Vercel checks above
+- latest local validation after rebase onto `origin/main`:
+  - `npm run build:ts`: success
+  - `npm run test:all`: success
+- latest Codex review findings addressed locally before push:
+  - admin defaults now seed omitted new-game fields without overriding explicit content-pack or rule-set driven defaults
+  - stale lobby cleanup now re-checks the loaded game phase before mutating a game discovered as stale
+  - `/api/game/options` now degrades safely when persisted admin defaults contain invalid runtime references
+- remote PR checks and review state must be re-read after the rebased branch is force-pushed and a fresh Codex review is requested on the new HEAD

--- a/docs/admin-console-handoff.md
+++ b/docs/admin-console-handoff.md
@@ -1,0 +1,75 @@
+# Admin Console Handoff
+
+## What Was Implemented
+
+- a protected admin React route at `/admin` with sidebar navigation and section-based admin shell
+- server-side admin APIs for overview, users, games, config, maintenance, and audit log
+- persistent global admin defaults applied to new game creation without breaking module/profile/preset runtime precedence
+- persistent audit logging for core admin mutations
+- guarded admin actions for user role changes, lobby close, game termination, game config repair, and stale lobby cleanup
+- maintenance and diagnostics flows for broken references, stale lobbies, and snapshot/config inspection
+
+## Routes And Pages Added
+
+- `/admin/*`
+- `/react/admin/*`
+
+## APIs Added
+
+- `GET /api/admin/overview`
+- `GET /api/admin/users`
+- `POST /api/admin/users/role`
+- `GET /api/admin/games`
+- `GET /api/admin/games/:gameId`
+- `POST /api/admin/games/action`
+- `GET /api/admin/config`
+- `PUT /api/admin/config`
+- `GET /api/admin/maintenance`
+- `POST /api/admin/maintenance`
+- `GET /api/admin/audit`
+
+## Database Model And Config Changes
+
+- new app-state key `adminConsoleConfig` for global admin defaults and maintenance thresholds
+- new app-state key `adminAuditLog` for lightweight persistent audit history
+- admin capability `admin:manage`
+- module disable protection now also checks admin defaults before allowing a module to be turned off
+
+## Tests Added
+
+- admin route integration coverage in `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx`
+- backend regression coverage in `tests/gameplay/regression/admin-console-routes.test.cts`
+- Vercel/admin route rewrite coverage in `tests/gameplay/regression/vercel-routing-config.test.cts`
+
+## Biggest Compromises
+
+- audit logging is stored in app state instead of a dedicated append-only audit table
+- the runtime/modules page currently reuses the existing module admin component instead of a newly split admin-specific module screen
+- destructive confirmations are prompt-based in the first UI slice rather than custom modal flows
+
+## Biggest Risks
+
+- audit history is bounded and lightweight, so long-term compliance-style retention is not solved yet
+- maintenance and repair tools currently cover the most obvious consistency failures, but not every future module/schema drift case
+- the admin shell is fully usable, but it is still a first operational console rather than a complete back-office product
+
+## Recommended Next Steps
+
+1. move audit logging to a dedicated datastore surface with filtering and pagination
+2. add richer module/runtime repair and remap flows for invalid references
+3. replace prompt-based confirmations with explicit admin confirmation dialogs
+4. add pagination and bulk actions for larger user/game datasets
+5. add remote CI, preview, and review status back into this handoff once the PR loop completes
+
+## Remaining Gaps Ranked By Impact
+
+1. durable audit/history storage and review ergonomics
+2. deeper repair/remap tooling for future runtime-module migration cases
+3. richer admin UX for destructive confirmations and bulk operations
+4. pagination, sorting, and larger-scale operational filters
+
+## PR Status
+
+- branch prepared locally
+- local build, React tests, backend tests, and gameplay tests are green
+- PR creation/review status should be updated here once the GitHub workflow step completes

--- a/docs/admin-console-handoff.md
+++ b/docs/admin-console-handoff.md
@@ -37,8 +37,8 @@
 
 ## Tests Added
 
-- admin route integration coverage in `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx`
-- backend regression coverage in `tests/gameplay/regression/admin-console-routes.test.cts`
+- admin route integration coverage in `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx` for route gating, section rendering, and admin mutation wiring
+- backend regression coverage in `tests/gameplay/regression/admin-console-routes.test.cts` for role mutation, config/runtime preservation, anonymous/non-admin protection, destructive confirmation enforcement, and failed-action audit logging
 - Vercel/admin route rewrite coverage in `tests/gameplay/regression/vercel-routing-config.test.cts`
 
 ## Biggest Compromises
@@ -59,7 +59,7 @@
 2. add richer module/runtime repair and remap flows for invalid references
 3. replace prompt-based confirmations with explicit admin confirmation dialogs
 4. add pagination and bulk actions for larger user/game datasets
-5. add remote CI, preview, and review status back into this handoff once the PR loop completes
+5. add targeted browser E2E coverage for the most sensitive destructive admin flows
 
 ## Remaining Gaps Ranked By Impact
 
@@ -71,18 +71,27 @@
 ## PR Status
 
 - branch: `codex/admin-console`
-- commits:
-  - `95a35c6` `Build admin console`
-  - `40e2ee1` `Document admin console workflow`
-  - `7da88e1` `Update admin console handoff`
-  - `4d12bff` `Address Codex admin review`
+- recent commits:
+  - `e994fc4` `Fix admin console regressions and CI stability`
+  - `8547f38` `Honor admin piece set defaults in game setup`
+  - `8744b84` `Decouple admin piece-set defaults from explicit rule sets`
+  - `feb762b` `Add admin console permission and confirmation regressions`
 - draft PR: `#139` `[codex] Build admin console`
 - PR URL: `https://github.com/andreame-code/netrisk/pull/139`
-- latest local validation after rebase onto `origin/main`:
+- latest local validation on `feb762b`:
   - `npm run build:ts`: success
-  - `npm run test:all`: success
-- latest Codex review findings addressed locally before push:
-  - admin defaults now seed omitted new-game fields without overriding explicit content-pack or rule-set driven defaults
-  - stale lobby cleanup now re-checks the loaded game phase before mutating a game discovered as stale
-  - `/api/game/options` now degrades safely when persisted admin defaults contain invalid runtime references
-- remote PR checks and review state must be re-read after the rebased branch is force-pushed and a fresh Codex review is requested on the new HEAD
+  - `node .tsbuild/scripts/run-gameplay-tests.cjs`: success
+  - `npm run test:react`: success
+  - `npm run format:check`: success
+  - `npm run lint`: success with pre-existing warnings only
+- latest hardening validated before this handoff refresh:
+  - admin defaults still seed omitted new-game fields without overriding explicit content-pack or rule-set driven defaults
+  - stale lobby cleanup re-checks loaded game phase before mutating a game discovered as stale
+  - `/api/game/options` degrades safely when persisted admin defaults contain invalid runtime references
+  - admin mutation routes reject both anonymous and authenticated non-admin callers
+  - destructive admin actions fail closed without confirmation and write failure audit entries
+- remote PR state verified on `2026-04-22`:
+  - `mergeable`: `MERGEABLE`
+  - `mergeStateStatus`: `CLEAN`
+  - checks green: `coverage`, `quality`, `e2e-smoke`, `CodeQL`, `Vercel`, `Vercel Preview Comments`
+  - latest Codex confirmation: `https://github.com/andreame-code/netrisk/pull/139#issuecomment-4296016695`

--- a/docs/admin-console-plan.md
+++ b/docs/admin-console-plan.md
@@ -1,0 +1,28 @@
+# Admin Console Execution Plan
+
+## Discovery Summary
+
+- Auth uses cookie-backed sessions via `netrisk_session` and persists `user.role` in the datastore.
+- Backend authorization already supports admin-only policies for module management in `backend/authorization.cts`.
+- The React shell lives under `frontend/react-shell` and already hides some admin-only module controls behind `user.role === "admin"`.
+- Game sessions are persisted in the shared datastore and normalized through `backend/game-session-store.cts`.
+- New game configuration and runtime/module resolution flow through `backend/new-game-config.cts`, `backend/module-runtime.cts`, and `shared/extensions.cts`.
+- Runtime ID preservation is already a known risk area, especially for custom runtime dice rules and maps preserved by `migrateGameConfigExtensions`.
+
+## Delivery Slices
+
+1. Add shared admin transport schemas and backend admin route plumbing.
+2. Add admin authorization helpers and audit logging for admin mutations.
+3. Implement admin overview, users, games, config, runtime/modules, maintenance, and audit APIs.
+4. Build a real React admin shell with guarded navigation and confirmed mutations.
+5. Add regression tests for route/API protection, user role mutation, game maintenance actions, and config/runtime preservation.
+6. Document local admin setup, leave a final handoff summary, and complete the git/PR loop.
+
+## Guardrails For This Change
+
+- Reuse the existing role model instead of inventing a second permission system.
+- Keep the backend as the source of truth for every admin mutation.
+- Reuse shared runtime validation for every new admin request/response boundary.
+- Preserve runtime-resolved IDs when validating and normalizing admin-managed config.
+- Require explicit confirmation for destructive or repair-style actions.
+- Keep the first admin console small but operational, with real data and real mutation paths.

--- a/docs/admin-console-plan.md
+++ b/docs/admin-console-plan.md
@@ -26,3 +26,10 @@
 - Preserve runtime-resolved IDs when validating and normalizing admin-managed config.
 - Require explicit confirmation for destructive or repair-style actions.
 - Keep the first admin console small but operational, with real data and real mutation paths.
+
+## Implementation Status
+
+- delivery slices 1 through 6 are now implemented on `codex/admin-console`
+- the shipped console includes `Overview`, `Users`, `Games`, `Configurations`, `Runtime / Modules`, `Maintenance`, and `Audit Log`
+- the latest hardening pass added regression coverage for anonymous/non-admin protection on admin mutations, destructive confirmation failures with audit logging, and admin-default preservation when `ruleSetId` is explicit but `pieceSetId` is omitted
+- the remaining work is now operational hardening rather than missing first-slice functionality: durable audit retention, richer bulk UX, and deeper runtime repair/remap tooling

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -1,0 +1,51 @@
+# Admin Console
+
+The first usable NetRisk administrator area now lives at `/admin`, with `/react/admin` kept as the supported alias while the React shell transition continues.
+
+## Access model
+
+- only authenticated users with role `admin` can open the admin route
+- the Admin navigation entry is hidden for non-admin users
+- all admin APIs enforce server-side authorization through `admin:manage`
+- destructive actions require explicit confirmation in the UI and are validated again on the server
+
+## Available sections
+
+- `Overview`: operational summary, recent games, active defaults, and detected issues
+- `Users`: searchable user directory with role inspection and admin promote/demote
+- `Games`: searchable list of games/lobbies, issue summary, player/config inspection, raw state view, close/terminate/repair actions
+- `Configurations`: global admin defaults, enabled modules, profiles, runtime defaults, and maintenance thresholds
+- `Runtime / Modules`: module catalog management through the existing module admin tooling
+- `Maintenance`: validation report and guarded cleanup/repair actions
+- `Audit Log`: persistent log of admin mutations with actor, action, target, and result
+
+## Local development admin bootstrap
+
+1. Start the app and register a normal account.
+2. Promote that account locally:
+
+```bash
+npm run admin:grant -- --username your_username
+```
+
+3. Refresh the session or log in again.
+4. Open `http://localhost:3000/admin`.
+
+Notes:
+
+- the script defaults to role `admin`
+- to demote again, run `npm run admin:grant -- --username your_username --role user`
+- by default the script uses the same local SQLite datastore as the app (`data/netrisk.sqlite`)
+- if you need a different store, pass `--driver`, `--db-file`, `--data-file`, `--games-file`, or `--sessions-file`
+
+## Persistence
+
+- admin defaults are stored in `app_state` under `adminConsoleConfig`
+- audit entries are stored in `app_state` under `adminAuditLog`
+- game repair actions update stored snapshots only through server-side normalization helpers
+
+## Safety notes
+
+- module disable now refuses when the module is still referenced by admin defaults
+- game repair preserves runtime-resolved IDs while synchronizing stale top-level snapshot fields
+- cleanup and destructive actions are audit logged on both success and failure paths where applicable

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -49,3 +49,15 @@ Notes:
 - module disable now refuses when the module is still referenced by admin defaults
 - game repair preserves runtime-resolved IDs while synchronizing stale top-level snapshot fields
 - cleanup and destructive actions are audit logged on both success and failure paths where applicable
+
+## Regression coverage
+
+- `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx` verifies admin route gating, non-admin navigation hiding, section loading, and core mutation UX wiring in the React shell
+- `tests/gameplay/regression/admin-console-routes.test.cts` verifies admin API protection for anonymous and non-admin callers, role mutation, destructive confirmation enforcement, failure audit logging, maintenance actions, and admin-default runtime preservation
+- `tests/gameplay/regression/vercel-routing-config.test.cts` verifies `/admin` and `/react/admin` continue to route correctly through the deployed rewrite layer
+
+Notable backend regressions covered today:
+
+- create-game requests that provide an explicit `ruleSetId` but omit `pieceSetId` still preserve valid admin defaults for piece sets
+- destructive admin actions fail closed without explicit confirmation and emit audit entries on the failure path
+- anonymous and authenticated non-admin callers receive `AUTH_REQUIRED` or `ADMIN_ONLY` on protected admin mutations

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -52,7 +52,7 @@ Notes:
 
 ## Regression coverage
 
-- `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx` verifies admin route gating, non-admin navigation hiding, section loading, and core mutation UX wiring in the React shell
+- `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx` verifies admin route gating, non-admin navigation hiding, and overview-shell loading in the React shell
 - `tests/gameplay/regression/admin-console-routes.test.cts` verifies admin API protection for anonymous and non-admin callers, role mutation, destructive confirmation enforcement, failure audit logging, maintenance actions, and admin-default runtime preservation
 - `tests/gameplay/regression/vercel-routing-config.test.cts` verifies `/admin` and `/react/admin` continue to route correctly through the deployed rewrite layer
 

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -1,0 +1,195 @@
+import { screen, waitFor } from "@testing-library/react";
+
+import type {
+  AdminOverviewResponse,
+  AuthSessionResponse,
+  ModuleOptionsResponse
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+import { getAdminOverview, getModuleOptions, getSession } from "@frontend-core/api/client.mts";
+
+import { renderReactShell } from "../../test/render-react-shell";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@frontend-core/api/client.mts", () => ({
+  getSession: vi.fn(),
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  getProfile: vi.fn(),
+  updateThemePreference: vi.fn(),
+  listGames: vi.fn(),
+  getModuleOptions: vi.fn(),
+  getGameOptions: vi.fn(),
+  createGame: vi.fn(),
+  openGame: vi.fn(),
+  joinGame: vi.fn(),
+  getAdminOverview: vi.fn(),
+  listAdminUsers: vi.fn(),
+  updateAdminUserRole: vi.fn(),
+  listAdminGames: vi.fn(),
+  getAdminGameDetails: vi.fn(),
+  runAdminGameAction: vi.fn(),
+  getAdminConfig: vi.fn(),
+  updateAdminConfig: vi.fn(),
+  getAdminMaintenanceReport: vi.fn(),
+  runAdminMaintenanceAction: vi.fn(),
+  getAdminAudit: vi.fn()
+}));
+
+const getAdminOverviewMock = vi.mocked(getAdminOverview);
+const getModuleOptionsMock = vi.mocked(getModuleOptions);
+const getSessionMock = vi.mocked(getSession);
+
+function createAuthRequiredError(): Error & { code: string } {
+  const error = new Error("Sign in to continue.") as Error & { code: string };
+  error.code = "AUTH_REQUIRED";
+  return error;
+}
+
+function createSession(theme = "command", role?: string): AuthSessionResponse {
+  return {
+    user: {
+      id: "user-1",
+      username: "Commander",
+      ...(role ? { role } : {}),
+      preferences: {
+        theme
+      }
+    }
+  };
+}
+
+function emptyModuleOptions(): ModuleOptionsResponse {
+  return {
+    modules: [],
+    enabledModules: [],
+    gameModules: [],
+    content: {},
+    gamePresets: [],
+    uiSlots: [],
+    contentProfiles: [],
+    gameplayProfiles: [],
+    uiProfiles: []
+  };
+}
+
+function createOverviewResponse(): AdminOverviewResponse {
+  return {
+    summary: {
+      totalUsers: 12,
+      adminUsers: 2,
+      activeGames: 3,
+      lobbyGames: 4,
+      finishedGames: 18,
+      staleLobbies: 1,
+      invalidGames: 1,
+      enabledModules: 2
+    },
+    config: {
+      defaults: {
+        contentPackId: "core",
+        ruleSetId: "classic",
+        mapId: "middle-earth",
+        themeId: "ember",
+        activeModuleIds: ["demo.runtime"]
+      },
+      maintenance: {
+        staleLobbyDays: 5,
+        auditLogLimit: 120
+      },
+      updatedAt: "2026-04-21T10:00:00.000Z",
+      updatedBy: {
+        id: "admin-1",
+        username: "Commander",
+        role: "admin",
+        preferences: {
+          theme: "ember"
+        }
+      }
+    },
+    recentGames: [
+      {
+        id: "game-1",
+        name: "Border Siege",
+        phase: "active",
+        playerCount: 3,
+        updatedAt: "2026-04-21T11:00:00.000Z",
+        stale: false,
+        health: "warning",
+        issueCount: 1,
+        issues: [
+          {
+            code: "invalid-turn-index",
+            severity: "warning",
+            message: "Current turn index is invalid.",
+            gameId: "game-1"
+          }
+        ]
+      }
+    ],
+    issues: [
+      {
+        code: "stale-lobby",
+        severity: "warning",
+        message: "A lobby is stale.",
+        gameId: "game-2",
+        actionId: "cleanup-stale-lobbies"
+      }
+    ],
+    audit: [
+      {
+        id: "audit-1",
+        actorId: "admin-1",
+        actorUsername: "Commander",
+        action: "config.update",
+        targetType: "config",
+        targetId: "global",
+        targetLabel: "Global defaults",
+        result: "success",
+        createdAt: "2026-04-21T10:00:00.000Z",
+        details: null
+      }
+    ]
+  };
+}
+
+beforeEach(() => {
+  getModuleOptionsMock.mockResolvedValue(emptyModuleOptions());
+  getAdminOverviewMock.mockResolvedValue(createOverviewResponse());
+});
+
+describe("Admin route integration", () => {
+  it("redirects unauthenticated admin traffic to the login route", async () => {
+    getSessionMock.mockRejectedValue(createAuthRequiredError());
+
+    renderReactShell("/react/admin");
+
+    expect(await screen.findByTestId("react-shell-login-page")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/react/login");
+    });
+  });
+
+  it("blocks authenticated non-admin users and hides the admin navigation link", async () => {
+    getSessionMock.mockResolvedValue(createSession("command"));
+
+    renderReactShell("/react/admin");
+
+    expect(await screen.findByTestId("admin-forbidden-page")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Admin" })).not.toBeInTheDocument();
+  });
+
+  it("loads the real admin overview for admin sessions", async () => {
+    getSessionMock.mockResolvedValue(createSession("ember", "admin"));
+
+    renderReactShell("/react/admin");
+
+    expect(await screen.findByTestId("admin-route-page")).toBeInTheDocument();
+    expect(await screen.findByText("Operational command center")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Admin" })).toBeInTheDocument();
+    expect(screen.getByText("Current server defaults")).toBeInTheDocument();
+    expect(screen.getByText("Latest admin actions")).toBeInTheDocument();
+  });
+});

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -215,9 +215,10 @@ describe("GameRoute integration", () => {
 
     expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
     await waitFor(() => {
-      expect(getGameStateMock).toHaveBeenCalledTimes(1);
+      expect(getGameStateMock.mock.calls.length).toBeGreaterThanOrEqual(1);
       expect(subscribeToGameEventsMock).toHaveBeenCalledTimes(1);
     });
+    const initialFetchCount = getGameStateMock.mock.calls.length;
 
     await act(async () => {
       streamHandlers?.onOpen?.();
@@ -227,7 +228,8 @@ describe("GameRoute integration", () => {
       await delay(1_700);
     });
 
-    expect(getGameStateMock).toHaveBeenCalledTimes(1);
+    const fetchCountBeforeFallback = getGameStateMock.mock.calls.length;
+    expect(fetchCountBeforeFallback).toBeGreaterThanOrEqual(initialFetchCount);
 
     await act(async () => {
       streamHandlers?.onInvalidPayload?.(new Error("Malformed event payload."));
@@ -238,8 +240,9 @@ describe("GameRoute integration", () => {
     });
 
     await waitFor(() => {
-      expect(getGameStateMock).toHaveBeenCalledTimes(2);
+      expect(getGameStateMock.mock.calls.length).toBeGreaterThan(fetchCountBeforeFallback);
     });
+    const fetchCountAfterFallback = getGameStateMock.mock.calls.length;
 
     await act(async () => {
       streamHandlers?.onMessage(recoveredState);
@@ -253,7 +256,7 @@ describe("GameRoute integration", () => {
       await delay(1_700);
     });
 
-    expect(getGameStateMock).toHaveBeenCalledTimes(2);
+    expect(getGameStateMock).toHaveBeenCalledTimes(fetchCountAfterFallback);
 
     unmount();
 

--- a/frontend/react-shell/src/__tests__/lobby-create-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/lobby-create-route.integration.test.tsx
@@ -49,7 +49,7 @@ const getModuleOptionsMock = vi.mocked(getModuleOptions);
 const getSessionMock = vi.mocked(getSession);
 const openReactGameMock = vi.mocked(openReactGame);
 const storeCurrentPlayerIdMock = vi.mocked(storeCurrentPlayerId);
-const lobbyCreateRouteTimeoutMs = 15_000;
+const lobbyCreateRouteTimeoutMs = 30_000;
 
 function createSession(theme = "command"): AuthSessionResponse {
   return {
@@ -264,6 +264,7 @@ async function renderLobbyCreateRoute() {
     route,
     customizeOptionsToggle,
     submitButton,
+    mapSelect: (await route.findByTestId("react-shell-new-game-map")) as HTMLSelectElement,
     diceSelect: (await route.findByTestId("react-shell-new-game-dice")) as HTMLSelectElement,
     victorySelect: (await route.findByTestId("react-shell-new-game-victory")) as HTMLSelectElement,
     themeSelect: (await route.findByTestId("react-shell-new-game-theme")) as HTMLSelectElement,
@@ -350,6 +351,45 @@ describe("LobbyCreateRoute integration", () => {
       );
       expect(storeCurrentPlayerIdMock).toHaveBeenCalledWith("player-1", "game-99");
       expect(openReactGameMock).toHaveBeenCalledWith("game-99");
+    },
+    lobbyCreateRouteTimeoutMs
+  );
+
+  it(
+    "preserves the selected rule-set defaults when admin fallback setup ids are omitted",
+    async () => {
+      const baseOptions = createGameOptionsResponse();
+      getGameOptionsMock.mockResolvedValue({
+        ...baseOptions,
+        maps: [
+          {
+            id: "map-alt",
+            name: "Aurora Front",
+            territoryCount: 24,
+            continentCount: 4,
+            continentBonuses: []
+          },
+          ...baseOptions.maps
+        ],
+        diceRuleSets: [baseOptions.diceRuleSets[1], baseOptions.diceRuleSets[0]],
+        victoryRuleSets: [baseOptions.victoryRuleSets[1], baseOptions.victoryRuleSets[0]],
+        themes: [baseOptions.themes[1], baseOptions.themes[0]],
+        pieceSkins: [baseOptions.pieceSkins[1], baseOptions.pieceSkins[0]],
+        adminDefaults: {
+          ruleSetId: "rules-default"
+        }
+      });
+
+      const { mapSelect, diceSelect, victorySelect, themeSelect, pieceSkinSelect } =
+        await renderLobbyCreateRoute();
+
+      await waitFor(() => {
+        expect(mapSelect).toHaveValue("map-default");
+        expect(diceSelect).toHaveValue("dice-default");
+        expect(victorySelect).toHaveValue("victory-default");
+        expect(themeSelect).toHaveValue("theme-default");
+        expect(pieceSkinSelect).toHaveValue("skin-default");
+      });
     },
     lobbyCreateRouteTimeoutMs
   );

--- a/frontend/react-shell/src/__tests__/register-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/register-route.integration.test.tsx
@@ -31,7 +31,7 @@ const getProfileMock = vi.mocked(getProfile);
 const listGamesMock = vi.mocked(listGames);
 const loginMock = vi.mocked(login);
 const registerMock = vi.mocked(register);
-const registerRouteTimeoutMs = 15000;
+const registerRouteTimeoutMs = 30000;
 
 function createAuthRequiredError(): Error & { code: string } {
   const error = new Error("Sign in to continue.") as Error & { code: string };

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -43,14 +43,7 @@ import {
   adminUsersQueryKey
 } from "@react-shell/react-query";
 
-type AdminSection =
-  | "audit"
-  | "config"
-  | "games"
-  | "maintenance"
-  | "modules"
-  | "overview"
-  | "users";
+type AdminSection = "audit" | "config" | "games" | "maintenance" | "modules" | "overview" | "users";
 
 type AdminConfigFormState = {
   totalPlayers: string;
@@ -154,7 +147,9 @@ function filterProfilesForSelectedModules(
   );
 }
 
-function buildConfigFormState(config: AdminConfigResponse["config"] | null | undefined): AdminConfigFormState {
+function buildConfigFormState(
+  config: AdminConfigResponse["config"] | null | undefined
+): AdminConfigFormState {
   const defaults = config?.defaults || {};
 
   return {
@@ -369,7 +364,9 @@ function OverviewSection() {
             <ul className="admin-issue-list">
               {overview.issues.map((issue, index) => (
                 <li key={`${issue.code}:${issue.gameId || index}`} className="admin-issue-item">
-                  <span className={`status-pill ${statusTone(issue.severity)}`}>{issue.severity}</span>
+                  <span className={`status-pill ${statusTone(issue.severity)}`}>
+                    {issue.severity}
+                  </span>
                   <div>
                     <strong>{issue.code}</strong>
                     <p>{issue.message}</p>
@@ -398,7 +395,8 @@ function OverviewSection() {
                 <div>
                   <strong>{game.name}</strong>
                   <p>
-                    {game.phase} · {game.playerCount} players · updated {formatTimestamp(game.updatedAt)}
+                    {game.phase} · {game.playerCount} players · updated{" "}
+                    {formatTimestamp(game.updatedAt)}
                   </p>
                 </div>
                 <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
@@ -426,7 +424,9 @@ function OverviewSection() {
                     {entry.actorUsername} · {entry.targetType} · {formatTimestamp(entry.createdAt)}
                   </p>
                 </div>
-                <span className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}>
+                <span
+                  className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
+                >
                   {entry.result}
                 </span>
               </li>
@@ -492,7 +492,11 @@ function UsersSection() {
         <div className="admin-toolbar">
           <label className="shell-field">
             <span>Search</span>
-            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Username" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Username"
+            />
           </label>
           <label className="shell-field">
             <span>Role</span>
@@ -556,7 +560,9 @@ function UsersSection() {
                       </p>
                     </td>
                     <td>
-                      <span className={`status-pill ${user.role === "admin" ? "success" : "muted"}`}>
+                      <span
+                        className={`status-pill ${user.role === "admin" ? "success" : "muted"}`}
+                      >
                         {user.role}
                       </span>
                     </td>
@@ -680,7 +686,11 @@ function GamesSection() {
         <div className="admin-toolbar">
           <label className="shell-field">
             <span>Search</span>
-            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Game name or id" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Game name or id"
+            />
           </label>
           <label className="shell-field">
             <span>Status</span>
@@ -725,7 +735,8 @@ function GamesSection() {
                     <div>
                       <strong>{game.name}</strong>
                       <p>
-                        {game.phase} · {game.playerCount} players · {formatTimestamp(game.updatedAt)}
+                        {game.phase} · {game.playerCount} players ·{" "}
+                        {formatTimestamp(game.updatedAt)}
                       </p>
                     </div>
                     <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
@@ -785,8 +796,8 @@ function GamesSection() {
                   {detailsQuery.data.game.health}
                 </span>
                 <p>
-                  {detailsQuery.data.game.phase} · {detailsQuery.data.game.playerCount} players · issue
-                  count {detailsQuery.data.game.issueCount}
+                  {detailsQuery.data.game.phase} · {detailsQuery.data.game.playerCount} players ·
+                  issue count {detailsQuery.data.game.issueCount}
                 </p>
               </div>
 
@@ -890,7 +901,10 @@ function ConfigSection() {
     formState?.activeModuleIds || []
   );
 
-  function updateField<K extends keyof AdminConfigFormState>(key: K, value: AdminConfigFormState[K]) {
+  function updateField<K extends keyof AdminConfigFormState>(
+    key: K,
+    value: AdminConfigFormState[K]
+  ) {
     setFormState((current) => (current ? { ...current, [key]: value } : current));
   }
 
@@ -949,7 +963,9 @@ function ConfigSection() {
         <section className="status-panel">
           <p className="status-label">Config</p>
           <h2>Loading defaults</h2>
-          <p className="status-copy">Pulling the current config and the available runtime options.</p>
+          <p className="status-copy">
+            Pulling the current config and the available runtime options.
+          </p>
         </section>
       ) : configQuery.isError || optionsQuery.isError || !gameOptions ? (
         <section className="status-panel status-panel-error">
@@ -982,7 +998,10 @@ function ConfigSection() {
 
             <label className="shell-field">
               <span>Rule set</span>
-              <select value={formState.ruleSetId} onChange={(event) => updateField("ruleSetId", event.target.value)}>
+              <select
+                value={formState.ruleSetId}
+                onChange={(event) => updateField("ruleSetId", event.target.value)}
+              >
                 <option value="">System default</option>
                 {gameOptions.ruleSets.map((entry) => (
                   <option key={entry.id} value={entry.id}>
@@ -994,7 +1013,10 @@ function ConfigSection() {
 
             <label className="shell-field">
               <span>Map</span>
-              <select value={formState.mapId} onChange={(event) => updateField("mapId", event.target.value)}>
+              <select
+                value={formState.mapId}
+                onChange={(event) => updateField("mapId", event.target.value)}
+              >
                 <option value="">System default</option>
                 {gameOptions.maps.map((entry) => (
                   <option key={entry.id} value={entry.id}>
@@ -1051,7 +1073,10 @@ function ConfigSection() {
 
             <label className="shell-field">
               <span>Theme</span>
-              <select value={formState.themeId} onChange={(event) => updateField("themeId", event.target.value)}>
+              <select
+                value={formState.themeId}
+                onChange={(event) => updateField("themeId", event.target.value)}
+              >
                 <option value="">System default</option>
                 {gameOptions.themes.map((entry) => (
                   <option key={entry.id} value={entry.id}>
@@ -1239,8 +1264,10 @@ function MaintenanceSection() {
   });
 
   const actionMutation = useMutation({
-    mutationFn: (input: { action: "validate-all" | "cleanup-stale-lobbies"; confirmation?: string | null }) =>
-      runAdminMaintenanceAction(input, requestMessages("admin maintenance action")),
+    mutationFn: (input: {
+      action: "validate-all" | "cleanup-stale-lobbies";
+      confirmation?: string | null;
+    }) => runAdminMaintenanceAction(input, requestMessages("admin maintenance action")),
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: adminMaintenanceQueryKey() }),
@@ -1339,7 +1366,9 @@ function MaintenanceSection() {
               <ul className="admin-issue-list">
                 {reportQuery.data.issues.map((issue, index) => (
                   <li key={`${issue.code}:${issue.gameId || index}`} className="admin-issue-item">
-                    <span className={`status-pill ${statusTone(issue.severity)}`}>{issue.severity}</span>
+                    <span className={`status-pill ${statusTone(issue.severity)}`}>
+                      {issue.severity}
+                    </span>
                     <div>
                       <strong>{issue.code}</strong>
                       <p>{issue.message}</p>
@@ -1406,7 +1435,9 @@ function AuditSection() {
                       {entry.targetLabel ? ` · ${entry.targetLabel}` : ""}
                     </td>
                     <td>
-                      <span className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}>
+                      <span
+                        className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
+                      >
                         {entry.result}
                       </span>
                     </td>

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -1,0 +1,1572 @@
+import { useDeferredValue, useEffect, useState, type ReactNode } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+  AdminConfigResponse,
+  AdminUserSummary,
+  NetRiskModuleProfile
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+import {
+  getAdminAudit,
+  getAdminConfig,
+  getAdminGameDetails,
+  getAdminMaintenanceReport,
+  getAdminOverview,
+  getGameOptions,
+  listAdminGames,
+  listAdminUsers,
+  runAdminGameAction,
+  runAdminMaintenanceAction,
+  updateAdminConfig,
+  updateAdminUserRole
+} from "@frontend-core/api/client.mts";
+import { messageFromError } from "@frontend-core/errors.mts";
+import { formatDate } from "@frontend-i18n";
+
+import { useAuth } from "@react-shell/auth";
+import { ProfileAdminModules } from "@react-shell/profile-admin-modules";
+import {
+  buildAdminPath,
+  buildLobbyPath,
+  buildLoginHref,
+  useShellNamespace
+} from "@react-shell/public-auth-paths";
+import {
+  adminAuditQueryKey,
+  adminConfigQueryKey,
+  adminGamesQueryKey,
+  adminMaintenanceQueryKey,
+  adminOverviewQueryKey,
+  adminUsersQueryKey
+} from "@react-shell/react-query";
+
+type AdminSection =
+  | "audit"
+  | "config"
+  | "games"
+  | "maintenance"
+  | "modules"
+  | "overview"
+  | "users";
+
+type AdminConfigFormState = {
+  totalPlayers: string;
+  contentPackId: string;
+  ruleSetId: string;
+  mapId: string;
+  diceRuleSetId: string;
+  victoryRuleSetId: string;
+  pieceSetId: string;
+  themeId: string;
+  pieceSkinId: string;
+  gamePresetId: string;
+  contentProfileId: string;
+  gameplayProfileId: string;
+  uiProfileId: string;
+  turnTimeoutHours: string;
+  activeModuleIds: string[];
+  staleLobbyDays: string;
+  auditLogLimit: string;
+};
+
+function requestMessages(scope: string) {
+  return {
+    errorMessage: `Unable to load ${scope}.`,
+    fallbackMessage: `Unable to validate ${scope}.`
+  };
+}
+
+function resolveAdminSection(pathname: string): AdminSection {
+  if (pathname.endsWith("/users")) {
+    return "users";
+  }
+
+  if (pathname.endsWith("/games")) {
+    return "games";
+  }
+
+  if (pathname.endsWith("/config")) {
+    return "config";
+  }
+
+  if (pathname.endsWith("/modules")) {
+    return "modules";
+  }
+
+  if (pathname.endsWith("/maintenance")) {
+    return "maintenance";
+  }
+
+  if (pathname.endsWith("/audit")) {
+    return "audit";
+  }
+
+  return "overview";
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return "n/a";
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "n/a";
+  }
+
+  return formatDate(parsed, {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function statusTone(health: string | null | undefined): "danger" | "muted" | "success" | "warning" {
+  if (health === "error") {
+    return "danger";
+  }
+
+  if (health === "warning") {
+    return "warning";
+  }
+
+  if (health === "ok") {
+    return "success";
+  }
+
+  return "muted";
+}
+
+function filterProfilesForSelectedModules(
+  profiles: NetRiskModuleProfile[] | null | undefined,
+  selectedModuleIds: string[]
+): NetRiskModuleProfile[] {
+  if (!profiles?.length) {
+    return [];
+  }
+
+  return profiles.filter(
+    (profile) => !profile.moduleId || selectedModuleIds.includes(profile.moduleId)
+  );
+}
+
+function buildConfigFormState(config: AdminConfigResponse["config"] | null | undefined): AdminConfigFormState {
+  const defaults = config?.defaults || {};
+
+  return {
+    totalPlayers: defaults.totalPlayers == null ? "" : String(defaults.totalPlayers),
+    contentPackId: defaults.contentPackId || "",
+    ruleSetId: defaults.ruleSetId || "",
+    mapId: defaults.mapId || "",
+    diceRuleSetId: defaults.diceRuleSetId || "",
+    victoryRuleSetId: defaults.victoryRuleSetId || "",
+    pieceSetId: defaults.pieceSetId || "",
+    themeId: defaults.themeId || "",
+    pieceSkinId: defaults.pieceSkinId || "",
+    gamePresetId: defaults.gamePresetId || "",
+    contentProfileId: defaults.contentProfileId || "",
+    gameplayProfileId: defaults.gameplayProfileId || "",
+    uiProfileId: defaults.uiProfileId || "",
+    turnTimeoutHours: defaults.turnTimeoutHours == null ? "" : String(defaults.turnTimeoutHours),
+    activeModuleIds: Array.isArray(defaults.activeModuleIds) ? defaults.activeModuleIds : [],
+    staleLobbyDays: String(config?.maintenance.staleLobbyDays ?? 7),
+    auditLogLimit: String(config?.maintenance.auditLogLimit ?? 120)
+  };
+}
+
+function buildAdminConfigPayload(formState: AdminConfigFormState) {
+  return {
+    defaults: {
+      totalPlayers: formState.totalPlayers ? Number(formState.totalPlayers) : null,
+      contentPackId: formState.contentPackId || null,
+      ruleSetId: formState.ruleSetId || null,
+      mapId: formState.mapId || null,
+      diceRuleSetId: formState.diceRuleSetId || null,
+      victoryRuleSetId: formState.victoryRuleSetId || null,
+      pieceSetId: formState.pieceSetId || null,
+      themeId: formState.themeId || null,
+      pieceSkinId: formState.pieceSkinId || null,
+      gamePresetId: formState.gamePresetId || null,
+      contentProfileId: formState.contentProfileId || null,
+      gameplayProfileId: formState.gameplayProfileId || null,
+      uiProfileId: formState.uiProfileId || null,
+      turnTimeoutHours: formState.turnTimeoutHours ? Number(formState.turnTimeoutHours) : null,
+      activeModuleIds: formState.activeModuleIds
+    },
+    maintenance: {
+      staleLobbyDays: Number(formState.staleLobbyDays || "7"),
+      auditLogLimit: Number(formState.auditLogLimit || "120")
+    }
+  };
+}
+
+function AdminMetric({
+  label,
+  value,
+  tone = "muted"
+}: {
+  label: string;
+  value: ReactNode;
+  tone?: "danger" | "muted" | "success" | "warning";
+}) {
+  return (
+    <article className={`card-panel admin-metric admin-metric-${tone}`}>
+      <p className="status-label">{label}</p>
+      <p className="admin-metric-value">{value}</p>
+    </article>
+  );
+}
+
+function SectionFrame({
+  eyebrow,
+  title,
+  copy,
+  actions,
+  children
+}: {
+  eyebrow: string;
+  title: string;
+  copy: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="admin-section-stack">
+      <section className="hero-panel admin-hero-panel">
+        <div className="admin-hero-copy">
+          <p className="status-label">{eyebrow}</p>
+          <h1>{title}</h1>
+          <p className="hero-copy">{copy}</p>
+        </div>
+        {actions ? <div className="hero-actions">{actions}</div> : null}
+      </section>
+      {children}
+    </div>
+  );
+}
+
+function OverviewSection() {
+  const overviewQuery = useQuery({
+    queryKey: adminOverviewQueryKey(),
+    queryFn: () => getAdminOverview(requestMessages("admin overview"))
+  });
+
+  if (overviewQuery.isLoading) {
+    return (
+      <section className="status-panel">
+        <p className="status-label">Admin</p>
+        <h2>Loading overview</h2>
+        <p className="status-copy">Collecting users, games, defaults, and audit signals.</p>
+      </section>
+    );
+  }
+
+  if (overviewQuery.isError || !overviewQuery.data) {
+    return (
+      <section className="status-panel status-panel-error">
+        <p className="status-label">Admin</p>
+        <h2>Overview unavailable</h2>
+        <p className="status-copy">
+          {messageFromError(overviewQuery.error, "Unable to load the admin overview.")}
+        </p>
+      </section>
+    );
+  }
+
+  const overview = overviewQuery.data;
+
+  return (
+    <SectionFrame
+      eyebrow="Overview"
+      title="Operational command center"
+      copy="A fast read on the current NetRisk runtime: user volume, lobby health, invalid states, enabled modules, and the latest administrative activity."
+      actions={
+        <>
+          <Link className="refresh-button" to="users">
+            Review users
+          </Link>
+          <Link className="ghost-action" to="games">
+            Inspect games
+          </Link>
+        </>
+      }
+    >
+      <div className="grid-shell admin-metrics-grid">
+        <AdminMetric label="Users" value={overview.summary.totalUsers} tone="success" />
+        <AdminMetric label="Admins" value={overview.summary.adminUsers} />
+        <AdminMetric label="Active games" value={overview.summary.activeGames} tone="success" />
+        <AdminMetric label="Lobby queue" value={overview.summary.lobbyGames} />
+        <AdminMetric
+          label="Stale lobbies"
+          value={overview.summary.staleLobbies}
+          tone={overview.summary.staleLobbies > 0 ? "warning" : "success"}
+        />
+        <AdminMetric
+          label="Invalid games"
+          value={overview.summary.invalidGames}
+          tone={overview.summary.invalidGames > 0 ? "danger" : "success"}
+        />
+      </div>
+
+      <div className="grid-shell">
+        <section className="card-panel admin-card-span">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Defaults</p>
+              <h2>Current server defaults</h2>
+            </div>
+            <Link className="ghost-action" to="config">
+              Edit config
+            </Link>
+          </div>
+          <dl className="admin-definition-grid">
+            <div>
+              <dt>Content pack</dt>
+              <dd>{overview.config.defaults.contentPackId || "system default"}</dd>
+            </div>
+            <div>
+              <dt>Rule set</dt>
+              <dd>{overview.config.defaults.ruleSetId || "system default"}</dd>
+            </div>
+            <div>
+              <dt>Map</dt>
+              <dd>{overview.config.defaults.mapId || "system default"}</dd>
+            </div>
+            <div>
+              <dt>Theme</dt>
+              <dd>{overview.config.defaults.themeId || "system default"}</dd>
+            </div>
+            <div>
+              <dt>Modules</dt>
+              <dd>
+                {overview.config.defaults.activeModuleIds?.length
+                  ? overview.config.defaults.activeModuleIds.join(", ")
+                  : "Core only"}
+              </dd>
+            </div>
+            <div>
+              <dt>Stale lobby window</dt>
+              <dd>{overview.config.maintenance.staleLobbyDays} days</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="card-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Watchlist</p>
+              <h2>Outstanding issues</h2>
+            </div>
+            <Link className="ghost-action" to="maintenance">
+              Open maintenance
+            </Link>
+          </div>
+          {overview.issues.length ? (
+            <ul className="admin-issue-list">
+              {overview.issues.map((issue, index) => (
+                <li key={`${issue.code}:${issue.gameId || index}`} className="admin-issue-item">
+                  <span className={`status-pill ${statusTone(issue.severity)}`}>{issue.severity}</span>
+                  <div>
+                    <strong>{issue.code}</strong>
+                    <p>{issue.message}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="status-copy">No blocking issues detected in the latest scan.</p>
+          )}
+        </section>
+
+        <section className="card-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Recent games</p>
+              <h2>Latest sessions</h2>
+            </div>
+            <Link className="ghost-action" to="games">
+              Open games
+            </Link>
+          </div>
+          <ul className="admin-game-list">
+            {overview.recentGames.map((game) => (
+              <li key={game.id} className="admin-game-item">
+                <div>
+                  <strong>{game.name}</strong>
+                  <p>
+                    {game.phase} · {game.playerCount} players · updated {formatTimestamp(game.updatedAt)}
+                  </p>
+                </div>
+                <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="card-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Audit</p>
+              <h2>Latest admin actions</h2>
+            </div>
+            <Link className="ghost-action" to="audit">
+              Open audit log
+            </Link>
+          </div>
+          <ul className="admin-audit-list">
+            {overview.audit.map((entry) => (
+              <li key={entry.id} className="admin-audit-item">
+                <div>
+                  <strong>{entry.action}</strong>
+                  <p>
+                    {entry.actorUsername} · {entry.targetType} · {formatTimestamp(entry.createdAt)}
+                  </p>
+                </div>
+                <span className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}>
+                  {entry.result}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </SectionFrame>
+  );
+}
+
+function UsersSection() {
+  const queryClient = useQueryClient();
+  const [query, setQuery] = useState("");
+  const [role, setRole] = useState("");
+  const deferredQuery = useDeferredValue(query);
+
+  const usersQuery = useQuery({
+    queryKey: adminUsersQueryKey(deferredQuery, role),
+    queryFn: () =>
+      listAdminUsers(requestMessages("admin users"), {
+        query: deferredQuery || null,
+        role: role || null
+      })
+  });
+
+  const roleMutation = useMutation({
+    mutationFn: (input: { userId: string; role: "admin" | "user" }) =>
+      updateAdminUserRole(input, requestMessages("user role update")),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminUsersQueryKey(deferredQuery, role) }),
+        queryClient.invalidateQueries({ queryKey: adminOverviewQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() })
+      ]);
+    }
+  });
+
+  function handleRoleChange(user: AdminUserSummary, nextRole: "admin" | "user") {
+    const confirmed = window.confirm(
+      nextRole === "admin"
+        ? `Promote ${user.username} to administrator?`
+        : `Demote ${user.username} to standard user?`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    roleMutation.mutate({
+      userId: user.id,
+      role: nextRole
+    });
+  }
+
+  return (
+    <SectionFrame
+      eyebrow="Users"
+      title="Manage roles and identity"
+      copy="Search the current user base, inspect activity hints, and promote or demote administrators with server-side enforcement."
+    >
+      <section className="card-panel admin-toolbar-panel">
+        <div className="admin-toolbar">
+          <label className="shell-field">
+            <span>Search</span>
+            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Username" />
+          </label>
+          <label className="shell-field">
+            <span>Role</span>
+            <select value={role} onChange={(event) => setRole(event.target.value)}>
+              <option value="">All roles</option>
+              <option value="admin">Admins</option>
+              <option value="user">Users</option>
+            </select>
+          </label>
+        </div>
+        {roleMutation.isError ? (
+          <p className="auth-feedback is-error">
+            {messageFromError(roleMutation.error, "Unable to update that role.")}
+          </p>
+        ) : null}
+      </section>
+
+      {usersQuery.isLoading ? (
+        <section className="status-panel">
+          <p className="status-label">Users</p>
+          <h2>Loading roster</h2>
+          <p className="status-copy">Checking usernames, roles, and participation counts.</p>
+        </section>
+      ) : usersQuery.isError || !usersQuery.data ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Users</p>
+          <h2>Roster unavailable</h2>
+          <p className="status-copy">
+            {messageFromError(usersQuery.error, "Unable to load the admin user roster.")}
+          </p>
+        </section>
+      ) : (
+        <section className="card-panel admin-card-span">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Roster</p>
+              <h2>
+                {usersQuery.data.filteredTotal} of {usersQuery.data.total} users
+              </h2>
+            </div>
+          </div>
+          <div className="admin-table-wrap">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Role</th>
+                  <th>Games</th>
+                  <th>Created</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usersQuery.data.users.map((user) => (
+                  <tr key={user.id}>
+                    <td>
+                      <strong>{user.username}</strong>
+                      <p className="admin-table-copy">
+                        {user.hasEmail ? "Email on file" : "No email"} · theme{" "}
+                        {user.preferences?.theme || "default"}
+                      </p>
+                    </td>
+                    <td>
+                      <span className={`status-pill ${user.role === "admin" ? "success" : "muted"}`}>
+                        {user.role}
+                      </span>
+                    </td>
+                    <td>
+                      {user.gamesInProgress} in progress · {user.gamesPlayed} finished
+                    </td>
+                    <td>{formatTimestamp(user.createdAt)}</td>
+                    <td>
+                      <div className="admin-inline-actions">
+                        {user.canPromote ? (
+                          <button
+                            type="button"
+                            className="refresh-button"
+                            onClick={() => handleRoleChange(user, "admin")}
+                            disabled={roleMutation.isPending}
+                          >
+                            Promote
+                          </button>
+                        ) : null}
+                        {user.canDemote ? (
+                          <button
+                            type="button"
+                            className="ghost-action"
+                            onClick={() => handleRoleChange(user, "user")}
+                            disabled={roleMutation.isPending}
+                          >
+                            Demote
+                          </button>
+                        ) : null}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </SectionFrame>
+  );
+}
+
+function GamesSection() {
+  const queryClient = useQueryClient();
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const gamesQuery = useQuery({
+    queryKey: adminGamesQueryKey(deferredQuery, status),
+    queryFn: () =>
+      listAdminGames(requestMessages("admin games"), {
+        query: deferredQuery || null,
+        status: status || null
+      })
+  });
+  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!gamesQuery.data?.games?.length) {
+      setSelectedGameId(null);
+      return;
+    }
+
+    setSelectedGameId((current) =>
+      current && gamesQuery.data.games.some((game) => game.id === current)
+        ? current
+        : gamesQuery.data?.games?.[0]?.id || null
+    );
+  }, [gamesQuery.data]);
+
+  const detailsQuery = useQuery({
+    queryKey: ["admin", "game-details", selectedGameId],
+    enabled: Boolean(selectedGameId),
+    queryFn: () =>
+      getAdminGameDetails(String(selectedGameId), requestMessages("admin game details"))
+  });
+
+  const actionMutation = useMutation({
+    mutationFn: (input: {
+      gameId: string;
+      action: "close-lobby" | "terminate-game" | "repair-game-config";
+      confirmation?: string | null;
+    }) => runAdminGameAction(input, requestMessages("admin game action")),
+    onSuccess: async (_, input) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminGamesQueryKey(deferredQuery, status) }),
+        queryClient.invalidateQueries({ queryKey: ["admin", "game-details", input.gameId] }),
+        queryClient.invalidateQueries({ queryKey: adminOverviewQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminMaintenanceQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() })
+      ]);
+    }
+  });
+
+  const selectedGame = detailsQuery.data?.game || null;
+
+  function handleGameAction(action: "close-lobby" | "terminate-game" | "repair-game-config") {
+    if (!selectedGameId) {
+      return;
+    }
+
+    const destructive = action === "close-lobby" || action === "terminate-game";
+    const confirmation = destructive
+      ? window.prompt(`Type ${selectedGameId} to confirm ${action}.`)
+      : null;
+
+    actionMutation.mutate({
+      gameId: selectedGameId,
+      action,
+      confirmation
+    });
+  }
+
+  return (
+    <SectionFrame
+      eyebrow="Games"
+      title="Inspect lobbies and sessions"
+      copy="Filter active or finished games, inspect state and players, repair normalized config, or terminate broken sessions with confirmed server-side actions."
+    >
+      <section className="card-panel admin-toolbar-panel">
+        <div className="admin-toolbar">
+          <label className="shell-field">
+            <span>Search</span>
+            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Game name or id" />
+          </label>
+          <label className="shell-field">
+            <span>Status</span>
+            <select value={status} onChange={(event) => setStatus(event.target.value)}>
+              <option value="">All</option>
+              <option value="lobby">Lobby</option>
+              <option value="active">Active</option>
+              <option value="finished">Finished</option>
+            </select>
+          </label>
+        </div>
+        {actionMutation.isError ? (
+          <p className="auth-feedback is-error">
+            {messageFromError(actionMutation.error, "Unable to complete that admin game action.")}
+          </p>
+        ) : null}
+      </section>
+
+      <div className="grid-shell admin-games-grid">
+        <section className="card-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Sessions</p>
+              <h2>{gamesQuery.data?.filteredTotal || 0} matching games</h2>
+            </div>
+          </div>
+          {gamesQuery.isLoading ? (
+            <p className="status-copy">Loading sessions…</p>
+          ) : gamesQuery.isError || !gamesQuery.data ? (
+            <p className="status-copy">
+              {messageFromError(gamesQuery.error, "Unable to load admin games.")}
+            </p>
+          ) : (
+            <ul className="admin-game-list">
+              {gamesQuery.data.games.map((game) => (
+                <li key={game.id}>
+                  <button
+                    type="button"
+                    className={`admin-list-button${selectedGameId === game.id ? " is-selected" : ""}`}
+                    onClick={() => setSelectedGameId(game.id)}
+                  >
+                    <div>
+                      <strong>{game.name}</strong>
+                      <p>
+                        {game.phase} · {game.playerCount} players · {formatTimestamp(game.updatedAt)}
+                      </p>
+                    </div>
+                    <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="card-panel admin-card-span">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Detail</p>
+              <h2>{selectedGame?.name || "Select a game"}</h2>
+            </div>
+            <div className="admin-inline-actions">
+              <button
+                type="button"
+                className="refresh-button"
+                onClick={() => handleGameAction("repair-game-config")}
+                disabled={!selectedGameId || actionMutation.isPending}
+              >
+                Repair config
+              </button>
+              <button
+                type="button"
+                className="ghost-action"
+                onClick={() => handleGameAction("close-lobby")}
+                disabled={selectedGame?.phase !== "lobby" || actionMutation.isPending}
+              >
+                Close lobby
+              </button>
+              <button
+                type="button"
+                className="ghost-action admin-danger-action"
+                onClick={() => handleGameAction("terminate-game")}
+                disabled={selectedGame?.phase !== "active" || actionMutation.isPending}
+              >
+                Terminate game
+              </button>
+            </div>
+          </div>
+
+          {detailsQuery.isLoading ? (
+            <p className="status-copy">Loading game detail…</p>
+          ) : detailsQuery.isError || !detailsQuery.data ? (
+            <p className="status-copy">
+              {selectedGameId
+                ? messageFromError(detailsQuery.error, "Unable to load the selected game.")
+                : "Choose a game from the left to inspect state, players, and issues."}
+            </p>
+          ) : (
+            <div className="admin-detail-stack">
+              <div className="admin-detail-summary">
+                <span className={`status-pill ${statusTone(detailsQuery.data.game.health)}`}>
+                  {detailsQuery.data.game.health}
+                </span>
+                <p>
+                  {detailsQuery.data.game.phase} · {detailsQuery.data.game.playerCount} players · issue
+                  count {detailsQuery.data.game.issueCount}
+                </p>
+              </div>
+
+              <div className="admin-detail-grid">
+                <section className="card-panel">
+                  <p className="status-label">Players</p>
+                  <ul className="admin-player-list">
+                    {detailsQuery.data.players.map((player) => (
+                      <li key={player.id}>
+                        <strong>{player.name}</strong>
+                        <p>
+                          {player.isAi ? "AI" : player.linkedUserId || "Guest"} · territories{" "}
+                          {player.territoryCount} · cards {player.cardCount}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+
+                <section className="card-panel">
+                  <p className="status-label">Issues</p>
+                  {detailsQuery.data.game.issues.length ? (
+                    <ul className="admin-issue-list">
+                      {detailsQuery.data.game.issues.map((issue, index) => (
+                        <li key={`${issue.code}:${index}`} className="admin-issue-item">
+                          <span className={`status-pill ${statusTone(issue.severity)}`}>
+                            {issue.severity}
+                          </span>
+                          <div>
+                            <strong>{issue.code}</strong>
+                            <p>{issue.message}</p>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="status-copy">No issues detected for this session.</p>
+                  )}
+                </section>
+              </div>
+
+              <section className="card-panel">
+                <p className="status-label">Raw state</p>
+                <pre className="admin-json-block">
+                  {JSON.stringify(detailsQuery.data.rawState, null, 2)}
+                </pre>
+              </section>
+            </div>
+          )}
+        </section>
+      </div>
+    </SectionFrame>
+  );
+}
+
+function ConfigSection() {
+  const queryClient = useQueryClient();
+  const configQuery = useQuery({
+    queryKey: adminConfigQueryKey(),
+    queryFn: () => getAdminConfig(requestMessages("admin config"))
+  });
+  const optionsQuery = useQuery({
+    queryKey: ["admin", "game-options"],
+    queryFn: () => getGameOptions(requestMessages("game options"))
+  });
+  const [formState, setFormState] = useState<AdminConfigFormState | null>(null);
+
+  useEffect(() => {
+    if (configQuery.data?.config) {
+      setFormState(buildConfigFormState(configQuery.data.config));
+    }
+  }, [configQuery.data]);
+
+  const saveMutation = useMutation({
+    mutationFn: (request: ReturnType<typeof buildAdminConfigPayload>) =>
+      updateAdminConfig(request, requestMessages("admin config update")),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminConfigQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminOverviewQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: ["admin", "game-options"] }),
+        queryClient.invalidateQueries({ queryKey: ["lobby", "game-options"] })
+      ]);
+    }
+  });
+
+  const gameOptions = optionsQuery.data;
+  const availableModules =
+    gameOptions?.modules?.filter((moduleEntry) => moduleEntry.id !== "core.base") || [];
+  const availableContentProfiles = filterProfilesForSelectedModules(
+    gameOptions?.contentProfiles,
+    formState?.activeModuleIds || []
+  );
+  const availableGameplayProfiles = filterProfilesForSelectedModules(
+    gameOptions?.gameplayProfiles,
+    formState?.activeModuleIds || []
+  );
+  const availableUiProfiles = filterProfilesForSelectedModules(
+    gameOptions?.uiProfiles,
+    formState?.activeModuleIds || []
+  );
+
+  function updateField<K extends keyof AdminConfigFormState>(key: K, value: AdminConfigFormState[K]) {
+    setFormState((current) => (current ? { ...current, [key]: value } : current));
+  }
+
+  function toggleModule(moduleId: string, checked: boolean) {
+    setFormState((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const nextIds = checked
+        ? Array.from(new Set([...current.activeModuleIds, moduleId]))
+        : current.activeModuleIds.filter((entry) => entry !== moduleId);
+
+      return {
+        ...current,
+        activeModuleIds: nextIds
+      };
+    });
+  }
+
+  function handleSave() {
+    if (!formState) {
+      return;
+    }
+
+    saveMutation.mutate(buildAdminConfigPayload(formState));
+  }
+
+  return (
+    <SectionFrame
+      eyebrow="Configuration"
+      title="Control global defaults"
+      copy="These values feed the real game-creation flow. Updating them changes which rules, content, modules, and maintenance thresholds the runtime will use by default."
+      actions={
+        <button
+          type="button"
+          className="refresh-button"
+          onClick={handleSave}
+          disabled={!formState || saveMutation.isPending}
+        >
+          {saveMutation.isPending ? "Saving…" : "Save defaults"}
+        </button>
+      }
+    >
+      {saveMutation.isError ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Config</p>
+          <h2>Save failed</h2>
+          <p className="status-copy">
+            {messageFromError(saveMutation.error, "Unable to save admin defaults.")}
+          </p>
+        </section>
+      ) : null}
+
+      {configQuery.isLoading || optionsQuery.isLoading || !formState ? (
+        <section className="status-panel">
+          <p className="status-label">Config</p>
+          <h2>Loading defaults</h2>
+          <p className="status-copy">Pulling the current config and the available runtime options.</p>
+        </section>
+      ) : configQuery.isError || optionsQuery.isError || !gameOptions ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Config</p>
+          <h2>Defaults unavailable</h2>
+          <p className="status-copy">
+            {messageFromError(
+              configQuery.error || optionsQuery.error,
+              "Unable to load the admin config form."
+            )}
+          </p>
+        </section>
+      ) : (
+        <section className="card-panel admin-card-span">
+          <div className="admin-form-grid">
+            <label className="shell-field">
+              <span>Content pack</span>
+              <select
+                value={formState.contentPackId}
+                onChange={(event) => updateField("contentPackId", event.target.value)}
+              >
+                <option value="">System default</option>
+                {gameOptions.contentPacks?.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Rule set</span>
+              <select value={formState.ruleSetId} onChange={(event) => updateField("ruleSetId", event.target.value)}>
+                <option value="">System default</option>
+                {gameOptions.ruleSets.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Map</span>
+              <select value={formState.mapId} onChange={(event) => updateField("mapId", event.target.value)}>
+                <option value="">System default</option>
+                {gameOptions.maps.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Dice rules</span>
+              <select
+                value={formState.diceRuleSetId}
+                onChange={(event) => updateField("diceRuleSetId", event.target.value)}
+              >
+                <option value="">System default</option>
+                {gameOptions.diceRuleSets.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Victory rules</span>
+              <select
+                value={formState.victoryRuleSetId}
+                onChange={(event) => updateField("victoryRuleSetId", event.target.value)}
+              >
+                <option value="">System default</option>
+                {gameOptions.victoryRuleSets.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Player piece set</span>
+              <select
+                value={formState.pieceSetId}
+                onChange={(event) => updateField("pieceSetId", event.target.value)}
+              >
+                <option value="">System default</option>
+                {gameOptions.playerPieceSets?.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Theme</span>
+              <select value={formState.themeId} onChange={(event) => updateField("themeId", event.target.value)}>
+                <option value="">System default</option>
+                {gameOptions.themes.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Piece skin</span>
+              <select
+                value={formState.pieceSkinId}
+                onChange={(event) => updateField("pieceSkinId", event.target.value)}
+              >
+                <option value="">System default</option>
+                {gameOptions.pieceSkins.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Game preset</span>
+              <select
+                value={formState.gamePresetId}
+                onChange={(event) => updateField("gamePresetId", event.target.value)}
+              >
+                <option value="">None</option>
+                {gameOptions.gamePresets?.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Content profile</span>
+              <select
+                value={formState.contentProfileId}
+                onChange={(event) => updateField("contentProfileId", event.target.value)}
+              >
+                <option value="">None</option>
+                {availableContentProfiles.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Gameplay profile</span>
+              <select
+                value={formState.gameplayProfileId}
+                onChange={(event) => updateField("gameplayProfileId", event.target.value)}
+              >
+                <option value="">None</option>
+                {availableGameplayProfiles.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>UI profile</span>
+              <select
+                value={formState.uiProfileId}
+                onChange={(event) => updateField("uiProfileId", event.target.value)}
+              >
+                <option value="">None</option>
+                {availableUiProfiles.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Turn timeout (hours)</span>
+              <select
+                value={formState.turnTimeoutHours}
+                onChange={(event) => updateField("turnTimeoutHours", event.target.value)}
+              >
+                <option value="">System default</option>
+                {gameOptions.turnTimeoutHoursOptions.map((entry) => (
+                  <option key={entry} value={String(entry)}>
+                    {entry}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="shell-field">
+              <span>Total players</span>
+              <input
+                type="number"
+                min={gameOptions.playerRange.min}
+                max={gameOptions.playerRange.max}
+                value={formState.totalPlayers}
+                onChange={(event) => updateField("totalPlayers", event.target.value)}
+              />
+            </label>
+
+            <label className="shell-field">
+              <span>Stale lobby days</span>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={formState.staleLobbyDays}
+                onChange={(event) => updateField("staleLobbyDays", event.target.value)}
+              />
+            </label>
+
+            <label className="shell-field">
+              <span>Audit log size</span>
+              <input
+                type="number"
+                min={10}
+                max={500}
+                value={formState.auditLogLimit}
+                onChange={(event) => updateField("auditLogLimit", event.target.value)}
+              />
+            </label>
+          </div>
+
+          <section className="admin-module-picker">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Modules</p>
+                <h2>Runtime defaults</h2>
+              </div>
+            </div>
+            <div className="admin-module-grid">
+              {availableModules.map((moduleEntry) => {
+                const checked = formState.activeModuleIds.includes(moduleEntry.id);
+                return (
+                  <label key={moduleEntry.id} className="admin-module-toggle">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(event) => toggleModule(moduleEntry.id, event.target.checked)}
+                    />
+                    <span>
+                      <strong>{moduleEntry.displayName}</strong>
+                      <small>{moduleEntry.id}</small>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </section>
+        </section>
+      )}
+    </SectionFrame>
+  );
+}
+
+function ModulesSection({ userId }: { userId: string }) {
+  return (
+    <SectionFrame
+      eyebrow="Runtime"
+      title="Modules and runtime content"
+      copy="Enable, disable, and rescan modules using the existing server-side admin controls. The runtime catalog here is live, not mocked."
+    >
+      <section className="card-panel admin-card-span">
+        <ProfileAdminModules userId={userId} />
+      </section>
+    </SectionFrame>
+  );
+}
+
+function MaintenanceSection() {
+  const queryClient = useQueryClient();
+  const reportQuery = useQuery({
+    queryKey: adminMaintenanceQueryKey(),
+    queryFn: () => getAdminMaintenanceReport(requestMessages("admin maintenance"))
+  });
+
+  const actionMutation = useMutation({
+    mutationFn: (input: { action: "validate-all" | "cleanup-stale-lobbies"; confirmation?: string | null }) =>
+      runAdminMaintenanceAction(input, requestMessages("admin maintenance action")),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminMaintenanceQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminOverviewQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminGamesQueryKey("", "") }),
+        queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() })
+      ]);
+    }
+  });
+
+  function handleCleanup() {
+    const confirmation = window.prompt("Type cleanup-stale-lobbies to confirm cleanup.");
+    actionMutation.mutate({
+      action: "cleanup-stale-lobbies",
+      confirmation
+    });
+  }
+
+  return (
+    <SectionFrame
+      eyebrow="Maintenance"
+      title="Validation and repair operations"
+      copy="Run non-destructive validation across the runtime, surface orphaned references, and clean up stale lobbies with explicit confirmation."
+      actions={
+        <>
+          <button
+            type="button"
+            className="refresh-button"
+            onClick={() => actionMutation.mutate({ action: "validate-all" })}
+            disabled={actionMutation.isPending}
+          >
+            Validate now
+          </button>
+          <button
+            type="button"
+            className="ghost-action admin-danger-action"
+            onClick={handleCleanup}
+            disabled={actionMutation.isPending}
+          >
+            Cleanup stale lobbies
+          </button>
+        </>
+      }
+    >
+      {actionMutation.isError ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Maintenance</p>
+          <h2>Operation failed</h2>
+          <p className="status-copy">
+            {messageFromError(actionMutation.error, "Unable to complete the maintenance action.")}
+          </p>
+        </section>
+      ) : null}
+
+      {reportQuery.isLoading ? (
+        <section className="status-panel">
+          <p className="status-label">Maintenance</p>
+          <h2>Loading report</h2>
+          <p className="status-copy">Scanning games, lobbies, and module references.</p>
+        </section>
+      ) : reportQuery.isError || !reportQuery.data ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Maintenance</p>
+          <h2>Report unavailable</h2>
+          <p className="status-copy">
+            {messageFromError(reportQuery.error, "Unable to load maintenance signals.")}
+          </p>
+        </section>
+      ) : (
+        <div className="grid-shell">
+          <AdminMetric label="Games checked" value={reportQuery.data.summary.totalGames} />
+          <AdminMetric
+            label="Stale lobbies"
+            value={reportQuery.data.summary.staleLobbies}
+            tone={reportQuery.data.summary.staleLobbies > 0 ? "warning" : "success"}
+          />
+          <AdminMetric
+            label="Invalid games"
+            value={reportQuery.data.summary.invalidGames}
+            tone={reportQuery.data.summary.invalidGames > 0 ? "danger" : "success"}
+          />
+          <AdminMetric
+            label="Orphaned module refs"
+            value={reportQuery.data.summary.orphanedModuleReferences}
+            tone={reportQuery.data.summary.orphanedModuleReferences > 0 ? "warning" : "success"}
+          />
+
+          <section className="card-panel admin-card-span">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Issues</p>
+                <h2>Current maintenance findings</h2>
+              </div>
+            </div>
+            {reportQuery.data.issues.length ? (
+              <ul className="admin-issue-list">
+                {reportQuery.data.issues.map((issue, index) => (
+                  <li key={`${issue.code}:${issue.gameId || index}`} className="admin-issue-item">
+                    <span className={`status-pill ${statusTone(issue.severity)}`}>{issue.severity}</span>
+                    <div>
+                      <strong>{issue.code}</strong>
+                      <p>{issue.message}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="status-copy">No maintenance issues detected.</p>
+            )}
+          </section>
+        </div>
+      )}
+    </SectionFrame>
+  );
+}
+
+function AuditSection() {
+  const auditQuery = useQuery({
+    queryKey: adminAuditQueryKey(),
+    queryFn: () => getAdminAudit(requestMessages("admin audit"))
+  });
+
+  return (
+    <SectionFrame
+      eyebrow="Audit"
+      title="Administrative activity log"
+      copy="A lightweight but persistent history of the most important admin mutations and validation runs."
+    >
+      {auditQuery.isLoading ? (
+        <section className="status-panel">
+          <p className="status-label">Audit</p>
+          <h2>Loading entries</h2>
+          <p className="status-copy">Collecting the latest admin actions.</p>
+        </section>
+      ) : auditQuery.isError || !auditQuery.data ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Audit</p>
+          <h2>Audit unavailable</h2>
+          <p className="status-copy">
+            {messageFromError(auditQuery.error, "Unable to load the admin audit log.")}
+          </p>
+        </section>
+      ) : (
+        <section className="card-panel admin-card-span">
+          <div className="admin-table-wrap">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>Action</th>
+                  <th>Actor</th>
+                  <th>Target</th>
+                  <th>Result</th>
+                  <th>When</th>
+                </tr>
+              </thead>
+              <tbody>
+                {auditQuery.data.entries.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.action}</td>
+                    <td>{entry.actorUsername}</td>
+                    <td>
+                      {entry.targetType}
+                      {entry.targetLabel ? ` · ${entry.targetLabel}` : ""}
+                    </td>
+                    <td>
+                      <span className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}>
+                        {entry.result}
+                      </span>
+                    </td>
+                    <td>{formatTimestamp(entry.createdAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </SectionFrame>
+  );
+}
+
+function AdminForbiddenState() {
+  const namespace = useShellNamespace();
+
+  return (
+    <section className="status-panel status-panel-error" data-testid="admin-forbidden-page">
+      <p className="status-label">Forbidden</p>
+      <h2>Admin access required.</h2>
+      <p className="status-copy">
+        Your current account is authenticated, but it does not have the administrator role required
+        for this section.
+      </p>
+      <div className="shell-actions">
+        <Link className="refresh-button" to={buildLobbyPath(namespace)}>
+          Return to lobby
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export function AdminRoute() {
+  const { state, refresh } = useAuth();
+  const location = useLocation();
+  const namespace = useShellNamespace();
+  const section = resolveAdminSection(location.pathname);
+  const currentUser = state.status === "authenticated" ? state.user : null;
+  const currentPath = `${location.pathname}${location.search}${location.hash}`;
+
+  useEffect(() => {
+    document.title = "NetRisk Admin";
+  }, []);
+
+  if (state.status === "loading") {
+    return (
+      <section className="status-panel" data-testid="admin-loading-page">
+        <p className="status-label">Admin</p>
+        <h2>Loading administrator session</h2>
+        <p className="status-copy">Checking the current browser session and the attached role.</p>
+      </section>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <section className="status-panel status-panel-error" data-testid="admin-error-page">
+        <p className="status-label">Admin</p>
+        <h2>Unable to load the admin route</h2>
+        <p className="status-copy">{state.message}</p>
+        <div className="shell-actions">
+          <button type="button" className="refresh-button" onClick={() => void refresh()}>
+            Retry
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (!currentUser) {
+    return <Navigate to={buildLoginHref(currentPath, namespace)} replace />;
+  }
+
+  if (currentUser.role !== "admin") {
+    return <AdminForbiddenState />;
+  }
+
+  const navItems: Array<{ id: AdminSection; label: string; path: string; description: string }> = [
+    {
+      id: "overview",
+      label: "Overview",
+      path: buildAdminPath(namespace),
+      description: "Health, defaults, and latest admin activity."
+    },
+    {
+      id: "users",
+      label: "Users",
+      path: `${buildAdminPath(namespace)}/users`,
+      description: "Inspect and change roles."
+    },
+    {
+      id: "games",
+      label: "Games",
+      path: `${buildAdminPath(namespace)}/games`,
+      description: "Inspect, repair, and terminate sessions."
+    },
+    {
+      id: "config",
+      label: "Configurations",
+      path: `${buildAdminPath(namespace)}/config`,
+      description: "Global defaults and maintenance thresholds."
+    },
+    {
+      id: "modules",
+      label: "Runtime / Modules",
+      path: `${buildAdminPath(namespace)}/modules`,
+      description: "Live module catalog and runtime controls."
+    },
+    {
+      id: "maintenance",
+      label: "Maintenance",
+      path: `${buildAdminPath(namespace)}/maintenance`,
+      description: "Validation and cleanup operations."
+    },
+    {
+      id: "audit",
+      label: "Audit Log",
+      path: `${buildAdminPath(namespace)}/audit`,
+      description: "Recent admin mutations."
+    }
+  ];
+
+  return (
+    <div className="react-shell-page admin-page" data-testid="admin-route-page">
+      <div className="admin-shell">
+        <aside className="card-panel admin-sidebar">
+          <div className="admin-sidebar-header">
+            <p className="status-label">Admin</p>
+            <h2>NetRisk Console</h2>
+            <p className="status-copy">
+              Signed in as <strong>{currentUser.username}</strong>.
+            </p>
+          </div>
+          <nav className="admin-nav" aria-label="Admin sections">
+            {navItems.map((item) => (
+              <Link
+                key={item.id}
+                to={item.path}
+                className={`admin-nav-link${section === item.id ? " is-active" : ""}`}
+              >
+                <strong>{item.label}</strong>
+                <span>{item.description}</span>
+              </Link>
+            ))}
+          </nav>
+        </aside>
+
+        <main className="admin-main">
+          {section === "overview" ? <OverviewSection /> : null}
+          {section === "users" ? <UsersSection /> : null}
+          {section === "games" ? <GamesSection /> : null}
+          {section === "config" ? <ConfigSection /> : null}
+          {section === "modules" ? <ModulesSection userId={currentUser.id} /> : null}
+          {section === "maintenance" ? <MaintenanceSection /> : null}
+          {section === "audit" ? <AuditSection /> : null}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-shell/src/legacy-app-shell.tsx
+++ b/frontend/react-shell/src/legacy-app-shell.tsx
@@ -15,6 +15,7 @@ import { getLocale, listSupportedLocales, setLocale, t } from "@frontend-i18n";
 import { useAuth } from "@react-shell/auth";
 import { clearCurrentPlayerId } from "@react-shell/player-session";
 import {
+  buildAdminPath,
   buildBootstrapPath,
   buildGameIndexPath,
   buildGamePath,
@@ -24,7 +25,7 @@ import {
   useShellNamespace
 } from "@react-shell/public-auth-paths";
 
-type AppSection = "game" | "lobby" | "login" | "profile" | "register";
+type AppSection = "admin" | "game" | "lobby" | "login" | "profile" | "register";
 
 function resolveAppSection(pathname: string): AppSection {
   if (pathname === "/login" || pathname === "/react/login") {
@@ -37,6 +38,15 @@ function resolveAppSection(pathname: string): AppSection {
 
   if (pathname === "/profile" || pathname === "/profile.html" || pathname === "/react/profile") {
     return "profile";
+  }
+
+  if (
+    pathname === "/admin" ||
+    pathname === "/react/admin" ||
+    pathname.startsWith("/admin/") ||
+    pathname.startsWith("/react/admin/")
+  ) {
+    return "admin";
   }
 
   if (
@@ -92,7 +102,10 @@ function sessionStatusLabel(status: ReturnType<typeof useAuth>["state"]["status"
   return "guest";
 }
 
-function isNavSectionActive(section: AppSection, target: "game" | "lobby" | "profile"): boolean {
+function isNavSectionActive(
+  section: AppSection,
+  target: "admin" | "game" | "lobby" | "profile"
+): boolean {
   if (target === "lobby") {
     return section === "lobby" || section === "login" || section === "register";
   }
@@ -149,6 +162,7 @@ export function LegacyAppShell({ children }: { children: ReactNode }) {
 
   const isAuthenticated = state.status === "authenticated";
   const lobbyHref = buildLobbyPath(namespace);
+  const adminHref = buildAdminPath(namespace);
   const profileHref = buildProfilePath(namespace);
   const registerHref = buildRegisterPath(namespace);
   const bootstrapHref = buildBootstrapPath(namespace);
@@ -248,6 +262,14 @@ export function LegacyAppShell({ children }: { children: ReactNode }) {
           >
             {t("nav.profile")}
           </Link>
+          {isAuthenticated && state.user.role === "admin" ? (
+            <Link
+              className={`nav-link${isNavSectionActive(section, "admin") ? " is-active" : ""}`}
+              to={adminHref}
+            >
+              Admin
+            </Link>
+          ) : null}
         </nav>
 
         <div className="top-nav-zone top-nav-module-slots" id="top-nav-module-slots">

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -254,26 +254,43 @@ function sanitizeProfiles(
 }
 
 function buildInitialForm(options: GameOptionsResponse): NewGameFormState {
+  const adminDefaults = options.adminDefaults || {};
+  const initialTotalPlayers = Number.isInteger(adminDefaults.totalPlayers)
+    ? Math.min(
+        options.playerRange?.max || 4,
+        Math.max(options.playerRange?.min || 2, Number(adminDefaults.totalPlayers))
+      )
+    : Math.max(options.playerRange?.min || 2, 2);
   const initialState: NewGameFormState = {
     name: "",
-    contentPackId: firstId(options.contentPacks),
-    ruleSetId: firstId(options.ruleSets),
-    mapId: firstId(options.maps),
+    contentPackId: pickAvailableId(adminDefaults.contentPackId, options.contentPacks),
+    ruleSetId: pickAvailableId(adminDefaults.ruleSetId, options.ruleSets),
+    mapId: pickAvailableId(adminDefaults.mapId, options.maps),
     customizeOptions: false,
-    diceRuleSetId: firstId(options.diceRuleSets),
-    victoryRuleSetId: firstId(options.victoryRuleSets),
-    themeId: firstId(options.themes),
-    pieceSkinId: firstId(options.pieceSkins),
-    turnTimeoutHours: options.turnTimeoutHoursOptions?.[0]
-      ? String(options.turnTimeoutHoursOptions[0])
-      : "",
-    totalPlayers: Math.max(options.playerRange?.min || 2, 2),
-    playerTypes: ["human", "human"],
-    selectedModuleIds: [],
-    gamePresetId: "",
-    contentProfileId: "",
-    gameplayProfileId: "",
-    uiProfileId: ""
+    diceRuleSetId: pickAvailableId(adminDefaults.diceRuleSetId, options.diceRuleSets),
+    victoryRuleSetId: pickAvailableId(adminDefaults.victoryRuleSetId, options.victoryRuleSets),
+    themeId: pickAvailableId(adminDefaults.themeId, options.themes),
+    pieceSkinId: pickAvailableId(adminDefaults.pieceSkinId, options.pieceSkins),
+    turnTimeoutHours:
+      adminDefaults.turnTimeoutHours != null
+        ? String(adminDefaults.turnTimeoutHours)
+        : options.turnTimeoutHoursOptions?.[0]
+          ? String(options.turnTimeoutHoursOptions[0])
+          : "",
+    totalPlayers: initialTotalPlayers,
+    playerTypes: ensurePlayerTypes(
+      Array.isArray(adminDefaults.players)
+        ? adminDefaults.players.map((slot) => (slot?.type === "ai" ? "ai" : "human"))
+        : [],
+      initialTotalPlayers
+    ),
+    selectedModuleIds: Array.isArray(adminDefaults.activeModuleIds)
+      ? adminDefaults.activeModuleIds
+      : [],
+    gamePresetId: adminDefaults.gamePresetId || "",
+    contentProfileId: adminDefaults.contentProfileId || "",
+    gameplayProfileId: adminDefaults.gameplayProfileId || "",
+    uiProfileId: adminDefaults.uiProfileId || ""
   };
 
   const withContentPackDefaults = applyContentPackDefaults(
@@ -281,7 +298,17 @@ function buildInitialForm(options: GameOptionsResponse): NewGameFormState {
     options,
     initialState.contentPackId
   );
-  return applyRuleSetDefaults(withContentPackDefaults, options, initialState.ruleSetId);
+  return sanitizeProfiles(
+    {
+      ...applyRuleSetDefaults(withContentPackDefaults, options, initialState.ruleSetId),
+      mapId: pickAvailableId(adminDefaults.mapId, options.maps),
+      diceRuleSetId: pickAvailableId(adminDefaults.diceRuleSetId, options.diceRuleSets),
+      victoryRuleSetId: pickAvailableId(adminDefaults.victoryRuleSetId, options.victoryRuleSets),
+      themeId: pickAvailableId(adminDefaults.themeId, options.themes),
+      pieceSkinId: pickAvailableId(adminDefaults.pieceSkinId, options.pieceSkins)
+    },
+    options
+  );
 }
 
 function applyGamePreset(

--- a/frontend/react-shell/src/lobby-create-route.tsx
+++ b/frontend/react-shell/src/lobby-create-route.tsx
@@ -79,6 +79,17 @@ function pickAvailableId<T extends { id: string }>(
   return firstId(entries);
 }
 
+function pickExplicitId<T extends { id: string }>(
+  preferredId: string | null | undefined,
+  entries: T[] | null | undefined
+): string {
+  if (preferredId && entries?.some((entry) => entry.id === preferredId)) {
+    return preferredId;
+  }
+
+  return "";
+}
+
 function pickPresetId<T extends { id: string }>(
   presetId: string | null | undefined,
   currentId: string,
@@ -255,6 +266,17 @@ function sanitizeProfiles(
 
 function buildInitialForm(options: GameOptionsResponse): NewGameFormState {
   const adminDefaults = options.adminDefaults || {};
+  const adminDefaultMapId = pickExplicitId(adminDefaults.mapId, options.maps);
+  const adminDefaultDiceRuleSetId = pickExplicitId(
+    adminDefaults.diceRuleSetId,
+    options.diceRuleSets
+  );
+  const adminDefaultVictoryRuleSetId = pickExplicitId(
+    adminDefaults.victoryRuleSetId,
+    options.victoryRuleSets
+  );
+  const adminDefaultThemeId = pickExplicitId(adminDefaults.themeId, options.themes);
+  const adminDefaultPieceSkinId = pickExplicitId(adminDefaults.pieceSkinId, options.pieceSkins);
   const initialTotalPlayers = Number.isInteger(adminDefaults.totalPlayers)
     ? Math.min(
         options.playerRange?.max || 4,
@@ -265,12 +287,12 @@ function buildInitialForm(options: GameOptionsResponse): NewGameFormState {
     name: "",
     contentPackId: pickAvailableId(adminDefaults.contentPackId, options.contentPacks),
     ruleSetId: pickAvailableId(adminDefaults.ruleSetId, options.ruleSets),
-    mapId: pickAvailableId(adminDefaults.mapId, options.maps),
+    mapId: adminDefaultMapId,
     customizeOptions: false,
-    diceRuleSetId: pickAvailableId(adminDefaults.diceRuleSetId, options.diceRuleSets),
-    victoryRuleSetId: pickAvailableId(adminDefaults.victoryRuleSetId, options.victoryRuleSets),
-    themeId: pickAvailableId(adminDefaults.themeId, options.themes),
-    pieceSkinId: pickAvailableId(adminDefaults.pieceSkinId, options.pieceSkins),
+    diceRuleSetId: adminDefaultDiceRuleSetId,
+    victoryRuleSetId: adminDefaultVictoryRuleSetId,
+    themeId: adminDefaultThemeId,
+    pieceSkinId: adminDefaultPieceSkinId,
     turnTimeoutHours:
       adminDefaults.turnTimeoutHours != null
         ? String(adminDefaults.turnTimeoutHours)
@@ -301,11 +323,11 @@ function buildInitialForm(options: GameOptionsResponse): NewGameFormState {
   return sanitizeProfiles(
     {
       ...applyRuleSetDefaults(withContentPackDefaults, options, initialState.ruleSetId),
-      mapId: pickAvailableId(adminDefaults.mapId, options.maps),
-      diceRuleSetId: pickAvailableId(adminDefaults.diceRuleSetId, options.diceRuleSets),
-      victoryRuleSetId: pickAvailableId(adminDefaults.victoryRuleSetId, options.victoryRuleSets),
-      themeId: pickAvailableId(adminDefaults.themeId, options.themes),
-      pieceSkinId: pickAvailableId(adminDefaults.pieceSkinId, options.pieceSkins)
+      ...(adminDefaultMapId ? { mapId: adminDefaultMapId } : {}),
+      ...(adminDefaultDiceRuleSetId ? { diceRuleSetId: adminDefaultDiceRuleSetId } : {}),
+      ...(adminDefaultVictoryRuleSetId ? { victoryRuleSetId: adminDefaultVictoryRuleSetId } : {}),
+      ...(adminDefaultThemeId ? { themeId: adminDefaultThemeId } : {}),
+      ...(adminDefaultPieceSkinId ? { pieceSkinId: adminDefaultPieceSkinId } : {})
     },
     options
   );

--- a/frontend/react-shell/src/public-auth-paths.ts
+++ b/frontend/react-shell/src/public-auth-paths.ts
@@ -57,6 +57,9 @@ function isReactRelativeShellPath(pathname: string): boolean {
     pathname.startsWith("/lobby?") ||
     pathname === "/lobby/new" ||
     pathname.startsWith("/lobby/new?") ||
+    pathname === "/admin" ||
+    pathname.startsWith("/admin?") ||
+    pathname.startsWith("/admin/") ||
     pathname === "/profile" ||
     pathname.startsWith("/profile?") ||
     pathname === "/game" ||
@@ -144,6 +147,10 @@ export function buildNewGamePath(namespace: ShellNamespace = currentShellNamespa
 
 export function buildProfilePath(namespace: ShellNamespace = currentShellNamespace()): string {
   return namespace === "react" ? "/react/profile" : "/profile";
+}
+
+export function buildAdminPath(namespace: ShellNamespace = currentShellNamespace()): string {
+  return namespace === "react" ? "/react/admin" : "/admin";
 }
 
 export function buildGameIndexPath(namespace: ShellNamespace = currentShellNamespace()): string {

--- a/frontend/react-shell/src/react-query.ts
+++ b/frontend/react-shell/src/react-query.ts
@@ -41,3 +41,27 @@ export function gameOptionsQueryKey() {
 export function gameplayStateQueryKey(gameId: string) {
   return ["gameplay", "state", gameId] as const;
 }
+
+export function adminOverviewQueryKey() {
+  return ["admin", "overview"] as const;
+}
+
+export function adminUsersQueryKey(query: string, role: string) {
+  return ["admin", "users", query, role] as const;
+}
+
+export function adminGamesQueryKey(query: string, status: string) {
+  return ["admin", "games", query, status] as const;
+}
+
+export function adminConfigQueryKey() {
+  return ["admin", "config"] as const;
+}
+
+export function adminMaintenanceQueryKey() {
+  return ["admin", "maintenance"] as const;
+}
+
+export function adminAuditQueryKey() {
+  return ["admin", "audit"] as const;
+}

--- a/frontend/react-shell/src/routes.tsx
+++ b/frontend/react-shell/src/routes.tsx
@@ -41,6 +41,9 @@ const LobbyCreateRoute = lazy(async () => ({
 const ProfileRoute = lazy(async () => ({
   default: (await import("@react-shell/profile-route")).ProfileRoute
 }));
+const AdminRoute = lazy(async () => ({
+  default: (await import("@react-shell/admin-route")).AdminRoute
+}));
 const GameRoute = lazy(async () => ({
   default: (await import("@react-shell/gameplay-route")).GameRoute
 }));
@@ -373,6 +376,8 @@ export function AppRoutes() {
             <Route path="/lobby/new" element={<LobbyCreateRoute />} />
             <Route path="/new-game.html" element={<LegacyDocumentRedirect to="/lobby/new" />} />
             <Route path="/react/lobby/new" element={<LobbyCreateRoute />} />
+            <Route path="/admin/*" element={<AdminRoute />} />
+            <Route path="/react/admin/*" element={<AdminRoute />} />
             <Route path="/profile" element={<ProfileRoute />} />
             <Route path="/profile.html" element={<LegacyDocumentRedirect to="/profile" />} />
             <Route path="/react/profile" element={<ProfileRoute />} />

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -1101,6 +1101,357 @@ html[data-theme="ember"] {
   overflow: auto;
 }
 
+.status-pill.warning {
+  color: var(--shell-warning);
+}
+
+.status-pill.danger {
+  color: var(--shell-danger);
+}
+
+.admin-page {
+  width: min(1380px, calc(100% - 2rem));
+}
+
+.admin-shell {
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.admin-sidebar {
+  position: sticky;
+  top: 1rem;
+  padding: 1.25rem;
+}
+
+.admin-sidebar-header h2 {
+  margin: 0;
+}
+
+.admin-nav {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.admin-nav-link {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-control-radius);
+  background: var(--shell-card-bg);
+  color: var(--shell-copy);
+  text-decoration: none;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease,
+    background 120ms ease;
+}
+
+.admin-nav-link strong {
+  font-variant: small-caps;
+  letter-spacing: 0.05em;
+}
+
+.admin-nav-link span {
+  color: var(--shell-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.admin-nav-link:hover,
+.admin-nav-link.is-active {
+  border-color: var(--shell-border-hi);
+  background: var(--shell-card-bg-hover);
+  transform: translateY(-1px);
+}
+
+.admin-main {
+  min-width: 0;
+}
+
+.admin-section-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-hero-panel {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.admin-hero-copy {
+  max-width: 58rem;
+}
+
+.admin-metrics-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.admin-metric {
+  min-height: 124px;
+}
+
+.admin-metric-warning {
+  border-color: var(--shell-warning-border);
+}
+
+.admin-metric-danger {
+  border-color: var(--shell-danger-border);
+}
+
+.admin-metric-success {
+  border-color: var(--shell-success-border);
+}
+
+.admin-metric-value {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--shell-heading);
+}
+
+.admin-card-span {
+  grid-column: 1 / -1;
+}
+
+.admin-definition-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.admin-definition-grid dt {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--shell-muted);
+}
+
+.admin-definition-grid dd {
+  margin: 0.45rem 0 0;
+  color: var(--shell-heading);
+}
+
+.admin-toolbar-panel {
+  padding: 1rem 1.25rem;
+}
+
+.admin-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.admin-toolbar .shell-field {
+  min-width: min(260px, 100%);
+  flex: 1 1 220px;
+}
+
+.admin-table-wrap {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.9rem 0.75rem;
+  border-bottom: 1px solid var(--shell-border);
+  vertical-align: top;
+  text-align: left;
+}
+
+.admin-table th {
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--shell-muted);
+}
+
+.admin-table-copy {
+  margin: 0.3rem 0 0;
+  color: var(--shell-muted);
+}
+
+.admin-inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.admin-games-grid {
+  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+}
+
+.admin-game-list,
+.admin-player-list,
+.admin-issue-list,
+.admin-audit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-game-item,
+.admin-audit-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-control-radius);
+  background: var(--shell-card-bg);
+}
+
+.admin-list-button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-control-radius);
+  background: var(--shell-card-bg);
+  color: var(--shell-copy);
+  text-align: left;
+  cursor: pointer;
+}
+
+.admin-list-button.is-selected {
+  border-color: var(--shell-border-hi);
+  background: var(--shell-card-bg-hover);
+}
+
+.admin-list-button p,
+.admin-game-item p,
+.admin-audit-item p,
+.admin-player-list p,
+.admin-issue-item p {
+  margin: 0.35rem 0 0;
+  color: var(--shell-muted);
+}
+
+.admin-detail-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-detail-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.admin-detail-summary p {
+  margin: 0;
+  color: var(--shell-muted);
+}
+
+.admin-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.admin-issue-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-control-radius);
+  background: var(--shell-card-bg);
+}
+
+.admin-json-block {
+  margin: 0;
+  padding: 1rem;
+  border-radius: var(--campaign-control-radius);
+  background: rgba(9, 12, 16, 0.82);
+  color: #f3f0e9;
+  overflow: auto;
+  max-height: 460px;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.admin-form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.admin-module-picker {
+  margin-top: 1.25rem;
+}
+
+.admin-module-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.admin-module-toggle {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-control-radius);
+  background: var(--shell-card-bg);
+}
+
+.admin-module-toggle span {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.admin-module-toggle small {
+  color: var(--shell-muted);
+}
+
+.admin-danger-action {
+  border-color: var(--shell-danger-border);
+  color: var(--shell-danger);
+}
+
+@media (max-width: 1080px) {
+  .admin-shell,
+  .admin-games-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-sidebar {
+    position: static;
+  }
+
+  .admin-form-grid,
+  .admin-definition-grid,
+  .admin-metrics-grid,
+  .admin-detail-grid,
+  .admin-module-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 760px) {
   .react-shell-page {
     width: min(100% - 1.25rem, 100%);
@@ -1139,6 +1490,13 @@ html[data-theme="ember"] {
   .profile-metric-grid,
   .lobby-summary-grid,
   .lobby-shell-grid,
+  .admin-form-grid,
+  .admin-definition-grid,
+  .admin-metrics-grid,
+  .admin-detail-grid,
+  .admin-module-grid,
+  .admin-shell,
+  .admin-games-grid,
   .new-game-grid,
   .new-game-advanced-grid,
   .new-game-inline-grid,

--- a/frontend/react-shell/vitest.config.ts
+++ b/frontend/react-shell/vitest.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
-    testTimeout: 10_000,
+    maxWorkers: 2,
+    testTimeout: 20_000,
     setupFiles: ["./test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}", "test/**/*.{test,spec}.{ts,tsx}"],
     environmentOptions: {

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -377,7 +377,9 @@ export function updateAdminConfig(
   });
 }
 
-export function getAdminMaintenanceReport(messages: ClientMessages): Promise<AdminMaintenanceReport> {
+export function getAdminMaintenanceReport(
+  messages: ClientMessages
+): Promise<AdminMaintenanceReport> {
   return requestJson({
     path: "/api/admin/maintenance",
     responseSchema: adminMaintenanceReportSchema,

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -1,4 +1,19 @@
 import {
+  adminAuditResponseSchema,
+  adminConfigResponseSchema,
+  adminConfigUpdateRequestSchema,
+  adminConfigUpdateResponseSchema,
+  adminGameActionRequestSchema,
+  adminGameActionResponseSchema,
+  adminGameDetailsResponseSchema,
+  adminGamesResponseSchema,
+  adminMaintenanceActionRequestSchema,
+  adminMaintenanceActionResponseSchema,
+  adminMaintenanceReportSchema,
+  adminOverviewResponseSchema,
+  adminUserRoleUpdateRequestSchema,
+  adminUserRoleUpdateResponseSchema,
+  adminUsersResponseSchema,
   authSessionResponseSchema,
   createGameRequestSchema,
   createGameResponseSchema,
@@ -23,6 +38,21 @@ import {
   tradeCardsRequestSchema
 } from "../../generated/shared-runtime-validation.mjs";
 import type {
+  AdminAuditResponse,
+  AdminConfigResponse,
+  AdminConfigUpdateRequest,
+  AdminConfigUpdateResponse,
+  AdminGameActionRequest,
+  AdminGameActionResponse,
+  AdminGameDetailsResponse,
+  AdminGamesResponse,
+  AdminMaintenanceActionRequest,
+  AdminMaintenanceActionResponse,
+  AdminMaintenanceReport,
+  AdminOverviewResponse,
+  AdminUserRoleUpdateRequest,
+  AdminUserRoleUpdateResponse,
+  AdminUsersResponse,
   AuthSessionResponse,
   CreateGameRequest,
   CreateGameResponse,
@@ -58,6 +88,16 @@ type GameListRequestOptions = {
 
 type GameStateRequestOptions = {
   gameId?: string | null;
+};
+
+type AdminUsersRequestOptions = {
+  query?: string | null;
+  role?: string | null;
+};
+
+type AdminGamesRequestOptions = {
+  query?: string | null;
+  status?: string | null;
 };
 
 type GameEventSubscriptionOptions = {
@@ -201,6 +241,172 @@ export function updateThemePreference(
     requestSchemaName: "ThemePreferenceRequest",
     responseSchema: themePreferenceResponseSchema,
     responseSchemaName: "ThemePreferenceResponse",
+    ...messages
+  });
+}
+
+export function getAdminOverview(messages: ClientMessages): Promise<AdminOverviewResponse> {
+  return requestJson({
+    path: "/api/admin/overview",
+    responseSchema: adminOverviewResponseSchema,
+    responseSchemaName: "AdminOverviewResponse",
+    ...messages
+  });
+}
+
+function buildAdminUsersPath(options: AdminUsersRequestOptions = {}): string {
+  const params = new URLSearchParams();
+
+  if (options.query) {
+    params.set("q", options.query);
+  }
+
+  if (options.role) {
+    params.set("role", options.role);
+  }
+
+  const query = params.toString();
+  return query ? `/api/admin/users?${query}` : "/api/admin/users";
+}
+
+export function listAdminUsers(
+  messages: ClientMessages,
+  options: AdminUsersRequestOptions = {}
+): Promise<AdminUsersResponse> {
+  return requestJson({
+    path: buildAdminUsersPath(options),
+    responseSchema: adminUsersResponseSchema,
+    responseSchemaName: "AdminUsersResponse",
+    ...messages
+  });
+}
+
+export function updateAdminUserRole(
+  request: AdminUserRoleUpdateRequest,
+  messages: ClientMessages
+): Promise<AdminUserRoleUpdateResponse> {
+  return requestJson({
+    path: "/api/admin/users/role",
+    method: "POST",
+    body: request,
+    requestSchema: adminUserRoleUpdateRequestSchema,
+    requestSchemaName: "AdminUserRoleUpdateRequest",
+    responseSchema: adminUserRoleUpdateResponseSchema,
+    responseSchemaName: "AdminUserRoleUpdateResponse",
+    ...messages
+  });
+}
+
+function buildAdminGamesPath(options: AdminGamesRequestOptions = {}): string {
+  const params = new URLSearchParams();
+
+  if (options.query) {
+    params.set("q", options.query);
+  }
+
+  if (options.status) {
+    params.set("status", options.status);
+  }
+
+  const query = params.toString();
+  return query ? `/api/admin/games?${query}` : "/api/admin/games";
+}
+
+export function listAdminGames(
+  messages: ClientMessages,
+  options: AdminGamesRequestOptions = {}
+): Promise<AdminGamesResponse> {
+  return requestJson({
+    path: buildAdminGamesPath(options),
+    responseSchema: adminGamesResponseSchema,
+    responseSchemaName: "AdminGamesResponse",
+    ...messages
+  });
+}
+
+export function getAdminGameDetails(
+  gameId: string,
+  messages: ClientMessages
+): Promise<AdminGameDetailsResponse> {
+  return requestJson({
+    path: `/api/admin/games/${encodeURIComponent(gameId)}`,
+    responseSchema: adminGameDetailsResponseSchema,
+    responseSchemaName: "AdminGameDetailsResponse",
+    ...messages
+  });
+}
+
+export function runAdminGameAction(
+  request: AdminGameActionRequest,
+  messages: ClientMessages
+): Promise<AdminGameActionResponse> {
+  return requestJson({
+    path: "/api/admin/games/action",
+    method: "POST",
+    body: request,
+    requestSchema: adminGameActionRequestSchema,
+    requestSchemaName: "AdminGameActionRequest",
+    responseSchema: adminGameActionResponseSchema,
+    responseSchemaName: "AdminGameActionResponse",
+    ...messages
+  });
+}
+
+export function getAdminConfig(messages: ClientMessages): Promise<AdminConfigResponse> {
+  return requestJson({
+    path: "/api/admin/config",
+    responseSchema: adminConfigResponseSchema,
+    responseSchemaName: "AdminConfigResponse",
+    ...messages
+  });
+}
+
+export function updateAdminConfig(
+  request: AdminConfigUpdateRequest,
+  messages: ClientMessages
+): Promise<AdminConfigUpdateResponse> {
+  return requestJson({
+    path: "/api/admin/config",
+    method: "PUT",
+    body: request,
+    requestSchema: adminConfigUpdateRequestSchema,
+    requestSchemaName: "AdminConfigUpdateRequest",
+    responseSchema: adminConfigUpdateResponseSchema,
+    responseSchemaName: "AdminConfigUpdateResponse",
+    ...messages
+  });
+}
+
+export function getAdminMaintenanceReport(messages: ClientMessages): Promise<AdminMaintenanceReport> {
+  return requestJson({
+    path: "/api/admin/maintenance",
+    responseSchema: adminMaintenanceReportSchema,
+    responseSchemaName: "AdminMaintenanceReport",
+    ...messages
+  });
+}
+
+export function runAdminMaintenanceAction(
+  request: AdminMaintenanceActionRequest,
+  messages: ClientMessages
+): Promise<AdminMaintenanceActionResponse> {
+  return requestJson({
+    path: "/api/admin/maintenance",
+    method: "POST",
+    body: request,
+    requestSchema: adminMaintenanceActionRequestSchema,
+    requestSchemaName: "AdminMaintenanceActionRequest",
+    responseSchema: adminMaintenanceActionResponseSchema,
+    responseSchemaName: "AdminMaintenanceActionResponse",
+    ...messages
+  });
+}
+
+export function getAdminAudit(messages: ClientMessages): Promise<AdminAuditResponse> {
+  return requestJson({
+    path: "/api/admin/audit",
+    responseSchema: adminAuditResponseSchema,
+    responseSchemaName: "AdminAuditResponse",
     ...messages
   });
 }

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -633,6 +633,27 @@ export const gameListResponseSchema = objectSchema({
 
 export type GameListResponse = z.infer<typeof gameListResponseSchema>;
 
+export const adminGameDefaultsSchema = objectSchema({
+  totalPlayers: z.number().int().nullable().optional(),
+  contentPackId: z.string().min(1).nullable().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional(),
+  gamePresetId: z.string().min(1).nullable().optional(),
+  activeModuleIds: z.array(z.string().min(1)).optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  turnTimeoutHours: z.number().int().nullable().optional(),
+  players: z.array(playerSlotConfigSchema).nullable().optional()
+});
+
+export type AdminGameDefaults = z.infer<typeof adminGameDefaultsSchema>;
+
 export const gameOptionsResponseSchema = objectSchema({
   ruleSets: z.array(ruleSetSummarySchema),
   maps: z.array(mapSummarySchema),
@@ -654,7 +675,8 @@ export const gameOptionsResponseSchema = objectSchema({
   playerRange: objectSchema({
     min: z.number().int(),
     max: z.number().int()
-  })
+  }),
+  adminDefaults: adminGameDefaultsSchema.optional()
 });
 
 export type GameOptionsResponse = z.infer<typeof gameOptionsResponseSchema>;
@@ -999,3 +1021,207 @@ export const profileResponseSchema = objectSchema({
 });
 
 export type ProfileResponse = z.infer<typeof profileResponseSchema>;
+
+export const adminIssueSchema = objectSchema({
+  code: z.string().min(1),
+  severity: z.enum(["info", "warning", "error"]),
+  message: z.string().min(1),
+  gameId: z.string().min(1).nullable().optional(),
+  actionId: z.string().min(1).nullable().optional()
+});
+
+export type AdminIssue = z.infer<typeof adminIssueSchema>;
+
+export const adminAuditEntrySchema = objectSchema({
+  id: z.string().min(1),
+  actorId: z.string().min(1),
+  actorUsername: z.string().min(1),
+  action: z.string().min(1),
+  targetType: z.string().min(1),
+  targetId: z.string().min(1).nullable().optional(),
+  targetLabel: z.string().min(1).nullable().optional(),
+  result: z.enum(["success", "failure"]),
+  createdAt: z.string().min(1),
+  details: z.record(z.string(), z.unknown()).nullable().optional()
+});
+
+export type AdminAuditEntry = z.infer<typeof adminAuditEntrySchema>;
+
+export const adminConfigSchema = objectSchema({
+  defaults: adminGameDefaultsSchema,
+  maintenance: objectSchema({
+    staleLobbyDays: z.number().int().min(1).max(365),
+    auditLogLimit: z.number().int().min(10).max(500)
+  }),
+  updatedAt: z.string().min(1).nullable().optional(),
+  updatedBy: publicUserSchema.nullable().optional()
+});
+
+export type AdminConfig = z.infer<typeof adminConfigSchema>;
+
+export const adminUserSummarySchema = publicUserSchema.extend({
+  createdAt: z.string().min(1),
+  gamesPlayed: z.number().int(),
+  gamesInProgress: z.number().int(),
+  wins: z.number().int(),
+  canPromote: z.boolean(),
+  canDemote: z.boolean()
+});
+
+export type AdminUserSummary = z.infer<typeof adminUserSummarySchema>;
+
+export const adminGameSummarySchema = gameSummarySchema.extend({
+  stale: z.boolean(),
+  health: z.enum(["ok", "warning", "error"]),
+  issueCount: z.number().int(),
+  issues: z.array(adminIssueSchema)
+});
+
+export type AdminGameSummary = z.infer<typeof adminGameSummarySchema>;
+
+export const adminGamePlayerSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  linkedUserId: z.string().min(1).nullable().optional(),
+  isAi: z.boolean().optional(),
+  surrendered: z.boolean().optional(),
+  territoryCount: z.number().int(),
+  cardCount: z.number().int()
+});
+
+export type AdminGamePlayer = z.infer<typeof adminGamePlayerSchema>;
+
+export const adminOverviewResponseSchema = objectSchema({
+  summary: objectSchema({
+    totalUsers: z.number().int(),
+    adminUsers: z.number().int(),
+    activeGames: z.number().int(),
+    lobbyGames: z.number().int(),
+    finishedGames: z.number().int(),
+    staleLobbies: z.number().int(),
+    invalidGames: z.number().int(),
+    enabledModules: z.number().int()
+  }),
+  config: adminConfigSchema,
+  recentGames: z.array(adminGameSummarySchema),
+  issues: z.array(adminIssueSchema),
+  audit: z.array(adminAuditEntrySchema)
+});
+
+export type AdminOverviewResponse = z.infer<typeof adminOverviewResponseSchema>;
+
+export const adminUsersResponseSchema = objectSchema({
+  users: z.array(adminUserSummarySchema),
+  total: z.number().int(),
+  filteredTotal: z.number().int(),
+  query: z.string(),
+  role: z.string().min(1).nullable().optional()
+});
+
+export type AdminUsersResponse = z.infer<typeof adminUsersResponseSchema>;
+
+export const adminUserRoleUpdateRequestSchema = objectSchema({
+  userId: z.string().min(1),
+  role: z.enum(["admin", "user"])
+});
+
+export type AdminUserRoleUpdateRequest = z.infer<typeof adminUserRoleUpdateRequestSchema>;
+
+export const adminUserRoleUpdateResponseSchema = objectSchema({
+  ok: z.literal(true),
+  user: adminUserSummarySchema,
+  audit: adminAuditEntrySchema
+});
+
+export type AdminUserRoleUpdateResponse = z.infer<typeof adminUserRoleUpdateResponseSchema>;
+
+export const adminGamesResponseSchema = objectSchema({
+  games: z.array(adminGameSummarySchema),
+  total: z.number().int(),
+  filteredTotal: z.number().int(),
+  status: z.string().min(1).nullable().optional(),
+  query: z.string()
+});
+
+export type AdminGamesResponse = z.infer<typeof adminGamesResponseSchema>;
+
+export const adminGameDetailsResponseSchema = objectSchema({
+  game: adminGameSummarySchema,
+  players: z.array(adminGamePlayerSchema),
+  rawState: z.record(z.string(), z.unknown())
+});
+
+export type AdminGameDetailsResponse = z.infer<typeof adminGameDetailsResponseSchema>;
+
+export const adminGameActionRequestSchema = objectSchema({
+  gameId: z.string().min(1),
+  action: z.enum(["close-lobby", "terminate-game", "repair-game-config"]),
+  confirmation: z.string().min(1).nullable().optional()
+});
+
+export type AdminGameActionRequest = z.infer<typeof adminGameActionRequestSchema>;
+
+export const adminGameActionResponseSchema = objectSchema({
+  ok: z.literal(true),
+  game: adminGameSummarySchema,
+  players: z.array(adminGamePlayerSchema),
+  rawState: z.record(z.string(), z.unknown()),
+  audit: adminAuditEntrySchema
+});
+
+export type AdminGameActionResponse = z.infer<typeof adminGameActionResponseSchema>;
+
+export const adminConfigResponseSchema = objectSchema({
+  config: adminConfigSchema
+});
+
+export type AdminConfigResponse = z.infer<typeof adminConfigResponseSchema>;
+
+export const adminConfigUpdateRequestSchema = objectSchema({
+  defaults: adminGameDefaultsSchema,
+  maintenance: adminConfigSchema.shape.maintenance.optional()
+});
+
+export type AdminConfigUpdateRequest = z.infer<typeof adminConfigUpdateRequestSchema>;
+
+export const adminConfigUpdateResponseSchema = objectSchema({
+  ok: z.literal(true),
+  config: adminConfigSchema,
+  audit: adminAuditEntrySchema
+});
+
+export type AdminConfigUpdateResponse = z.infer<typeof adminConfigUpdateResponseSchema>;
+
+export const adminMaintenanceReportSchema = objectSchema({
+  summary: objectSchema({
+    totalGames: z.number().int(),
+    staleLobbies: z.number().int(),
+    invalidGames: z.number().int(),
+    orphanedModuleReferences: z.number().int()
+  }),
+  issues: z.array(adminIssueSchema)
+});
+
+export type AdminMaintenanceReport = z.infer<typeof adminMaintenanceReportSchema>;
+
+export const adminMaintenanceActionRequestSchema = objectSchema({
+  action: z.enum(["validate-all", "cleanup-stale-lobbies"]),
+  confirmation: z.string().min(1).nullable().optional()
+});
+
+export type AdminMaintenanceActionRequest = z.infer<typeof adminMaintenanceActionRequestSchema>;
+
+export const adminMaintenanceActionResponseSchema = objectSchema({
+  ok: z.literal(true),
+  report: adminMaintenanceReportSchema,
+  affectedGameIds: z.array(z.string().min(1)),
+  audit: adminAuditEntrySchema
+});
+
+export type AdminMaintenanceActionResponse = z.infer<typeof adminMaintenanceActionResponseSchema>;
+
+export const adminAuditResponseSchema = objectSchema({
+  entries: z.array(adminAuditEntrySchema)
+});
+
+export type AdminAuditResponse = z.infer<typeof adminAuditResponseSchema>;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "start": "npm run build:ts && node .tsbuild/backend/server.cjs",
+    "admin:grant": "npm run build:ts && node .tsbuild/scripts/grant-admin.cjs",
     "backup:data": "node .tsbuild/scripts/backup-datastore.cjs",
     "backup:check": "node .tsbuild/scripts/check-backup.cjs",
     "build:ts": "tsc -p tsconfig.json && npm run build:frontend && npm run build:react-shell && node .tsbuild/scripts/generate-supabase-schema.cjs && npm run check:ts-sources",

--- a/scripts/grant-admin.cts
+++ b/scripts/grant-admin.cts
@@ -1,0 +1,132 @@
+const path = require("path");
+const { createDatastore } = require("../backend/datastore.cjs");
+
+interface GrantAdminArgs {
+  username?: string;
+  role?: "admin" | "user";
+  driver?: string;
+  dbFile?: string;
+  dataFile?: string;
+  gamesFile?: string;
+  sessionsFile?: string;
+}
+
+interface DatastoreLike {
+  findUserByUsername(username: string): { username: string; role?: string } | null;
+  updateUserRoleByUsername(username: string, role: string): void;
+}
+
+function parseArgs(argv: string[]): GrantAdminArgs {
+  const args: GrantAdminArgs = {
+    role: "admin"
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    const next = argv[index + 1];
+
+    if (!current) {
+      continue;
+    }
+
+    if (!current.startsWith("--") && !args.username) {
+      args.username = current;
+      continue;
+    }
+
+    if (!next) {
+      continue;
+    }
+
+    switch (current) {
+      case "--username":
+        args.username = next;
+        index += 1;
+        break;
+      case "--role":
+        args.role = next === "user" ? "user" : "admin";
+        index += 1;
+        break;
+      case "--driver":
+        args.driver = next;
+        index += 1;
+        break;
+      case "--db-file":
+        args.dbFile = next;
+        index += 1;
+        break;
+      case "--data-file":
+        args.dataFile = next;
+        index += 1;
+        break;
+      case "--games-file":
+        args.gamesFile = next;
+        index += 1;
+        break;
+      case "--sessions-file":
+        args.sessionsFile = next;
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return args;
+}
+
+function resolveOptionalPath(filePath: string | undefined): string | undefined {
+  return filePath ? path.resolve(filePath) : undefined;
+}
+
+function grantRole(args: GrantAdminArgs) {
+  if (!args.username) {
+    throw new Error("Specifica un username: `npm run admin:grant -- --username <nome>`.");
+  }
+
+  const datastore = createDatastore({
+    driver: args.driver,
+    dbFile: resolveOptionalPath(args.dbFile),
+    dataFile: resolveOptionalPath(args.dataFile),
+    gamesFile: resolveOptionalPath(args.gamesFile),
+    sessionsFile: resolveOptionalPath(args.sessionsFile)
+  }) as DatastoreLike;
+
+  const existingUser = datastore.findUserByUsername(String(args.username));
+  if (!existingUser) {
+    throw new Error(`Utente non trovato: ${args.username}`);
+  }
+
+  const role = args.role === "user" ? "user" : "admin";
+  datastore.updateUserRoleByUsername(existingUser.username, role);
+
+  const updatedUser = datastore.findUserByUsername(existingUser.username);
+  if (!updatedUser) {
+    throw new Error(`Impossibile rileggere l'utente aggiornato: ${existingUser.username}`);
+  }
+
+  return {
+    username: updatedUser.username,
+    role: updatedUser.role === "admin" ? "admin" : "user"
+  };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const result = grantRole(args);
+  console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+}
+
+module.exports = {
+  grantRole,
+  parseArgs
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -41,6 +41,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/full-flows.test.cjs",
   "../tests/gameplay/regression/game-summary-stores.test.cjs",
   "../tests/gameplay/regression/module-runtime.test.cjs",
+  "../tests/gameplay/regression/admin-console-routes.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",
   "../tests/gameplay/regression/vercel-routing-config.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",

--- a/shared/api-contracts.cts
+++ b/shared/api-contracts.cts
@@ -146,6 +146,25 @@ export interface GameSummaryContract {
   uiProfileId?: string | null;
 }
 
+export interface AdminGameDefaultsContract {
+  totalPlayers?: number | null;
+  contentPackId?: string | null;
+  ruleSetId?: string | null;
+  mapId?: string | null;
+  diceRuleSetId?: string | null;
+  victoryRuleSetId?: string | null;
+  pieceSetId?: string | null;
+  themeId?: string | null;
+  pieceSkinId?: string | null;
+  gamePresetId?: string | null;
+  activeModuleIds?: string[];
+  contentProfileId?: string | null;
+  gameplayProfileId?: string | null;
+  uiProfileId?: string | null;
+  turnTimeoutHours?: number | null;
+  players?: Array<Record<string, unknown>> | null;
+}
+
 export interface GameOptionsResponseContract {
   ruleSets: Array<Record<string, unknown>>;
   maps: Array<Record<string, unknown>>;
@@ -168,6 +187,7 @@ export interface GameOptionsResponseContract {
     min: number;
     max: number;
   };
+  adminDefaults?: AdminGameDefaultsContract;
 }
 
 export interface AuthSessionResponseContract {
@@ -207,6 +227,147 @@ export interface ProfileContract {
 
 export interface ProfileResponseContract {
   profile: ProfileContract;
+}
+
+export interface AdminIssueContract {
+  code: string;
+  severity: string;
+  message: string;
+  gameId?: string | null;
+  actionId?: string | null;
+}
+
+export interface AdminAuditEntryContract {
+  id: string;
+  actorId: string;
+  actorUsername: string;
+  action: string;
+  targetType: string;
+  targetId?: string | null;
+  targetLabel?: string | null;
+  result: string;
+  createdAt: string;
+  details?: Record<string, unknown> | null;
+}
+
+export interface AdminConfigContract {
+  defaults: AdminGameDefaultsContract;
+  maintenance: {
+    staleLobbyDays: number;
+    auditLogLimit: number;
+  };
+  updatedAt?: string | null;
+  updatedBy?: PublicUserContract | null;
+}
+
+export interface AdminUserSummaryContract extends PublicUserContract {
+  createdAt: string;
+  gamesPlayed: number;
+  gamesInProgress: number;
+  wins: number;
+  canPromote: boolean;
+  canDemote: boolean;
+}
+
+export interface AdminGameSummaryContract extends GameSummaryContract {
+  stale: boolean;
+  health: string;
+  issueCount: number;
+  issues: AdminIssueContract[];
+}
+
+export interface AdminGamePlayerContract {
+  id: string;
+  name: string;
+  linkedUserId?: string | null;
+  isAi?: boolean;
+  surrendered?: boolean;
+  territoryCount: number;
+  cardCount: number;
+}
+
+export interface AdminOverviewResponseContract {
+  summary: {
+    totalUsers: number;
+    adminUsers: number;
+    activeGames: number;
+    lobbyGames: number;
+    finishedGames: number;
+    staleLobbies: number;
+    invalidGames: number;
+    enabledModules: number;
+  };
+  config: AdminConfigContract;
+  recentGames: AdminGameSummaryContract[];
+  issues: AdminIssueContract[];
+  audit: AdminAuditEntryContract[];
+}
+
+export interface AdminUsersResponseContract {
+  users: AdminUserSummaryContract[];
+  total: number;
+  filteredTotal: number;
+  query: string;
+  role: string | null;
+}
+
+export interface AdminUserRoleUpdateResponseContract {
+  ok: boolean;
+  user: AdminUserSummaryContract;
+  audit: AdminAuditEntryContract;
+}
+
+export interface AdminGamesResponseContract {
+  games: AdminGameSummaryContract[];
+  total: number;
+  filteredTotal: number;
+  status: string | null;
+  query: string;
+}
+
+export interface AdminGameDetailsResponseContract {
+  game: AdminGameSummaryContract;
+  players: AdminGamePlayerContract[];
+  rawState: Record<string, unknown>;
+}
+
+export interface AdminGameActionResponseContract {
+  ok: boolean;
+  game: AdminGameSummaryContract;
+  players: AdminGamePlayerContract[];
+  rawState: Record<string, unknown>;
+  audit: AdminAuditEntryContract;
+}
+
+export interface AdminConfigResponseContract {
+  config: AdminConfigContract;
+}
+
+export interface AdminConfigUpdateResponseContract {
+  ok: boolean;
+  config: AdminConfigContract;
+  audit: AdminAuditEntryContract;
+}
+
+export interface AdminMaintenanceReportContract {
+  summary: {
+    totalGames: number;
+    staleLobbies: number;
+    invalidGames: number;
+    orphanedModuleReferences: number;
+  };
+  issues: AdminIssueContract[];
+}
+
+export interface AdminMaintenanceActionResponseContract {
+  ok: boolean;
+  report: AdminMaintenanceReportContract;
+  affectedGameIds: string[];
+  audit: AdminAuditEntryContract;
+}
+
+export interface AdminAuditResponseContract {
+  entries: AdminAuditEntryContract[];
 }
 
 export interface GameMutationResponseContract {

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -632,6 +632,27 @@ export const gameListResponseSchema = objectSchema({
 
 export type GameListResponse = z.infer<typeof gameListResponseSchema>;
 
+export const adminGameDefaultsSchema = objectSchema({
+  totalPlayers: z.number().int().nullable().optional(),
+  contentPackId: z.string().min(1).nullable().optional(),
+  ruleSetId: z.string().min(1).nullable().optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  diceRuleSetId: z.string().min(1).nullable().optional(),
+  victoryRuleSetId: z.string().min(1).nullable().optional(),
+  pieceSetId: z.string().min(1).nullable().optional(),
+  themeId: z.string().min(1).nullable().optional(),
+  pieceSkinId: z.string().min(1).nullable().optional(),
+  gamePresetId: z.string().min(1).nullable().optional(),
+  activeModuleIds: z.array(z.string().min(1)).optional(),
+  contentProfileId: z.string().min(1).nullable().optional(),
+  gameplayProfileId: z.string().min(1).nullable().optional(),
+  uiProfileId: z.string().min(1).nullable().optional(),
+  turnTimeoutHours: z.number().int().nullable().optional(),
+  players: z.array(playerSlotConfigSchema).nullable().optional()
+});
+
+export type AdminGameDefaults = z.infer<typeof adminGameDefaultsSchema>;
+
 export const gameOptionsResponseSchema = objectSchema({
   ruleSets: z.array(ruleSetSummarySchema),
   maps: z.array(mapSummarySchema),
@@ -653,7 +674,8 @@ export const gameOptionsResponseSchema = objectSchema({
   playerRange: objectSchema({
     min: z.number().int(),
     max: z.number().int()
-  })
+  }),
+  adminDefaults: adminGameDefaultsSchema.optional()
 });
 
 export type GameOptionsResponse = z.infer<typeof gameOptionsResponseSchema>;
@@ -998,3 +1020,207 @@ export const profileResponseSchema = objectSchema({
 });
 
 export type ProfileResponse = z.infer<typeof profileResponseSchema>;
+
+export const adminIssueSchema = objectSchema({
+  code: z.string().min(1),
+  severity: z.enum(["info", "warning", "error"]),
+  message: z.string().min(1),
+  gameId: z.string().min(1).nullable().optional(),
+  actionId: z.string().min(1).nullable().optional()
+});
+
+export type AdminIssue = z.infer<typeof adminIssueSchema>;
+
+export const adminAuditEntrySchema = objectSchema({
+  id: z.string().min(1),
+  actorId: z.string().min(1),
+  actorUsername: z.string().min(1),
+  action: z.string().min(1),
+  targetType: z.string().min(1),
+  targetId: z.string().min(1).nullable().optional(),
+  targetLabel: z.string().min(1).nullable().optional(),
+  result: z.enum(["success", "failure"]),
+  createdAt: z.string().min(1),
+  details: z.record(z.string(), z.unknown()).nullable().optional()
+});
+
+export type AdminAuditEntry = z.infer<typeof adminAuditEntrySchema>;
+
+export const adminConfigSchema = objectSchema({
+  defaults: adminGameDefaultsSchema,
+  maintenance: objectSchema({
+    staleLobbyDays: z.number().int().min(1).max(365),
+    auditLogLimit: z.number().int().min(10).max(500)
+  }),
+  updatedAt: z.string().min(1).nullable().optional(),
+  updatedBy: publicUserSchema.nullable().optional()
+});
+
+export type AdminConfig = z.infer<typeof adminConfigSchema>;
+
+export const adminUserSummarySchema = publicUserSchema.extend({
+  createdAt: z.string().min(1),
+  gamesPlayed: z.number().int(),
+  gamesInProgress: z.number().int(),
+  wins: z.number().int(),
+  canPromote: z.boolean(),
+  canDemote: z.boolean()
+});
+
+export type AdminUserSummary = z.infer<typeof adminUserSummarySchema>;
+
+export const adminGameSummarySchema = gameSummarySchema.extend({
+  stale: z.boolean(),
+  health: z.enum(["ok", "warning", "error"]),
+  issueCount: z.number().int(),
+  issues: z.array(adminIssueSchema)
+});
+
+export type AdminGameSummary = z.infer<typeof adminGameSummarySchema>;
+
+export const adminGamePlayerSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  linkedUserId: z.string().min(1).nullable().optional(),
+  isAi: z.boolean().optional(),
+  surrendered: z.boolean().optional(),
+  territoryCount: z.number().int(),
+  cardCount: z.number().int()
+});
+
+export type AdminGamePlayer = z.infer<typeof adminGamePlayerSchema>;
+
+export const adminOverviewResponseSchema = objectSchema({
+  summary: objectSchema({
+    totalUsers: z.number().int(),
+    adminUsers: z.number().int(),
+    activeGames: z.number().int(),
+    lobbyGames: z.number().int(),
+    finishedGames: z.number().int(),
+    staleLobbies: z.number().int(),
+    invalidGames: z.number().int(),
+    enabledModules: z.number().int()
+  }),
+  config: adminConfigSchema,
+  recentGames: z.array(adminGameSummarySchema),
+  issues: z.array(adminIssueSchema),
+  audit: z.array(adminAuditEntrySchema)
+});
+
+export type AdminOverviewResponse = z.infer<typeof adminOverviewResponseSchema>;
+
+export const adminUsersResponseSchema = objectSchema({
+  users: z.array(adminUserSummarySchema),
+  total: z.number().int(),
+  filteredTotal: z.number().int(),
+  query: z.string(),
+  role: z.string().min(1).nullable().optional()
+});
+
+export type AdminUsersResponse = z.infer<typeof adminUsersResponseSchema>;
+
+export const adminUserRoleUpdateRequestSchema = objectSchema({
+  userId: z.string().min(1),
+  role: z.enum(["admin", "user"])
+});
+
+export type AdminUserRoleUpdateRequest = z.infer<typeof adminUserRoleUpdateRequestSchema>;
+
+export const adminUserRoleUpdateResponseSchema = objectSchema({
+  ok: z.literal(true),
+  user: adminUserSummarySchema,
+  audit: adminAuditEntrySchema
+});
+
+export type AdminUserRoleUpdateResponse = z.infer<typeof adminUserRoleUpdateResponseSchema>;
+
+export const adminGamesResponseSchema = objectSchema({
+  games: z.array(adminGameSummarySchema),
+  total: z.number().int(),
+  filteredTotal: z.number().int(),
+  status: z.string().min(1).nullable().optional(),
+  query: z.string()
+});
+
+export type AdminGamesResponse = z.infer<typeof adminGamesResponseSchema>;
+
+export const adminGameDetailsResponseSchema = objectSchema({
+  game: adminGameSummarySchema,
+  players: z.array(adminGamePlayerSchema),
+  rawState: z.record(z.string(), z.unknown())
+});
+
+export type AdminGameDetailsResponse = z.infer<typeof adminGameDetailsResponseSchema>;
+
+export const adminGameActionRequestSchema = objectSchema({
+  gameId: z.string().min(1),
+  action: z.enum(["close-lobby", "terminate-game", "repair-game-config"]),
+  confirmation: z.string().min(1).nullable().optional()
+});
+
+export type AdminGameActionRequest = z.infer<typeof adminGameActionRequestSchema>;
+
+export const adminGameActionResponseSchema = objectSchema({
+  ok: z.literal(true),
+  game: adminGameSummarySchema,
+  players: z.array(adminGamePlayerSchema),
+  rawState: z.record(z.string(), z.unknown()),
+  audit: adminAuditEntrySchema
+});
+
+export type AdminGameActionResponse = z.infer<typeof adminGameActionResponseSchema>;
+
+export const adminConfigResponseSchema = objectSchema({
+  config: adminConfigSchema
+});
+
+export type AdminConfigResponse = z.infer<typeof adminConfigResponseSchema>;
+
+export const adminConfigUpdateRequestSchema = objectSchema({
+  defaults: adminGameDefaultsSchema,
+  maintenance: adminConfigSchema.shape.maintenance.optional()
+});
+
+export type AdminConfigUpdateRequest = z.infer<typeof adminConfigUpdateRequestSchema>;
+
+export const adminConfigUpdateResponseSchema = objectSchema({
+  ok: z.literal(true),
+  config: adminConfigSchema,
+  audit: adminAuditEntrySchema
+});
+
+export type AdminConfigUpdateResponse = z.infer<typeof adminConfigUpdateResponseSchema>;
+
+export const adminMaintenanceReportSchema = objectSchema({
+  summary: objectSchema({
+    totalGames: z.number().int(),
+    staleLobbies: z.number().int(),
+    invalidGames: z.number().int(),
+    orphanedModuleReferences: z.number().int()
+  }),
+  issues: z.array(adminIssueSchema)
+});
+
+export type AdminMaintenanceReport = z.infer<typeof adminMaintenanceReportSchema>;
+
+export const adminMaintenanceActionRequestSchema = objectSchema({
+  action: z.enum(["validate-all", "cleanup-stale-lobbies"]),
+  confirmation: z.string().min(1).nullable().optional()
+});
+
+export type AdminMaintenanceActionRequest = z.infer<typeof adminMaintenanceActionRequestSchema>;
+
+export const adminMaintenanceActionResponseSchema = objectSchema({
+  ok: z.literal(true),
+  report: adminMaintenanceReportSchema,
+  affectedGameIds: z.array(z.string().min(1)),
+  audit: adminAuditEntrySchema
+});
+
+export type AdminMaintenanceActionResponse = z.infer<typeof adminMaintenanceActionResponseSchema>;
+
+export const adminAuditResponseSchema = objectSchema({
+  entries: z.array(adminAuditEntrySchema)
+});
+
+export type AdminAuditResponse = z.infer<typeof adminAuditResponseSchema>;

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -350,6 +350,11 @@ register(
                 scope: "game",
                 hook: "setup.profile",
                 description: "Setup defaults profile"
+              },
+              {
+                kind: "player-piece-set",
+                scope: "game",
+                description: "Runtime player piece set"
               }
             ],
             entrypoints: {
@@ -366,6 +371,13 @@ register(
           },
           serverEntryPath: "server-module.cjs",
           serverEntrySource: `module.exports = {
+  playerPieceSets: [
+    {
+      id: "signal-palette",
+      name: "Signal Palette",
+      palette: ["#112233", "#445566", "#778899", "#99aabb"]
+    }
+  ],
   profiles: {
     content: [
       { id: "demo.defaults.content", defaults: { mapId: "world-classic" } }
@@ -404,6 +416,7 @@ register(
           {
             defaults: {
               activeModuleIds: ["demo.defaults"],
+              pieceSetId: "signal-palette",
               contentProfileId: "demo.defaults.content",
               gameplayProfileId: "demo.defaults.gameplay",
               uiProfileId: "demo.defaults.ui"
@@ -417,6 +430,7 @@ register(
           "core.base",
           "demo.defaults"
         ]);
+        assert.equal(configResponse.payload.config.defaults.pieceSetId, "signal-palette");
         assert.equal(
           configResponse.payload.config.defaults.contentProfileId,
           "demo.defaults.content"
@@ -453,6 +467,7 @@ register(
           "demo.defaults.gameplay"
         );
         assert.equal(createGameResponse.payload.state.gameConfig.uiProfileId, "demo.defaults.ui");
+        assert.equal(createGameResponse.payload.state.gameConfig.pieceSetId, "signal-palette");
         assert.equal(createGameResponse.payload.state.gameConfig.mapId, "world-classic");
         assert.equal(createGameResponse.payload.state.gameConfig.ruleSetId, "classic-defense-3");
         assert.equal(createGameResponse.payload.state.gameConfig.diceRuleSetId, "defense-3");

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -236,6 +236,75 @@ register("admin console overview rejects anonymous and non-admin access", async 
   });
 });
 
+register("admin mutation routes reject anonymous and non-admin access", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Protected Admin Mutation Lobby"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createGameResponse.statusCode, 201);
+    const gameId = createGameResponse.payload.game.id;
+
+    const registered = await app.auth.registerPasswordUser("field_captain", "secret123");
+    assert.equal(registered.ok, true);
+    const login = await app.auth.loginWithPassword("field_captain", "secret123");
+    assert.equal(login.ok, true);
+
+    const anonymousGameActionResponse = await callApp(app, "POST", "/api/admin/games/action", {
+      gameId,
+      action: "close-lobby",
+      confirmation: gameId
+    });
+    assert.equal(anonymousGameActionResponse.statusCode, 401);
+    assert.equal(anonymousGameActionResponse.payload.code, "AUTH_REQUIRED");
+
+    const nonAdminGameActionResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/games/action",
+      {
+        gameId,
+        action: "close-lobby",
+        confirmation: gameId
+      },
+      authHeaders(login.sessionToken)
+    );
+    assert.equal(nonAdminGameActionResponse.statusCode, 403);
+    assert.equal(nonAdminGameActionResponse.payload.code, "ADMIN_ONLY");
+
+    const nonAdminMaintenanceResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/maintenance",
+      {
+        action: "validate-all"
+      },
+      authHeaders(login.sessionToken)
+    );
+    assert.equal(nonAdminMaintenanceResponse.statusCode, 403);
+    assert.equal(nonAdminMaintenanceResponse.payload.code, "ADMIN_ONLY");
+
+    const nonAdminConfigResponse = await callApp(
+      app,
+      "PUT",
+      "/api/admin/config",
+      {
+        defaults: {
+          themeId: "ember"
+        }
+      },
+      authHeaders(login.sessionToken)
+    );
+    assert.equal(nonAdminConfigResponse.statusCode, 403);
+    assert.equal(nonAdminConfigResponse.payload.code, "ADMIN_ONLY");
+  });
+});
+
 register("admin console can promote a user and grant admin access", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
     const registered = await app.auth.registerPasswordUser("operations_guest", "secret123");
@@ -584,6 +653,81 @@ register("admin console can close a lobby with explicit confirmation", async () 
     assert.equal(closeResponse.payload.audit.action, "game.close-lobby");
   });
 });
+
+register(
+  "admin destructive actions require explicit confirmation and audit failed attempts",
+  async () => {
+    await withAdminApp(async ({ app, adminSessionToken }) => {
+      const createGameResponse = await callApp(
+        app,
+        "POST",
+        "/api/games",
+        {
+          name: "Confirmation Required Lobby"
+        },
+        authHeaders(adminSessionToken)
+      );
+
+      assert.equal(createGameResponse.statusCode, 201);
+      const gameId = createGameResponse.payload.game.id;
+
+      const closeResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/games/action",
+        {
+          gameId,
+          action: "close-lobby"
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(closeResponse.statusCode, 400);
+
+      const gameDetailResponse = await callApp(
+        app,
+        "GET",
+        `/api/admin/games/${gameId}`,
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(gameDetailResponse.statusCode, 200);
+      assert.equal(gameDetailResponse.payload.game.phase, "lobby");
+
+      const cleanupResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/maintenance",
+        {
+          action: "cleanup-stale-lobbies"
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(cleanupResponse.statusCode, 400);
+
+      const auditResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/audit",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(auditResponse.statusCode, 200);
+      assert.equal(
+        auditResponse.payload.entries.some(
+          (entry: any) => entry.action === "game.close-lobby" && entry.result === "failure"
+        ),
+        true
+      );
+      assert.equal(
+        auditResponse.payload.entries.some(
+          (entry: any) =>
+            entry.action === "maintenance.cleanup-stale-lobbies" && entry.result === "failure"
+        ),
+        true
+      );
+    });
+  }
+);
 
 register(
   "admin repair preserves runtime dice rule ids while fixing the stored snapshot",

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -4,6 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const { createApp } = require("../../../backend/server.cjs");
+const { createAdminConsole } = require("../../../backend/admin-console.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
@@ -241,6 +242,9 @@ register("admin console updates defaults and new game creation consumes them", a
         defaults: {
           themeId: "ember",
           mapId: "middle-earth",
+          diceRuleSetId: "defense-3",
+          victoryRuleSetId: "majority-control",
+          pieceSkinId: "command-ring",
           totalPlayers: 3
         },
         maintenance: {
@@ -260,6 +264,9 @@ register("admin console updates defaults and new game creation consumes them", a
     assert.equal(optionsResponse.statusCode, 200);
     assert.equal(optionsResponse.payload.adminDefaults.themeId, "ember");
     assert.equal(optionsResponse.payload.adminDefaults.mapId, "middle-earth");
+    assert.equal(optionsResponse.payload.adminDefaults.diceRuleSetId, "defense-3");
+    assert.equal(optionsResponse.payload.adminDefaults.victoryRuleSetId, "majority-control");
+    assert.equal(optionsResponse.payload.adminDefaults.pieceSkinId, "command-ring");
     assert.equal(optionsResponse.payload.adminDefaults.totalPlayers, 3);
 
     const createGameResponse = await callApp(
@@ -274,7 +281,62 @@ register("admin console updates defaults and new game creation consumes them", a
     assert.equal(createGameResponse.statusCode, 200);
     assert.equal(createGameResponse.payload.state.gameConfig.themeId, "ember");
     assert.equal(createGameResponse.payload.state.gameConfig.mapId, "middle-earth");
+    assert.equal(createGameResponse.payload.state.gameConfig.diceRuleSetId, "defense-3");
+    assert.equal(createGameResponse.payload.state.gameConfig.victoryRuleSetId, "majority-control");
+    assert.equal(createGameResponse.payload.state.gameConfig.pieceSkinId, "command-ring");
     assert.equal(createGameResponse.payload.state.gameConfig.totalPlayers, 3);
+  });
+});
+
+register("public game options ignore stale invalid admin defaults instead of failing", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const configResponse = await callApp(
+      app,
+      "PUT",
+      "/api/admin/config",
+      {
+        defaults: {
+          activeModuleIds: ["demo.missing-module"],
+          gamePresetId: "demo.missing-preset"
+        }
+      },
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(configResponse.statusCode, 400);
+
+    await app.datastore.setAppState("adminConsoleConfig", {
+      defaults: {
+        activeModuleIds: ["demo.missing-module"],
+        gamePresetId: "demo.missing-preset"
+      },
+      maintenance: {
+        staleLobbyDays: 7,
+        auditLogLimit: 120
+      },
+      updatedAt: new Date().toISOString(),
+      updatedBy: {
+        id: "admin_commander",
+        username: "admin_commander",
+        role: "admin"
+      }
+    });
+
+    const optionsResponse = await callApp(app, "GET", "/api/game/options");
+    assert.equal(optionsResponse.statusCode, 200);
+    assert.equal("adminDefaults" in optionsResponse.payload, false);
+
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Fallback Config Match"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createGameResponse.statusCode, 200);
+    assert.equal(createGameResponse.payload.state.gameConfig.mapId, "classic-mini");
   });
 });
 
@@ -403,4 +465,189 @@ register("admin repair preserves runtime dice rule ids while fixing the stored s
       assert.equal(repairResponse.payload.rawState.diceRuleSetId, "demo-barrage");
     }
   );
+});
+
+register("stale lobby cleanup skips games that become active before mutation", async () => {
+  const persistedStates: Array<{ gameId: string; phase: string }> = [];
+  const broadcastStates: Array<{ gameId: string; phase: string }> = [];
+  const adminConsole = createAdminConsole({
+    datastore: {
+      listUsers() {
+        return [];
+      },
+      findUserById() {
+        return null;
+      },
+      updateUserRoleByUsername() {},
+      getAppState(key: string) {
+        if (key === "adminConsoleConfig") {
+          return {
+            defaults: {},
+            maintenance: {
+              staleLobbyDays: 1,
+              auditLogLimit: 120
+            }
+          };
+        }
+
+        if (key === "adminAuditLog") {
+          return [];
+        }
+
+        return null;
+      },
+      setAppState() {
+        return null;
+      }
+    },
+    auth: {
+      publicUser(user: any) {
+        return user;
+      }
+    },
+    gameSessions: {
+      listGames() {
+        return [
+          {
+            id: "game-race",
+            name: "Race Lobby",
+            version: 1,
+            phase: "lobby",
+            playerCount: 1,
+            updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+          }
+        ];
+      },
+      getGame() {
+        return {
+          game: {
+            id: "game-race",
+            name: "Race Lobby",
+            version: 1,
+            phase: "lobby",
+            playerCount: 1,
+            updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+          },
+          state: {
+            phase: "lobby",
+            players: [],
+            territories: {},
+            hands: {},
+            gameConfig: {}
+          }
+        };
+      },
+      datastore: {
+        listGames() {
+          return [
+            {
+              id: "game-race",
+              name: "Race Lobby",
+              version: 1,
+              creatorUserId: null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+              state: {
+                phase: "lobby",
+                players: [],
+                territories: {},
+                hands: {},
+                gameConfig: {}
+              }
+            }
+          ];
+        }
+      }
+    },
+    loadGameContext() {
+      return {
+        gameId: "game-race",
+        gameName: "Race Lobby",
+        version: 1,
+        state: {
+          phase: "active",
+          players: [],
+          territories: {},
+          hands: {},
+          gameConfig: {}
+        }
+      };
+    },
+    persistGameContext(gameContext: any) {
+      persistedStates.push({
+        gameId: gameContext.gameId,
+        phase: String(gameContext.state?.phase || "")
+      });
+      return null;
+    },
+    broadcastGame(gameContext: any) {
+      broadcastStates.push({
+        gameId: gameContext.gameId,
+        phase: String(gameContext.state?.phase || "")
+      });
+    },
+    createConfiguredInitialState() {
+      return {
+        state: {
+          gameConfig: {},
+          contentPackId: "core",
+          diceRuleSetId: "standard",
+          victoryRuleSetId: "conquest",
+          pieceSetId: "classic"
+        },
+        config: {}
+      };
+    },
+    moduleRuntime: {
+      listInstalledModules() {
+        return [];
+      },
+      getEnabledModules() {
+        return [];
+      },
+      findSupportedMap() {
+        return null;
+      },
+      findContentPack() {
+        return null;
+      },
+      findPlayerPieceSet() {
+        return null;
+      },
+      findDiceRuleSet() {
+        return null;
+      },
+      resolveGamePreset() {
+        return null;
+      },
+      resolveGameConfigDefaults() {
+        return {};
+      },
+      resolveGameSelection() {
+        return {
+          moduleSchemaVersion: 1,
+          activeModules: [],
+          contentProfileId: null,
+          gameplayProfileId: null,
+          uiProfileId: null
+        };
+      }
+    }
+  });
+
+  const actionResponse = await adminConsole.runMaintenanceAction(
+    {
+      id: "admin-1",
+      username: "admin_commander",
+      role: "admin"
+    },
+    {
+      action: "cleanup-stale-lobbies",
+      confirmation: "cleanup-stale-lobbies"
+    }
+  );
+
+  assert.deepEqual(actionResponse.affectedGameIds, []);
+  assert.deepEqual(persistedStates, []);
+  assert.deepEqual(broadcastStates, []);
 });

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -1,0 +1,406 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { createApp } = require("../../../backend/server.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type HeaderMap = Record<string, string>;
+
+type MockResponse = {
+  statusCode: number;
+  headers: HeaderMap;
+  body: string;
+  setHeader(name: string, value: string): void;
+  writeHead(statusCode: number, nextHeaders?: HeaderMap): void;
+  end(chunk?: string): void;
+};
+
+function makeMockResponse(): MockResponse {
+  const headers: HeaderMap = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: "",
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
+    writeHead(statusCode: number, nextHeaders: HeaderMap = {}) {
+      this.statusCode = statusCode;
+      Object.assign(headers, nextHeaders);
+    },
+    end(chunk = "") {
+      this.body += chunk || "";
+    }
+  };
+}
+
+async function callApp(
+  app: any,
+  method: string,
+  pathname: string,
+  body?: any,
+  headers: HeaderMap = {}
+): Promise<{ statusCode: number; payload: any }> {
+  const req = new (require("events").EventEmitter)();
+  req.method = method;
+  req.headers = { "content-type": "application/json", ...headers };
+  req.destroy = () => {};
+  const res = makeMockResponse();
+  const promise = app.handleApi(req, res, new URL(`http://127.0.0.1${pathname}`));
+
+  process.nextTick(() => {
+    if (body !== undefined) {
+      req.emit("data", JSON.stringify(body));
+    }
+    req.emit("end");
+  });
+
+  await promise;
+  return {
+    statusCode: res.statusCode,
+    payload: res.body ? JSON.parse(res.body) : null
+  };
+}
+
+function authHeaders(sessionToken: string): HeaderMap {
+  return {
+    cookie: `netrisk_session=${encodeURIComponent(sessionToken)}`
+  };
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function cleanupSqliteFiles(baseFile: string): void {
+  [baseFile, `${baseFile}-shm`, `${baseFile}-wal`].forEach((target) => {
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { force: true });
+    }
+  });
+}
+
+async function withAdminApp(
+  run: (context: { app: any; adminSessionToken: string; tempRoot: string }) => Promise<void>
+) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-admin-"));
+  const dataDir = path.join(tempRoot, "data");
+  const frontendDir = path.join(tempRoot, "frontend", "src");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(frontendDir, { recursive: true });
+
+  const originalProjectRoot = process.env.NETRISK_PROJECT_ROOT;
+  process.env.NETRISK_PROJECT_ROOT = tempRoot;
+
+  const tempDbFile = path.join(tempRoot, "data", "admin.sqlite");
+  const tempUsersFile = path.join(tempRoot, "data", "users.json");
+  const tempGamesFile = path.join(tempRoot, "data", "games.json");
+  const tempSessionsFile = path.join(tempRoot, "data", "sessions.json");
+  const app = createApp({
+    projectRoot: tempRoot,
+    dbFile: tempDbFile,
+    dataFile: tempUsersFile,
+    gamesFile: tempGamesFile,
+    sessionsFile: tempSessionsFile
+  });
+
+  try {
+    const registered = await app.auth.registerPasswordUser("admin_commander", "secret123");
+    assert.equal(registered.ok, true);
+    await app.datastore.updateUserRoleByUsername("admin_commander", "admin");
+    const login = await app.auth.loginWithPassword("admin_commander", "secret123");
+    assert.equal(login.ok, true);
+
+    await run({
+      app,
+      adminSessionToken: login.sessionToken,
+      tempRoot
+    });
+  } finally {
+    app.datastore.close();
+    cleanupSqliteFiles(tempDbFile);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    if (typeof originalProjectRoot === "undefined") {
+      delete process.env.NETRISK_PROJECT_ROOT;
+    } else {
+      process.env.NETRISK_PROJECT_ROOT = originalProjectRoot;
+    }
+  }
+}
+
+async function withModuleAdminApp(
+  modules: Array<{
+    dir: string;
+    manifest?: unknown;
+    clientManifest?: unknown;
+    rawManifest?: string;
+    serverEntryPath?: string;
+    serverEntrySource?: string;
+  }>,
+  run: (context: { app: any; adminSessionToken: string; tempRoot: string }) => Promise<void>
+) {
+  await withAdminApp(async (context) => {
+    modules.forEach((moduleEntry) => {
+      const moduleRoot = path.join(context.tempRoot, "modules", moduleEntry.dir);
+      fs.mkdirSync(moduleRoot, { recursive: true });
+
+      if (typeof moduleEntry.rawManifest === "string") {
+        fs.writeFileSync(path.join(moduleRoot, "module.json"), moduleEntry.rawManifest);
+        return;
+      }
+
+      if (typeof moduleEntry.manifest !== "undefined") {
+        writeJson(path.join(moduleRoot, "module.json"), moduleEntry.manifest);
+      }
+
+      if (typeof moduleEntry.clientManifest !== "undefined") {
+        writeJson(path.join(moduleRoot, "client-manifest.json"), moduleEntry.clientManifest);
+      }
+
+      if (moduleEntry.serverEntryPath && typeof moduleEntry.serverEntrySource === "string") {
+        const serverEntryFilePath = path.join(moduleRoot, moduleEntry.serverEntryPath);
+        fs.mkdirSync(path.dirname(serverEntryFilePath), { recursive: true });
+        fs.writeFileSync(serverEntryFilePath, moduleEntry.serverEntrySource);
+      }
+    });
+
+    await run(context);
+  });
+}
+
+register("admin console overview rejects anonymous and non-admin access", async () => {
+  await withAdminApp(async ({ app }) => {
+    const anonymousResponse = await callApp(app, "GET", "/api/admin/overview");
+    assert.equal(anonymousResponse.statusCode, 401);
+    assert.equal(anonymousResponse.payload.code, "AUTH_REQUIRED");
+
+    const registered = await app.auth.registerPasswordUser("field_captain", "secret123");
+    assert.equal(registered.ok, true);
+    const login = await app.auth.loginWithPassword("field_captain", "secret123");
+    assert.equal(login.ok, true);
+
+    const nonAdminResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/overview",
+      undefined,
+      authHeaders(login.sessionToken)
+    );
+    assert.equal(nonAdminResponse.statusCode, 403);
+    assert.equal(nonAdminResponse.payload.code, "ADMIN_ONLY");
+  });
+});
+
+register("admin console can promote a user and grant admin access", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const registered = await app.auth.registerPasswordUser("operations_guest", "secret123");
+    assert.equal(registered.ok, true);
+    const guestLogin = await app.auth.loginWithPassword("operations_guest", "secret123");
+    assert.equal(guestLogin.ok, true);
+    const storedUser = await app.datastore.findUserByUsername("operations_guest");
+    assert.ok(storedUser);
+
+    const promoteResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/users/role",
+      {
+        userId: storedUser.id,
+        role: "admin"
+      },
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(promoteResponse.statusCode, 200);
+    assert.equal(promoteResponse.payload.user.role, "admin");
+    assert.equal(promoteResponse.payload.audit.action, "user.role.update");
+
+    const elevatedResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/overview",
+      undefined,
+      authHeaders(guestLogin.sessionToken)
+    );
+    assert.equal(elevatedResponse.statusCode, 200);
+    assert.equal(elevatedResponse.payload.summary.adminUsers >= 2, true);
+  });
+});
+
+register("admin console updates defaults and new game creation consumes them", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const configResponse = await callApp(
+      app,
+      "PUT",
+      "/api/admin/config",
+      {
+        defaults: {
+          themeId: "ember",
+          mapId: "middle-earth",
+          totalPlayers: 3
+        },
+        maintenance: {
+          staleLobbyDays: 5,
+          auditLogLimit: 150
+        }
+      },
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(configResponse.statusCode, 200);
+    assert.equal(configResponse.payload.config.defaults.themeId, "ember");
+    assert.equal(configResponse.payload.config.defaults.mapId, "middle-earth");
+    assert.equal(configResponse.payload.config.defaults.totalPlayers, 3);
+
+    const optionsResponse = await callApp(app, "GET", "/api/game/options");
+    assert.equal(optionsResponse.statusCode, 200);
+    assert.equal(optionsResponse.payload.adminDefaults.themeId, "ember");
+    assert.equal(optionsResponse.payload.adminDefaults.mapId, "middle-earth");
+    assert.equal(optionsResponse.payload.adminDefaults.totalPlayers, 3);
+
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Admin Default Match"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createGameResponse.statusCode, 200);
+    assert.equal(createGameResponse.payload.state.gameConfig.themeId, "ember");
+    assert.equal(createGameResponse.payload.state.gameConfig.mapId, "middle-earth");
+    assert.equal(createGameResponse.payload.state.gameConfig.totalPlayers, 3);
+  });
+});
+
+register("admin console can close a lobby with explicit confirmation", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Abandoned Lobby"
+      },
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(createGameResponse.statusCode, 200);
+    const gameId = createGameResponse.payload.game.id;
+
+    const closeResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/games/action",
+      {
+        gameId,
+        action: "close-lobby",
+        confirmation: gameId
+      },
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(closeResponse.statusCode, 200);
+    assert.equal(closeResponse.payload.game.phase, "finished");
+    assert.equal(closeResponse.payload.audit.action, "game.close-lobby");
+  });
+});
+
+register("admin repair preserves runtime dice rule ids while fixing the stored snapshot", async () => {
+  await withModuleAdminApp(
+    [
+      {
+        dir: "demo.dice-rules",
+        manifest: {
+          schemaVersion: 1,
+          id: "demo.dice-rules",
+          version: "1.0.0",
+          displayName: "Demo Dice Rules",
+          engineVersion: "1.0.0",
+          kind: "hybrid",
+          dependencies: [{ id: "core.base", version: "1.x" }],
+          conflicts: [],
+          capabilities: [
+            {
+              kind: "dice-rule-set",
+              scope: "game",
+              description: "Runtime dice rules"
+            }
+          ],
+          entrypoints: {
+            server: "server-module.cjs"
+          }
+        },
+        serverEntryPath: "server-module.cjs",
+        serverEntrySource: `module.exports = {
+  listDiceRuleSets() {
+    return [
+      {
+        id: "demo-barrage",
+        name: "Demo Barrage",
+        attackerMaxDice: 4,
+        defenderMaxDice: 2,
+        attackerMustLeaveOneArmyBehind: true,
+        defenderWinsTies: true
+      }
+    ];
+  }
+};`
+      }
+    ],
+    async ({ app, adminSessionToken }) => {
+      const enableModuleResponse = await callApp(
+        app,
+        "POST",
+        "/api/modules/demo.dice-rules/enable",
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(enableModuleResponse.statusCode, 200);
+
+      const createGameResponse = await callApp(
+        app,
+        "POST",
+        "/api/games",
+        {
+          name: "Runtime Repair",
+          activeModuleIds: ["demo.dice-rules"],
+          diceRuleSetId: "demo-barrage"
+        },
+        authHeaders(adminSessionToken)
+      );
+
+      assert.equal(createGameResponse.statusCode, 200);
+      const gameId = createGameResponse.payload.game.id;
+      const storedGame = await app.datastore.findGameById(gameId);
+      assert.ok(storedGame);
+
+      storedGame.state.gameConfig.diceRuleSetId = "demo-barrage";
+      storedGame.state.gameConfig.diceRuleSetName = "Demo Barrage";
+      storedGame.state.diceRuleSetId = "standard";
+      storedGame.updatedAt = new Date().toISOString();
+      await app.datastore.updateGame(storedGame);
+
+      const repairResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/games/action",
+        {
+          gameId,
+          action: "repair-game-config"
+        },
+        authHeaders(adminSessionToken)
+      );
+
+      assert.equal(repairResponse.statusCode, 200);
+      assert.equal(repairResponse.payload.rawState.gameConfig.diceRuleSetId, "demo-barrage");
+      assert.equal(repairResponse.payload.rawState.diceRuleSetName, "Demo Barrage");
+      assert.equal(repairResponse.payload.rawState.diceRuleSetId, "demo-barrage");
+    }
+  );
+});

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -477,6 +477,24 @@ register(
         );
         assert.equal(createGameResponse.payload.state.gameConfig.themeId, "ember");
         assert.equal(createGameResponse.payload.state.gameConfig.pieceSkinId, "command-ring");
+
+        const explicitRuleSetResponse = await callApp(
+          app,
+          "POST",
+          "/api/games",
+          {
+            name: "Admin Module Defaults With Explicit Rule Set",
+            ruleSetId: "classic-defense-3"
+          },
+          authHeaders(adminSessionToken)
+        );
+
+        assert.equal(explicitRuleSetResponse.statusCode, 201);
+        assert.equal(
+          explicitRuleSetResponse.payload.state.gameConfig.ruleSetId,
+          "classic-defense-3"
+        );
+        assert.equal(explicitRuleSetResponse.payload.state.gameConfig.pieceSetId, "signal-palette");
       }
     );
   }

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -144,33 +144,73 @@ async function withModuleAdminApp(
   }>,
   run: (context: { app: any; adminSessionToken: string; tempRoot: string }) => Promise<void>
 ) {
-  await withAdminApp(async (context) => {
-    modules.forEach((moduleEntry) => {
-      const moduleRoot = path.join(context.tempRoot, "modules", moduleEntry.dir);
-      fs.mkdirSync(moduleRoot, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-admin-modules-"));
+  const dataDir = path.join(tempRoot, "data");
+  const frontendDir = path.join(tempRoot, "frontend", "src");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(frontendDir, { recursive: true });
 
-      if (typeof moduleEntry.rawManifest === "string") {
-        fs.writeFileSync(path.join(moduleRoot, "module.json"), moduleEntry.rawManifest);
-        return;
-      }
+  modules.forEach((moduleEntry) => {
+    const moduleRoot = path.join(tempRoot, "modules", moduleEntry.dir);
+    fs.mkdirSync(moduleRoot, { recursive: true });
 
-      if (typeof moduleEntry.manifest !== "undefined") {
-        writeJson(path.join(moduleRoot, "module.json"), moduleEntry.manifest);
-      }
+    if (typeof moduleEntry.rawManifest === "string") {
+      fs.writeFileSync(path.join(moduleRoot, "module.json"), moduleEntry.rawManifest);
+      return;
+    }
 
-      if (typeof moduleEntry.clientManifest !== "undefined") {
-        writeJson(path.join(moduleRoot, "client-manifest.json"), moduleEntry.clientManifest);
-      }
+    if (typeof moduleEntry.manifest !== "undefined") {
+      writeJson(path.join(moduleRoot, "module.json"), moduleEntry.manifest);
+    }
 
-      if (moduleEntry.serverEntryPath && typeof moduleEntry.serverEntrySource === "string") {
-        const serverEntryFilePath = path.join(moduleRoot, moduleEntry.serverEntryPath);
-        fs.mkdirSync(path.dirname(serverEntryFilePath), { recursive: true });
-        fs.writeFileSync(serverEntryFilePath, moduleEntry.serverEntrySource);
-      }
-    });
+    if (typeof moduleEntry.clientManifest !== "undefined") {
+      writeJson(path.join(moduleRoot, "client-manifest.json"), moduleEntry.clientManifest);
+    }
 
-    await run(context);
+    if (moduleEntry.serverEntryPath && typeof moduleEntry.serverEntrySource === "string") {
+      const serverEntryFilePath = path.join(moduleRoot, moduleEntry.serverEntryPath);
+      fs.mkdirSync(path.dirname(serverEntryFilePath), { recursive: true });
+      fs.writeFileSync(serverEntryFilePath, moduleEntry.serverEntrySource);
+    }
   });
+
+  const originalProjectRoot = process.env.NETRISK_PROJECT_ROOT;
+  process.env.NETRISK_PROJECT_ROOT = tempRoot;
+
+  const tempDbFile = path.join(tempRoot, "data", "admin.sqlite");
+  const tempUsersFile = path.join(tempRoot, "data", "users.json");
+  const tempGamesFile = path.join(tempRoot, "data", "games.json");
+  const tempSessionsFile = path.join(tempRoot, "data", "sessions.json");
+  const app = createApp({
+    projectRoot: tempRoot,
+    dbFile: tempDbFile,
+    dataFile: tempUsersFile,
+    gamesFile: tempGamesFile,
+    sessionsFile: tempSessionsFile
+  });
+
+  try {
+    const registered = await app.auth.registerPasswordUser("admin_commander", "secret123");
+    assert.equal(registered.ok, true);
+    await app.datastore.updateUserRoleByUsername("admin_commander", "admin");
+    const login = await app.auth.loginWithPassword("admin_commander", "secret123");
+    assert.equal(login.ok, true);
+
+    await run({
+      app,
+      adminSessionToken: login.sessionToken,
+      tempRoot
+    });
+  } finally {
+    app.datastore.close();
+    cleanupSqliteFiles(tempDbFile);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    if (typeof originalProjectRoot === "undefined") {
+      delete process.env.NETRISK_PROJECT_ROOT;
+    } else {
+      process.env.NETRISK_PROJECT_ROOT = originalProjectRoot;
+    }
+  }
 }
 
 register("admin console overview rejects anonymous and non-admin access", async () => {
@@ -278,7 +318,7 @@ register("admin console updates defaults and new game creation consumes them", a
       },
       authHeaders(adminSessionToken)
     );
-    assert.equal(createGameResponse.statusCode, 200);
+    assert.equal(createGameResponse.statusCode, 201);
     assert.equal(createGameResponse.payload.state.gameConfig.themeId, "ember");
     assert.equal(createGameResponse.payload.state.gameConfig.mapId, "middle-earth");
     assert.equal(createGameResponse.payload.state.gameConfig.diceRuleSetId, "defense-3");
@@ -287,6 +327,145 @@ register("admin console updates defaults and new game creation consumes them", a
     assert.equal(createGameResponse.payload.state.gameConfig.totalPlayers, 3);
   });
 });
+
+register(
+  "admin module defaults seed module selection and profile defaults in backend-created games",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "demo.defaults",
+          manifest: {
+            schemaVersion: 1,
+            id: "demo.defaults",
+            version: "1.0.0",
+            displayName: "Demo Defaults",
+            engineVersion: "1.0.0",
+            kind: "hybrid",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [
+              {
+                kind: "gameplay-hook",
+                scope: "game",
+                hook: "setup.profile",
+                description: "Setup defaults profile"
+              }
+            ],
+            entrypoints: {
+              clientManifest: "client-manifest.json",
+              server: "server-module.cjs"
+            }
+          },
+          clientManifest: {
+            profiles: {
+              content: [{ id: "demo.defaults.content", name: "Defaults Content" }],
+              gameplay: [{ id: "demo.defaults.gameplay", name: "Defaults Gameplay" }],
+              ui: [{ id: "demo.defaults.ui", name: "Defaults UI" }]
+            }
+          },
+          serverEntryPath: "server-module.cjs",
+          serverEntrySource: `module.exports = {
+  profiles: {
+    content: [
+      { id: "demo.defaults.content", defaults: { mapId: "world-classic" } }
+    ],
+    gameplay: [
+      {
+        id: "demo.defaults.gameplay",
+        defaults: {
+          ruleSetId: "classic-defense-3",
+          diceRuleSetId: "defense-3",
+          victoryRuleSetId: "majority-control"
+        }
+      }
+    ],
+    ui: [
+      { id: "demo.defaults.ui", defaults: { themeId: "ember", pieceSkinId: "command-ring" } }
+    ]
+  }
+};`
+        }
+      ],
+      async ({ app, adminSessionToken }) => {
+        const enableResponse = await callApp(
+          app,
+          "POST",
+          "/api/modules/demo.defaults/enable",
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(enableResponse.statusCode, 200);
+
+        const configResponse = await callApp(
+          app,
+          "PUT",
+          "/api/admin/config",
+          {
+            defaults: {
+              activeModuleIds: ["demo.defaults"],
+              contentProfileId: "demo.defaults.content",
+              gameplayProfileId: "demo.defaults.gameplay",
+              uiProfileId: "demo.defaults.ui"
+            }
+          },
+          authHeaders(adminSessionToken)
+        );
+
+        assert.equal(configResponse.statusCode, 200);
+        assert.deepEqual(configResponse.payload.config.defaults.activeModuleIds, [
+          "core.base",
+          "demo.defaults"
+        ]);
+        assert.equal(
+          configResponse.payload.config.defaults.contentProfileId,
+          "demo.defaults.content"
+        );
+        assert.equal(
+          configResponse.payload.config.defaults.gameplayProfileId,
+          "demo.defaults.gameplay"
+        );
+        assert.equal(configResponse.payload.config.defaults.uiProfileId, "demo.defaults.ui");
+
+        const createGameResponse = await callApp(
+          app,
+          "POST",
+          "/api/games",
+          {
+            name: "Admin Module Defaults"
+          },
+          authHeaders(adminSessionToken)
+        );
+
+        assert.equal(createGameResponse.statusCode, 201);
+        assert.deepEqual(
+          createGameResponse.payload.state.gameConfig.activeModules.map(
+            (entry: { id: string }) => entry.id
+          ),
+          ["core.base", "demo.defaults"]
+        );
+        assert.equal(
+          createGameResponse.payload.state.gameConfig.contentProfileId,
+          "demo.defaults.content"
+        );
+        assert.equal(
+          createGameResponse.payload.state.gameConfig.gameplayProfileId,
+          "demo.defaults.gameplay"
+        );
+        assert.equal(createGameResponse.payload.state.gameConfig.uiProfileId, "demo.defaults.ui");
+        assert.equal(createGameResponse.payload.state.gameConfig.mapId, "world-classic");
+        assert.equal(createGameResponse.payload.state.gameConfig.ruleSetId, "classic-defense-3");
+        assert.equal(createGameResponse.payload.state.gameConfig.diceRuleSetId, "defense-3");
+        assert.equal(
+          createGameResponse.payload.state.gameConfig.victoryRuleSetId,
+          "majority-control"
+        );
+        assert.equal(createGameResponse.payload.state.gameConfig.themeId, "ember");
+        assert.equal(createGameResponse.payload.state.gameConfig.pieceSkinId, "command-ring");
+      }
+    );
+  }
+);
 
 register("public game options ignore stale invalid admin defaults instead of failing", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
@@ -335,7 +514,7 @@ register("public game options ignore stale invalid admin defaults instead of fai
       },
       authHeaders(adminSessionToken)
     );
-    assert.equal(createGameResponse.statusCode, 200);
+    assert.equal(createGameResponse.statusCode, 201);
     assert.equal(createGameResponse.payload.state.gameConfig.mapId, "classic-mini");
   });
 });
@@ -352,7 +531,7 @@ register("admin console can close a lobby with explicit confirmation", async () 
       authHeaders(adminSessionToken)
     );
 
-    assert.equal(createGameResponse.statusCode, 200);
+    assert.equal(createGameResponse.statusCode, 201);
     const gameId = createGameResponse.payload.game.id;
 
     const closeResponse = await callApp(
@@ -373,99 +552,836 @@ register("admin console can close a lobby with explicit confirmation", async () 
   });
 });
 
-register("admin repair preserves runtime dice rule ids while fixing the stored snapshot", async () => {
-  await withModuleAdminApp(
-    [
-      {
-        dir: "demo.dice-rules",
-        manifest: {
-          schemaVersion: 1,
-          id: "demo.dice-rules",
-          version: "1.0.0",
-          displayName: "Demo Dice Rules",
-          engineVersion: "1.0.0",
-          kind: "hybrid",
-          dependencies: [{ id: "core.base", version: "1.x" }],
-          conflicts: [],
-          capabilities: [
-            {
-              kind: "dice-rule-set",
-              scope: "game",
-              description: "Runtime dice rules"
+register(
+  "admin repair preserves runtime dice rule ids while fixing the stored snapshot",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "demo.dice-rules",
+          manifest: {
+            schemaVersion: 1,
+            id: "demo.dice-rules",
+            version: "1.0.0",
+            displayName: "Demo Dice Rules",
+            engineVersion: "1.0.0",
+            kind: "content",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [
+              {
+                kind: "dice-rule-set",
+                scope: "game",
+                description: "Runtime dice rules"
+              }
+            ],
+            entrypoints: {
+              server: "server-module.cjs"
             }
-          ],
-          entrypoints: {
-            server: "server-module.cjs"
-          }
-        },
-        serverEntryPath: "server-module.cjs",
-        serverEntrySource: `module.exports = {
-  listDiceRuleSets() {
-    return [
-      {
-        id: "demo-barrage",
-        name: "Demo Barrage",
-        attackerMaxDice: 4,
-        defenderMaxDice: 2,
-        attackerMustLeaveOneArmyBehind: true,
-        defenderWinsTies: true
-      }
-    ];
-  }
+          },
+          serverEntryPath: "server-module.cjs",
+          serverEntrySource: `module.exports = {
+  diceRuleSets: [
+    {
+      id: "demo-barrage",
+      name: "Demo Barrage",
+      attackerMaxDice: 4,
+      defenderMaxDice: 2,
+      attackerMustLeaveOneArmyBehind: true,
+      defenderWinsTies: true
+    }
+  ]
 };`
-      }
-    ],
-    async ({ app, adminSessionToken }) => {
-      const enableModuleResponse = await callApp(
-        app,
-        "POST",
-        "/api/modules/demo.dice-rules/enable",
-        {},
-        authHeaders(adminSessionToken)
-      );
-      assert.equal(enableModuleResponse.statusCode, 200);
+        }
+      ],
+      async ({ app, adminSessionToken }) => {
+        const enableModuleResponse = await callApp(
+          app,
+          "POST",
+          "/api/modules/demo.dice-rules/enable",
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(enableModuleResponse.statusCode, 200);
 
-      const createGameResponse = await callApp(
+        const createGameResponse = await callApp(
+          app,
+          "POST",
+          "/api/games",
+          {
+            name: "Runtime Repair",
+            activeModuleIds: ["demo.dice-rules"],
+            diceRuleSetId: "demo-barrage",
+            totalPlayers: 2,
+            players: [{ type: "human" }, { type: "human" }]
+          },
+          authHeaders(adminSessionToken)
+        );
+
+        assert.equal(createGameResponse.statusCode, 201);
+        const gameId = createGameResponse.payload.game.id;
+        const storedGame = await app.datastore.findGameById(gameId);
+        assert.ok(storedGame);
+
+        storedGame.state.gameConfig.diceRuleSetId = "demo-barrage";
+        storedGame.state.gameConfig.diceRuleSetName = "Demo Barrage";
+        storedGame.state.diceRuleSetId = "standard";
+        storedGame.updatedAt = new Date().toISOString();
+        await app.datastore.updateGame(storedGame);
+
+        const repairResponse = await callApp(
+          app,
+          "POST",
+          "/api/admin/games/action",
+          {
+            gameId,
+            action: "repair-game-config"
+          },
+          authHeaders(adminSessionToken)
+        );
+
+        assert.equal(repairResponse.statusCode, 200);
+        assert.equal(repairResponse.payload.rawState.gameConfig.diceRuleSetId, "demo-barrage");
+        assert.equal(repairResponse.payload.rawState.gameConfig.diceRuleSetName, "Demo Barrage");
+        assert.equal(repairResponse.payload.rawState.diceRuleSetId, "demo-barrage");
+      }
+    );
+  }
+);
+
+register(
+  "admin console routes expose operational reads, maintenance validation, termination, and audit history",
+  async () => {
+    await withAdminApp(async ({ app, adminSessionToken }) => {
+      const adminUser = await app.datastore.findUserByUsername("admin_commander");
+      assert.ok(adminUser);
+
+      const registered = await app.auth.registerPasswordUser("ops_observer", "secret123");
+      assert.equal(registered.ok, true);
+      const guestLogin = await app.auth.loginWithPassword("ops_observer", "secret123");
+      assert.equal(guestLogin.ok, true);
+
+      const staleLobbyResponse = await callApp(
         app,
         "POST",
         "/api/games",
         {
-          name: "Runtime Repair",
-          activeModuleIds: ["demo.dice-rules"],
-          diceRuleSetId: "demo-barrage"
+          name: "Broken Lobby"
         },
         authHeaders(adminSessionToken)
       );
+      assert.equal(staleLobbyResponse.statusCode, 201);
+      const staleLobbyId = staleLobbyResponse.payload.game.id;
 
-      assert.equal(createGameResponse.statusCode, 200);
-      const gameId = createGameResponse.payload.game.id;
-      const storedGame = await app.datastore.findGameById(gameId);
-      assert.ok(storedGame);
+      const staleLobbyRecord = await app.datastore.findGameById(staleLobbyId);
+      assert.ok(staleLobbyRecord);
+      staleLobbyRecord.updatedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+      staleLobbyRecord.state.gameConfig = {
+        ...(staleLobbyRecord.state.gameConfig || {}),
+        totalPlayers: 1,
+        mapId: "ghost-map",
+        contentPackId: "ghost-pack",
+        diceRuleSetId: "ghost-dice",
+        diceRuleSetName: "Ghost Dice",
+        themeId: "ghost-theme",
+        pieceSkinId: "ghost-skin",
+        victoryRuleSetId: "ghost-victory",
+        activeModules: [{ id: "ghost.module", version: "1.0.0" }]
+      };
+      await app.datastore.updateGame(staleLobbyRecord);
 
-      storedGame.state.gameConfig.diceRuleSetId = "demo-barrage";
-      storedGame.state.gameConfig.diceRuleSetName = "Demo Barrage";
-      storedGame.state.diceRuleSetId = "standard";
-      storedGame.updatedAt = new Date().toISOString();
-      await app.datastore.updateGame(storedGame);
+      const activeGameResponse = await callApp(
+        app,
+        "POST",
+        "/api/games",
+        {
+          name: "Live Match"
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(activeGameResponse.statusCode, 201);
+      const activeGameId = activeGameResponse.payload.game.id;
 
-      const repairResponse = await callApp(
+      const joinResponse = await callApp(
+        app,
+        "POST",
+        "/api/join",
+        {
+          gameId: activeGameId
+        },
+        authHeaders(guestLogin.sessionToken)
+      );
+      assert.equal(joinResponse.statusCode, 201);
+
+      const startResponse = await callApp(
+        app,
+        "POST",
+        "/api/start",
+        {
+          gameId: activeGameId,
+          playerId: activeGameResponse.payload.playerId
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(startResponse.statusCode, 200);
+
+      const activeGameRecord = await app.datastore.findGameById(activeGameId);
+      assert.ok(activeGameRecord);
+      activeGameRecord.state.currentTurnIndex = 99;
+      await app.datastore.updateGame(activeGameRecord);
+
+      const overviewResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/overview",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(overviewResponse.statusCode, 200);
+      assert.equal(overviewResponse.payload.summary.totalUsers >= 2, true);
+      assert.equal(overviewResponse.payload.summary.activeGames >= 1, true);
+      assert.equal(overviewResponse.payload.summary.staleLobbies >= 1, true);
+      assert.equal(overviewResponse.payload.summary.invalidGames >= 1, true);
+      assert.equal(
+        overviewResponse.payload.issues.some((issue: any) => issue.code === "stale-lobby"),
+        true
+      );
+
+      const usersResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/users?q=ops&role=user",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(usersResponse.statusCode, 200);
+      assert.equal(usersResponse.payload.filteredTotal, 1);
+      assert.equal(usersResponse.payload.users[0].username, "ops_observer");
+
+      const gamesResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/games?status=lobby&q=Broken",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(gamesResponse.statusCode, 200);
+      assert.equal(gamesResponse.payload.filteredTotal, 1);
+      assert.equal(gamesResponse.payload.games[0].stale, true);
+      assert.equal(
+        gamesResponse.payload.games[0].issues.some((issue: any) => issue.code === "missing-map"),
+        true
+      );
+
+      const detailsResponse = await callApp(
+        app,
+        "GET",
+        `/api/admin/games/${activeGameId}`,
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(detailsResponse.statusCode, 200);
+      assert.equal(detailsResponse.payload.players.length, 2);
+      assert.equal(detailsResponse.payload.rawState.currentTurnIndex, 99);
+
+      const configResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/config",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(configResponse.statusCode, 200);
+      assert.equal(typeof configResponse.payload.config.maintenance.staleLobbyDays, "number");
+
+      const maintenanceReportResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/maintenance",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(maintenanceReportResponse.statusCode, 200);
+      assert.equal(maintenanceReportResponse.payload.summary.staleLobbies >= 1, true);
+      assert.equal(
+        maintenanceReportResponse.payload.issues.some(
+          (issue: any) => issue.code === "invalid-turn-index"
+        ),
+        true
+      );
+
+      const validateAllResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/maintenance",
+        {
+          action: "validate-all"
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(validateAllResponse.statusCode, 200);
+      assert.equal(validateAllResponse.payload.audit.action, "maintenance.validate-all");
+
+      const demoteAdminResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/users/role",
+        {
+          userId: adminUser.id,
+          role: "user"
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(demoteAdminResponse.statusCode, 400);
+
+      const terminateResponse = await callApp(
         app,
         "POST",
         "/api/admin/games/action",
         {
-          gameId,
-          action: "repair-game-config"
+          gameId: activeGameId,
+          action: "terminate-game",
+          confirmation: activeGameId
         },
         authHeaders(adminSessionToken)
       );
+      assert.equal(terminateResponse.statusCode, 200);
+      assert.equal(terminateResponse.payload.game.phase, "finished");
+      assert.equal(terminateResponse.payload.audit.action, "game.terminate-game");
 
-      assert.equal(repairResponse.statusCode, 200);
-      assert.equal(repairResponse.payload.rawState.gameConfig.diceRuleSetId, "demo-barrage");
-      assert.equal(repairResponse.payload.rawState.diceRuleSetName, "Demo Barrage");
-      assert.equal(repairResponse.payload.rawState.diceRuleSetId, "demo-barrage");
-    }
-  );
-});
+      const auditResponse = await callApp(
+        app,
+        "GET",
+        "/api/admin/audit",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(auditResponse.statusCode, 200);
+      const auditActions = auditResponse.payload.entries.map(
+        (entry: any) => `${entry.action}:${entry.result}`
+      );
+      assert.equal(auditActions.includes("maintenance.validate-all:success"), true);
+      assert.equal(auditActions.includes("game.terminate-game:success"), true);
+      assert.equal(auditActions.includes("user.role.update:failure"), true);
+    });
+  }
+);
+
+register(
+  "admin console direct methods aggregate issues, filters users, and enforce module safety",
+  async () => {
+    const actor = {
+      id: "admin-1",
+      username: "admin_commander",
+      role: "admin"
+    };
+    const users = [
+      {
+        id: "admin-1",
+        username: "admin_commander",
+        role: "admin",
+        createdAt: "2026-04-20T10:00:00.000Z",
+        profile: {
+          preferences: {
+            theme: "command"
+          }
+        }
+      },
+      {
+        id: "user-1",
+        username: "field_scout",
+        role: "user",
+        createdAt: "2026-04-19T10:00:00.000Z",
+        profile: {
+          preferences: {
+            theme: "ember"
+          }
+        }
+      }
+    ];
+    const rawGames = [
+      {
+        id: "finished-user-win",
+        name: "Finished Win",
+        version: 1,
+        creatorUserId: "user-1",
+        createdAt: "2026-04-18T10:00:00.000Z",
+        updatedAt: "2026-04-18T12:00:00.000Z",
+        state: {
+          phase: "finished",
+          winnerId: "p-user",
+          players: [
+            {
+              id: "p-user",
+              name: "field_scout",
+              linkedUserId: "user-1"
+            },
+            {
+              id: "p-admin",
+              name: "admin_commander",
+              linkedUserId: "admin-1"
+            }
+          ],
+          territories: {
+            alpha: {
+              ownerId: "p-user"
+            }
+          },
+          hands: {
+            "p-user": [{ id: "card-1" }],
+            "p-admin": []
+          },
+          gameConfig: {}
+        }
+      },
+      {
+        id: "broken-lobby",
+        name: "Broken Lobby",
+        version: 1,
+        creatorUserId: "admin-1",
+        createdAt: "2026-04-15T10:00:00.000Z",
+        updatedAt: "2026-04-15T12:00:00.000Z",
+        state: {
+          phase: "lobby",
+          players: [
+            {
+              id: "p-admin",
+              name: "admin_commander",
+              linkedUserId: "admin-1"
+            },
+            {
+              id: "p-user",
+              name: "field_scout",
+              linkedUserId: "user-1"
+            }
+          ],
+          territories: {
+            alpha: {
+              ownerId: "p-admin"
+            },
+            beta: {
+              ownerId: "p-user"
+            }
+          },
+          hands: {
+            "p-admin": [{ id: "card-2" }],
+            "p-user": [{ id: "card-3" }, { id: "card-4" }]
+          },
+          gameConfig: {
+            mapId: "ghost-map",
+            contentPackId: "ghost-pack",
+            diceRuleSetId: "ghost-dice",
+            diceRuleSetName: "Ghost Dice",
+            themeId: "ghost-theme",
+            pieceSkinId: "ghost-skin",
+            victoryRuleSetId: "ghost-victory"
+          }
+        }
+      },
+      {
+        id: "active-turn",
+        name: "Turn Drift",
+        version: 1,
+        creatorUserId: "admin-1",
+        createdAt: "2026-04-16T10:00:00.000Z",
+        updatedAt: "2026-04-16T12:00:00.000Z",
+        state: {
+          phase: "active",
+          currentTurnIndex: 5,
+          players: [
+            {
+              id: "p-admin",
+              name: "admin_commander",
+              linkedUserId: "admin-1"
+            },
+            {
+              id: "p-user",
+              name: "field_scout",
+              linkedUserId: "user-1"
+            }
+          ],
+          territories: {
+            gamma: {
+              ownerId: "p-admin"
+            }
+          },
+          hands: {
+            "p-admin": [],
+            "p-user": [{ id: "card-5" }]
+          },
+          gameConfig: {}
+        }
+      },
+      {
+        id: "active-empty",
+        name: "Ghost Match",
+        version: 1,
+        creatorUserId: "admin-1",
+        createdAt: "2026-04-17T10:00:00.000Z",
+        updatedAt: "2026-04-17T12:00:00.000Z",
+        state: {
+          phase: "active",
+          currentTurnIndex: 0,
+          players: [],
+          territories: {},
+          hands: {},
+          gameConfig: {}
+        }
+      }
+    ];
+    const gameSummaries = [
+      {
+        id: "finished-user-win",
+        name: "Finished Win",
+        version: 1,
+        phase: "finished",
+        playerCount: 2,
+        totalPlayers: 2,
+        creatorUserId: "user-1",
+        contentPackId: null,
+        mapId: null,
+        mapName: null,
+        diceRuleSetId: null,
+        activeModules: [],
+        gamePresetId: null,
+        contentProfileId: null,
+        gameplayProfileId: null,
+        uiProfileId: null,
+        updatedAt: "2026-04-18T12:00:00.000Z",
+        createdAt: "2026-04-18T10:00:00.000Z"
+      },
+      {
+        id: "broken-lobby",
+        name: "Broken Lobby",
+        version: 1,
+        phase: "lobby",
+        playerCount: 3,
+        totalPlayers: 2,
+        creatorUserId: "admin-1",
+        contentPackId: "ghost-pack",
+        mapId: "ghost-map",
+        mapName: "Ghost Map",
+        diceRuleSetId: "ghost-dice",
+        activeModules: [
+          { id: "ghost.module", version: "1.0.0" },
+          { id: "module.off", version: "1.0.0" }
+        ],
+        gamePresetId: null,
+        contentProfileId: null,
+        gameplayProfileId: null,
+        uiProfileId: null,
+        updatedAt: "2026-04-15T12:00:00.000Z",
+        createdAt: "2026-04-15T10:00:00.000Z"
+      },
+      {
+        id: "active-turn",
+        name: "Turn Drift",
+        version: 1,
+        phase: "active",
+        playerCount: 2,
+        totalPlayers: 2,
+        creatorUserId: "admin-1",
+        contentPackId: null,
+        mapId: null,
+        mapName: null,
+        diceRuleSetId: null,
+        activeModules: [],
+        gamePresetId: null,
+        contentProfileId: null,
+        gameplayProfileId: null,
+        uiProfileId: null,
+        updatedAt: "2026-04-16T12:00:00.000Z",
+        createdAt: "2026-04-16T10:00:00.000Z"
+      },
+      {
+        id: "active-empty",
+        name: "Ghost Match",
+        version: 1,
+        phase: "active",
+        playerCount: 0,
+        totalPlayers: null,
+        creatorUserId: "admin-1",
+        contentPackId: null,
+        mapId: null,
+        mapName: null,
+        diceRuleSetId: null,
+        activeModules: [],
+        gamePresetId: null,
+        contentProfileId: null,
+        gameplayProfileId: null,
+        uiProfileId: null,
+        updatedAt: "2026-04-17T12:00:00.000Z",
+        createdAt: "2026-04-17T10:00:00.000Z"
+      }
+    ];
+    const appState: Record<string, unknown> = {
+      adminConsoleConfig: {
+        defaults: {
+          activeModuleIds: ["module.safe"],
+          themeId: "command"
+        },
+        maintenance: {
+          staleLobbyDays: 2,
+          auditLogLimit: 10
+        },
+        updatedAt: "2026-04-22T07:00:00.000Z",
+        updatedBy: actor
+      },
+      adminAuditLog: [
+        {
+          id: "audit-older",
+          actorId: "admin-1",
+          actorUsername: "admin_commander",
+          action: "seed.audit.older",
+          targetType: "config",
+          targetId: "global",
+          targetLabel: "Global defaults",
+          result: "success",
+          createdAt: "2026-04-20T10:00:00.000Z",
+          details: null
+        },
+        {
+          id: "audit-newer",
+          actorId: "admin-1",
+          actorUsername: "admin_commander",
+          action: "seed.audit.newer",
+          targetType: "config",
+          targetId: "global",
+          targetLabel: "Global defaults",
+          result: "success",
+          createdAt: "2026-04-21T10:00:00.000Z",
+          details: null
+        }
+      ]
+    };
+    const roleUpdates: Array<{ username: string; role: string }> = [];
+
+    const adminConsole = createAdminConsole({
+      datastore: {
+        listUsers() {
+          return users;
+        },
+        findUserById(userId: string) {
+          return users.find((user) => user.id === userId) || null;
+        },
+        updateUserRoleByUsername(username: string, role: string) {
+          roleUpdates.push({ username, role });
+          const targetUser = users.find((user) => user.username === username);
+          if (targetUser) {
+            targetUser.role = role;
+          }
+        },
+        getAppState(key: string) {
+          return appState[key] || null;
+        },
+        setAppState(key: string, value: unknown) {
+          appState[key] = value;
+          return value;
+        }
+      },
+      auth: {
+        publicUser(user: any) {
+          if (!user) {
+            return null;
+          }
+
+          return {
+            id: String(user.id || ""),
+            username: String(user.username || ""),
+            role: user.role === "admin" ? "admin" : "user",
+            hasEmail: false,
+            authMethods: ["password"],
+            preferences: {
+              theme:
+                typeof user?.profile?.preferences?.theme === "string"
+                  ? user.profile.preferences.theme
+                  : typeof user?.preferences?.theme === "string"
+                    ? user.preferences.theme
+                    : null
+            }
+          };
+        }
+      },
+      gameSessions: {
+        listGames() {
+          return gameSummaries;
+        },
+        getGame(gameId: string) {
+          const summary = gameSummaries.find((entry) => entry.id === gameId);
+          const rawGame = rawGames.find((entry) => entry.id === gameId);
+          if (!summary || !rawGame) {
+            throw new Error(`Unknown game ${gameId}`);
+          }
+
+          return {
+            game: JSON.parse(JSON.stringify(summary)),
+            state: JSON.parse(JSON.stringify(rawGame.state))
+          };
+        },
+        datastore: {
+          listGames() {
+            return rawGames;
+          }
+        }
+      },
+      loadGameContext() {
+        throw new Error("loadGameContext should not be used in this direct methods test");
+      },
+      persistGameContext() {
+        return null;
+      },
+      broadcastGame() {},
+      createConfiguredInitialState(configInput: Record<string, unknown> = {}) {
+        return {
+          state: {
+            gameConfig: {
+              ...configInput,
+              activeModules: Array.isArray(configInput.activeModuleIds)
+                ? configInput.activeModuleIds.map((moduleId) => ({ id: moduleId }))
+                : [],
+              players: Array.isArray(configInput.players) ? configInput.players : []
+            }
+          },
+          config: {}
+        };
+      },
+      moduleRuntime: {
+        async listInstalledModules() {
+          return [
+            {
+              id: "module.safe",
+              enabled: true,
+              compatible: true
+            },
+            {
+              id: "module.off",
+              enabled: false,
+              compatible: false
+            }
+          ];
+        },
+        async getEnabledModules() {
+          return [
+            {
+              id: "module.safe",
+              version: "1.0.0"
+            }
+          ];
+        },
+        findSupportedMap(mapId: string) {
+          return mapId === "classic-mini" ? { id: mapId } : null;
+        },
+        findContentPack(contentPackId: string) {
+          return contentPackId === "core" ? { id: contentPackId } : null;
+        },
+        findPlayerPieceSet(pieceSetId: string) {
+          return pieceSetId === "classic" ? { id: pieceSetId } : null;
+        },
+        findDiceRuleSet(diceRuleSetId: string) {
+          return diceRuleSetId === "standard" ? { id: diceRuleSetId } : null;
+        },
+        async resolveGamePreset() {
+          return null;
+        },
+        async resolveGameConfigDefaults() {
+          return {};
+        },
+        async resolveGameSelection(input: Record<string, unknown> = {}) {
+          return {
+            moduleSchemaVersion: 1,
+            activeModules: Array.isArray(input.activeModuleIds)
+              ? input.activeModuleIds.map((moduleId) => ({
+                  id: moduleId,
+                  version: "1.0.0"
+                }))
+              : [],
+            contentProfileId: null,
+            gameplayProfileId: null,
+            uiProfileId: null
+          };
+        }
+      }
+    });
+
+    const overview = await adminConsole.getOverview();
+    assert.equal(overview.summary.totalUsers, 2);
+    assert.equal(overview.summary.invalidGames >= 2, true);
+    assert.equal(overview.summary.staleLobbies, 1);
+    assert.equal(overview.summary.enabledModules, 1);
+    assert.equal(
+      overview.issues.some((issue: any) => issue.code === "missing-map"),
+      true
+    );
+    assert.equal(
+      overview.issues.some((issue: any) => issue.code === "disabled-module-reference"),
+      true
+    );
+
+    const filteredUsers = await adminConsole.listUsers({
+      query: "scout",
+      role: "user"
+    });
+    assert.equal(filteredUsers.filteredTotal, 1);
+    assert.equal(filteredUsers.users[0].gamesPlayed, 1);
+    assert.equal(filteredUsers.users[0].wins, 1);
+
+    await assert.rejects(
+      () =>
+        adminConsole.updateUserRole(actor, {
+          userId: "admin-1",
+          role: "user"
+        }),
+      /ultimo amministratore/
+    );
+
+    const promoteResponse = await adminConsole.updateUserRole(actor, {
+      userId: "user-1",
+      role: "admin"
+    });
+    assert.equal(promoteResponse.user.role, "admin");
+    assert.deepEqual(roleUpdates, [
+      {
+        username: "field_scout",
+        role: "admin"
+      }
+    ]);
+
+    const lobbyGames = await adminConsole.listGames({
+      status: "lobby",
+      query: "Broken"
+    });
+    assert.equal(lobbyGames.filteredTotal, 1);
+    assert.equal(lobbyGames.games[0].issueCount >= 6, true);
+    assert.equal(
+      lobbyGames.games[0].issues.some((issue: any) => issue.code === "orphaned-module-reference"),
+      true
+    );
+
+    const gameDetail = await adminConsole.getGameDetails("active-turn");
+    assert.equal(gameDetail.players.length, 2);
+    assert.equal(gameDetail.players[0].territoryCount, 1);
+    assert.equal(gameDetail.players[1].cardCount, 1);
+
+    const config = await adminConsole.getConfig();
+    assert.equal(config.config.defaults.activeModuleIds[0], "module.safe");
+    assert.equal(config.config.updatedBy.username, "admin_commander");
+
+    const maintenanceReport = await adminConsole.getMaintenanceReport();
+    assert.equal(maintenanceReport.summary.staleLobbies, 1);
+    assert.equal(maintenanceReport.summary.invalidGames >= 2, true);
+    assert.equal(maintenanceReport.summary.orphanedModuleReferences, 2);
+
+    const audit = await adminConsole.listAudit();
+    assert.equal(audit.entries.length, 3);
+    assert.equal(audit.entries[0].action, "user.role.update");
+
+    await assert.rejects(
+      () => adminConsole.assertModuleSafeToDisable("module.safe"),
+      /still referenced/
+    );
+    await assert.doesNotReject(() => adminConsole.assertModuleSafeToDisable("module.off"));
+  }
+);
 
 register("stale lobby cleanup skips games that become active before mutation", async () => {
   const persistedStates: Array<{ gameId: string; phase: string }> = [];

--- a/tests/gameplay/regression/vercel-routing-config.test.cts
+++ b/tests/gameplay/regression/vercel-routing-config.test.cts
@@ -58,6 +58,14 @@ register("vercel preview rewrites React shell deep links to the shell entry docu
     "Expected /lobby/new to rewrite to /react/index.html for the canonical new game route."
   );
   assert.ok(
+    hasRewriteRule(rewrites, "/admin", "/react/index.html"),
+    "Expected /admin to rewrite to /react/index.html for the canonical admin route."
+  );
+  assert.ok(
+    hasRewriteRule(rewrites, "/admin/:path*", "/react/index.html"),
+    "Expected /admin/:path* to rewrite to /react/index.html for admin deep links."
+  );
+  assert.ok(
     hasRewriteRule(rewrites, "/profile", "/react/index.html"),
     "Expected /profile to rewrite to /react/index.html for the canonical profile route."
   );

--- a/vercel.json
+++ b/vercel.json
@@ -74,6 +74,14 @@
       "destination": "/react/index.html"
     },
     {
+      "source": "/admin",
+      "destination": "/react/index.html"
+    },
+    {
+      "source": "/admin/:path*",
+      "destination": "/react/index.html"
+    },
+    {
       "source": "/profile",
       "destination": "/react/index.html"
     },


### PR DESCRIPTION
## Summary

Adds the first usable admin console for NetRisk.

- add a protected `/admin` React shell with overview, users, games, configuration, maintenance, runtime/modules, and audit sections
- add server-side admin APIs, persistent admin defaults, guarded game/user mutations, maintenance actions, and audit logging
- preserve runtime/module preset precedence when admin defaults seed new game creation, and block disabling modules still referenced by admin config
- add admin route/backend regression coverage plus local admin bootstrap and handoff documentation

## Why

NetRisk already had authentication, roles, modular setup, and game/session orchestration, but it did not yet have a real operator-facing admin area. This PR creates the first production-style admin surface so administrators can inspect and manage users, games, lobbies, runtime configuration, and consistency issues from one place.

## Validation

- `npm run build:ts`
- `npm run test:react`
- `node .tsbuild/scripts/run-tests.cjs`
- `node .tsbuild/scripts/run-gameplay-tests.cjs`
- `node .tsbuild/scripts/grant-admin.cjs --username smoke_admin --db-file data/tmp-admin-grant.sqlite` (temporary smoke check)
