### PR TITLE
🛡️ Sentinel: Strengthen password policy (min 8, max 128)

### DIFF
--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -265,10 +265,19 @@ function registrationValidationError(
     );
   }
 
-  if (input.password.length < 4) {
+  // Enforce minimum password length for security (NIST 800-63B)
+  // and a maximum to prevent DoS attacks during hashing.
+  if (input.password.length < 8) {
     return authFailure(
-      "Password troppo corta: usa almeno 4 caratteri.",
+      "Password troppo corta: usa almeno 8 caratteri.",
       "auth.register.shortPassword"
+    );
+  }
+
+  if (input.password.length > 128) {
+    return authFailure(
+      "Password troppo lunga: usa massimo 128 caratteri.",
+      "auth.register.longPassword"
     );
   }
 

--- a/frontend/src/core/register-validation.mts
+++ b/frontend/src/core/register-validation.mts
@@ -9,6 +9,7 @@ export type RegistrationValidationKey =
   | "register.errors.requiredFields"
   | "register.errors.invalidUsername"
   | "register.errors.shortPassword"
+  | "register.errors.longPassword"
   | "register.errors.passwordMismatch"
   | "register.errors.invalidEmail";
 
@@ -26,8 +27,12 @@ export function validateRegistrationInput(
     return "register.errors.invalidUsername";
   }
 
-  if (input.password.length < 4) {
+  if (input.password.length < 8) {
     return "register.errors.shortPassword";
+  }
+
+  if (input.password.length > 128) {
+    return "register.errors.longPassword";
   }
 
   if (input.password !== input.confirmPassword) {

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -156,7 +156,7 @@ export type LoginRequest = z.infer<typeof loginRequestSchema>;
 
 export const registerRequestSchema = objectSchema({
   username: z.string().min(1),
-  password: z.string().min(1),
+  password: z.string().min(8).max(128),
   email: z.string().optional()
 });
 

--- a/frontend/src/locales/en.mts
+++ b/frontend/src/locales/en.mts
@@ -29,7 +29,8 @@ export const en = Object.freeze({
   "auth.register.requiredFields": "Enter username and password.",
   "auth.register.invalidUsername":
     "Valid username: 3-32 characters, letters, numbers, underscore, and hyphen.",
-  "auth.register.shortPassword": "Password too short: use at least 4 characters.",
+  "auth.register.shortPassword": "Password too short: use at least 8 characters.",
+  "auth.register.longPassword": "Password too long: use at most 128 characters.",
   "auth.register.invalidEmail": "Invalid email.",
   "auth.register.emailProtectionUnavailable":
     "Optional email is available only when AUTH_ENCRYPTION_KEY is configured on the server.",
@@ -464,13 +465,14 @@ export const en = Object.freeze({
   "register.guideline.username":
     "Username: 3-32 characters, letters, numbers, underscore, or hyphen.",
   "register.guideline.email": "Email is optional.",
-  "register.guideline.password": "Password: at least 4 characters.",
+  "register.guideline.password": "Password: at least 8 characters.",
   "register.submit": "Register",
   "register.auth.loggedIn": "You are already logged in as {username}.",
   "register.errors.requiredFields": "Fill in the required fields.",
   "register.errors.invalidUsername":
     "Valid username: 3-32 characters, letters, numbers, underscore, and hyphen.",
-  "register.errors.shortPassword": "Use a password with at least 4 characters.",
+  "register.errors.shortPassword": "Use a password with at least 8 characters.",
+  "register.errors.longPassword": "Use a password with at most 128 characters.",
   "register.errors.passwordMismatch": "Passwords do not match.",
   "register.errors.invalidEmail": "Invalid email.",
   "register.errors.submitFailed": "Registration failed.",

--- a/frontend/src/locales/it.mts
+++ b/frontend/src/locales/it.mts
@@ -29,7 +29,8 @@ export const it = Object.freeze({
   "auth.register.requiredFields": "Inserisci utente e password.",
   "auth.register.invalidUsername":
     "Username valido: 3-32 caratteri, lettere, numeri, underscore e trattino.",
-  "auth.register.shortPassword": "Password troppo corta: usa almeno 4 caratteri.",
+  "auth.register.shortPassword": "Password troppo corta: usa almeno 8 caratteri.",
+  "auth.register.longPassword": "Password troppo lunga: usa massimo 128 caratteri.",
   "auth.register.invalidEmail": "Email non valida.",
   "auth.register.emailProtectionUnavailable":
     "Email opzionale disponibile solo con AUTH_ENCRYPTION_KEY configurata sul server.",
@@ -468,13 +469,14 @@ export const it = Object.freeze({
   "register.guideline.username":
     "Username: 3-32 caratteri, lettere, numeri, underscore o trattino.",
   "register.guideline.email": "Email non obbligatoria.",
-  "register.guideline.password": "Password: almeno 4 caratteri.",
+  "register.guideline.password": "Password: almeno 8 caratteri.",
   "register.submit": "Registrati",
   "register.auth.loggedIn": "Hai gia effettuato l'accesso come {username}.",
   "register.errors.requiredFields": "Compila i campi obbligatori.",
   "register.errors.invalidUsername":
     "Username valido: 3-32 caratteri, lettere, numeri, underscore e trattino.",
-  "register.errors.shortPassword": "Usa una password con almeno 4 caratteri.",
+  "register.errors.shortPassword": "Usa una password con almeno 8 caratteri.",
+  "register.errors.longPassword": "Usa una password con massimo 128 caratteri.",
   "register.errors.passwordMismatch": "Le password non coincidono.",
   "register.errors.invalidEmail": "Email non valida.",
   "register.errors.submitFailed": "Registrazione non riuscita.",

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -3385,7 +3385,7 @@ register("auth store migra password legacy in hash al login riuscito", async () 
             username: "legacy",
             credentials: {
               password: {
-                secret: "secret"
+                secret: "Secret123!"
               }
             },
             role: "user",
@@ -3406,7 +3406,7 @@ register("auth store migra password legacy in hash al login riuscito", async () 
       sessionsFile: tempSessionsFile,
       dbFile: tempDbFile
     });
-    const login = await auth.loginWithPassword("legacy", "secret");
+    const login = await auth.loginWithPassword("legacy", "Secret123!");
     assert.equal(login.ok, true);
 
     const storedUser = await auth.datastore.findUserByUsername("legacy");
@@ -3445,7 +3445,7 @@ register("auth store accetta email opzionale ma rifiuta password debole", async 
 
     const weak = await auth.registerPasswordUser({
       username: "weak-user",
-      password: "123",
+      password: "short",
       email: "weak@example.com"
     });
     assert.equal(weak.ok, false);
@@ -6605,10 +6605,10 @@ register(
       });
 
       try {
-        const registered = await app.auth.registerPasswordUser("supa_tester", "secret");
+        const registered = await app.auth.registerPasswordUser("supa_tester", "Secret123!");
         assert.equal(registered.ok, true);
 
-        const login = await app.auth.loginWithPassword("supa_tester", "secret");
+        const login = await app.auth.loginWithPassword("supa_tester", "Secret123!");
         assert.equal(login.ok, true);
         assert.equal(typeof login.sessionToken, "string");
 

--- a/server.log
+++ b/server.log
@@ -1,3 +1,0 @@
-(node:125819) ExperimentalWarning: SQLite is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-Server attivo su http://localhost:3000

--- a/server.log
+++ b/server.log
@@ -1,0 +1,3 @@
+(node:125819) ExperimentalWarning: SQLite is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+Server attivo su http://localhost:3000

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -155,7 +155,7 @@ export type LoginRequest = z.infer<typeof loginRequestSchema>;
 
 export const registerRequestSchema = objectSchema({
   username: z.string().min(1),
-  password: z.string().min(1),
+  password: z.string().min(8).max(128),
   email: z.string().optional()
 });
 


### PR DESCRIPTION
🛡️ Sentinel: Strengthen password policy to improve account security and mitigate DoS risks.

### 🚨 Severity: MEDIUM

### 💡 Vulnerability:
The application previously enforced a weak minimum password length of 4 characters and had no maximum length limit on password inputs. Weak passwords are susceptible to brute-force attacks, while extremely long passwords can be used to perform Denial of Service (DoS) attacks by exhausting CPU resources during the password hashing process (scrypt).

### 🎯 Impact:
- **Weak Passwords:** Higher risk of unauthorized account access via credential guessing.
- **DoS Risk:** An attacker could submit massive password strings, causing the server to hang or crash while attempting to hash them.

### 🔧 Fix:
- Increased minimum password length from 4 to 8 characters.
- Introduced a 128-character maximum length for password inputs.
- Applied changes consistently across `backend/auth.cts`, `frontend/src/core/register-validation.mts`, and the shared Zod schema in `shared/runtime-validation.cts`.
- Updated all relevant English and Italian localization strings to inform users of the new requirements.

### ✅ Verification:
- **Automated Tests:** All 191 gameplay tests passed (`npm run test:gameplay`).
- **Frontend Verification:** Verified the new requirements and error messages using a Playwright script. Confirmed that the UI correctly displays guidelines and validation errors for both short and long passwords.
- **Sync:** Ensured frontend runtime validation is in sync with the shared schema.

---
*PR created automatically by Jules for task [15314582872641798280](https://jules.google.com/task/15314582872641798280) started by @andreame-code*