### PR TITLE
Fix missing gameplay regression suite registration

### DIFF
--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -43,6 +43,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/module-runtime.test.cjs",
   "../tests/gameplay/regression/admin-console-routes.test.cjs",
   "../tests/gameplay/regression/startup-init-error.test.cjs",
+  "../tests/gameplay/regression/tooling-and-supabase-regressions.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",
   "../tests/gameplay/regression/vercel-routing-config.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",


### PR DESCRIPTION
## Summary
- register the tooling and Supabase regression suite in the gameplay runner
- restore coverage for the tests added in PR #142
- keep the follow-up scoped to the last Codex review comment

## Validation
- npm run build:ts
- node .tsbuild/scripts/run-gameplay-tests.cjs
- npm run lint
- npm run format:check