### PR TITLE
Redesign the admin operator console

### DIFF
--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -187,7 +187,10 @@ describe("Admin route integration", () => {
     renderReactShell("/react/admin");
 
     expect(await screen.findByTestId("admin-route-page")).toBeInTheDocument();
+    expect(await screen.findByText("Operator console")).toBeInTheDocument();
     expect(await screen.findByText("Operational command center")).toBeInTheDocument();
+    expect(screen.getByText("Monitor")).toBeInTheDocument();
+    expect(screen.getByText("Operate")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Admin" })).toBeInTheDocument();
     expect(screen.getByText("Current server defaults")).toBeInTheDocument();
     expect(screen.getByText("Latest admin actions")).toBeInTheDocument();

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -1,16 +1,36 @@
 import { screen, waitFor } from "@testing-library/react";
 
 import type {
+  AdminConfigResponse,
+  AdminGameDetailsResponse,
+  AdminGamesResponse,
+  AdminMaintenanceReport,
   AdminOverviewResponse,
+  AdminUsersResponse,
   AuthSessionResponse,
+  GameOptionsResponse,
   ModuleOptionsResponse
 } from "@frontend-generated/shared-runtime-validation.mts";
 
-import { getAdminOverview, getModuleOptions, getSession } from "@frontend-core/api/client.mts";
+import {
+  getAdminConfig,
+  getAdminGameDetails,
+  getAdminMaintenanceReport,
+  getAdminOverview,
+  getGameOptions,
+  getModuleOptions,
+  getSession,
+  listAdminGames,
+  listAdminUsers,
+  runAdminGameAction,
+  runAdminMaintenanceAction,
+  updateAdminConfig,
+  updateAdminUserRole
+} from "@frontend-core/api/client.mts";
 
 import { renderReactShell } from "../../test/render-react-shell";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@frontend-core/api/client.mts", () => ({
   getSession: vi.fn(),
@@ -39,8 +59,18 @@ vi.mock("@frontend-core/api/client.mts", () => ({
 }));
 
 const getAdminOverviewMock = vi.mocked(getAdminOverview);
+const getAdminConfigMock = vi.mocked(getAdminConfig);
+const getAdminGameDetailsMock = vi.mocked(getAdminGameDetails);
+const getAdminMaintenanceReportMock = vi.mocked(getAdminMaintenanceReport);
+const getGameOptionsMock = vi.mocked(getGameOptions);
 const getModuleOptionsMock = vi.mocked(getModuleOptions);
 const getSessionMock = vi.mocked(getSession);
+const listAdminGamesMock = vi.mocked(listAdminGames);
+const listAdminUsersMock = vi.mocked(listAdminUsers);
+const runAdminGameActionMock = vi.mocked(runAdminGameAction);
+const runAdminMaintenanceActionMock = vi.mocked(runAdminMaintenanceAction);
+const updateAdminConfigMock = vi.mocked(updateAdminConfig);
+const updateAdminUserRoleMock = vi.mocked(updateAdminUserRole);
 
 function createAuthRequiredError(): Error & { code: string } {
   const error = new Error("Sign in to continue.") as Error & { code: string };
@@ -155,9 +185,332 @@ function createOverviewResponse(): AdminOverviewResponse {
   };
 }
 
+function createAuditEntry(
+  overrides: Partial<AdminOverviewResponse["audit"][number]> = {}
+): AdminOverviewResponse["audit"][number] {
+  return {
+    id: "audit-1",
+    actorId: "admin-1",
+    actorUsername: "Commander",
+    action: "config.update",
+    targetType: "config",
+    targetId: "global",
+    targetLabel: "Global defaults",
+    result: "success",
+    createdAt: "2026-04-21T10:00:00.000Z",
+    details: null,
+    ...overrides
+  };
+}
+
+function createUserSummary(
+  overrides: Partial<AdminUsersResponse["users"][number]> = {}
+): AdminUsersResponse["users"][number] {
+  return {
+    id: "user-2",
+    username: "Strategist",
+    role: "user",
+    hasEmail: true,
+    preferences: {
+      theme: "ember"
+    },
+    createdAt: "2026-04-20T08:00:00.000Z",
+    gamesPlayed: 7,
+    gamesInProgress: 2,
+    wins: 3,
+    canPromote: true,
+    canDemote: false,
+    ...overrides
+  };
+}
+
+function createUsersResponse(): AdminUsersResponse {
+  return {
+    users: [createUserSummary()],
+    total: 1,
+    filteredTotal: 1,
+    query: "",
+    role: null
+  };
+}
+
+function createGameSummary(
+  overrides: Partial<AdminGamesResponse["games"][number]> = {}
+): AdminGamesResponse["games"][number] {
+  return {
+    id: "game-1",
+    name: "Border Siege",
+    phase: "lobby",
+    playerCount: 3,
+    updatedAt: "2026-04-21T11:00:00.000Z",
+    contentPackId: "core",
+    diceRuleSetId: "standard-dice",
+    totalPlayers: 4,
+    mapName: "Middle Earth",
+    mapId: "middle-earth",
+    aiCount: 0,
+    creatorUserId: "user-1",
+    activeModules: [{ id: "demo.runtime", version: "1.0.0" }],
+    gamePresetId: "preset-1",
+    contentProfileId: "content-profile",
+    gameplayProfileId: "gameplay-profile",
+    uiProfileId: "ui-profile",
+    stale: false,
+    health: "warning",
+    issueCount: 1,
+    issues: [
+      {
+        code: "invalid-turn-index",
+        severity: "warning",
+        message: "Current turn index is invalid.",
+        gameId: "game-1"
+      }
+    ],
+    ...overrides
+  };
+}
+
+function createGamesResponse(): AdminGamesResponse {
+  return {
+    games: [createGameSummary()],
+    total: 1,
+    filteredTotal: 1,
+    status: null,
+    query: ""
+  };
+}
+
+function createGameDetailsResponse(): AdminGameDetailsResponse {
+  return {
+    game: createGameSummary(),
+    players: [
+      {
+        id: "player-1",
+        name: "Commander",
+        linkedUserId: "user-1",
+        isAi: false,
+        surrendered: false,
+        territoryCount: 12,
+        cardCount: 3
+      }
+    ],
+    rawState: {
+      phase: "lobby",
+      turnIndex: 0
+    }
+  };
+}
+
+function createAdminConfigResponse(): AdminConfigResponse {
+  return {
+    config: {
+      defaults: {
+        totalPlayers: 4,
+        contentPackId: "core",
+        ruleSetId: "classic",
+        mapId: "middle-earth",
+        diceRuleSetId: "standard-dice",
+        victoryRuleSetId: "classic-victory",
+        pieceSetId: "wooden-armies",
+        themeId: "ember",
+        pieceSkinId: "standard-skin",
+        gamePresetId: "preset-1",
+        contentProfileId: "content-profile",
+        gameplayProfileId: "gameplay-profile",
+        uiProfileId: "ui-profile",
+        turnTimeoutHours: 24,
+        activeModuleIds: ["demo.runtime"]
+      },
+      maintenance: {
+        staleLobbyDays: 5,
+        auditLogLimit: 120
+      },
+      updatedAt: "2026-04-21T10:00:00.000Z",
+      updatedBy: {
+        id: "admin-1",
+        username: "Commander",
+        role: "admin",
+        preferences: {
+          theme: "ember"
+        }
+      }
+    }
+  };
+}
+
+function createGameOptionsResponse(): GameOptionsResponse {
+  return {
+    ruleSets: [
+      {
+        id: "classic",
+        name: "Classic",
+        defaults: {
+          extensionSchemaVersion: 1,
+          mapId: "middle-earth",
+          diceRuleSetId: "standard-dice",
+          victoryRuleSetId: "classic-victory",
+          themeId: "ember",
+          pieceSkinId: "standard-skin"
+        },
+        defaultDiceRuleSetId: "standard-dice",
+        defaultVictoryRuleSetId: "classic-victory"
+      }
+    ],
+    maps: [
+      {
+        id: "middle-earth",
+        name: "Middle Earth",
+        territoryCount: 42,
+        continentCount: 6
+      }
+    ],
+    diceRuleSets: [
+      {
+        id: "standard-dice",
+        name: "Standard dice",
+        attackerMaxDice: 3,
+        defenderMaxDice: 2
+      }
+    ],
+    victoryRuleSets: [
+      {
+        id: "classic-victory",
+        name: "Classic victory",
+        description: "Hold the world."
+      }
+    ],
+    themes: [
+      {
+        id: "ember",
+        name: "Ember",
+        description: "Warm operator theme."
+      }
+    ],
+    pieceSkins: [
+      {
+        id: "standard-skin",
+        name: "Standard skin",
+        description: "Default board skin.",
+        renderStyleId: "standard",
+        usesPlayerColor: true
+      }
+    ],
+    modules: [
+      {
+        id: "demo.runtime",
+        version: "1.0.0",
+        displayName: "Demo Runtime",
+        description: "Optional runtime module.",
+        kind: "runtime",
+        sourcePath: "modules/demo.runtime",
+        status: "ready",
+        enabled: true,
+        compatible: true,
+        warnings: [],
+        errors: [],
+        capabilities: []
+      }
+    ],
+    enabledModules: [{ id: "demo.runtime", version: "1.0.0" }],
+    gamePresets: [
+      {
+        id: "preset-1",
+        name: "Standard preset",
+        description: "Default runtime preset.",
+        activeModuleIds: ["demo.runtime"],
+        defaults: {
+          ruleSetId: "classic",
+          mapId: "middle-earth",
+          diceRuleSetId: "standard-dice",
+          victoryRuleSetId: "classic-victory",
+          themeId: "ember",
+          pieceSkinId: "standard-skin",
+          pieceSetId: "wooden-armies"
+        }
+      }
+    ],
+    contentProfiles: [
+      {
+        id: "content-profile",
+        name: "Core Content",
+        description: "Default content profile.",
+        moduleId: "demo.runtime"
+      }
+    ],
+    gameplayProfiles: [
+      {
+        id: "gameplay-profile",
+        name: "Classic Gameplay",
+        description: "Default gameplay profile.",
+        moduleId: "demo.runtime"
+      }
+    ],
+    uiProfiles: [
+      {
+        id: "ui-profile",
+        name: "Ops UI",
+        description: "Default UI profile.",
+        moduleId: "demo.runtime"
+      }
+    ],
+    uiSlots: [],
+    playerPieceSets: [
+      {
+        id: "wooden-armies",
+        name: "Wooden armies",
+        paletteSize: 6
+      }
+    ],
+    contentPacks: [
+      {
+        id: "core",
+        name: "Core Pack",
+        description: "Core content pack.",
+        defaultSiteThemeId: "ember",
+        defaultMapId: "middle-earth",
+        defaultDiceRuleSetId: "standard-dice",
+        defaultCardRuleSetId: "classic-cards",
+        defaultVictoryRuleSetId: "classic-victory",
+        defaultPieceSetId: "wooden-armies"
+      }
+    ],
+    turnTimeoutHoursOptions: [12, 24, 48],
+    playerRange: {
+      min: 2,
+      max: 6
+    }
+  };
+}
+
+function createMaintenanceReport(): AdminMaintenanceReport {
+  return {
+    summary: {
+      totalGames: 4,
+      staleLobbies: 1,
+      invalidGames: 1,
+      orphanedModuleReferences: 0
+    },
+    issues: [
+      {
+        code: "stale-lobby",
+        severity: "warning",
+        message: "A lobby is stale.",
+        gameId: "game-2",
+        actionId: "cleanup-stale-lobbies"
+      }
+    ]
+  };
+}
+
 beforeEach(() => {
+  vi.clearAllMocks();
   getModuleOptionsMock.mockResolvedValue(emptyModuleOptions());
   getAdminOverviewMock.mockResolvedValue(createOverviewResponse());
+  getSessionMock.mockResolvedValue(createSession("ember", "admin"));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("Admin route integration", () => {
@@ -194,5 +547,200 @@ describe("Admin route integration", () => {
     expect(screen.getByRole("link", { name: "Admin" })).toBeInTheDocument();
     expect(screen.getByText("Current server defaults")).toBeInTheDocument();
     expect(screen.getByText("Latest admin actions")).toBeInTheDocument();
+  });
+
+  it("requires confirmation before clearing config overrides and saving the reset", async () => {
+    getAdminConfigMock.mockResolvedValue(createAdminConfigResponse());
+    getGameOptionsMock.mockResolvedValue(createGameOptionsResponse());
+    updateAdminConfigMock.mockResolvedValue({
+      ok: true,
+      config: createAdminConfigResponse().config,
+      audit: createAuditEntry()
+    });
+
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const { user } = renderReactShell("/react/admin/config");
+
+    const ruleSetField = (await screen.findByRole("combobox", {
+      name: /Rule set/i
+    })) as HTMLSelectElement;
+    expect(ruleSetField.value).toBe("classic");
+
+    await user.click(screen.getByRole("button", { name: "Clear default overrides" }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Clear all configured default overrides")
+    );
+    expect(ruleSetField.value).toBe("classic");
+    expect(updateAdminConfigMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Clear default overrides" }));
+
+    await waitFor(() => {
+      expect(ruleSetField.value).toBe("");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(updateAdminConfigMock).toHaveBeenCalledWith(
+        {
+          defaults: {
+            totalPlayers: null,
+            contentPackId: null,
+            ruleSetId: null,
+            mapId: null,
+            diceRuleSetId: null,
+            victoryRuleSetId: null,
+            pieceSetId: null,
+            themeId: null,
+            pieceSkinId: null,
+            gamePresetId: null,
+            contentProfileId: null,
+            gameplayProfileId: null,
+            uiProfileId: null,
+            turnTimeoutHours: null,
+            activeModuleIds: []
+          },
+          maintenance: {
+            staleLobbyDays: 5,
+            auditLogLimit: 120
+          }
+        },
+        expect.anything()
+      );
+    });
+  });
+
+  it("requires confirmation before changing a user role", async () => {
+    const usersResponse = createUsersResponse();
+    listAdminUsersMock.mockResolvedValue(usersResponse);
+    updateAdminUserRoleMock.mockResolvedValue({
+      ok: true,
+      user: createUserSummary({ role: "admin", canPromote: false, canDemote: true }),
+      audit: createAuditEntry({
+        action: "user.role.update",
+        targetType: "user",
+        targetId: "user-2",
+        targetLabel: "Strategist"
+      })
+    });
+
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const { user } = renderReactShell("/react/admin/users");
+
+    await screen.findByText("Strategist");
+
+    await user.click(screen.getByRole("button", { name: "Promote to admin" }));
+
+    expect(confirmSpy).toHaveBeenCalledWith("Promote Strategist to administrator?");
+    expect(updateAdminUserRoleMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Promote to admin" }));
+
+    await waitFor(() => {
+      expect(updateAdminUserRoleMock).toHaveBeenCalledWith(
+        {
+          userId: usersResponse.users[0].id,
+          role: "admin"
+        },
+        expect.anything()
+      );
+    });
+  });
+
+  it("guards destructive game actions when typed confirmation is cancelled", async () => {
+    listAdminGamesMock.mockResolvedValue(createGamesResponse());
+    getAdminGameDetailsMock.mockResolvedValue(createGameDetailsResponse());
+    runAdminGameActionMock.mockResolvedValue({
+      ok: true,
+      game: createGameSummary({ phase: "finished", health: "ok", issueCount: 0, issues: [] }),
+      players: createGameDetailsResponse().players,
+      rawState: {
+        phase: "finished"
+      },
+      audit: createAuditEntry({
+        action: "game.close-lobby",
+        targetType: "game",
+        targetId: "game-1",
+        targetLabel: "Border Siege"
+      })
+    });
+
+    const promptSpy = vi
+      .spyOn(window, "prompt")
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce("game-1");
+    const { user } = renderReactShell("/react/admin/games");
+
+    await screen.findByText("Inspect lobbies and sessions");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Close lobby" })).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Close lobby" }));
+
+    expect(promptSpy).toHaveBeenCalledWith("Type game-1 to confirm close-lobby.");
+    expect(runAdminGameActionMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Close lobby" }));
+
+    await waitFor(() => {
+      expect(runAdminGameActionMock).toHaveBeenCalledWith(
+        {
+          gameId: "game-1",
+          action: "close-lobby",
+          confirmation: "game-1"
+        },
+        expect.anything()
+      );
+    });
+  });
+
+  it("guards stale-lobby cleanup when the typed confirmation is cancelled", async () => {
+    const report = createMaintenanceReport();
+    getAdminMaintenanceReportMock.mockResolvedValue(report);
+    runAdminMaintenanceActionMock.mockResolvedValue({
+      ok: true,
+      report,
+      affectedGameIds: ["game-2"],
+      audit: createAuditEntry({
+        action: "maintenance.cleanup-stale-lobbies",
+        targetType: "maintenance",
+        targetId: "cleanup-stale-lobbies",
+        targetLabel: "Stale lobbies"
+      })
+    });
+
+    const promptSpy = vi
+      .spyOn(window, "prompt")
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce("cleanup-stale-lobbies");
+    const { user } = renderReactShell("/react/admin/maintenance");
+
+    await screen.findByText("Validation and repair operations");
+
+    await user.click(screen.getByRole("button", { name: "Cleanup stale lobbies" }));
+
+    expect(promptSpy).toHaveBeenCalledWith("Type cleanup-stale-lobbies to confirm cleanup.");
+    expect(runAdminMaintenanceActionMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cleanup stale lobbies" }));
+
+    await waitFor(() => {
+      expect(runAdminMaintenanceActionMock).toHaveBeenCalledWith(
+        {
+          action: "cleanup-stale-lobbies",
+          confirmation: "cleanup-stale-lobbies"
+        },
+        expect.anything()
+      );
+    });
   });
 });

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -45,6 +45,26 @@ import {
 
 type AdminSection = "audit" | "config" | "games" | "maintenance" | "modules" | "overview" | "users";
 
+type AdminNavItem = {
+  id: AdminSection;
+  group: "Monitor" | "Operate";
+  label: string;
+  path: string;
+  description: string;
+};
+
+type AdminFrameContext = {
+  basePath: string;
+  currentUser: {
+    id: string;
+    username: string;
+    role?: string | null;
+  };
+  environmentLabel: string;
+  hostLabel: string;
+  sectionLabel: string;
+};
+
 type AdminConfigFormState = {
   totalPlayers: string;
   contentPackId: string;
@@ -64,6 +84,24 @@ type AdminConfigFormState = {
   staleLobbyDays: string;
   auditLogLimit: string;
 };
+
+const ADMIN_CONFIG_OVERRIDE_FIELDS: Array<keyof AdminConfigFormState> = [
+  "totalPlayers",
+  "contentPackId",
+  "ruleSetId",
+  "mapId",
+  "diceRuleSetId",
+  "victoryRuleSetId",
+  "pieceSetId",
+  "themeId",
+  "pieceSkinId",
+  "gamePresetId",
+  "contentProfileId",
+  "gameplayProfileId",
+  "uiProfileId",
+  "turnTimeoutHours",
+  "activeModuleIds"
+];
 
 function requestMessages(scope: string) {
   return {
@@ -199,20 +237,206 @@ function buildAdminConfigPayload(formState: AdminConfigFormState) {
   };
 }
 
+function resolveEnvironmentLabel(): string {
+  if (typeof window === "undefined") {
+    return "Unknown";
+  }
+
+  const hostname = window.location.hostname.toLowerCase();
+
+  if (!hostname || hostname === "localhost" || hostname === "127.0.0.1") {
+    return "Local";
+  }
+
+  if (hostname.includes("preview") || hostname.includes("vercel")) {
+    return "Preview";
+  }
+
+  if (hostname.includes("staging")) {
+    return "Staging";
+  }
+
+  if (hostname.includes("dev")) {
+    return "Development";
+  }
+
+  return "Production";
+}
+
+function severityRank(value: string | null | undefined): number {
+  if (value === "error") {
+    return 0;
+  }
+
+  if (value === "warning") {
+    return 1;
+  }
+
+  if (value === "info") {
+    return 2;
+  }
+
+  if (value === "ok") {
+    return 3;
+  }
+
+  return 4;
+}
+
+function sortBySeverity<T extends { severity: string | null | undefined }>(items: T[]): T[] {
+  return [...items].sort(
+    (left, right) => severityRank(left.severity) - severityRank(right.severity)
+  );
+}
+
+function countConfigDifferences(
+  current: AdminConfigFormState | null,
+  baseline: AdminConfigFormState | null
+): number {
+  if (!current || !baseline) {
+    return 0;
+  }
+
+  return (Object.keys(baseline) as Array<keyof AdminConfigFormState>).reduce((count, key) => {
+    const currentValue = current[key];
+    const baselineValue = baseline[key];
+
+    if (Array.isArray(currentValue) && Array.isArray(baselineValue)) {
+      const matches =
+        currentValue.length === baselineValue.length &&
+        currentValue.every((entry, index) => entry === baselineValue[index]);
+      return matches ? count : count + 1;
+    }
+
+    return currentValue === baselineValue ? count : count + 1;
+  }, 0);
+}
+
+function clearAdminConfigOverrides(current: AdminConfigFormState): AdminConfigFormState {
+  const cleared = { ...current };
+
+  for (const key of ADMIN_CONFIG_OVERRIDE_FIELDS) {
+    if (key === "activeModuleIds") {
+      cleared.activeModuleIds = [];
+      continue;
+    }
+
+    cleared[key] = "";
+  }
+
+  return cleared;
+}
+
 function AdminMetric({
   label,
   value,
-  tone = "muted"
+  tone = "muted",
+  hint
 }: {
   label: string;
   value: ReactNode;
   tone?: "danger" | "muted" | "success" | "warning";
+  hint?: ReactNode;
 }) {
   return (
     <article className={`card-panel admin-metric admin-metric-${tone}`}>
       <p className="status-label">{label}</p>
       <p className="admin-metric-value">{value}</p>
+      {hint ? <p className="admin-metric-copy">{hint}</p> : null}
     </article>
+  );
+}
+
+function AdminField({
+  label,
+  hint,
+  children
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="shell-field admin-field">
+      <span>{label}</span>
+      {hint ? <small>{hint}</small> : null}
+      {children}
+    </label>
+  );
+}
+
+function AdminMetaList({
+  items,
+  columns = 2
+}: {
+  items: Array<{ label: string; value: ReactNode }>;
+  columns?: 2 | 3;
+}) {
+  return (
+    <dl className={`admin-meta-grid admin-meta-grid-${columns}`}>
+      {items.map((item) => (
+        <div key={item.label} className="admin-meta-item">
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function AdminEmptyState({ label, title, copy }: { label: string; title: string; copy: string }) {
+  return (
+    <section className="status-panel admin-empty-state">
+      <p className="status-label">{label}</p>
+      <h2>{title}</h2>
+      <p className="status-copy">{copy}</p>
+    </section>
+  );
+}
+
+function AdminIssueFeed({
+  issues,
+  emptyCopy
+}: {
+  issues: Array<{
+    code: string;
+    severity: string | null | undefined;
+    message: string;
+    gameId?: string | null;
+    actionId?: string | null;
+  }>;
+  emptyCopy: string;
+}) {
+  const orderedIssues = sortBySeverity(issues);
+
+  if (!orderedIssues.length) {
+    return <p className="status-copy">{emptyCopy}</p>;
+  }
+
+  return (
+    <ul className="admin-issue-list">
+      {orderedIssues.map((issue, index) => (
+        <li
+          key={`${issue.code}:${issue.gameId || issue.actionId || index}`}
+          className="admin-issue-item"
+        >
+          <span className={`status-pill ${statusTone(issue.severity)}`}>
+            {issue.severity || "info"}
+          </span>
+          <div>
+            <strong>{issue.code}</strong>
+            <p>{issue.message}</p>
+            {issue.gameId || issue.actionId ? (
+              <p className="admin-item-meta">
+                {issue.gameId ? `Game ${issue.gameId}` : null}
+                {issue.gameId && issue.actionId ? " · " : null}
+                {issue.actionId ? `Action ${issue.actionId}` : null}
+              </p>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -220,31 +444,70 @@ function SectionFrame({
   eyebrow,
   title,
   copy,
+  frameContext,
+  status,
   actions,
+  toolbar,
   children
 }: {
   eyebrow: string;
   title: string;
   copy: string;
+  frameContext: AdminFrameContext;
+  status?: ReactNode;
   actions?: ReactNode;
+  toolbar?: ReactNode;
   children: ReactNode;
 }) {
   return (
     <div className="admin-section-stack">
-      <section className="hero-panel admin-hero-panel">
+      <section className="hero-panel admin-hero-panel admin-page-header">
         <div className="admin-hero-copy">
+          <div className="admin-breadcrumbs" aria-label="Breadcrumb">
+            <span>Admin</span>
+            <span>/</span>
+            <span>{frameContext.sectionLabel}</span>
+          </div>
           <p className="status-label">{eyebrow}</p>
           <h1>{title}</h1>
           <p className="hero-copy">{copy}</p>
+          {status ? <div className="admin-header-status">{status}</div> : null}
         </div>
-        {actions ? <div className="hero-actions">{actions}</div> : null}
+        <div className="admin-hero-side">
+          <section className="admin-context-panel" aria-label="Operator session">
+            <p className="status-label">Operator session</p>
+            <strong>{frameContext.currentUser.username}</strong>
+            <p className="admin-context-copy">
+              {(frameContext.currentUser.role || "admin").toUpperCase()} access
+            </p>
+            <AdminMetaList
+              columns={2}
+              items={[
+                {
+                  label: "Environment",
+                  value: frameContext.environmentLabel
+                },
+                {
+                  label: "Host",
+                  value: frameContext.hostLabel
+                }
+              ]}
+            />
+          </section>
+          {actions ? <div className="hero-actions admin-hero-actions">{actions}</div> : null}
+        </div>
       </section>
+      {toolbar ? (
+        <section className="card-panel admin-toolbar-panel admin-toolbar-panel-sticky">
+          {toolbar}
+        </section>
+      ) : null}
       {children}
     </div>
   );
 }
 
-function OverviewSection() {
+function OverviewSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const overviewQuery = useQuery({
     queryKey: adminOverviewQueryKey(),
     queryFn: () => getAdminOverview(requestMessages("admin overview"))
@@ -273,110 +536,115 @@ function OverviewSection() {
   }
 
   const overview = overviewQuery.data;
+  const priorityIssues = sortBySeverity(overview.issues);
+  const riskSignalCount = overview.summary.invalidGames + overview.summary.staleLobbies;
 
   return (
     <SectionFrame
       eyebrow="Overview"
       title="Operational command center"
       copy="A fast read on the current NetRisk runtime: user volume, lobby health, invalid states, enabled modules, and the latest administrative activity."
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">Active games {overview.summary.activeGames}</span>
+          <span className="chip">Risk signals {riskSignalCount}</span>
+          <span className="chip">Enabled modules {overview.summary.enabledModules}</span>
+        </>
+      }
       actions={
         <>
-          <Link className="refresh-button" to="users">
+          <Link className="refresh-button" to={`${frameContext.basePath}/users`}>
             Review users
           </Link>
-          <Link className="ghost-action" to="games">
+          <Link className="ghost-action" to={`${frameContext.basePath}/games`}>
             Inspect games
+          </Link>
+          <Link className="ghost-action" to={`${frameContext.basePath}/maintenance`}>
+            Open maintenance
           </Link>
         </>
       }
     >
-      <div className="grid-shell admin-metrics-grid">
-        <AdminMetric label="Users" value={overview.summary.totalUsers} tone="success" />
-        <AdminMetric label="Admins" value={overview.summary.adminUsers} />
-        <AdminMetric label="Active games" value={overview.summary.activeGames} tone="success" />
-        <AdminMetric label="Lobby queue" value={overview.summary.lobbyGames} />
-        <AdminMetric
-          label="Stale lobbies"
-          value={overview.summary.staleLobbies}
-          tone={overview.summary.staleLobbies > 0 ? "warning" : "success"}
-        />
-        <AdminMetric
-          label="Invalid games"
-          value={overview.summary.invalidGames}
-          tone={overview.summary.invalidGames > 0 ? "danger" : "success"}
-        />
-      </div>
-
-      <div className="grid-shell">
-        <section className="card-panel admin-card-span">
+      <div className="admin-kpi-layout">
+        <section className="card-panel admin-kpi-band admin-kpi-band-risk">
           <div className="card-header">
             <div>
-              <p className="status-label">Defaults</p>
-              <h2>Current server defaults</h2>
+              <p className="status-label">Risk focus</p>
+              <h2>Warnings first</h2>
             </div>
-            <Link className="ghost-action" to="config">
-              Edit config
-            </Link>
           </div>
-          <dl className="admin-definition-grid">
-            <div>
-              <dt>Content pack</dt>
-              <dd>{overview.config.defaults.contentPackId || "system default"}</dd>
-            </div>
-            <div>
-              <dt>Rule set</dt>
-              <dd>{overview.config.defaults.ruleSetId || "system default"}</dd>
-            </div>
-            <div>
-              <dt>Map</dt>
-              <dd>{overview.config.defaults.mapId || "system default"}</dd>
-            </div>
-            <div>
-              <dt>Theme</dt>
-              <dd>{overview.config.defaults.themeId || "system default"}</dd>
-            </div>
-            <div>
-              <dt>Modules</dt>
-              <dd>
-                {overview.config.defaults.activeModuleIds?.length
-                  ? overview.config.defaults.activeModuleIds.join(", ")
-                  : "Core only"}
-              </dd>
-            </div>
-            <div>
-              <dt>Stale lobby window</dt>
-              <dd>{overview.config.maintenance.staleLobbyDays} days</dd>
-            </div>
-          </dl>
+          <div className="admin-kpi-grid admin-kpi-grid-risk">
+            <AdminMetric
+              label="Invalid games"
+              value={overview.summary.invalidGames}
+              tone={overview.summary.invalidGames > 0 ? "danger" : "success"}
+              hint="Sessions that need immediate inspection"
+            />
+            <AdminMetric
+              label="Stale lobbies"
+              value={overview.summary.staleLobbies}
+              tone={overview.summary.staleLobbies > 0 ? "warning" : "success"}
+              hint="Open lobbies older than the cleanup window"
+            />
+            <AdminMetric
+              label="Lobby queue"
+              value={overview.summary.lobbyGames}
+              tone={overview.summary.lobbyGames > 0 ? "muted" : "success"}
+              hint="Current waiting rooms"
+            />
+          </div>
         </section>
 
-        <section className="card-panel">
+        <section className="card-panel admin-kpi-band">
           <div className="card-header">
             <div>
-              <p className="status-label">Watchlist</p>
+              <p className="status-label">Healthy throughput</p>
+              <h2>Runtime baseline</h2>
+            </div>
+          </div>
+          <div className="admin-kpi-grid">
+            <AdminMetric
+              label="Users"
+              value={overview.summary.totalUsers}
+              tone="success"
+              hint="Registered accounts"
+            />
+            <AdminMetric
+              label="Admins"
+              value={overview.summary.adminUsers}
+              hint="Operator accounts"
+            />
+            <AdminMetric
+              label="Active games"
+              value={overview.summary.activeGames}
+              tone="success"
+              hint="Currently progressing sessions"
+            />
+            <AdminMetric
+              label="Finished games"
+              value={overview.summary.finishedGames}
+              hint="Completed sessions on record"
+            />
+          </div>
+        </section>
+      </div>
+
+      <div className="grid-shell admin-overview-grid">
+        <section className="card-panel admin-card-span admin-priority-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Priority queue</p>
               <h2>Outstanding issues</h2>
             </div>
-            <Link className="ghost-action" to="maintenance">
+            <Link className="ghost-action" to={`${frameContext.basePath}/maintenance`}>
               Open maintenance
             </Link>
           </div>
-          {overview.issues.length ? (
-            <ul className="admin-issue-list">
-              {overview.issues.map((issue, index) => (
-                <li key={`${issue.code}:${issue.gameId || index}`} className="admin-issue-item">
-                  <span className={`status-pill ${statusTone(issue.severity)}`}>
-                    {issue.severity}
-                  </span>
-                  <div>
-                    <strong>{issue.code}</strong>
-                    <p>{issue.message}</p>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="status-copy">No blocking issues detected in the latest scan.</p>
-          )}
+          <AdminIssueFeed
+            issues={priorityIssues}
+            emptyCopy="No blocking issues detected in the latest scan."
+          />
         </section>
 
         <section className="card-panel">
@@ -385,24 +653,34 @@ function OverviewSection() {
               <p className="status-label">Recent games</p>
               <h2>Latest sessions</h2>
             </div>
-            <Link className="ghost-action" to="games">
+            <Link className="ghost-action" to={`${frameContext.basePath}/games`}>
               Open games
             </Link>
           </div>
-          <ul className="admin-game-list">
-            {overview.recentGames.map((game) => (
-              <li key={game.id} className="admin-game-item">
-                <div>
-                  <strong>{game.name}</strong>
-                  <p>
-                    {game.phase} · {game.playerCount} players · updated{" "}
-                    {formatTimestamp(game.updatedAt)}
-                  </p>
-                </div>
-                <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
-              </li>
-            ))}
-          </ul>
+          {overview.recentGames.length ? (
+            <ul className="admin-game-list">
+              {overview.recentGames.map((game) => (
+                <li key={game.id} className="admin-game-item">
+                  <div>
+                    <strong>{game.name}</strong>
+                    <p>
+                      {game.phase} · {game.playerCount} players · updated{" "}
+                      {formatTimestamp(game.updatedAt)}
+                    </p>
+                    <p className="admin-item-meta">
+                      {(game.mapName || game.mapId || "Map unset") + " · "}
+                      {game.issueCount} issues
+                    </p>
+                  </div>
+                  <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="status-copy">
+              No recent games are available in the current overview snapshot.
+            </p>
+          )}
         </section>
 
         <section className="card-panel">
@@ -411,37 +689,99 @@ function OverviewSection() {
               <p className="status-label">Audit</p>
               <h2>Latest admin actions</h2>
             </div>
-            <Link className="ghost-action" to="audit">
+            <Link className="ghost-action" to={`${frameContext.basePath}/audit`}>
               Open audit log
             </Link>
           </div>
-          <ul className="admin-audit-list">
-            {overview.audit.map((entry) => (
-              <li key={entry.id} className="admin-audit-item">
-                <div>
-                  <strong>{entry.action}</strong>
-                  <p>
-                    {entry.actorUsername} · {entry.targetType} · {formatTimestamp(entry.createdAt)}
-                  </p>
-                </div>
-                <span
-                  className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
-                >
-                  {entry.result}
-                </span>
-              </li>
-            ))}
-          </ul>
+          {overview.audit.length ? (
+            <ul className="admin-audit-list">
+              {overview.audit.map((entry) => (
+                <li key={entry.id} className="admin-audit-item">
+                  <div>
+                    <strong>{entry.action}</strong>
+                    <p>
+                      {entry.actorUsername} · {entry.targetType}
+                      {entry.targetLabel ? ` · ${entry.targetLabel}` : ""} ·{" "}
+                      {formatTimestamp(entry.createdAt)}
+                    </p>
+                  </div>
+                  <span
+                    className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
+                  >
+                    {entry.result}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="status-copy">No recent administrative actions have been recorded yet.</p>
+          )}
+        </section>
+
+        <section className="card-panel admin-card-span">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Defaults</p>
+              <h2>Current server defaults</h2>
+            </div>
+            <Link className="ghost-action" to={`${frameContext.basePath}/config`}>
+              Edit config
+            </Link>
+          </div>
+          <AdminMetaList
+            columns={3}
+            items={[
+              {
+                label: "Content pack",
+                value: overview.config.defaults.contentPackId || "system default"
+              },
+              {
+                label: "Rule set",
+                value: overview.config.defaults.ruleSetId || "system default"
+              },
+              {
+                label: "Map",
+                value: overview.config.defaults.mapId || "system default"
+              },
+              {
+                label: "Theme",
+                value: overview.config.defaults.themeId || "system default"
+              },
+              {
+                label: "Modules",
+                value: overview.config.defaults.activeModuleIds?.length
+                  ? overview.config.defaults.activeModuleIds.join(", ")
+                  : "Core only"
+              },
+              {
+                label: "Stale lobby window",
+                value: `${overview.config.maintenance.staleLobbyDays} days`
+              },
+              {
+                label: "Audit window",
+                value: `${overview.config.maintenance.auditLogLimit} entries`
+              },
+              {
+                label: "Updated",
+                value: formatTimestamp(overview.config.updatedAt)
+              },
+              {
+                label: "Updated by",
+                value: overview.config.updatedBy?.username || "system"
+              }
+            ]}
+          />
         </section>
       </div>
     </SectionFrame>
   );
 }
 
-function UsersSection() {
+function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const queryClient = useQueryClient();
   const [query, setQuery] = useState("");
   const [role, setRole] = useState("");
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const deferredQuery = useDeferredValue(query);
 
   const usersQuery = useQuery({
@@ -465,6 +805,19 @@ function UsersSection() {
     }
   });
 
+  useEffect(() => {
+    if (!usersQuery.data?.users.length) {
+      setSelectedUserId(null);
+      return;
+    }
+
+    setSelectedUserId((current) =>
+      current && usersQuery.data.users.some((user) => user.id === current)
+        ? current
+        : usersQuery.data.users[0].id
+    );
+  }, [usersQuery.data]);
+
   function handleRoleChange(user: AdminUserSummary, nextRole: "admin" | "user") {
     const confirmed = window.confirm(
       nextRole === "admin"
@@ -482,37 +835,73 @@ function UsersSection() {
     });
   }
 
+  const selectedUser = usersQuery.data?.users.find((user) => user.id === selectedUserId) || null;
+  const hasFilters = Boolean(query || role);
+
   return (
     <SectionFrame
       eyebrow="Users"
       title="Manage roles and identity"
       copy="Search the current user base, inspect activity hints, and promote or demote administrators with server-side enforcement."
-    >
-      <section className="card-panel admin-toolbar-panel">
-        <div className="admin-toolbar">
-          <label className="shell-field">
-            <span>Search</span>
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">Filtered {usersQuery.data?.filteredTotal || 0}</span>
+          <span className="chip">Role {role || "all"}</span>
+          <span className="chip">Selection {selectedUser?.username || "none"}</span>
+        </>
+      }
+      actions={
+        <>
+          {hasFilters ? (
+            <button
+              type="button"
+              className="refresh-button"
+              onClick={() => {
+                setQuery("");
+                setRole("");
+              }}
+            >
+              Clear filters
+            </button>
+          ) : null}
+          <Link className="ghost-action" to={`${frameContext.basePath}/audit`}>
+            Review audit
+          </Link>
+        </>
+      }
+      toolbar={
+        <div className="admin-toolbar admin-toolbar-dense">
+          <AdminField label="Search" hint="Filter by username">
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Username"
             />
-          </label>
-          <label className="shell-field">
-            <span>Role</span>
+          </AdminField>
+          <AdminField label="Role" hint="Focus on operators or standard users">
             <select value={role} onChange={(event) => setRole(event.target.value)}>
               <option value="">All roles</option>
               <option value="admin">Admins</option>
               <option value="user">Users</option>
             </select>
-          </label>
+          </AdminField>
+          <div className="admin-toolbar-summary">
+            <span className="chip">{usersQuery.data?.total || 0} total accounts</span>
+            <span className="chip">{usersQuery.data?.filteredTotal || 0} visible</span>
+          </div>
         </div>
-        {roleMutation.isError ? (
-          <p className="auth-feedback is-error">
+      }
+    >
+      {roleMutation.isError ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Users</p>
+          <h2>Role update failed</h2>
+          <p className="status-copy">
             {messageFromError(roleMutation.error, "Unable to update that role.")}
           </p>
-        ) : null}
-      </section>
+        </section>
+      ) : null}
 
       {usersQuery.isLoading ? (
         <section className="status-panel">
@@ -528,84 +917,178 @@ function UsersSection() {
             {messageFromError(usersQuery.error, "Unable to load the admin user roster.")}
           </p>
         </section>
+      ) : !usersQuery.data.users.length ? (
+        <AdminEmptyState
+          label="Users"
+          title="No users match the current filters"
+          copy="Try broadening the search or clearing the current role filter."
+        />
       ) : (
-        <section className="card-panel admin-card-span">
-          <div className="card-header">
-            <div>
-              <p className="status-label">Roster</p>
-              <h2>
-                {usersQuery.data.filteredTotal} of {usersQuery.data.total} users
-              </h2>
+        <div className="admin-users-grid">
+          <section className="card-panel">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Roster</p>
+                <h2>
+                  {usersQuery.data.filteredTotal} of {usersQuery.data.total} users
+                </h2>
+              </div>
             </div>
-          </div>
-          <div className="admin-table-wrap">
-            <table className="admin-table">
-              <thead>
-                <tr>
-                  <th>User</th>
-                  <th>Role</th>
-                  <th>Games</th>
-                  <th>Created</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {usersQuery.data.users.map((user) => (
-                  <tr key={user.id}>
-                    <td>
-                      <strong>{user.username}</strong>
-                      <p className="admin-table-copy">
-                        {user.hasEmail ? "Email on file" : "No email"} · theme{" "}
-                        {user.preferences?.theme || "default"}
-                      </p>
-                    </td>
-                    <td>
-                      <span
-                        className={`status-pill ${user.role === "admin" ? "success" : "muted"}`}
-                      >
-                        {user.role}
-                      </span>
-                    </td>
-                    <td>
-                      {user.gamesInProgress} in progress · {user.gamesPlayed} finished
-                    </td>
-                    <td>{formatTimestamp(user.createdAt)}</td>
-                    <td>
-                      <div className="admin-inline-actions">
-                        {user.canPromote ? (
-                          <button
-                            type="button"
-                            className="refresh-button"
-                            onClick={() => handleRoleChange(user, "admin")}
-                            disabled={roleMutation.isPending}
-                          >
-                            Promote
-                          </button>
-                        ) : null}
-                        {user.canDemote ? (
-                          <button
-                            type="button"
-                            className="ghost-action"
-                            onClick={() => handleRoleChange(user, "user")}
-                            disabled={roleMutation.isPending}
-                          >
-                            Demote
-                          </button>
-                        ) : null}
-                      </div>
-                    </td>
+            <div className="admin-table-wrap">
+              <table className="admin-table admin-table-compact">
+                <thead>
+                  <tr>
+                    <th>User</th>
+                    <th>Role</th>
+                    <th>Activity</th>
+                    <th>Created</th>
+                    <th>Actions</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
+                </thead>
+                <tbody>
+                  {usersQuery.data.users.map((user) => (
+                    <tr key={user.id} className={selectedUserId === user.id ? "is-selected" : ""}>
+                      <td>
+                        <button
+                          type="button"
+                          className="admin-row-select"
+                          onClick={() => setSelectedUserId(user.id)}
+                          aria-pressed={selectedUserId === user.id}
+                        >
+                          <strong>{user.username}</strong>
+                          <span className="admin-table-copy">
+                            {user.hasEmail ? "Email on file" : "No email"} · theme{" "}
+                            {user.preferences?.theme || "default"}
+                          </span>
+                        </button>
+                      </td>
+                      <td>
+                        <span
+                          className={`status-pill ${user.role === "admin" ? "success" : "muted"}`}
+                        >
+                          {user.role}
+                        </span>
+                      </td>
+                      <td>
+                        {user.gamesInProgress} active · {user.gamesPlayed} played · {user.wins} wins
+                      </td>
+                      <td>{formatTimestamp(user.createdAt)}</td>
+                      <td>
+                        <div className="admin-inline-actions">
+                          {user.canPromote ? (
+                            <button
+                              type="button"
+                              className="refresh-button"
+                              onClick={() => handleRoleChange(user, "admin")}
+                              disabled={roleMutation.isPending}
+                            >
+                              Promote
+                            </button>
+                          ) : null}
+                          {user.canDemote ? (
+                            <button
+                              type="button"
+                              className="ghost-action"
+                              onClick={() => handleRoleChange(user, "user")}
+                              disabled={roleMutation.isPending}
+                            >
+                              Demote
+                            </button>
+                          ) : null}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="card-panel admin-sticky-detail-panel">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Selected user</p>
+                <h2>{selectedUser?.username || "No selection"}</h2>
+              </div>
+              {selectedUser ? (
+                <span
+                  className={`status-pill ${selectedUser.role === "admin" ? "success" : "muted"}`}
+                >
+                  {selectedUser.role}
+                </span>
+              ) : null}
+            </div>
+
+            {selectedUser ? (
+              <div className="admin-detail-stack">
+                <AdminMetaList
+                  items={[
+                    {
+                      label: "Email",
+                      value: selectedUser.hasEmail ? "On file" : "Not provided"
+                    },
+                    {
+                      label: "Theme",
+                      value: selectedUser.preferences?.theme || "default"
+                    },
+                    {
+                      label: "Created",
+                      value: formatTimestamp(selectedUser.createdAt)
+                    },
+                    {
+                      label: "Wins",
+                      value: selectedUser.wins
+                    },
+                    {
+                      label: "Games active",
+                      value: selectedUser.gamesInProgress
+                    },
+                    {
+                      label: "Games played",
+                      value: selectedUser.gamesPlayed
+                    }
+                  ]}
+                />
+                <div className="admin-inline-actions">
+                  {selectedUser.canPromote ? (
+                    <button
+                      type="button"
+                      className="refresh-button"
+                      onClick={() => handleRoleChange(selectedUser, "admin")}
+                      disabled={roleMutation.isPending}
+                    >
+                      Promote to admin
+                    </button>
+                  ) : null}
+                  {selectedUser.canDemote ? (
+                    <button
+                      type="button"
+                      className="ghost-action"
+                      onClick={() => handleRoleChange(selectedUser, "user")}
+                      disabled={roleMutation.isPending}
+                    >
+                      Revert to user
+                    </button>
+                  ) : null}
+                </div>
+                <p className="status-copy">
+                  Role changes still require the existing confirmation dialog and remain part of the
+                  audit trail.
+                </p>
+              </div>
+            ) : (
+              <p className="status-copy">
+                Select a user from the table to review profile details and role actions.
+              </p>
+            )}
+          </section>
+        </div>
       )}
     </SectionFrame>
   );
 }
 
-function GamesSection() {
+function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const queryClient = useQueryClient();
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState("");
@@ -658,6 +1141,7 @@ function GamesSection() {
   });
 
   const selectedGame = detailsQuery.data?.game || null;
+  const hasFilters = Boolean(query || status);
 
   function handleGameAction(action: "close-lobby" | "terminate-game" | "repair-game-config") {
     if (!selectedGameId) {
@@ -681,33 +1165,66 @@ function GamesSection() {
       eyebrow="Games"
       title="Inspect lobbies and sessions"
       copy="Filter active or finished games, inspect state and players, repair normalized config, or terminate broken sessions with confirmed server-side actions."
-    >
-      <section className="card-panel admin-toolbar-panel">
-        <div className="admin-toolbar">
-          <label className="shell-field">
-            <span>Search</span>
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">Matches {gamesQuery.data?.filteredTotal || 0}</span>
+          <span className="chip">Filter {status || "all"}</span>
+          <span className="chip">Selected {selectedGame?.name || selectedGameId || "none"}</span>
+        </>
+      }
+      actions={
+        <>
+          {hasFilters ? (
+            <button
+              type="button"
+              className="refresh-button"
+              onClick={() => {
+                setQuery("");
+                setStatus("");
+              }}
+            >
+              Clear filters
+            </button>
+          ) : null}
+          <Link className="ghost-action" to={`${frameContext.basePath}/maintenance`}>
+            Open maintenance
+          </Link>
+        </>
+      }
+      toolbar={
+        <div className="admin-toolbar admin-toolbar-dense">
+          <AdminField label="Search" hint="Filter by game name or id">
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Game name or id"
             />
-          </label>
-          <label className="shell-field">
-            <span>Status</span>
+          </AdminField>
+          <AdminField label="Status" hint="Limit the queue or live sessions">
             <select value={status} onChange={(event) => setStatus(event.target.value)}>
               <option value="">All</option>
               <option value="lobby">Lobby</option>
               <option value="active">Active</option>
               <option value="finished">Finished</option>
             </select>
-          </label>
+          </AdminField>
+          <div className="admin-toolbar-summary">
+            <span className="chip">{gamesQuery.data?.total || 0} tracked games</span>
+            <span className="chip">{gamesQuery.data?.filteredTotal || 0} visible</span>
+          </div>
         </div>
-        {actionMutation.isError ? (
-          <p className="auth-feedback is-error">
+      }
+    >
+      {actionMutation.isError ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Games</p>
+          <h2>Game action failed</h2>
+          <p className="status-copy">
             {messageFromError(actionMutation.error, "Unable to complete that admin game action.")}
           </p>
-        ) : null}
-      </section>
+        </section>
+      ) : null}
 
       <div className="grid-shell admin-games-grid">
         <section className="card-panel">
@@ -723,6 +1240,12 @@ function GamesSection() {
             <p className="status-copy">
               {messageFromError(gamesQuery.error, "Unable to load admin games.")}
             </p>
+          ) : !gamesQuery.data.games.length ? (
+            <AdminEmptyState
+              label="Games"
+              title="No games match the current filters"
+              copy="Try broadening the search or removing the status filter."
+            />
           ) : (
             <ul className="admin-game-list">
               {gamesQuery.data.games.map((game) => (
@@ -732,11 +1255,15 @@ function GamesSection() {
                     className={`admin-list-button${selectedGameId === game.id ? " is-selected" : ""}`}
                     onClick={() => setSelectedGameId(game.id)}
                   >
-                    <div>
+                    <div className="admin-list-copy">
                       <strong>{game.name}</strong>
                       <p>
                         {game.phase} · {game.playerCount} players ·{" "}
                         {formatTimestamp(game.updatedAt)}
+                      </p>
+                      <p className="admin-item-meta">
+                        {game.mapName || game.mapId || "Map unset"} · {game.issueCount} issues
+                        {game.stale ? " · stale" : ""}
                       </p>
                     </div>
                     <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
@@ -753,7 +1280,7 @@ function GamesSection() {
               <p className="status-label">Detail</p>
               <h2>{selectedGame?.name || "Select a game"}</h2>
             </div>
-            <div className="admin-inline-actions">
+            <div className="admin-inline-actions admin-action-cluster">
               <button
                 type="button"
                 className="refresh-button"
@@ -801,50 +1328,92 @@ function GamesSection() {
                 </p>
               </div>
 
+              <AdminMetaList
+                columns={3}
+                items={[
+                  {
+                    label: "Map",
+                    value: selectedGame?.mapName || selectedGame?.mapId || "system default"
+                  },
+                  {
+                    label: "Content pack",
+                    value: selectedGame?.contentPackId || "system default"
+                  },
+                  {
+                    label: "Dice rules",
+                    value: selectedGame?.diceRuleSetId || "system default"
+                  },
+                  {
+                    label: "Total players",
+                    value: selectedGame?.totalPlayers ?? "not pinned"
+                  },
+                  {
+                    label: "AI seats",
+                    value: selectedGame?.aiCount ?? 0
+                  },
+                  {
+                    label: "Creator",
+                    value: selectedGame?.creatorUserId || "unknown"
+                  },
+                  {
+                    label: "Modules",
+                    value: selectedGame?.activeModules?.length
+                      ? selectedGame.activeModules.map((moduleEntry) => moduleEntry.id).join(", ")
+                      : "Core only"
+                  },
+                  {
+                    label: "Preset",
+                    value: selectedGame?.gamePresetId || "none"
+                  },
+                  {
+                    label: "Updated",
+                    value: formatTimestamp(selectedGame?.updatedAt)
+                  }
+                ]}
+              />
+
               <div className="admin-detail-grid">
-                <section className="card-panel">
+                <section className="admin-subpanel">
                   <p className="status-label">Players</p>
-                  <ul className="admin-player-list">
+                  <ul className="admin-player-list admin-player-list-detailed">
                     {detailsQuery.data.players.map((player) => (
-                      <li key={player.id}>
-                        <strong>{player.name}</strong>
-                        <p>
-                          {player.isAi ? "AI" : player.linkedUserId || "Guest"} · territories{" "}
-                          {player.territoryCount} · cards {player.cardCount}
-                        </p>
+                      <li key={player.id} className="admin-player-item">
+                        <div>
+                          <strong>{player.name}</strong>
+                          <p>
+                            {player.isAi ? "AI seat" : player.linkedUserId || "Guest"} · territories{" "}
+                            {player.territoryCount} · cards {player.cardCount}
+                          </p>
+                        </div>
+                        <div className="admin-inline-actions">
+                          {player.surrendered ? (
+                            <span className="status-pill warning">surrendered</span>
+                          ) : null}
+                        </div>
                       </li>
                     ))}
                   </ul>
                 </section>
 
-                <section className="card-panel">
+                <section className="admin-subpanel">
                   <p className="status-label">Issues</p>
-                  {detailsQuery.data.game.issues.length ? (
-                    <ul className="admin-issue-list">
-                      {detailsQuery.data.game.issues.map((issue, index) => (
-                        <li key={`${issue.code}:${index}`} className="admin-issue-item">
-                          <span className={`status-pill ${statusTone(issue.severity)}`}>
-                            {issue.severity}
-                          </span>
-                          <div>
-                            <strong>{issue.code}</strong>
-                            <p>{issue.message}</p>
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="status-copy">No issues detected for this session.</p>
-                  )}
+                  <AdminIssueFeed
+                    issues={detailsQuery.data.game.issues}
+                    emptyCopy="No issues detected for this session."
+                  />
                 </section>
               </div>
 
-              <section className="card-panel">
-                <p className="status-label">Raw state</p>
+              <details className="admin-debug-panel">
+                <summary>Advanced and debug state</summary>
+                <p className="status-copy">
+                  Raw server state stays available for investigation, but it now sits behind an
+                  explicit debug disclosure.
+                </p>
                 <pre className="admin-json-block">
                   {JSON.stringify(detailsQuery.data.rawState, null, 2)}
                 </pre>
-              </section>
+              </details>
             </div>
           )}
         </section>
@@ -853,7 +1422,7 @@ function GamesSection() {
   );
 }
 
-function ConfigSection() {
+function ConfigSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const queryClient = useQueryClient();
   const configQuery = useQuery({
     queryKey: adminConfigQueryKey(),
@@ -900,6 +1469,16 @@ function ConfigSection() {
     gameOptions?.uiProfiles,
     formState?.activeModuleIds || []
   );
+  const savedFormState = configQuery.data?.config
+    ? buildConfigFormState(configQuery.data.config)
+    : null;
+  const dirtyFieldCount = countConfigDifferences(formState, savedFormState);
+  const isDirty = dirtyFieldCount > 0;
+  const orderedModules = [...availableModules].sort((left, right) => {
+    const leftSelected = formState?.activeModuleIds.includes(left.id) ? 1 : 0;
+    const rightSelected = formState?.activeModuleIds.includes(right.id) ? 1 : 0;
+    return rightSelected - leftSelected || left.displayName.localeCompare(right.displayName);
+  });
 
   function updateField<K extends keyof AdminConfigFormState>(
     key: K,
@@ -925,6 +1504,16 @@ function ConfigSection() {
     });
   }
 
+  function handleRevert() {
+    if (savedFormState) {
+      setFormState(savedFormState);
+    }
+  }
+
+  function handleResetOverrides() {
+    setFormState((current) => (current ? clearAdminConfigOverrides(current) : current));
+  }
+
   function handleSave() {
     if (!formState) {
       return;
@@ -938,15 +1527,63 @@ function ConfigSection() {
       eyebrow="Configuration"
       title="Control global defaults"
       copy="These values feed the real game-creation flow. Updating them changes which rules, content, modules, and maintenance thresholds the runtime will use by default."
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">
+            {isDirty ? `${dirtyFieldCount} unsaved changes` : "All changes saved"}
+          </span>
+          <span className="chip">{formState?.activeModuleIds.length || 0} active modules</span>
+          <span className="chip">Saved {formatTimestamp(configQuery.data?.config?.updatedAt)}</span>
+        </>
+      }
       actions={
-        <button
-          type="button"
-          className="refresh-button"
-          onClick={handleSave}
-          disabled={!formState || saveMutation.isPending}
-        >
-          {saveMutation.isPending ? "Saving…" : "Save defaults"}
-        </button>
+        <>
+          <button
+            type="button"
+            className="refresh-button"
+            onClick={handleSave}
+            disabled={!formState || !isDirty || saveMutation.isPending}
+          >
+            {saveMutation.isPending ? "Saving…" : "Save changes"}
+          </button>
+          <button
+            type="button"
+            className="ghost-action"
+            onClick={handleRevert}
+            disabled={!savedFormState || !isDirty || saveMutation.isPending}
+          >
+            Revert changes
+          </button>
+          <button
+            type="button"
+            className="ghost-action"
+            onClick={handleResetOverrides}
+            disabled={!formState || saveMutation.isPending}
+          >
+            Clear default overrides
+          </button>
+        </>
+      }
+      toolbar={
+        <div className="admin-toolbar admin-toolbar-dense">
+          <div className="admin-toolbar-summary">
+            <span className="chip">
+              Updated by {configQuery.data?.config?.updatedBy?.username || "system"}
+            </span>
+            <span className="chip">
+              Lobby cleanup after{" "}
+              {formState?.staleLobbyDays ||
+                configQuery.data?.config?.maintenance.staleLobbyDays ||
+                0}{" "}
+              days
+            </span>
+            <span className="chip">
+              Audit window{" "}
+              {formState?.auditLogLimit || configQuery.data?.config?.maintenance.auditLogLimit || 0}
+            </span>
+          </div>
+        </div>
       }
     >
       {saveMutation.isError ? (
@@ -979,275 +1616,312 @@ function ConfigSection() {
           </p>
         </section>
       ) : (
-        <section className="card-panel admin-card-span">
-          <div className="admin-form-grid">
-            <label className="shell-field">
-              <span>Content pack</span>
-              <select
-                value={formState.contentPackId}
-                onChange={(event) => updateField("contentPackId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.contentPacks?.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Rule set</span>
-              <select
-                value={formState.ruleSetId}
-                onChange={(event) => updateField("ruleSetId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.ruleSets.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Map</span>
-              <select
-                value={formState.mapId}
-                onChange={(event) => updateField("mapId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.maps.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Dice rules</span>
-              <select
-                value={formState.diceRuleSetId}
-                onChange={(event) => updateField("diceRuleSetId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.diceRuleSets.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Victory rules</span>
-              <select
-                value={formState.victoryRuleSetId}
-                onChange={(event) => updateField("victoryRuleSetId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.victoryRuleSets.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Player piece set</span>
-              <select
-                value={formState.pieceSetId}
-                onChange={(event) => updateField("pieceSetId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.playerPieceSets?.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Theme</span>
-              <select
-                value={formState.themeId}
-                onChange={(event) => updateField("themeId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.themes.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Piece skin</span>
-              <select
-                value={formState.pieceSkinId}
-                onChange={(event) => updateField("pieceSkinId", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.pieceSkins.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Game preset</span>
-              <select
-                value={formState.gamePresetId}
-                onChange={(event) => updateField("gamePresetId", event.target.value)}
-              >
-                <option value="">None</option>
-                {gameOptions.gamePresets?.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Content profile</span>
-              <select
-                value={formState.contentProfileId}
-                onChange={(event) => updateField("contentProfileId", event.target.value)}
-              >
-                <option value="">None</option>
-                {availableContentProfiles.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Gameplay profile</span>
-              <select
-                value={formState.gameplayProfileId}
-                onChange={(event) => updateField("gameplayProfileId", event.target.value)}
-              >
-                <option value="">None</option>
-                {availableGameplayProfiles.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>UI profile</span>
-              <select
-                value={formState.uiProfileId}
-                onChange={(event) => updateField("uiProfileId", event.target.value)}
-              >
-                <option value="">None</option>
-                {availableUiProfiles.map((entry) => (
-                  <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Turn timeout (hours)</span>
-              <select
-                value={formState.turnTimeoutHours}
-                onChange={(event) => updateField("turnTimeoutHours", event.target.value)}
-              >
-                <option value="">System default</option>
-                {gameOptions.turnTimeoutHoursOptions.map((entry) => (
-                  <option key={entry} value={String(entry)}>
-                    {entry}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="shell-field">
-              <span>Total players</span>
-              <input
-                type="number"
-                min={gameOptions.playerRange.min}
-                max={gameOptions.playerRange.max}
-                value={formState.totalPlayers}
-                onChange={(event) => updateField("totalPlayers", event.target.value)}
-              />
-            </label>
-
-            <label className="shell-field">
-              <span>Stale lobby days</span>
-              <input
-                type="number"
-                min={1}
-                max={365}
-                value={formState.staleLobbyDays}
-                onChange={(event) => updateField("staleLobbyDays", event.target.value)}
-              />
-            </label>
-
-            <label className="shell-field">
-              <span>Audit log size</span>
-              <input
-                type="number"
-                min={10}
-                max={500}
-                value={formState.auditLogLimit}
-                onChange={(event) => updateField("auditLogLimit", event.target.value)}
-              />
-            </label>
-          </div>
-
-          <section className="admin-module-picker">
+        <div className="admin-config-grid">
+          <section className="card-panel admin-config-group">
             <div className="card-header">
               <div>
-                <p className="status-label">Modules</p>
-                <h2>Runtime defaults</h2>
+                <p className="status-label">Gameplay defaults</p>
+                <h2>New game baseline</h2>
               </div>
             </div>
-            <div className="admin-module-grid">
-              {availableModules.map((moduleEntry) => {
-                const checked = formState.activeModuleIds.includes(moduleEntry.id);
-                return (
-                  <label key={moduleEntry.id} className="admin-module-toggle">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(event) => toggleModule(moduleEntry.id, event.target.checked)}
-                    />
-                    <span>
-                      <strong>{moduleEntry.displayName}</strong>
-                      <small>{moduleEntry.id}</small>
-                    </span>
-                  </label>
-                );
-              })}
+            <div className="admin-form-grid admin-form-grid-2">
+              <AdminField label="Rule set" hint="Primary turn and combat rules">
+                <select
+                  value={formState.ruleSetId}
+                  onChange={(event) => updateField("ruleSetId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.ruleSets.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Map" hint="Default territory layout">
+                <select
+                  value={formState.mapId}
+                  onChange={(event) => updateField("mapId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.maps.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Dice rules" hint="Attack and defense dice behavior">
+                <select
+                  value={formState.diceRuleSetId}
+                  onChange={(event) => updateField("diceRuleSetId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.diceRuleSets.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Victory rules" hint="How a winner is decided">
+                <select
+                  value={formState.victoryRuleSetId}
+                  onChange={(event) => updateField("victoryRuleSetId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.victoryRuleSets.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Total players" hint="Lobby cap when a preset is not forcing it">
+                <input
+                  type="number"
+                  min={gameOptions.playerRange.min}
+                  max={gameOptions.playerRange.max}
+                  value={formState.totalPlayers}
+                  onChange={(event) => updateField("totalPlayers", event.target.value)}
+                />
+              </AdminField>
+              <AdminField label="Turn timeout" hint="Default idle timeout in hours">
+                <select
+                  value={formState.turnTimeoutHours}
+                  onChange={(event) => updateField("turnTimeoutHours", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.turnTimeoutHoursOptions.map((entry) => (
+                    <option key={entry} value={String(entry)}>
+                      {entry}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Game preset" hint="Optional packaged configuration">
+                <select
+                  value={formState.gamePresetId}
+                  onChange={(event) => updateField("gamePresetId", event.target.value)}
+                >
+                  <option value="">None</option>
+                  {gameOptions.gamePresets?.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
             </div>
           </section>
-        </section>
+
+          <section className="card-panel admin-config-group">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Visual defaults</p>
+                <h2>Presentation baseline</h2>
+              </div>
+            </div>
+            <div className="admin-form-grid admin-form-grid-2">
+              <AdminField label="Theme" hint="Default shell theme">
+                <select
+                  value={formState.themeId}
+                  onChange={(event) => updateField("themeId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.themes.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Player piece set" hint="Board token set">
+                <select
+                  value={formState.pieceSetId}
+                  onChange={(event) => updateField("pieceSetId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.playerPieceSets?.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Piece skin" hint="Variant art layer for pieces">
+                <select
+                  value={formState.pieceSkinId}
+                  onChange={(event) => updateField("pieceSkinId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.pieceSkins.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="UI profile" hint="Default shell slot configuration">
+                <select
+                  value={formState.uiProfileId}
+                  onChange={(event) => updateField("uiProfileId", event.target.value)}
+                >
+                  <option value="">None</option>
+                  {availableUiProfiles.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+            </div>
+          </section>
+
+          <section className="card-panel admin-card-span admin-config-group">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Module and runtime defaults</p>
+                <h2>Content, profiles, and enabled modules</h2>
+              </div>
+              <span className="status-pill muted">{formState.activeModuleIds.length} selected</span>
+            </div>
+            <div className="admin-form-grid admin-form-grid-3">
+              <AdminField label="Content pack" hint="Top-level packaged content">
+                <select
+                  value={formState.contentPackId}
+                  onChange={(event) => updateField("contentPackId", event.target.value)}
+                >
+                  <option value="">System default</option>
+                  {gameOptions.contentPacks?.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Content profile" hint="Filtered by the active module set">
+                <select
+                  value={formState.contentProfileId}
+                  onChange={(event) => updateField("contentProfileId", event.target.value)}
+                >
+                  <option value="">None</option>
+                  {availableContentProfiles.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+              <AdminField label="Gameplay profile" hint="Module-aware default rule bundle">
+                <select
+                  value={formState.gameplayProfileId}
+                  onChange={(event) => updateField("gameplayProfileId", event.target.value)}
+                >
+                  <option value="">None</option>
+                  {availableGameplayProfiles.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {entry.name}
+                    </option>
+                  ))}
+                </select>
+              </AdminField>
+            </div>
+
+            <section className="admin-module-picker">
+              <div className="card-header">
+                <div>
+                  <p className="status-label">Runtime modules</p>
+                  <h2>Enabled by default</h2>
+                </div>
+              </div>
+              {orderedModules.length ? (
+                <div className="admin-module-grid">
+                  {orderedModules.map((moduleEntry) => {
+                    const checked = formState.activeModuleIds.includes(moduleEntry.id);
+                    return (
+                      <label
+                        key={moduleEntry.id}
+                        className={`admin-module-toggle${checked ? " is-selected" : ""}`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={(event) => toggleModule(moduleEntry.id, event.target.checked)}
+                        />
+                        <span>
+                          <strong>{moduleEntry.displayName}</strong>
+                          <small>{moduleEntry.id}</small>
+                          <small>{moduleEntry.description || "No description supplied."}</small>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="status-copy">No optional runtime modules are currently installed.</p>
+              )}
+            </section>
+          </section>
+
+          <section className="card-panel admin-config-group">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Maintenance thresholds</p>
+                <h2>Retention and cleanup controls</h2>
+              </div>
+            </div>
+            <div className="admin-form-grid admin-form-grid-2">
+              <AdminField label="Stale lobby days" hint="Used by the cleanup maintenance action">
+                <input
+                  type="number"
+                  min={1}
+                  max={365}
+                  value={formState.staleLobbyDays}
+                  onChange={(event) => updateField("staleLobbyDays", event.target.value)}
+                />
+              </AdminField>
+              <AdminField label="Audit log size" hint="Maximum retained admin entries">
+                <input
+                  type="number"
+                  min={10}
+                  max={500}
+                  value={formState.auditLogLimit}
+                  onChange={(event) => updateField("auditLogLimit", event.target.value)}
+                />
+              </AdminField>
+            </div>
+          </section>
+        </div>
       )}
     </SectionFrame>
   );
 }
 
-function ModulesSection({ userId }: { userId: string }) {
+function ModulesSection({
+  userId,
+  frameContext
+}: {
+  userId: string;
+  frameContext: AdminFrameContext;
+}) {
   return (
     <SectionFrame
       eyebrow="Runtime"
       title="Modules and runtime content"
       copy="Enable, disable, and rescan modules using the existing server-side admin controls. The runtime catalog here is live, not mocked."
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">Live catalog</span>
+          <span className="chip">Server-backed controls</span>
+        </>
+      }
+      actions={
+        <Link className="ghost-action" to={`${frameContext.basePath}/config`}>
+          Open defaults
+        </Link>
+      }
     >
       <section className="card-panel admin-card-span">
         <ProfileAdminModules userId={userId} />
@@ -1256,7 +1930,7 @@ function ModulesSection({ userId }: { userId: string }) {
   );
 }
 
-function MaintenanceSection() {
+function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const queryClient = useQueryClient();
   const reportQuery = useQuery({
     queryKey: adminMaintenanceQueryKey(),
@@ -1291,6 +1965,14 @@ function MaintenanceSection() {
       eyebrow="Maintenance"
       title="Validation and repair operations"
       copy="Run non-destructive validation across the runtime, surface orphaned references, and clean up stale lobbies with explicit confirmation."
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">Validate is read-only</span>
+          <span className="chip">Cleanup requires typed confirmation</span>
+          <span className="chip">Audit recorded automatically</span>
+        </>
+      }
       actions={
         <>
           <button
@@ -1311,6 +1993,15 @@ function MaintenanceSection() {
           </button>
         </>
       }
+      toolbar={
+        <div className="admin-toolbar admin-toolbar-dense">
+          <div className="admin-toolbar-summary">
+            <span className="chip">{reportQuery.data?.summary.totalGames || 0} games checked</span>
+            <span className="chip">{reportQuery.data?.issues.length || 0} findings</span>
+            <span className="chip">{actionMutation.isPending ? "Operation running" : "Idle"}</span>
+          </div>
+        </div>
+      }
     >
       {actionMutation.isError ? (
         <section className="status-panel status-panel-error">
@@ -1318,6 +2009,16 @@ function MaintenanceSection() {
           <h2>Operation failed</h2>
           <p className="status-copy">
             {messageFromError(actionMutation.error, "Unable to complete the maintenance action.")}
+          </p>
+        </section>
+      ) : null}
+      {actionMutation.data ? (
+        <section className="card-panel admin-callout-panel">
+          <p className="status-label">Last operation</p>
+          <h2>{actionMutation.data.audit.action}</h2>
+          <p className="status-copy">
+            Result {actionMutation.data.audit.result} · affected games{" "}
+            {actionMutation.data.affectedGameIds.length}
           </p>
         </section>
       ) : null}
@@ -1337,66 +2038,147 @@ function MaintenanceSection() {
           </p>
         </section>
       ) : (
-        <div className="grid-shell">
-          <AdminMetric label="Games checked" value={reportQuery.data.summary.totalGames} />
-          <AdminMetric
-            label="Stale lobbies"
-            value={reportQuery.data.summary.staleLobbies}
-            tone={reportQuery.data.summary.staleLobbies > 0 ? "warning" : "success"}
-          />
-          <AdminMetric
-            label="Invalid games"
-            value={reportQuery.data.summary.invalidGames}
-            tone={reportQuery.data.summary.invalidGames > 0 ? "danger" : "success"}
-          />
-          <AdminMetric
-            label="Orphaned module refs"
-            value={reportQuery.data.summary.orphanedModuleReferences}
-            tone={reportQuery.data.summary.orphanedModuleReferences > 0 ? "warning" : "success"}
-          />
+        <div className="admin-maintenance-stack">
+          <div className="admin-kpi-grid admin-kpi-grid-wide">
+            <AdminMetric
+              label="Games checked"
+              value={reportQuery.data.summary.totalGames}
+              hint="Runtime coverage"
+            />
+            <AdminMetric
+              label="Stale lobbies"
+              value={reportQuery.data.summary.staleLobbies}
+              tone={reportQuery.data.summary.staleLobbies > 0 ? "warning" : "success"}
+              hint="Candidates for cleanup"
+            />
+            <AdminMetric
+              label="Invalid games"
+              value={reportQuery.data.summary.invalidGames}
+              tone={reportQuery.data.summary.invalidGames > 0 ? "danger" : "success"}
+              hint="Sessions failing validation"
+            />
+            <AdminMetric
+              label="Orphaned module refs"
+              value={reportQuery.data.summary.orphanedModuleReferences}
+              tone={reportQuery.data.summary.orphanedModuleReferences > 0 ? "warning" : "success"}
+              hint="Broken module references"
+            />
+          </div>
 
-          <section className="card-panel admin-card-span">
-            <div className="card-header">
-              <div>
-                <p className="status-label">Issues</p>
-                <h2>Current maintenance findings</h2>
+          <div className="grid-shell admin-maintenance-grid">
+            <section className="card-panel admin-card-span">
+              <div className="card-header">
+                <div>
+                  <p className="status-label">Issues</p>
+                  <h2>Current maintenance findings</h2>
+                </div>
               </div>
-            </div>
-            {reportQuery.data.issues.length ? (
-              <ul className="admin-issue-list">
-                {reportQuery.data.issues.map((issue, index) => (
-                  <li key={`${issue.code}:${issue.gameId || index}`} className="admin-issue-item">
-                    <span className={`status-pill ${statusTone(issue.severity)}`}>
-                      {issue.severity}
-                    </span>
-                    <div>
-                      <strong>{issue.code}</strong>
-                      <p>{issue.message}</p>
-                    </div>
-                  </li>
-                ))}
+              <AdminIssueFeed
+                issues={reportQuery.data.issues}
+                emptyCopy="No maintenance issues detected."
+              />
+            </section>
+
+            <section className="card-panel">
+              <div className="card-header">
+                <div>
+                  <p className="status-label">Safety</p>
+                  <h2>Operator guidance</h2>
+                </div>
+              </div>
+              <ul className="admin-note-list">
+                <li>Validate now performs a read-only scan and is safe to run repeatedly.</li>
+                <li>
+                  Cleanup stale lobbies remains destructive and still requires typed confirmation.
+                </li>
+                <li>Every operation continues to land in the audit log for traceability.</li>
               </ul>
-            ) : (
-              <p className="status-copy">No maintenance issues detected.</p>
-            )}
-          </section>
+            </section>
+          </div>
         </div>
       )}
     </SectionFrame>
   );
 }
 
-function AuditSection() {
+function AuditSection({ frameContext }: { frameContext: AdminFrameContext }) {
+  const [query, setQuery] = useState("");
+  const [resultFilter, setResultFilter] = useState("");
+  const deferredQuery = useDeferredValue(query);
   const auditQuery = useQuery({
     queryKey: adminAuditQueryKey(),
     queryFn: () => getAdminAudit(requestMessages("admin audit"))
   });
+  const filteredEntries =
+    auditQuery.data?.entries.filter((entry) => {
+      const matchesResult = !resultFilter || entry.result === resultFilter;
+      const haystack = [
+        entry.action,
+        entry.actorUsername,
+        entry.targetType,
+        entry.targetId || "",
+        entry.targetLabel || "",
+        entry.result
+      ]
+        .join(" ")
+        .toLowerCase();
+      const matchesQuery = !deferredQuery || haystack.includes(deferredQuery.toLowerCase());
+      return matchesResult && matchesQuery;
+    }) || [];
+  const hasFilters = Boolean(query || resultFilter);
+  const failureCount =
+    auditQuery.data?.entries.filter((entry) => entry.result === "failure").length || 0;
 
   return (
     <SectionFrame
       eyebrow="Audit"
       title="Administrative activity log"
       copy="A lightweight but persistent history of the most important admin mutations and validation runs."
+      frameContext={frameContext}
+      status={
+        <>
+          <span className="chip">{auditQuery.data?.entries.length || 0} entries</span>
+          <span className="chip">{failureCount} failures</span>
+          <span className="chip">{filteredEntries.length} visible</span>
+        </>
+      }
+      actions={
+        <>
+          {hasFilters ? (
+            <button
+              type="button"
+              className="refresh-button"
+              onClick={() => {
+                setQuery("");
+                setResultFilter("");
+              }}
+            >
+              Clear filters
+            </button>
+          ) : null}
+          <Link className="ghost-action" to={frameContext.basePath}>
+            Return to overview
+          </Link>
+        </>
+      }
+      toolbar={
+        <div className="admin-toolbar admin-toolbar-dense">
+          <AdminField label="Search" hint="Filter by actor, action, or target">
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Action, actor, or target"
+            />
+          </AdminField>
+          <AdminField label="Result" hint="Focus on failures when triaging">
+            <select value={resultFilter} onChange={(event) => setResultFilter(event.target.value)}>
+              <option value="">All results</option>
+              <option value="success">Success</option>
+              <option value="failure">Failure</option>
+            </select>
+          </AdminField>
+        </div>
+      }
     >
       {auditQuery.isLoading ? (
         <section className="status-panel">
@@ -1412,41 +2194,44 @@ function AuditSection() {
             {messageFromError(auditQuery.error, "Unable to load the admin audit log.")}
           </p>
         </section>
+      ) : !filteredEntries.length ? (
+        <AdminEmptyState
+          label="Audit"
+          title="No audit entries match the current filters"
+          copy="Try broadening the search or clearing the result filter."
+        />
       ) : (
         <section className="card-panel admin-card-span">
-          <div className="admin-table-wrap">
-            <table className="admin-table">
-              <thead>
-                <tr>
-                  <th>Action</th>
-                  <th>Actor</th>
-                  <th>Target</th>
-                  <th>Result</th>
-                  <th>When</th>
-                </tr>
-              </thead>
-              <tbody>
-                {auditQuery.data.entries.map((entry) => (
-                  <tr key={entry.id}>
-                    <td>{entry.action}</td>
-                    <td>{entry.actorUsername}</td>
-                    <td>
-                      {entry.targetType}
+          <ul className="admin-audit-feed">
+            {filteredEntries.map((entry) => (
+              <li key={entry.id} className="admin-audit-feed-item">
+                <div className="admin-audit-feed-header">
+                  <div>
+                    <strong>{entry.action}</strong>
+                    <p>
+                      {entry.actorUsername} · {entry.targetType}
                       {entry.targetLabel ? ` · ${entry.targetLabel}` : ""}
-                    </td>
-                    <td>
-                      <span
-                        className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
-                      >
-                        {entry.result}
-                      </span>
-                    </td>
-                    <td>{formatTimestamp(entry.createdAt)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                    </p>
+                    <p className="admin-item-meta">
+                      {entry.targetId ? `Target ${entry.targetId} · ` : ""}
+                      {formatTimestamp(entry.createdAt)}
+                    </p>
+                  </div>
+                  <span
+                    className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
+                  >
+                    {entry.result}
+                  </span>
+                </div>
+                {entry.details ? (
+                  <details className="admin-inline-details">
+                    <summary>View details</summary>
+                    <pre className="admin-json-block">{JSON.stringify(entry.details, null, 2)}</pre>
+                  </details>
+                ) : null}
+              </li>
+            ))}
+          </ul>
         </section>
       )}
     </SectionFrame>
@@ -1480,10 +2265,70 @@ export function AdminRoute() {
   const section = resolveAdminSection(location.pathname);
   const currentUser = state.status === "authenticated" ? state.user : null;
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
+  const basePath = buildAdminPath(namespace);
+  const [navOpen, setNavOpen] = useState(false);
+  const environmentLabel = resolveEnvironmentLabel();
+  const hostLabel = typeof window === "undefined" ? "unknown" : window.location.host || "localhost";
+  const navItems: AdminNavItem[] = [
+    {
+      id: "overview",
+      group: "Monitor",
+      label: "Overview",
+      path: basePath,
+      description: "Health, defaults, and latest admin activity."
+    },
+    {
+      id: "games",
+      group: "Monitor",
+      label: "Games",
+      path: `${basePath}/games`,
+      description: "Inspect, repair, and terminate sessions."
+    },
+    {
+      id: "maintenance",
+      group: "Monitor",
+      label: "Maintenance",
+      path: `${basePath}/maintenance`,
+      description: "Validation and cleanup operations."
+    },
+    {
+      id: "audit",
+      group: "Monitor",
+      label: "Audit log",
+      path: `${basePath}/audit`,
+      description: "Recent admin mutations and failures."
+    },
+    {
+      id: "users",
+      group: "Operate",
+      label: "Users",
+      path: `${basePath}/users`,
+      description: "Inspect identities and change roles."
+    },
+    {
+      id: "config",
+      group: "Operate",
+      label: "Global defaults",
+      path: `${basePath}/config`,
+      description: "Gameplay, visual, and maintenance defaults."
+    },
+    {
+      id: "modules",
+      group: "Operate",
+      label: "Runtime modules",
+      path: `${basePath}/modules`,
+      description: "Live catalog and runtime controls."
+    }
+  ];
+  const activeItem = navItems.find((item) => item.id === section) || navItems[0];
 
   useEffect(() => {
-    document.title = "NetRisk Admin";
-  }, []);
+    document.title = `NetRisk Admin · ${activeItem.label}`;
+  }, [activeItem.label]);
+
+  useEffect(() => {
+    setNavOpen(false);
+  }, [section]);
 
   if (state.status === "loading") {
     return (
@@ -1518,50 +2363,21 @@ export function AdminRoute() {
     return <AdminForbiddenState />;
   }
 
-  const navItems: Array<{ id: AdminSection; label: string; path: string; description: string }> = [
-    {
-      id: "overview",
-      label: "Overview",
-      path: buildAdminPath(namespace),
-      description: "Health, defaults, and latest admin activity."
+  const navGroups = ["Monitor", "Operate"].map((group) => ({
+    group,
+    items: navItems.filter((item) => item.group === group)
+  }));
+  const frameContext: AdminFrameContext = {
+    basePath,
+    currentUser: {
+      id: currentUser.id,
+      username: currentUser.username,
+      role: currentUser.role
     },
-    {
-      id: "users",
-      label: "Users",
-      path: `${buildAdminPath(namespace)}/users`,
-      description: "Inspect and change roles."
-    },
-    {
-      id: "games",
-      label: "Games",
-      path: `${buildAdminPath(namespace)}/games`,
-      description: "Inspect, repair, and terminate sessions."
-    },
-    {
-      id: "config",
-      label: "Configurations",
-      path: `${buildAdminPath(namespace)}/config`,
-      description: "Global defaults and maintenance thresholds."
-    },
-    {
-      id: "modules",
-      label: "Runtime / Modules",
-      path: `${buildAdminPath(namespace)}/modules`,
-      description: "Live module catalog and runtime controls."
-    },
-    {
-      id: "maintenance",
-      label: "Maintenance",
-      path: `${buildAdminPath(namespace)}/maintenance`,
-      description: "Validation and cleanup operations."
-    },
-    {
-      id: "audit",
-      label: "Audit Log",
-      path: `${buildAdminPath(namespace)}/audit`,
-      description: "Recent admin mutations."
-    }
-  ];
+    environmentLabel,
+    hostLabel,
+    sectionLabel: activeItem.label
+  };
 
   return (
     <div className="react-shell-page admin-page" data-testid="admin-route-page">
@@ -1569,33 +2385,84 @@ export function AdminRoute() {
         <aside className="card-panel admin-sidebar">
           <div className="admin-sidebar-header">
             <p className="status-label">Admin</p>
-            <h2>NetRisk Console</h2>
+            <h2>Operator console</h2>
             <p className="status-copy">
-              Signed in as <strong>{currentUser.username}</strong>.
+              Production-safe controls for runtime health, live sessions, global defaults, and audit
+              visibility.
             </p>
           </div>
-          <nav className="admin-nav" aria-label="Admin sections">
-            {navItems.map((item) => (
-              <Link
-                key={item.id}
-                to={item.path}
-                className={`admin-nav-link${section === item.id ? " is-active" : ""}`}
-              >
-                <strong>{item.label}</strong>
-                <span>{item.description}</span>
-              </Link>
+          <section className="admin-sidebar-summary">
+            <AdminMetaList
+              columns={2}
+              items={[
+                {
+                  label: "Environment",
+                  value: environmentLabel
+                },
+                {
+                  label: "Signed in",
+                  value: currentUser.username
+                },
+                {
+                  label: "Section",
+                  value: activeItem.label
+                },
+                {
+                  label: "Host",
+                  value: hostLabel
+                }
+              ]}
+            />
+          </section>
+          <button
+            type="button"
+            className="ghost-action admin-nav-toggle"
+            aria-expanded={navOpen}
+            aria-controls="admin-nav-groups"
+            onClick={() => setNavOpen((current) => !current)}
+          >
+            {navOpen ? "Hide sections" : `Open sections · ${activeItem.label}`}
+          </button>
+          <nav
+            id="admin-nav-groups"
+            className={`admin-nav-shell${navOpen ? " is-open" : ""}`}
+            aria-label="Admin sections"
+          >
+            {navGroups.map((group) => (
+              <section key={group.group} className="admin-nav-group">
+                <p className="admin-nav-group-label">{group.group}</p>
+                <div className="admin-nav">
+                  {group.items.map((item) => (
+                    <Link
+                      key={item.id}
+                      to={item.path}
+                      className={`admin-nav-link${section === item.id ? " is-active" : ""}`}
+                    >
+                      <strong>{item.label}</strong>
+                      <span>{item.description}</span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
             ))}
           </nav>
+          <div className="admin-sidebar-footer">
+            <Link className="ghost-action" to={buildLobbyPath(namespace)}>
+              Return to lobby
+            </Link>
+          </div>
         </aside>
 
         <main className="admin-main">
-          {section === "overview" ? <OverviewSection /> : null}
-          {section === "users" ? <UsersSection /> : null}
-          {section === "games" ? <GamesSection /> : null}
-          {section === "config" ? <ConfigSection /> : null}
-          {section === "modules" ? <ModulesSection userId={currentUser.id} /> : null}
-          {section === "maintenance" ? <MaintenanceSection /> : null}
-          {section === "audit" ? <AuditSection /> : null}
+          {section === "overview" ? <OverviewSection frameContext={frameContext} /> : null}
+          {section === "users" ? <UsersSection frameContext={frameContext} /> : null}
+          {section === "games" ? <GamesSection frameContext={frameContext} /> : null}
+          {section === "config" ? <ConfigSection frameContext={frameContext} /> : null}
+          {section === "modules" ? (
+            <ModulesSection userId={currentUser.id} frameContext={frameContext} />
+          ) : null}
+          {section === "maintenance" ? <MaintenanceSection frameContext={frameContext} /> : null}
+          {section === "audit" ? <AuditSection frameContext={frameContext} /> : null}
         </main>
       </div>
     </div>

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -1153,6 +1153,10 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
       ? window.prompt(`Type ${selectedGameId} to confirm ${action}.`)
       : null;
 
+    if (destructive && !confirmation?.trim()) {
+      return;
+    }
+
     actionMutation.mutate({
       gameId: selectedGameId,
       action,
@@ -1511,6 +1515,14 @@ function ConfigSection({ frameContext }: { frameContext: AdminFrameContext }) {
   }
 
   function handleResetOverrides() {
+    const confirmed = window.confirm(
+      "Clear all configured default overrides from this form? Maintenance thresholds will stay as-is."
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
     setFormState((current) => (current ? clearAdminConfigOverrides(current) : current));
   }
 
@@ -1954,6 +1966,11 @@ function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext 
 
   function handleCleanup() {
     const confirmation = window.prompt("Type cleanup-stale-lobbies to confirm cleanup.");
+
+    if (!confirmation?.trim()) {
+      return;
+    }
+
     actionMutation.mutate({
       action: "cleanup-stale-lobbies",
       confirmation

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -989,9 +989,7 @@ html[data-theme="ember"] {
 .territory-node.is-reinforce,
 .territory-node.is-fortify-source,
 .territory-node.is-fortify-target {
-  transform:
-    translate(-50%, -50%)
-    translateY(calc(-2px * var(--map-territory-node-scale, 1)))
+  transform: translate(-50%, -50%) translateY(calc(-2px * var(--map-territory-node-scale, 1)))
     scale(1.05);
 }
 
@@ -1110,62 +1108,130 @@ html[data-theme="ember"] {
 }
 
 .admin-page {
-  width: min(1380px, calc(100% - 2rem));
+  width: min(1480px, calc(100% - 2rem));
+}
+
+.admin-page .status-label {
+  color: var(--shell-muted);
+}
+
+.admin-page h1,
+.admin-page h2 {
+  font-variant: normal;
+  letter-spacing: -0.02em;
+  text-shadow: none;
 }
 
 .admin-shell {
   display: grid;
-  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
-  gap: 1rem;
+  grid-template-columns: minmax(260px, 310px) minmax(0, 1fr);
+  gap: 1.25rem;
   align-items: start;
 }
 
 .admin-sidebar {
   position: sticky;
   top: 1rem;
+  display: grid;
+  gap: 1rem;
   padding: 1.25rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 22%), var(--shell-panel-bg);
 }
 
-.admin-sidebar-header h2 {
+.admin-sidebar-header {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.admin-sidebar-header h2,
+.admin-page-header h1 {
   margin: 0;
+}
+
+.admin-sidebar-summary,
+.admin-context-panel,
+.admin-subpanel,
+.admin-callout-panel {
+  border: 1px solid var(--shell-border);
+  border-radius: calc(var(--campaign-card-radius) - 2px);
+  background: var(--shell-card-bg);
+  box-shadow: var(--bevel);
+}
+
+.admin-sidebar-summary,
+.admin-context-panel,
+.admin-subpanel,
+.admin-callout-panel {
+  padding: 1rem;
+}
+
+.admin-sidebar-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.admin-nav-toggle {
+  display: none;
+  width: 100%;
+}
+
+.admin-nav-shell,
+.admin-nav-group {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.admin-nav-group-label {
+  margin: 0;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--shell-muted);
 }
 
 .admin-nav {
   display: grid;
   gap: 0.65rem;
-  margin-top: 1rem;
 }
 
 .admin-nav-link {
   display: grid;
-  gap: 0.2rem;
-  padding: 0.9rem 1rem;
+  gap: 0.35rem;
+  padding: 0.95rem 1rem;
   border: 1px solid var(--shell-border);
-  border-radius: var(--campaign-control-radius);
+  border-radius: var(--campaign-card-radius);
   background: var(--shell-card-bg);
   color: var(--shell-copy);
   text-decoration: none;
   transition:
     border-color 120ms ease,
     transform 120ms ease,
-    background 120ms ease;
+    background 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .admin-nav-link strong {
-  font-variant: small-caps;
-  letter-spacing: 0.05em;
+  font-size: 0.98rem;
+  font-weight: 700;
 }
 
 .admin-nav-link span {
   color: var(--shell-muted);
-  font-size: 0.9rem;
-  line-height: 1.4;
+  font-size: 0.88rem;
+  line-height: 1.45;
 }
 
 .admin-nav-link:hover,
 .admin-nav-link.is-active {
   border-color: var(--shell-border-hi);
   background: var(--shell-card-bg-hover);
+  box-shadow:
+    inset 3px 0 0 var(--shell-accent),
+    var(--bevel),
+    var(--shadow-soft);
   transform: translateY(-1px);
 }
 
@@ -1178,57 +1244,75 @@ html[data-theme="ember"] {
   gap: 1rem;
 }
 
-.admin-hero-panel {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
+.admin-page-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+  gap: 1.25rem;
+  align-items: start;
 }
 
 .admin-hero-copy {
-  max-width: 58rem;
-}
-
-.admin-metrics-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.admin-metric {
-  min-height: 124px;
-}
-
-.admin-metric-warning {
-  border-color: var(--shell-warning-border);
-}
-
-.admin-metric-danger {
-  border-color: var(--shell-danger-border);
-}
-
-.admin-metric-success {
-  border-color: var(--shell-success-border);
-}
-
-.admin-metric-value {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 2.8rem);
-  font-weight: 700;
-  line-height: 1;
-  color: var(--shell-heading);
-}
-
-.admin-card-span {
-  grid-column: 1 / -1;
-}
-
-.admin-definition-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
+  max-width: 60rem;
+}
+
+.admin-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  color: var(--shell-muted);
+}
+
+.admin-page-header h1 {
+  font-size: clamp(1.9rem, 3vw, 2.9rem);
+  line-height: 1.04;
+}
+
+.admin-header-status,
+.admin-toolbar-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.admin-hero-side {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.admin-context-panel strong {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 1.1rem;
+}
+
+.admin-context-copy {
+  margin: 0.4rem 0 0;
+  color: var(--shell-copy);
+}
+
+.admin-meta-grid {
+  display: grid;
+  gap: 0.85rem;
   margin: 0;
 }
 
-.admin-definition-grid dt {
+.admin-meta-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.admin-meta-grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.admin-meta-item {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.admin-meta-item dt {
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.12em;
@@ -1236,24 +1320,129 @@ html[data-theme="ember"] {
   color: var(--shell-muted);
 }
 
-.admin-definition-grid dd {
-  margin: 0.45rem 0 0;
+.admin-meta-item dd {
+  margin: 0;
+  color: var(--shell-heading);
+  word-break: break-word;
+}
+
+.admin-hero-actions {
+  margin-top: 0;
+}
+
+.admin-kpi-layout,
+.admin-config-grid,
+.admin-maintenance-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-kpi-layout {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.admin-kpi-band {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-kpi-band-risk {
+  border-color: var(--shell-warning-border);
+}
+
+.admin-kpi-grid,
+.admin-form-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.admin-kpi-grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.admin-kpi-grid-wide {
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.admin-metric {
+  min-height: 138px;
+  padding: 1rem 1.05rem;
+}
+
+.admin-metric-warning {
+  border-color: var(--shell-warning-border);
+  background: var(--shell-warning-bg);
+}
+
+.admin-metric-danger {
+  border-color: var(--shell-danger-border);
+  background: var(--shell-danger-bg);
+}
+
+.admin-metric-success {
+  border-color: var(--shell-success-border);
+  background: var(--shell-success-bg);
+}
+
+.admin-metric-value {
+  margin: 0;
+  font-size: clamp(1.85rem, 3.2vw, 2.55rem);
+  font-weight: 700;
+  line-height: 1;
   color: var(--shell-heading);
 }
 
+.admin-metric-copy {
+  margin: auto 0 0;
+  color: var(--shell-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.admin-card-span {
+  grid-column: 1 / -1;
+}
+
+.admin-overview-grid,
+.admin-maintenance-grid {
+  align-items: start;
+}
+
+.admin-priority-panel {
+  border-color: var(--shell-warning-border);
+}
+
 .admin-toolbar-panel {
-  padding: 1rem 1.25rem;
+  padding: 1rem 1.15rem;
+}
+
+.admin-toolbar-panel-sticky {
+  position: sticky;
+  top: 1rem;
+  z-index: 2;
 }
 
 .admin-toolbar {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+  align-items: end;
+}
+
+.admin-toolbar-dense {
+  justify-content: space-between;
 }
 
 .admin-toolbar .shell-field {
-  min-width: min(260px, 100%);
-  flex: 1 1 220px;
+  min-width: min(280px, 100%);
+  flex: 1 1 240px;
+}
+
+.admin-field small,
+.admin-item-meta,
+.admin-table-copy,
+.admin-note-list {
+  color: var(--shell-muted);
 }
 
 .admin-table-wrap {
@@ -1262,27 +1451,46 @@ html[data-theme="ember"] {
 
 .admin-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .admin-table th,
 .admin-table td {
-  padding: 0.9rem 0.75rem;
+  padding: 0.9rem 0.85rem;
   border-bottom: 1px solid var(--shell-border);
   vertical-align: top;
   text-align: left;
 }
 
 .admin-table th {
+  position: sticky;
+  top: 0;
+  background: var(--shell-panel-bg);
   font-size: 0.74rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--shell-muted);
 }
 
-.admin-table-copy {
-  margin: 0.3rem 0 0;
-  color: var(--shell-muted);
+.admin-table tbody tr:hover td,
+.admin-table tbody tr.is-selected td {
+  background: var(--shell-card-bg-hover);
+}
+
+.admin-row-select {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.admin-row-select strong {
+  font-size: 0.98rem;
 }
 
 .admin-inline-actions {
@@ -1291,14 +1499,35 @@ html[data-theme="ember"] {
   gap: 0.5rem;
 }
 
+.admin-action-cluster {
+  justify-content: flex-end;
+}
+
+.admin-users-grid,
 .admin-games-grid {
-  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+}
+
+.admin-users-grid {
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 360px);
+}
+
+.admin-games-grid {
+  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+}
+
+.admin-sticky-detail-panel {
+  position: sticky;
+  top: 7rem;
 }
 
 .admin-game-list,
 .admin-player-list,
 .admin-issue-list,
-.admin-audit-list {
+.admin-audit-list,
+.admin-audit-feed {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -1307,44 +1536,61 @@ html[data-theme="ember"] {
 }
 
 .admin-game-item,
-.admin-audit-item {
+.admin-audit-item,
+.admin-audit-feed-item,
+.admin-player-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.85rem 0.95rem;
+  padding: 0.95rem 1rem;
   border: 1px solid var(--shell-border);
-  border-radius: var(--campaign-control-radius);
+  border-radius: var(--campaign-card-radius);
   background: var(--shell-card-bg);
 }
 
 .admin-list-button {
   width: 100%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.85rem 0.95rem;
+  padding: 0.95rem 1rem;
   border: 1px solid var(--shell-border);
-  border-radius: var(--campaign-control-radius);
+  border-radius: var(--campaign-card-radius);
   background: var(--shell-card-bg);
   color: var(--shell-copy);
   text-align: left;
   cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    transform 120ms ease;
 }
 
+.admin-list-button:hover,
 .admin-list-button.is-selected {
   border-color: var(--shell-border-hi);
   background: var(--shell-card-bg-hover);
+  transform: translateY(-1px);
 }
 
-.admin-list-button p,
+.admin-list-copy,
+.admin-audit-feed-header {
+  display: grid;
+  gap: 0.3rem;
+}
+
 .admin-game-item p,
 .admin-audit-item p,
-.admin-player-list p,
-.admin-issue-item p {
-  margin: 0.35rem 0 0;
-  color: var(--shell-muted);
+.admin-player-item p,
+.admin-issue-item p,
+.admin-audit-feed-item p {
+  margin: 0;
+}
+
+.admin-item-meta {
+  font-size: 0.82rem;
 }
 
 .admin-detail-stack {
@@ -1370,37 +1616,69 @@ html[data-theme="ember"] {
   gap: 1rem;
 }
 
+.admin-subpanel {
+  display: grid;
+  gap: 0.9rem;
+}
+
 .admin-issue-item {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.75rem;
   align-items: start;
-  padding: 0.8rem 0.9rem;
+  padding: 0.9rem 1rem;
   border: 1px solid var(--shell-border);
-  border-radius: var(--campaign-control-radius);
+  border-radius: var(--campaign-card-radius);
   background: var(--shell-card-bg);
 }
 
+.admin-debug-panel,
+.admin-inline-details {
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-card-radius);
+  background: var(--shell-card-bg);
+  padding: 0.95rem 1rem;
+}
+
+.admin-debug-panel summary,
+.admin-inline-details summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.admin-debug-panel[open],
+.admin-inline-details[open] {
+  border-color: var(--shell-border-hi);
+}
+
 .admin-json-block {
-  margin: 0;
+  margin: 0.9rem 0 0;
   padding: 1rem;
   border-radius: var(--campaign-control-radius);
-  background: rgba(9, 12, 16, 0.82);
+  background: rgba(9, 12, 16, 0.88);
   color: #f3f0e9;
   overflow: auto;
-  max-height: 460px;
+  max-height: 420px;
   font-size: 0.82rem;
   line-height: 1.45;
 }
 
-.admin-form-grid {
+.admin-config-group {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
 }
 
+.admin-form-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.admin-form-grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .admin-module-picker {
-  margin-top: 1.25rem;
+  display: grid;
+  gap: 1rem;
 }
 
 .admin-module-grid {
@@ -1411,21 +1689,52 @@ html[data-theme="ember"] {
 
 .admin-module-toggle {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.8rem;
   align-items: flex-start;
-  padding: 0.85rem 0.95rem;
+  padding: 0.95rem 1rem;
   border: 1px solid var(--shell-border);
-  border-radius: var(--campaign-control-radius);
+  border-radius: var(--campaign-card-radius);
   background: var(--shell-card-bg);
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.admin-module-toggle.is-selected {
+  border-color: var(--shell-accent);
+  background: var(--shell-card-bg-hover);
 }
 
 .admin-module-toggle span {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.25rem;
 }
 
 .admin-module-toggle small {
   color: var(--shell-muted);
+}
+
+.admin-note-list {
+  display: grid;
+  gap: 0.7rem;
+  padding-left: 1.1rem;
+  margin: 0;
+  line-height: 1.55;
+}
+
+.admin-audit-feed-item {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.admin-audit-feed-header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+}
+
+.admin-empty-state,
+.admin-callout-panel {
+  border-color: var(--shell-border-hi);
 }
 
 .admin-danger-action {
@@ -1433,22 +1742,65 @@ html[data-theme="ember"] {
   color: var(--shell-danger);
 }
 
-@media (max-width: 1080px) {
-  .admin-shell,
-  .admin-games-grid {
+.refresh-button:disabled,
+.ghost-action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: var(--bevel);
+}
+
+.ghost-action,
+button.ghost-action {
+  appearance: none;
+}
+
+@media (max-width: 1180px) {
+  .admin-page-header,
+  .admin-users-grid,
+  .admin-games-grid,
+  .admin-kpi-layout,
+  .admin-detail-grid,
+  .admin-form-grid-3,
+  .admin-meta-grid-3 {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .admin-sidebar {
+  .admin-sticky-detail-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 1080px) {
+  .admin-shell,
+  .admin-config-grid,
+  .admin-maintenance-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-sidebar,
+  .admin-toolbar-panel-sticky {
     position: static;
   }
 
-  .admin-form-grid,
-  .admin-definition-grid,
-  .admin-metrics-grid,
-  .admin-detail-grid,
-  .admin-module-grid {
+  .admin-module-grid,
+  .admin-form-grid-2,
+  .admin-meta-grid-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .admin-nav-toggle {
+    display: inline-flex;
+  }
+
+  .admin-nav-shell {
+    display: none;
+  }
+
+  .admin-nav-shell.is-open {
+    display: grid;
   }
 }
 
@@ -1490,6 +1842,15 @@ html[data-theme="ember"] {
   .profile-metric-grid,
   .lobby-summary-grid,
   .lobby-shell-grid,
+  .admin-page-header,
+  .admin-kpi-layout,
+  .admin-users-grid,
+  .admin-config-grid,
+  .admin-maintenance-grid,
+  .admin-form-grid-2,
+  .admin-form-grid-3,
+  .admin-meta-grid-2,
+  .admin-meta-grid-3,
   .admin-form-grid,
   .admin-definition-grid,
   .admin-metrics-grid,
@@ -1506,6 +1867,17 @@ html[data-theme="ember"] {
   .game-status-banner,
   .game-meta-grid,
   .game-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-toolbar,
+  .admin-inline-actions,
+  .admin-detail-summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-audit-feed-header {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- redesign the admin route as a section-aware operator console with grouped navigation, contextual headers, and responsive admin chrome
- turn overview, users, games, config, maintenance, and audit into more digestible operational panels while preserving the existing queries, mutations, confirmations, and backend contracts
- add config dirty-state/revert affordances, a collapsible raw-state debug panel, and updated admin integration coverage

## Validation
- npm run typecheck:react-shell
- npx vitest run --config frontend/react-shell/vitest.config.ts frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
- npm run test:react
- npm run build:react-shell
- npm run lint -- --quiet