### PR TITLE
[codex] Add PR readiness gate for Codex draft PRs

### DIFF
--- a/.github/codex-pr-readiness.json
+++ b/.github/codex-pr-readiness.json
@@ -1,0 +1,45 @@
+{
+  "targetLabel": "codex",
+  "branchPrefix": "codex/",
+  "codexActors": ["chatgpt-codex-connector"],
+  "codexGreenlightPhrases": [
+    "codex greenlight",
+    "codex pr readiness: greenlight",
+    "codex final approval"
+  ],
+  "requiredCheckNames": ["quality", "coverage", "e2e-smoke", "Analyze (javascript-typescript)"],
+  "requiredQualitySteps": {
+    "typecheck": ["Run repository typecheck", "Run React shell typecheck"],
+    "build": ["Run build"],
+    "lint": ["Run lint"],
+    "format": ["Run format check"],
+    "reactTests": ["Run React shell tests"]
+  },
+  "maxCommitsBehindBase": 0,
+  "summaryCommentMarker": "<!-- codex-pr-readiness-summary -->",
+  "skipTestAllowlist": [],
+  "temporaryMarkerAllowlist": [],
+  "syncRequirements": [
+    {
+      "ifChanged": ["shared/runtime-validation.cts"],
+      "mustAlsoChange": ["frontend/src/generated/shared-runtime-validation.mts"],
+      "message": "Shared runtime validation changes must keep generated frontend artifacts in sync."
+    }
+  ],
+  "productionFileGlobs": [
+    "backend/**",
+    "shared/**",
+    "scripts/**",
+    "frontend/src/**",
+    "frontend/react-shell/src/**",
+    "api/**",
+    "modules/**",
+    "supabase/**"
+  ],
+  "testFileGlobs": ["tests/**", "e2e/**", "frontend/react-shell/src/__tests__/**"],
+  "docFileGlobs": ["docs/**", "*.md", "**/*.md"],
+  "largeDiffChangeThreshold": 700,
+  "significantChangeThreshold": 250,
+  "lowTestAdditionsMinProductionAdditions": 80,
+  "lowTestAdditionsRatio": 0.05
+}

--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -32,8 +32,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request' &&
-        startsWith(github.event.workflow_run.head_branch, 'codex/')) ||
+        github.event.workflow_run.event == 'pull_request') ||
       (github.event_name == 'pull_request_target' &&
         github.event.pull_request.draft == true &&
         (startsWith(github.event.pull_request.head.ref, 'codex/') ||

--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -1,0 +1,99 @@
+name: Codex PR Readiness
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, labeled, unlabeled, converted_to_draft]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  issue_comment:
+    types: [created, edited]
+  workflow_run:
+    workflows: ["Quality", "Coverage", "E2E Smoke", "CodeQL Advanced"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to evaluate"
+        required: false
+  schedule:
+    - cron: "*/30 * * * *"
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codex-pr-readiness:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        startsWith(github.event.workflow_run.head_branch, 'codex/')) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.draft == true &&
+        (startsWith(github.event.pull_request.head.ref, 'codex/') ||
+          contains(github.event.pull_request.labels.*.name, 'codex'))) ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.pull_request.draft == true &&
+        (startsWith(github.event.pull_request.head.ref, 'codex/') ||
+          contains(github.event.pull_request.labels.*.name, 'codex'))) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (contains(github.event.comment.body, 'codex') ||
+          contains(github.event.comment.body, 'Codex') ||
+          contains(github.event.comment.body, 'greenlight') ||
+          contains(github.event.comment.body, 'Greenlight')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile readiness evaluator
+        run: npx tsc -p tsconfig.json --incremental false
+
+      - name: Evaluate Codex PR readiness
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
+        shell: bash
+        run: |
+          args=(
+            --apply
+            --event-path "$GITHUB_EVENT_PATH"
+            --repository "$GITHUB_REPOSITORY"
+            --json-output ".codex-pr-readiness-output.json"
+            --summary-output ".codex-pr-readiness-summary.md"
+          )
+
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            args+=(--pr-number "$INPUT_PR_NUMBER")
+          fi
+
+          node .tsbuild/scripts/evaluate-codex-pr-readiness.cjs "${args[@]}"
+
+      - name: Publish workflow summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ -f ".codex-pr-readiness-summary.md" ]; then
+            cat ".codex-pr-readiness-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "# Codex PR Readiness" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No readiness summary was generated for this run." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -1218,7 +1218,9 @@ function createAdminConsole(options: AdminConsoleOptions) {
   async function authoredModuleDisableGuard(moduleId: string): Promise<void> {
     const config = await loadConfigRecord();
     if (config.defaults.victoryRuleSetId === moduleId) {
-      throw new Error(`Victory objective module "${moduleId}" is still referenced by admin defaults.`);
+      throw new Error(
+        `Victory objective module "${moduleId}" is still referenced by admin defaults.`
+      );
     }
 
     const rawGames = asArray(await maybeResolve(options.gameSessions.datastore.listGames()));
@@ -1232,7 +1234,9 @@ function createAdminConsole(options: AdminConsoleOptions) {
     });
 
     if (activeReference) {
-      throw new Error(`Victory objective module "${moduleId}" is still referenced by an active game.`);
+      throw new Error(
+        `Victory objective module "${moduleId}" is still referenced by an active game.`
+      );
     }
   }
 

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -156,13 +156,25 @@ type AdminConsoleOptions = {
   moduleRuntime: {
     listInstalledModules(): Promise<Array<Record<string, unknown>>>;
     getEnabledModules(): Promise<Array<{ id: string; version: string }>>;
+    getModuleOptions(): Promise<Record<string, unknown>>;
     findSupportedMap(mapId: string): Record<string, unknown> | null;
     findContentPack(contentPackId: string): Record<string, unknown> | null;
     findPlayerPieceSet(pieceSetId: string): Record<string, unknown> | null;
     findDiceRuleSet(diceRuleSetId: string): Record<string, unknown> | null;
+    findVictoryRuleSet(victoryRuleSetId: string): Record<string, unknown> | null;
     resolveGamePreset(input?: Record<string, unknown>): Promise<Record<string, unknown> | null>;
     resolveGameConfigDefaults(input?: Record<string, unknown>): Promise<Record<string, unknown>>;
     resolveGameSelection(input?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  };
+  authoredModules?: {
+    listEditorOptions(): Promise<unknown> | unknown;
+    listModules(): Promise<unknown> | unknown;
+    getModule(moduleId: string): Promise<unknown> | unknown;
+    validateDraft(input: unknown): Promise<unknown> | unknown;
+    saveDraft(input: unknown): Promise<unknown> | unknown;
+    publishModule(moduleId: string): Promise<unknown> | unknown;
+    disableModule(moduleId: string): Promise<unknown> | unknown;
+    enableModule(moduleId: string): Promise<unknown> | unknown;
   };
 };
 
@@ -348,7 +360,16 @@ async function maybeResolve<T>(value: Promise<T> | T): Promise<T> {
 }
 
 function createAdminConsole(options: AdminConsoleOptions) {
+  async function ensureRuntimeCatalogReady(): Promise<void> {
+    if (typeof options.moduleRuntime.getModuleOptions !== "function") {
+      return;
+    }
+
+    await maybeResolve(options.moduleRuntime.getModuleOptions());
+  }
+
   async function resolveAdminDefaults(input: Record<string, unknown> = {}) {
+    await ensureRuntimeCatalogReady();
     const configured = await maybeResolve(
       options.createConfiguredInitialState(input, {
         resolveContentPack: (contentPackId: string) =>
@@ -358,6 +379,10 @@ function createAdminConsole(options: AdminConsoleOptions) {
         resolvePlayerPieceSet: (pieceSetId: string) =>
           options.moduleRuntime.findPlayerPieceSet(pieceSetId),
         resolveSupportedMap: (mapId: string) => options.moduleRuntime.findSupportedMap(mapId),
+        resolveVictoryRuleSet: (victoryRuleSetId: string) =>
+          typeof options.moduleRuntime.findVictoryRuleSet === "function"
+            ? options.moduleRuntime.findVictoryRuleSet(victoryRuleSetId)
+            : findVictoryRuleSet(victoryRuleSetId),
         resolveGamePreset: (presetInput: Record<string, unknown>) =>
           options.moduleRuntime.resolveGamePreset(presetInput),
         resolveGameModuleConfigDefaults: (selectionInput: Record<string, unknown>) =>
@@ -527,7 +552,12 @@ function createAdminConsole(options: AdminConsoleOptions) {
     const issues: AdminIssue[] = [];
     const state = rawGame?.state || ({ players: [], territories: {}, hands: {} } as GameState);
     const config = ensureGameConfig(state);
-    const installedModules = await options.moduleRuntime.listInstalledModules();
+    const [installedModules] = await Promise.all([
+      options.moduleRuntime.listInstalledModules(),
+      typeof options.moduleRuntime.getModuleOptions === "function"
+        ? maybeResolve(options.moduleRuntime.getModuleOptions())
+        : Promise.resolve(null)
+    ]);
     const installedById = new Map(
       installedModules.map((moduleEntry) => [String(moduleEntry.id || ""), moduleEntry])
     );
@@ -616,7 +646,13 @@ function createAdminConsole(options: AdminConsoleOptions) {
     }
 
     const victoryRuleSetId = asNonEmptyString(config.victoryRuleSetId);
-    if (victoryRuleSetId && !findVictoryRuleSet(victoryRuleSetId)) {
+    const resolvedVictoryRuleSet =
+      victoryRuleSetId && typeof options.moduleRuntime.findVictoryRuleSet === "function"
+        ? options.moduleRuntime.findVictoryRuleSet(victoryRuleSetId)
+        : victoryRuleSetId
+          ? findVictoryRuleSet(victoryRuleSetId)
+          : null;
+    if (victoryRuleSetId && !resolvedVictoryRuleSet) {
       issues.push({
         code: "missing-victory-rule-set",
         severity: "error",
@@ -1171,6 +1207,167 @@ function createAdminConsole(options: AdminConsoleOptions) {
     };
   }
 
+  function requireAuthoredModules() {
+    if (!options.authoredModules) {
+      throw new Error("Authored module service is not configured.");
+    }
+
+    return options.authoredModules;
+  }
+
+  async function authoredModuleDisableGuard(moduleId: string): Promise<void> {
+    const config = await loadConfigRecord();
+    if (config.defaults.victoryRuleSetId === moduleId) {
+      throw new Error(`Victory objective module "${moduleId}" is still referenced by admin defaults.`);
+    }
+
+    const rawGames = asArray(await maybeResolve(options.gameSessions.datastore.listGames()));
+    const activeReference = rawGames.find((game) => {
+      if (String(game?.state?.phase || "") === "finished") {
+        return false;
+      }
+
+      const gameConfig = ensureGameConfig(game?.state || {});
+      return asNonEmptyString(gameConfig.victoryRuleSetId) === moduleId;
+    });
+
+    if (activeReference) {
+      throw new Error(`Victory objective module "${moduleId}" is still referenced by an active game.`);
+    }
+  }
+
+  async function getAuthoredModuleEditorOptions() {
+    await ensureRuntimeCatalogReady();
+    return maybeResolve(requireAuthoredModules().listEditorOptions());
+  }
+
+  async function listAuthoredModules() {
+    await ensureRuntimeCatalogReady();
+    return {
+      modules: await maybeResolve(requireAuthoredModules().listModules())
+    };
+  }
+
+  async function getAuthoredModule(moduleId: string) {
+    await ensureRuntimeCatalogReady();
+    return maybeResolve(requireAuthoredModules().getModule(moduleId));
+  }
+
+  async function validateAuthoredModuleDraft(input: unknown) {
+    await ensureRuntimeCatalogReady();
+    return maybeResolve(requireAuthoredModules().validateDraft(input));
+  }
+
+  async function saveAuthoredModuleDraft(actor: PublicUser, input: unknown) {
+    await ensureRuntimeCatalogReady();
+    const detail = (await maybeResolve(requireAuthoredModules().saveDraft(input))) as {
+      module: { id: string; name: string; moduleType?: string | null; status?: string | null };
+      validation: { valid?: boolean; errors?: unknown[]; warnings?: unknown[] };
+      preview?: Record<string, unknown>;
+      runtime?: Record<string, unknown>;
+    };
+    const audit = await recordAuditSafely({
+      actor,
+      action: "content-studio.module.save-draft",
+      targetType: "authored-module",
+      targetId: detail.module.id,
+      targetLabel: detail.module.name,
+      result: "success",
+      details: {
+        moduleType: detail.module.moduleType || null,
+        status: detail.module.status || "draft",
+        valid: Boolean(detail.validation?.valid),
+        errorCount: Array.isArray(detail.validation?.errors) ? detail.validation.errors.length : 0
+      }
+    });
+
+    return {
+      ok: true,
+      ...detail,
+      audit
+    };
+  }
+
+  async function publishAuthoredModule(actor: PublicUser, moduleId: string) {
+    await ensureRuntimeCatalogReady();
+    const detail = (await maybeResolve(requireAuthoredModules().publishModule(moduleId))) as {
+      module: { id: string; name: string; moduleType?: string | null; status?: string | null };
+      validation: { errors?: unknown[] };
+    };
+    const audit = await recordAuditSafely({
+      actor,
+      action: "content-studio.module.publish",
+      targetType: "authored-module",
+      targetId: detail.module.id,
+      targetLabel: detail.module.name,
+      result: "success",
+      details: {
+        moduleType: detail.module.moduleType || null,
+        status: detail.module.status || "published",
+        errorCount: Array.isArray(detail.validation?.errors) ? detail.validation.errors.length : 0
+      }
+    });
+
+    return {
+      ok: true,
+      ...detail,
+      audit
+    };
+  }
+
+  async function disableAuthoredModule(actor: PublicUser, moduleId: string) {
+    await ensureRuntimeCatalogReady();
+    await authoredModuleDisableGuard(moduleId);
+    const detail = (await maybeResolve(requireAuthoredModules().disableModule(moduleId))) as {
+      module: { id: string; name: string; moduleType?: string | null; status?: string | null };
+    };
+    const audit = await recordAuditSafely({
+      actor,
+      action: "content-studio.module.disable",
+      targetType: "authored-module",
+      targetId: detail.module.id,
+      targetLabel: detail.module.name,
+      result: "success",
+      details: {
+        moduleType: detail.module.moduleType || null,
+        status: detail.module.status || "disabled"
+      }
+    });
+
+    return {
+      ok: true,
+      ...detail,
+      audit
+    };
+  }
+
+  async function enableAuthoredModule(actor: PublicUser, moduleId: string) {
+    await ensureRuntimeCatalogReady();
+    const detail = (await maybeResolve(requireAuthoredModules().enableModule(moduleId))) as {
+      module: { id: string; name: string; moduleType?: string | null; status?: string | null };
+      validation: { errors?: unknown[] };
+    };
+    const audit = await recordAuditSafely({
+      actor,
+      action: "content-studio.module.enable",
+      targetType: "authored-module",
+      targetId: detail.module.id,
+      targetLabel: detail.module.name,
+      result: "success",
+      details: {
+        moduleType: detail.module.moduleType || null,
+        status: detail.module.status || "published",
+        errorCount: Array.isArray(detail.validation?.errors) ? detail.validation.errors.length : 0
+      }
+    });
+
+    return {
+      ok: true,
+      ...detail,
+      audit
+    };
+  }
+
   async function assertModuleSafeToDisable(moduleId: string) {
     const config = await loadConfigRecord();
     const activeModuleIds = asArray(config.defaults.activeModuleIds as string[] | undefined);
@@ -1191,6 +1388,14 @@ function createAdminConsole(options: AdminConsoleOptions) {
     getMaintenanceReport,
     runMaintenanceAction,
     listAudit,
+    getAuthoredModuleEditorOptions,
+    listAuthoredModules,
+    getAuthoredModule,
+    validateAuthoredModuleDraft,
+    saveAuthoredModuleDraft,
+    publishAuthoredModule,
+    disableAuthoredModule,
+    enableAuthoredModule,
     recordAudit,
     assertModuleSafeToDisable,
     loadConfigRecord

--- a/backend/authored-modules.cts
+++ b/backend/authored-modules.cts
@@ -1,4 +1,7 @@
-const { authoredModuleInputSchema, authoredModuleSchema } = require("../shared/runtime-validation.cjs");
+const {
+  authoredModuleInputSchema,
+  authoredModuleSchema
+} = require("../shared/runtime-validation.cjs");
 const { registeredMaps } = require("../shared/maps/index.cjs");
 
 import type {
@@ -130,10 +133,7 @@ function readableList(values: string[]): string {
   return `${values.slice(0, -1).join(", ")}, and ${values[values.length - 1]}`;
 }
 
-function objectiveSummary(
-  objective: AuthoredVictoryObjective,
-  map: SupportedMap | null
-): string {
+function objectiveSummary(objective: AuthoredVictoryObjective, map: SupportedMap | null): string {
   if (objective.type === "control-continents") {
     const continentNames = (objective.continentIds || [])
       .map((continentId) =>
@@ -159,7 +159,9 @@ function objectiveSummary(
 }
 
 function moduleSummaryText(moduleEntry: AuthoredModule, map: SupportedMap | null): string {
-  const enabledObjectives = (moduleEntry.content.objectives || []).filter((objective) => objective.enabled);
+  const enabledObjectives = (moduleEntry.content.objectives || []).filter(
+    (objective) => objective.enabled
+  );
   if (!enabledObjectives.length) {
     return "No enabled win conditions yet.";
   }
@@ -171,7 +173,10 @@ function moduleSummaryText(moduleEntry: AuthoredModule, map: SupportedMap | null
   return `Win condition: complete any of the ${enabledObjectives.length} enabled objectives for ${moduleEntry.name || "this module"}.`;
 }
 
-function buildPreview(moduleEntry: AuthoredModule, map: SupportedMap | null): AuthoredModulePreview {
+function buildPreview(
+  moduleEntry: AuthoredModule,
+  map: SupportedMap | null
+): AuthoredModulePreview {
   return {
     summary: moduleSummaryText(moduleEntry, map),
     objectiveSummaries: (moduleEntry.content.objectives || []).map((objective) =>
@@ -180,7 +185,10 @@ function buildPreview(moduleEntry: AuthoredModule, map: SupportedMap | null): Au
   };
 }
 
-function buildRuntime(moduleEntry: AuthoredModule, map: SupportedMap | null): AuthoredModuleRuntime {
+function buildRuntime(
+  moduleEntry: AuthoredModule,
+  map: SupportedMap | null
+): AuthoredModuleRuntime {
   const mapOption = map ? buildMapOption(map) : null;
 
   return {
@@ -272,7 +280,11 @@ function validateModule(
     errors.push(issue("required-id", "id", "Module id is required."));
   } else if (!ID_PATTERN.test(moduleId)) {
     errors.push(
-      issue("invalid-id", "id", "Use letters, numbers, dashes, underscores, or dots for the module id.")
+      issue(
+        "invalid-id",
+        "id",
+        "Use letters, numbers, dashes, underscores, or dots for the module id."
+      )
     );
   }
 
@@ -289,7 +301,9 @@ function validateModule(
   }
 
   if (!mapId) {
-    errors.push(issue("required-map", "content.mapId", "Select a target map for this objective module."));
+    errors.push(
+      issue("required-map", "content.mapId", "Select a target map for this objective module.")
+    );
   } else if (!mapOption) {
     errors.push(
       issue(
@@ -302,7 +316,11 @@ function validateModule(
 
   if (!objectives.length) {
     errors.push(
-      issue("required-objectives", "content.objectives", "Add at least one objective before publishing.")
+      issue(
+        "required-objectives",
+        "content.objectives",
+        "Add at least one objective before publishing."
+      )
     );
   }
 
@@ -335,7 +353,9 @@ function validateModule(
     }
 
     if (!title) {
-      errors.push(issue("required-objective-title", `${basePath}.title`, "Objective title is required."));
+      errors.push(
+        issue("required-objective-title", `${basePath}.title`, "Objective title is required.")
+      );
     }
 
     if (!objectiveDescription) {
@@ -452,7 +472,10 @@ function toDetailPayload(
   };
 }
 
-function toSummaryPayload(moduleEntry: AuthoredModule, mapCatalog: MapCatalog): AuthoredModuleSummary {
+function toSummaryPayload(
+  moduleEntry: AuthoredModule,
+  mapCatalog: MapCatalog
+): AuthoredModuleSummary {
   const detail = validateModule(moduleEntry, mapCatalog);
 
   return {
@@ -655,9 +678,12 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
     stateKey: AUTHORED_MODULES_STATE_KEY,
     setMapCatalog(nextCatalog: Partial<MapCatalog>) {
       mapCatalog = {
-        listMaps: typeof nextCatalog.listMaps === "function" ? nextCatalog.listMaps : mapCatalog.listMaps,
+        listMaps:
+          typeof nextCatalog.listMaps === "function" ? nextCatalog.listMaps : mapCatalog.listMaps,
         resolveMap:
-          typeof nextCatalog.resolveMap === "function" ? nextCatalog.resolveMap : mapCatalog.resolveMap
+          typeof nextCatalog.resolveMap === "function"
+            ? nextCatalog.resolveMap
+            : mapCatalog.resolveMap
       };
     },
     async listEditorOptions(): Promise<AdminAuthoredModuleEditorOptionsResponse> {
@@ -706,14 +732,19 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
           description: moduleEntry.description,
           source: "authored" as const,
           mapId: normalizeString(moduleEntry.content.mapId) || null,
-          objectiveCount: moduleEntry.content.objectives.filter((objective) => objective.enabled).length,
+          objectiveCount: moduleEntry.content.objectives.filter((objective) => objective.enabled)
+            .length,
           moduleType: moduleEntry.moduleType,
           runtime: detail.runtime
         }));
     },
-    async findPublishedVictoryRuleSetRuntime(moduleId: string): Promise<AuthoredModuleRuntime | null> {
+    async findPublishedVictoryRuleSetRuntime(
+      moduleId: string
+    ): Promise<AuthoredModuleRuntime | null> {
       const modules = await readModules();
-      const moduleEntry = modules.find((entry) => entry.id === moduleId && entry.status === "published");
+      const moduleEntry = modules.find(
+        (entry) => entry.id === moduleId && entry.status === "published"
+      );
       if (!moduleEntry) {
         return null;
       }

--- a/backend/authored-modules.cts
+++ b/backend/authored-modules.cts
@@ -3,6 +3,7 @@ const {
   authoredModuleSchema
 } = require("../shared/runtime-validation.cjs");
 const { registeredMaps } = require("../shared/maps/index.cjs");
+const { listVictoryRuleSets } = require("../shared/victory-rule-sets.cjs");
 
 import type {
   AuthoredMapOption,
@@ -98,6 +99,12 @@ function defaultMapCatalog(): MapCatalog {
     }
   };
 }
+
+const builtInVictoryRuleSetIds = new Set(
+  listVictoryRuleSets()
+    .map((entry: { id?: unknown }) => normalizeString(entry?.id))
+    .filter(isNonEmptyString)
+);
 
 function buildMapOption(map: SupportedMap): AuthoredMapOption {
   const territories = Array.isArray(map?.territories) ? map.territories : [];
@@ -284,6 +291,14 @@ function validateModule(
         "invalid-id",
         "id",
         "Use letters, numbers, dashes, underscores, or dots for the module id."
+      )
+    );
+  } else if (builtInVictoryRuleSetIds.has(moduleId)) {
+    errors.push(
+      issue(
+        "reserved-module-id",
+        "id",
+        `Module id "${moduleId}" is already used by a built-in victory rule set.`
       )
     );
   }

--- a/backend/authored-modules.cts
+++ b/backend/authored-modules.cts
@@ -1,0 +1,734 @@
+const { authoredModuleInputSchema, authoredModuleSchema } = require("../shared/runtime-validation.cjs");
+const { registeredMaps } = require("../shared/maps/index.cjs");
+
+import type {
+  AuthoredMapOption,
+  AuthoredModule,
+  AuthoredModuleInput,
+  AuthoredModulePreview,
+  AuthoredModuleRuntime,
+  AuthoredModuleSummary,
+  AuthoredModuleValidation,
+  AuthoredModuleValidationIssue,
+  AuthoredVictoryObjective,
+  AdminAuthoredModuleDetailResponse,
+  AdminAuthoredModuleEditorOptionsResponse,
+  AdminAuthoredModuleValidateResponse
+} from "../shared/runtime-validation.cjs";
+import type { SupportedMap } from "../shared/maps/index.cjs";
+
+type MapCatalog = {
+  listMaps(): SupportedMap[];
+  resolveMap(mapId: string): SupportedMap | null;
+};
+
+type AuthoredModulesOptions = {
+  datastore: {
+    getAppState?: (key: string) => unknown | Promise<unknown>;
+    setAppState?: (key: string, value: unknown) => unknown | Promise<unknown>;
+  };
+};
+
+type ServiceError = Error & {
+  statusCode?: number;
+  validation?: AuthoredModuleValidation;
+};
+
+const AUTHORED_MODULES_STATE_KEY = "authoredGameplayModules";
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
+
+function maybeResolve<T>(value: Promise<T> | T): Promise<T> {
+  return Promise.resolve(value);
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeString(value: unknown): string {
+  return asString(value).trim();
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function createServiceError(
+  message: string,
+  statusCode: number = 400,
+  validation?: AuthoredModuleValidation
+): ServiceError {
+  const error = new Error(message) as ServiceError;
+  error.statusCode = statusCode;
+  if (validation) {
+    error.validation = validation;
+  }
+  return error;
+}
+
+function issue(
+  code: string,
+  path: string,
+  message: string,
+  severity: "warning" | "error" = "error"
+): AuthoredModuleValidationIssue {
+  return {
+    code,
+    path,
+    message,
+    severity
+  };
+}
+
+function defaultMapCatalog(): MapCatalog {
+  return {
+    listMaps() {
+      return registeredMaps.map((entry: SupportedMap) => clone(entry));
+    },
+    resolveMap(mapId: string) {
+      const match = registeredMaps.find((entry: SupportedMap) => entry.id === mapId) || null;
+      return match ? clone(match) : null;
+    }
+  };
+}
+
+function buildMapOption(map: SupportedMap): AuthoredMapOption {
+  const territories = Array.isArray(map?.territories) ? map.territories : [];
+  const continents = Array.isArray(map?.continents) ? map.continents : [];
+
+  return {
+    id: String(map?.id || ""),
+    name: String(map?.name || ""),
+    territoryCount: territories.length,
+    continentCount: continents.length,
+    continents: continents.map((continent) => ({
+      id: String(continent?.id || ""),
+      name: String(continent?.name || ""),
+      bonus: Number(continent?.bonus || 0),
+      territoryCount: Array.isArray(continent?.territoryIds) ? continent.territoryIds.length : 0
+    }))
+  };
+}
+
+function readableList(values: string[]): string {
+  if (!values.length) {
+    return "";
+  }
+
+  if (values.length === 1) {
+    return values[0] as string;
+  }
+
+  if (values.length === 2) {
+    return `${values[0]} and ${values[1]}`;
+  }
+
+  return `${values.slice(0, -1).join(", ")}, and ${values[values.length - 1]}`;
+}
+
+function objectiveSummary(
+  objective: AuthoredVictoryObjective,
+  map: SupportedMap | null
+): string {
+  if (objective.type === "control-continents") {
+    const continentNames = (objective.continentIds || [])
+      .map((continentId) =>
+        Array.isArray(map?.continents)
+          ? map.continents.find((entry) => entry.id === continentId)?.name || continentId
+          : continentId
+      )
+      .filter(isNonEmptyString);
+
+    return continentNames.length
+      ? `Control ${readableList(continentNames)} simultaneously.`
+      : "Control the selected continents simultaneously.";
+  }
+
+  const territoryCount =
+    typeof objective.territoryCount === "number" && Number.isInteger(objective.territoryCount)
+      ? objective.territoryCount
+      : null;
+
+  return territoryCount
+    ? `Own at least ${territoryCount} territories.`
+    : "Own the configured minimum territory count.";
+}
+
+function moduleSummaryText(moduleEntry: AuthoredModule, map: SupportedMap | null): string {
+  const enabledObjectives = (moduleEntry.content.objectives || []).filter((objective) => objective.enabled);
+  if (!enabledObjectives.length) {
+    return "No enabled win conditions yet.";
+  }
+
+  if (enabledObjectives.length === 1) {
+    return `Win condition: ${objectiveSummary(enabledObjectives[0] as AuthoredVictoryObjective, map)}`;
+  }
+
+  return `Win condition: complete any of the ${enabledObjectives.length} enabled objectives for ${moduleEntry.name || "this module"}.`;
+}
+
+function buildPreview(moduleEntry: AuthoredModule, map: SupportedMap | null): AuthoredModulePreview {
+  return {
+    summary: moduleSummaryText(moduleEntry, map),
+    objectiveSummaries: (moduleEntry.content.objectives || []).map((objective) =>
+      objectiveSummary(objective as AuthoredVictoryObjective, map)
+    )
+  };
+}
+
+function buildRuntime(moduleEntry: AuthoredModule, map: SupportedMap | null): AuthoredModuleRuntime {
+  const mapOption = map ? buildMapOption(map) : null;
+
+  return {
+    id: moduleEntry.id,
+    name: moduleEntry.name,
+    description: moduleEntry.description,
+    version: moduleEntry.version,
+    moduleType: moduleEntry.moduleType,
+    kind: "authored-victory-objectives",
+    map: mapOption
+      ? {
+          id: mapOption.id,
+          name: mapOption.name,
+          territoryCount: mapOption.territoryCount,
+          continentCount: mapOption.continentCount
+        }
+      : {
+          id: normalizeString(moduleEntry.content.mapId),
+          name: normalizeString(moduleEntry.content.mapId),
+          territoryCount: 0,
+          continentCount: 0
+        },
+    objectives: (moduleEntry.content.objectives || []).map((objective) => {
+      if (objective.type === "control-continents") {
+        const continentNames = (objective.continentIds || []).map((continentId) => {
+          const name = Array.isArray(map?.continents)
+            ? map.continents.find((entry) => entry.id === continentId)?.name
+            : null;
+          return name || continentId;
+        });
+
+        return {
+          id: objective.id,
+          title: objective.title,
+          description: objective.description,
+          enabled: objective.enabled,
+          type: objective.type,
+          continentIds: [...objective.continentIds],
+          continentNames,
+          summary: objectiveSummary(objective, map)
+        };
+      }
+
+      return {
+        id: objective.id,
+        title: objective.title,
+        description: objective.description,
+        enabled: objective.enabled,
+        type: objective.type,
+        territoryCount:
+          typeof objective.territoryCount === "number" && Number.isInteger(objective.territoryCount)
+            ? objective.territoryCount
+            : null,
+        summary: objectiveSummary(objective, map)
+      };
+    }),
+    preview: buildPreview(moduleEntry, map)
+  };
+}
+
+function validateModule(
+  moduleEntry: AuthoredModule,
+  mapCatalog: MapCatalog
+): {
+  validation: AuthoredModuleValidation;
+  preview: AuthoredModulePreview;
+  runtime: AuthoredModuleRuntime;
+  map: AuthoredMapOption | null;
+  objectiveCount: number;
+  enabledObjectiveCount: number;
+} {
+  const errors: AuthoredModuleValidationIssue[] = [];
+  const warnings: AuthoredModuleValidationIssue[] = [];
+  const moduleId = normalizeString(moduleEntry.id);
+  const name = normalizeString(moduleEntry.name);
+  const description = normalizeString(moduleEntry.description);
+  const version = normalizeString(moduleEntry.version);
+  const mapId = normalizeString(moduleEntry.content?.mapId);
+  const map = mapId ? mapCatalog.resolveMap(mapId) : null;
+  const mapOption = map ? buildMapOption(map) : null;
+  const objectives = Array.isArray(moduleEntry.content?.objectives)
+    ? moduleEntry.content.objectives
+    : [];
+  const enabledObjectiveCount = objectives.filter((objective) => objective?.enabled).length;
+  const seenObjectiveIds = new Set<string>();
+  const validContinentIds = new Set((mapOption?.continents || []).map((continent) => continent.id));
+
+  if (!moduleId) {
+    errors.push(issue("required-id", "id", "Module id is required."));
+  } else if (!ID_PATTERN.test(moduleId)) {
+    errors.push(
+      issue("invalid-id", "id", "Use letters, numbers, dashes, underscores, or dots for the module id.")
+    );
+  }
+
+  if (!name) {
+    errors.push(issue("required-name", "name", "Module name is required."));
+  }
+
+  if (!description) {
+    errors.push(issue("required-description", "description", "Module description is required."));
+  }
+
+  if (!version) {
+    errors.push(issue("required-version", "version", "Module version is required."));
+  }
+
+  if (!mapId) {
+    errors.push(issue("required-map", "content.mapId", "Select a target map for this objective module."));
+  } else if (!mapOption) {
+    errors.push(
+      issue(
+        "invalid-map",
+        "content.mapId",
+        `Map "${mapId}" is not currently available in the runtime catalog.`
+      )
+    );
+  }
+
+  if (!objectives.length) {
+    errors.push(
+      issue("required-objectives", "content.objectives", "Add at least one objective before publishing.")
+    );
+  }
+
+  objectives.forEach((objective, index) => {
+    const basePath = `content.objectives.${index}`;
+    const objectiveId = normalizeString(objective?.id);
+    const title = normalizeString(objective?.title);
+    const objectiveDescription = normalizeString(objective?.description);
+
+    if (!objectiveId) {
+      errors.push(issue("required-objective-id", `${basePath}.id`, "Objective id is required."));
+    } else if (!ID_PATTERN.test(objectiveId)) {
+      errors.push(
+        issue(
+          "invalid-objective-id",
+          `${basePath}.id`,
+          "Use letters, numbers, dashes, underscores, or dots for the objective id."
+        )
+      );
+    } else if (seenObjectiveIds.has(objectiveId)) {
+      errors.push(
+        issue(
+          "duplicate-objective-id",
+          `${basePath}.id`,
+          `Objective id "${objectiveId}" is already used in this module.`
+        )
+      );
+    } else {
+      seenObjectiveIds.add(objectiveId);
+    }
+
+    if (!title) {
+      errors.push(issue("required-objective-title", `${basePath}.title`, "Objective title is required."));
+    }
+
+    if (!objectiveDescription) {
+      errors.push(
+        issue(
+          "required-objective-description",
+          `${basePath}.description`,
+          "Objective description is required."
+        )
+      );
+    }
+
+    if (objective.type === "control-continents") {
+      const continentIds = Array.isArray(objective.continentIds) ? objective.continentIds : [];
+      if (!continentIds.length) {
+        errors.push(
+          issue(
+            "required-continents",
+            `${basePath}.continentIds`,
+            "Select at least one continent for this objective."
+          )
+        );
+      }
+
+      const seenContinentIds = new Set<string>();
+      continentIds.forEach((continentId, continentIndex) => {
+        const normalizedContinentId = normalizeString(continentId);
+        const continentPath = `${basePath}.continentIds.${continentIndex}`;
+        if (!normalizedContinentId) {
+          errors.push(issue("required-continent-id", continentPath, "Continent id is required."));
+          return;
+        }
+
+        if (seenContinentIds.has(normalizedContinentId)) {
+          errors.push(
+            issue(
+              "duplicate-continent-id",
+              continentPath,
+              `Continent "${normalizedContinentId}" is already selected for this objective.`
+            )
+          );
+          return;
+        }
+        seenContinentIds.add(normalizedContinentId);
+
+        if (mapOption && !validContinentIds.has(normalizedContinentId)) {
+          errors.push(
+            issue(
+              "invalid-continent-id",
+              continentPath,
+              `Continent "${normalizedContinentId}" does not exist on ${mapOption.name}.`
+            )
+          );
+        }
+      });
+    }
+
+    if (objective.type === "control-territory-count") {
+      const territoryCount = objective.territoryCount;
+      if (!Number.isInteger(territoryCount) || Number(territoryCount) < 1) {
+        errors.push(
+          issue(
+            "invalid-territory-count",
+            `${basePath}.territoryCount`,
+            "Territory objectives require a whole number greater than zero."
+          )
+        );
+      } else if (mapOption && Number(territoryCount) > mapOption.territoryCount) {
+        errors.push(
+          issue(
+            "territory-count-out-of-range",
+            `${basePath}.territoryCount`,
+            `Territory count cannot exceed ${mapOption.territoryCount} for ${mapOption.name}.`
+          )
+        );
+      }
+    }
+  });
+
+  if (objectives.length > 0 && enabledObjectiveCount === 0) {
+    errors.push(
+      issue(
+        "no-enabled-objectives",
+        "content.objectives",
+        "Enable at least one objective before publishing this module."
+      )
+    );
+  }
+
+  return {
+    validation: {
+      valid: errors.length === 0,
+      errors,
+      warnings
+    },
+    preview: buildPreview(moduleEntry, map),
+    runtime: buildRuntime(moduleEntry, map),
+    map: mapOption,
+    objectiveCount: objectives.length,
+    enabledObjectiveCount
+  };
+}
+
+function toDetailPayload(
+  moduleEntry: AuthoredModule,
+  mapCatalog: MapCatalog
+): AdminAuthoredModuleDetailResponse {
+  const { validation, preview, runtime } = validateModule(moduleEntry, mapCatalog);
+  return {
+    module: clone(moduleEntry),
+    validation,
+    preview,
+    runtime
+  };
+}
+
+function toSummaryPayload(moduleEntry: AuthoredModule, mapCatalog: MapCatalog): AuthoredModuleSummary {
+  const detail = validateModule(moduleEntry, mapCatalog);
+
+  return {
+    ...clone(moduleEntry),
+    validation: detail.validation,
+    preview: detail.preview,
+    map: detail.map
+      ? {
+          id: detail.map.id,
+          name: detail.map.name,
+          territoryCount: detail.map.territoryCount,
+          continentCount: detail.map.continentCount
+        }
+      : null,
+    objectiveCount: detail.objectiveCount,
+    enabledObjectiveCount: detail.enabledObjectiveCount
+  };
+}
+
+function normalizeStoredModule(input: unknown): AuthoredModule | null {
+  const parsed = authoredModuleSchema.safeParse(input);
+  return parsed.success ? clone(parsed.data) : null;
+}
+
+function sortModules(modules: AuthoredModule[]): AuthoredModule[] {
+  return modules.sort((left, right) =>
+    String(right.updatedAt || "").localeCompare(String(left.updatedAt || ""))
+  );
+}
+
+function createAuthoredModulesService(options: AuthoredModulesOptions) {
+  let mapCatalog = defaultMapCatalog();
+
+  async function readModules(): Promise<AuthoredModule[]> {
+    if (typeof options.datastore.getAppState !== "function") {
+      return [];
+    }
+
+    const raw = await maybeResolve(options.datastore.getAppState(AUTHORED_MODULES_STATE_KEY));
+    const source = Array.isArray(raw)
+      ? raw
+      : raw && typeof raw === "object" && Array.isArray((raw as { modules?: unknown[] }).modules)
+        ? (raw as { modules: unknown[] }).modules
+        : [];
+
+    return sortModules(
+      source
+        .map((entry) => normalizeStoredModule(entry))
+        .filter((entry): entry is AuthoredModule => Boolean(entry))
+    );
+  }
+
+  async function writeModules(modules: AuthoredModule[]): Promise<void> {
+    if (typeof options.datastore.setAppState !== "function") {
+      throw createServiceError("Datastore does not support authored module persistence.", 500);
+    }
+
+    await maybeResolve(
+      options.datastore.setAppState(
+        AUTHORED_MODULES_STATE_KEY,
+        sortModules(modules.map((entry) => clone(entry)))
+      )
+    );
+  }
+
+  async function getModuleOrThrow(moduleId: string): Promise<AuthoredModule> {
+    const modules = await readModules();
+    const match = modules.find((entry) => entry.id === moduleId) || null;
+    if (!match) {
+      throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
+    }
+
+    return match;
+  }
+
+  function parseInput(input: unknown): AuthoredModuleInput {
+    const parsed = authoredModuleInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw createServiceError("Authored module payload is not valid.", 400);
+    }
+
+    return clone(parsed.data);
+  }
+
+  async function validateDraft(input: unknown): Promise<AdminAuthoredModuleValidateResponse> {
+    const parsed = parseInput(input);
+    const moduleEntry: AuthoredModule = {
+      ...parsed,
+      status: "draft",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    const detail = toDetailPayload(moduleEntry, mapCatalog);
+
+    return {
+      validation: detail.validation,
+      preview: detail.preview,
+      runtime: detail.runtime
+    };
+  }
+
+  async function saveDraft(input: unknown): Promise<AdminAuthoredModuleDetailResponse> {
+    const parsed = parseInput(input);
+    const modules = await readModules();
+    const existingIndex = modules.findIndex((entry) => entry.id === parsed.id);
+    const now = new Date().toISOString();
+
+    if (existingIndex >= 0 && modules[existingIndex]?.status !== "draft") {
+      throw createServiceError(
+        "Only draft modules are editable in this phase. Create a new draft to change published content.",
+        409
+      );
+    }
+
+    const nextEntry: AuthoredModule = {
+      ...clone(existingIndex >= 0 ? modules[existingIndex] : null),
+      ...parsed,
+      status: "draft",
+      createdAt: existingIndex >= 0 ? modules[existingIndex].createdAt : now,
+      updatedAt: now
+    };
+
+    if (existingIndex >= 0) {
+      modules[existingIndex] = nextEntry;
+    } else {
+      modules.push(nextEntry);
+    }
+
+    await writeModules(modules);
+    return toDetailPayload(nextEntry, mapCatalog);
+  }
+
+  async function publishModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
+    const modules = await readModules();
+    const index = modules.findIndex((entry) => entry.id === moduleId);
+    if (index < 0) {
+      throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
+    }
+
+    const detail = toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    if (!detail.validation.valid) {
+      throw createServiceError(
+        "This module still has validation errors and cannot be published.",
+        400,
+        detail.validation
+      );
+    }
+
+    modules[index] = {
+      ...clone(modules[index] as AuthoredModule),
+      status: "published",
+      updatedAt: new Date().toISOString()
+    };
+    await writeModules(modules);
+    return toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+  }
+
+  async function disableModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
+    const modules = await readModules();
+    const index = modules.findIndex((entry) => entry.id === moduleId);
+    if (index < 0) {
+      throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
+    }
+
+    modules[index] = {
+      ...clone(modules[index] as AuthoredModule),
+      status: "disabled",
+      updatedAt: new Date().toISOString()
+    };
+    await writeModules(modules);
+    return toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+  }
+
+  async function enableModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
+    const modules = await readModules();
+    const index = modules.findIndex((entry) => entry.id === moduleId);
+    if (index < 0) {
+      throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
+    }
+
+    const detail = toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    if (!detail.validation.valid) {
+      throw createServiceError(
+        "This module no longer validates cleanly and cannot be enabled.",
+        400,
+        detail.validation
+      );
+    }
+
+    modules[index] = {
+      ...clone(modules[index] as AuthoredModule),
+      status: "published",
+      updatedAt: new Date().toISOString()
+    };
+    await writeModules(modules);
+    return toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+  }
+
+  return {
+    stateKey: AUTHORED_MODULES_STATE_KEY,
+    setMapCatalog(nextCatalog: Partial<MapCatalog>) {
+      mapCatalog = {
+        listMaps: typeof nextCatalog.listMaps === "function" ? nextCatalog.listMaps : mapCatalog.listMaps,
+        resolveMap:
+          typeof nextCatalog.resolveMap === "function" ? nextCatalog.resolveMap : mapCatalog.resolveMap
+      };
+    },
+    async listEditorOptions(): Promise<AdminAuthoredModuleEditorOptionsResponse> {
+      return {
+        moduleTypes: ["victory-objectives"],
+        maps: mapCatalog
+          .listMaps()
+          .map((entry) => buildMapOption(entry))
+          .sort((left, right) => left.name.localeCompare(right.name))
+      };
+    },
+    async listModules(): Promise<AuthoredModuleSummary[]> {
+      const modules = await readModules();
+      return modules.map((moduleEntry) => toSummaryPayload(moduleEntry, mapCatalog));
+    },
+    async getModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
+      return toDetailPayload(await getModuleOrThrow(moduleId), mapCatalog);
+    },
+    async validateDraft(input: unknown) {
+      return validateDraft(input);
+    },
+    async saveDraft(input: unknown) {
+      return saveDraft(input);
+    },
+    async publishModule(moduleId: string) {
+      return publishModule(moduleId);
+    },
+    async disableModule(moduleId: string) {
+      return disableModule(moduleId);
+    },
+    async enableModule(moduleId: string) {
+      return enableModule(moduleId);
+    },
+    async listPublishedVictoryRuleSets() {
+      const modules = await readModules();
+      return modules
+        .filter((moduleEntry) => moduleEntry.status === "published")
+        .map((moduleEntry) => ({
+          moduleEntry,
+          detail: toDetailPayload(moduleEntry, mapCatalog)
+        }))
+        .filter((entry) => entry.detail.validation.valid)
+        .map(({ moduleEntry, detail }) => ({
+          id: moduleEntry.id,
+          name: moduleEntry.name,
+          description: moduleEntry.description,
+          source: "authored" as const,
+          mapId: normalizeString(moduleEntry.content.mapId) || null,
+          objectiveCount: moduleEntry.content.objectives.filter((objective) => objective.enabled).length,
+          moduleType: moduleEntry.moduleType,
+          runtime: detail.runtime
+        }));
+    },
+    async findPublishedVictoryRuleSetRuntime(moduleId: string): Promise<AuthoredModuleRuntime | null> {
+      const modules = await readModules();
+      const moduleEntry = modules.find((entry) => entry.id === moduleId && entry.status === "published");
+      if (!moduleEntry) {
+        return null;
+      }
+
+      const detail = toDetailPayload(moduleEntry, mapCatalog);
+      return detail.validation.valid ? detail.runtime : null;
+    },
+    async isModuleStored(moduleId: string): Promise<boolean> {
+      const modules = await readModules();
+      return modules.some((entry) => entry.id === moduleId);
+    }
+  };
+}
+
+module.exports = {
+  AUTHORED_MODULES_STATE_KEY,
+  createAuthoredModulesService
+};

--- a/backend/engine/victory-detection.cts
+++ b/backend/engine/victory-detection.cts
@@ -282,7 +282,9 @@ function resolveAuthoredVictoryModule(
   state: GameState,
   victoryRuleSetId: string
 ): ActiveVictoryContext["authoredVictoryModule"] {
-  const parsed = authoredVictoryModuleRuntimeSchema.safeParse(state.gameConfig?.victoryObjectiveModule);
+  const parsed = authoredVictoryModuleRuntimeSchema.safeParse(
+    state.gameConfig?.victoryObjectiveModule
+  );
   if (!parsed.success) {
     return null;
   }
@@ -377,8 +379,7 @@ function evaluateAuthoredVictoryObjectives(context: ActiveVictoryContext): Victo
 
     return declareVictory(context.state, player, context.victoryRuleSet, {
       summary:
-        player.name +
-        ` completes the objective "${matchedObjective.title}" and wins the game.`,
+        player.name + ` completes the objective "${matchedObjective.title}" and wins the game.`,
       summaryKey: "game.log.victoryAuthoredObjective",
       summaryParams: {
         objectiveId: matchedObjective.id,

--- a/backend/engine/victory-detection.cts
+++ b/backend/engine/victory-detection.cts
@@ -3,11 +3,14 @@ import {
   MAJORITY_CONTROL_VICTORY_RULE_SET_ID,
   TurnPhase,
   createLocalizedError,
+  findVictoryRuleSet,
   getVictoryRuleSet,
   migrateGameStateExtensions,
   type GameState,
-  type Player
+  type Player,
+  type VictoryRuleSet
 } from "../../shared/models.cjs";
+const { authoredVictoryModuleRuntimeSchema } = require("../../shared/runtime-validation.cjs");
 
 export interface VictoryResult {
   ok: true;
@@ -34,9 +37,48 @@ export interface VictoryResult {
 
 interface ActiveVictoryContext {
   state: GameState;
-  victoryRuleSet: ReturnType<typeof getVictoryRuleSet>;
+  victoryRuleSet: VictoryRuleSet;
   activePlayers: Player[];
   majorityControlThresholdPercent: number;
+  authoredVictoryModule: null | {
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    moduleType: "victory-objectives";
+    kind: "authored-victory-objectives";
+    map: {
+      id: string;
+      name: string;
+      territoryCount: number;
+      continentCount: number;
+    };
+    objectives: Array<
+      | {
+          id: string;
+          title: string;
+          description: string;
+          enabled: boolean;
+          type: "control-continents";
+          continentIds: string[];
+          continentNames: string[];
+          summary: string;
+        }
+      | {
+          id: string;
+          title: string;
+          description: string;
+          enabled: boolean;
+          type: "control-territory-count";
+          territoryCount: number;
+          summary: string;
+        }
+    >;
+    preview: {
+      summary: string;
+      objectiveSummaries: string[];
+    };
+  };
 }
 
 function territoryCountByPlayer(state: GameState, playerId: string | null): number {
@@ -236,6 +278,121 @@ function resolveMajorityControlThresholdPercent(state: GameState): number {
   return 70;
 }
 
+function resolveAuthoredVictoryModule(
+  state: GameState,
+  victoryRuleSetId: string
+): ActiveVictoryContext["authoredVictoryModule"] {
+  const parsed = authoredVictoryModuleRuntimeSchema.safeParse(state.gameConfig?.victoryObjectiveModule);
+  if (!parsed.success) {
+    return null;
+  }
+
+  if (parsed.data.id !== victoryRuleSetId) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
+function orderedActivePlayers(state: GameState, activePlayers: Player[]): Player[] {
+  if (
+    !Number.isInteger(state.currentTurnIndex) ||
+    Number(state.currentTurnIndex) < 0 ||
+    Number(state.currentTurnIndex) >= state.players.length
+  ) {
+    return activePlayers;
+  }
+
+  const currentPlayerId = state.players[Number(state.currentTurnIndex)]?.id || null;
+  if (!currentPlayerId) {
+    return activePlayers;
+  }
+
+  return [...activePlayers].sort((left, right) => {
+    if (left.id === currentPlayerId) {
+      return -1;
+    }
+
+    if (right.id === currentPlayerId) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
+function playerControlsContinent(
+  state: GameState,
+  playerId: string | null,
+  continentId: string
+): boolean {
+  if (!playerId || !Array.isArray(state.continents)) {
+    return false;
+  }
+
+  const continent = state.continents.find((entry) => entry?.id === continentId) || null;
+  if (!continent || !Array.isArray(continent.territoryIds) || continent.territoryIds.length === 0) {
+    return false;
+  }
+
+  return continent.territoryIds.every(
+    (territoryId) => state.territories?.[territoryId]?.ownerId === playerId
+  );
+}
+
+function evaluateAuthoredObjectiveForPlayer(
+  state: GameState,
+  player: Player,
+  objective: NonNullable<ActiveVictoryContext["authoredVictoryModule"]>["objectives"][number]
+): boolean {
+  if (!objective.enabled) {
+    return false;
+  }
+
+  if (objective.type === "control-continents") {
+    return objective.continentIds.every((continentId) =>
+      playerControlsContinent(state, player.id, continentId)
+    );
+  }
+
+  return territoryCountByPlayer(state, player.id) >= objective.territoryCount;
+}
+
+function evaluateAuthoredVictoryObjectives(context: ActiveVictoryContext): VictoryResult {
+  if (!context.authoredVictoryModule) {
+    return noVictoryResult(context.activePlayers);
+  }
+
+  const orderedPlayers = orderedActivePlayers(context.state, context.activePlayers);
+
+  for (const player of orderedPlayers) {
+    const matchedObjective =
+      context.authoredVictoryModule.objectives.find((objective) =>
+        evaluateAuthoredObjectiveForPlayer(context.state, player, objective)
+      ) || null;
+
+    if (!matchedObjective) {
+      continue;
+    }
+
+    return declareVictory(context.state, player, context.victoryRuleSet, {
+      summary:
+        player.name +
+        ` completes the objective "${matchedObjective.title}" and wins the game.`,
+      summaryKey: "game.log.victoryAuthoredObjective",
+      summaryParams: {
+        objectiveId: matchedObjective.id,
+        objectiveTitle: matchedObjective.title,
+        objectiveType: matchedObjective.type,
+        objectiveSummary: matchedObjective.summary,
+        victoryModuleId: context.authoredVictoryModule.id
+      }
+    });
+  }
+
+  return noVictoryResult(context.activePlayers);
+}
+
 const victoryEvaluators: Record<string, (context: ActiveVictoryContext) => VictoryResult> = {
   [DEFAULT_VICTORY_RULE_SET_ID]: evaluateConquestVictory,
   [MAJORITY_CONTROL_VICTORY_RULE_SET_ID]: evaluateMajorityControlVictory
@@ -245,8 +402,29 @@ export function detectVictory(state: GameState): VictoryResult {
   migrateGameStateExtensions(state);
   validateState(state);
   const victoryRuleSetId = state.gameConfig?.victoryRuleSetId || DEFAULT_VICTORY_RULE_SET_ID;
-  const victoryRuleSet = getVictoryRuleSet(victoryRuleSetId);
+  const authoredVictoryModule = resolveAuthoredVictoryModule(state, victoryRuleSetId);
+  const builtInVictoryRuleSet = findVictoryRuleSet(victoryRuleSetId);
+  const victoryRuleSet: VictoryRuleSet = authoredVictoryModule
+    ? {
+        id: authoredVictoryModule.id,
+        name: authoredVictoryModule.name,
+        description: authoredVictoryModule.description,
+        source: "authored",
+        mapId: authoredVictoryModule.map.id,
+        objectiveCount: authoredVictoryModule.objectives.filter((objective) => objective.enabled)
+          .length,
+        moduleType: authoredVictoryModule.moduleType
+      }
+    : getVictoryRuleSet(victoryRuleSetId);
   const majorityControlThresholdPercent = resolveMajorityControlThresholdPercent(state);
+
+  if (!authoredVictoryModule && !builtInVictoryRuleSet && state.gameConfig?.victoryRuleSetId) {
+    throw createLocalizedError(
+      `Victory detection found unsupported rule set "${victoryRuleSetId}".`,
+      "game.victory.internal.invalidRuleSet",
+      { victoryRuleSetId }
+    );
+  }
 
   const activePlayers = state.players.filter((player) => isActivePlayer(state, player));
   if (activePlayers.length === 0) {
@@ -261,11 +439,22 @@ export function detectVictory(state: GameState): VictoryResult {
     return aiOnlyRemainResult(state, activePlayers);
   }
 
+  if (authoredVictoryModule) {
+    return evaluateAuthoredVictoryObjectives({
+      state,
+      victoryRuleSet,
+      activePlayers,
+      majorityControlThresholdPercent,
+      authoredVictoryModule
+    });
+  }
+
   const evaluateVictory = victoryEvaluators[victoryRuleSet.id] || evaluateConquestVictory;
   return evaluateVictory({
     state,
     victoryRuleSet,
     activePlayers,
-    majorityControlThresholdPercent
+    majorityControlThresholdPercent,
+    authoredVictoryModule: null
   });
 }

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -21,6 +21,7 @@ const { listReinforcementRuleSets } = require("../shared/reinforcement-rule-sets
 const { listSiteThemes } = require("../shared/site-themes.cjs");
 const { buildContinentDefinition, buildMapDefinition } = require("../shared/typed-map-data.cjs");
 const {
+  findVictoryRuleSet: findBuiltInVictoryRuleSet,
   listPieceSkins,
   listVictoryRuleSets,
   listVisualThemes
@@ -68,6 +69,7 @@ import type {
 } from "../shared/extensions.cjs";
 import type { MapSummary, SupportedMap } from "../shared/maps/index.cjs";
 import type { PlayerPieceSet, PlayerPieceSetSummary } from "../shared/player-piece-sets.cjs";
+import type { AuthoredVictoryModuleRuntime } from "../shared/runtime-validation.cjs";
 
 type CatalogState = {
   enabledById: Record<string, boolean>;
@@ -80,6 +82,11 @@ type ModuleRuntimeOptions = {
     getAppState?: (key: string) => unknown | Promise<unknown>;
     setAppState?: (key: string, value: unknown) => unknown | Promise<unknown>;
     listGames?: () => Array<Record<string, unknown>> | Promise<Array<Record<string, unknown>>>;
+  };
+  authoredModules?: {
+    listPublishedVictoryRuleSets?: () =>
+      | AuthoredPublishedVictoryRuleSet[]
+      | Promise<AuthoredPublishedVictoryRuleSet[]>;
   };
 };
 
@@ -105,6 +112,17 @@ type RuntimeModulePlayerPieceSetEntry = {
 type RuntimeModuleDiceRuleSetEntry = {
   moduleId: string;
   diceRuleSet: DiceRuleSet;
+};
+
+type AuthoredPublishedVictoryRuleSet = {
+  id: string;
+  name: string;
+  description: string;
+  source: "authored";
+  mapId?: string | null;
+  objectiveCount?: number;
+  moduleType?: string | null;
+  runtime: AuthoredVictoryModuleRuntime;
 };
 
 const MODULE_CATALOG_STATE_KEY = "moduleCatalogState";
@@ -218,6 +236,12 @@ function cloneVictoryRuleSet(ruleSet: VictoryRuleSet): VictoryRuleSet {
   return {
     ...ruleSet
   };
+}
+
+function cloneAuthoredVictoryRuntime(
+  runtime: AuthoredVictoryModuleRuntime
+): AuthoredVictoryModuleRuntime {
+  return JSON.parse(JSON.stringify(runtime ?? null)) as AuthoredVictoryModuleRuntime;
 }
 
 function cloneRuleSetSummary(ruleSet: BuiltInNewGameRuleSetSummary): BuiltInNewGameRuleSetSummary {
@@ -1011,7 +1035,8 @@ function buildResolvedModuleCatalog(
   runtimeMapEntries: RuntimeModuleMapEntry[],
   runtimeContentPackEntries: RuntimeModuleContentPackEntry[],
   runtimePlayerPieceSetEntries: RuntimeModulePlayerPieceSetEntry[],
-  runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[]
+  runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[],
+  authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = []
 ): NetRiskResolvedModuleCatalog {
   const clonedModules = modules.map(cloneInstalledModule);
   const enabled = clonedModules.filter(
@@ -1036,6 +1061,13 @@ function buildResolvedModuleCatalog(
     enabledRuntimePlayerPieceSetEntries,
     enabledRuntimeDiceRuleSetEntries
   );
+  const authoredVictoryRuleSetIds = authoredVictoryRuleSets.map((entry) => entry.id);
+
+  if (authoredVictoryRuleSetIds.length) {
+    content.victoryRuleSetIds = Array.from(
+      new Set([...(content.victoryRuleSetIds || []), ...authoredVictoryRuleSetIds])
+    );
+  }
 
   return {
     modules: clonedModules,
@@ -1089,7 +1121,21 @@ function buildResolvedModuleCatalog(
       content.contentPackIds
     ),
     victoryRuleSets: filterVictoryRuleSetsByAllowedIds(
-      listVictoryRuleSets().map(cloneVictoryRuleSet),
+      [
+        ...listVictoryRuleSets().map(cloneVictoryRuleSet),
+        ...authoredVictoryRuleSets.map((entry) =>
+          cloneVictoryRuleSet({
+            id: entry.id,
+            name: entry.name,
+            description: entry.description,
+            source: entry.source,
+            mapId: entry.mapId || null,
+            objectiveCount:
+              typeof entry.objectiveCount === "number" ? entry.objectiveCount : undefined,
+            moduleType: entry.moduleType || null
+          })
+        )
+      ],
       content.victoryRuleSetIds
     ),
     themes: filterThemesByAllowedIds(
@@ -1116,14 +1162,16 @@ function buildModuleOptions(
   runtimeMapEntries: RuntimeModuleMapEntry[],
   runtimeContentPackEntries: RuntimeModuleContentPackEntry[],
   runtimePlayerPieceSetEntries: RuntimeModulePlayerPieceSetEntry[],
-  runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[]
+  runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[],
+  authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = []
 ): ModuleOptionsSnapshot {
   const resolvedCatalog = buildResolvedModuleCatalog(
     modules,
     runtimeMapEntries,
     runtimeContentPackEntries,
     runtimePlayerPieceSetEntries,
-    runtimeDiceRuleSetEntries
+    runtimeDiceRuleSetEntries,
+    authoredVictoryRuleSets
   );
 
   return {
@@ -1257,6 +1305,8 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
   let runtimeContentPacksById = new Map<string, RuntimeModuleContentPackEntry>();
   let runtimePlayerPieceSetsById = new Map<string, RuntimeModulePlayerPieceSetEntry>();
   let runtimeDiceRuleSetsById = new Map<string, RuntimeModuleDiceRuleSetEntry>();
+  let authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = [];
+  let authoredVictoryRuleSetRuntimesById = new Map<string, AuthoredVictoryModuleRuntime>();
 
   function registerServerModuleMaps(
     moduleId: string,
@@ -1816,12 +1866,33 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
 
   async function getModuleOptions() {
     const modules = await ensureCatalog();
+    await refreshAuthoredVictoryRuleSets();
     return buildModuleOptions(
       modules,
       listEnabledRuntimeMaps(modules),
       listEnabledRuntimeContentPacks(modules),
       listEnabledRuntimePlayerPieceSets(modules),
-      listEnabledRuntimeDiceRuleSets(modules)
+      listEnabledRuntimeDiceRuleSets(modules),
+      authoredVictoryRuleSets
+    );
+  }
+
+  async function refreshAuthoredVictoryRuleSets() {
+    if (typeof options.authoredModules?.listPublishedVictoryRuleSets !== "function") {
+      authoredVictoryRuleSets = [];
+      authoredVictoryRuleSetRuntimesById = new Map();
+      return;
+    }
+
+    const published = await options.authoredModules.listPublishedVictoryRuleSets();
+    authoredVictoryRuleSets = Array.isArray(published)
+      ? published.map((entry) => ({
+          ...entry,
+          runtime: cloneAuthoredVictoryRuntime(entry.runtime)
+        }))
+      : [];
+    authoredVictoryRuleSetRuntimesById = new Map(
+      authoredVictoryRuleSets.map((entry) => [entry.id, cloneAuthoredVictoryRuntime(entry.runtime)])
     );
   }
 
@@ -1835,6 +1906,22 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
     },
     async getModuleOptions() {
       return getModuleOptions();
+    },
+    listSupportedMaps(): SupportedMap[] {
+      const builtInMaps = listCoreBaseMapSummaries()
+        .map((summary: { id: string }) => findCoreBaseSupportedMap(summary.id))
+        .filter((entry: SupportedMap | null): entry is SupportedMap => Boolean(entry))
+        .map(cloneSupportedMap);
+      const runtimeMaps = Array.from(runtimeMapsById.values())
+        .filter((runtimeEntry) => {
+          const ownerModule = cachedModules.find(
+            (moduleEntry) => moduleEntry.id === runtimeEntry.moduleId
+          );
+          return Boolean(ownerModule?.enabled && ownerModule.compatible);
+        })
+        .map((runtimeEntry) => cloneSupportedMap(runtimeEntry.map));
+
+      return [...builtInMaps, ...runtimeMaps];
     },
     findSupportedMap(mapId: string): SupportedMap | null {
       const builtInMap = findCoreBaseSupportedMap(mapId);
@@ -1915,6 +2002,35 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       }
 
       return cloneDiceRuleSet(runtimeEntry.diceRuleSet);
+    },
+    findVictoryRuleSet(victoryRuleSetId: string): VictoryRuleSet | null {
+      const builtInVictoryRuleSet = findBuiltInVictoryRuleSet(victoryRuleSetId);
+      if (builtInVictoryRuleSet) {
+        return cloneVictoryRuleSet(builtInVictoryRuleSet);
+      }
+
+      const authoredVictoryRuleSet =
+        authoredVictoryRuleSets.find((entry) => entry.id === victoryRuleSetId) || null;
+      if (!authoredVictoryRuleSet) {
+        return null;
+      }
+
+      return cloneVictoryRuleSet({
+        id: authoredVictoryRuleSet.id,
+        name: authoredVictoryRuleSet.name,
+        description: authoredVictoryRuleSet.description,
+        source: authoredVictoryRuleSet.source,
+        mapId: authoredVictoryRuleSet.mapId || null,
+        objectiveCount:
+          typeof authoredVictoryRuleSet.objectiveCount === "number"
+            ? authoredVictoryRuleSet.objectiveCount
+            : undefined,
+        moduleType: authoredVictoryRuleSet.moduleType || null
+      });
+    },
+    findVictoryRuleSetRuntime(victoryRuleSetId: string): AuthoredVictoryModuleRuntime | null {
+      const runtime = authoredVictoryRuleSetRuntimesById.get(victoryRuleSetId);
+      return runtime ? cloneAuthoredVictoryRuntime(runtime) : null;
     },
     async getEnabledModules() {
       return enabledReferences(await ensureCatalog());
@@ -2229,6 +2345,14 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
         listEnabledRuntimePlayerPieceSets(selectedModuleEntries),
         listEnabledRuntimeDiceRuleSets(selectedModuleEntries)
       );
+      if (authoredVictoryRuleSets.length) {
+        selectedContent.victoryRuleSetIds = Array.from(
+          new Set([
+            ...(selectedContent.victoryRuleSetIds || []),
+            ...authoredVictoryRuleSets.map((entry) => entry.id)
+          ])
+        );
+      }
       const availableContentProfiles = new Set(
         selectedContentProfiles.map((profile) => profile.id)
       );

--- a/backend/new-game-config.cts
+++ b/backend/new-game-config.cts
@@ -52,6 +52,7 @@ import {
   type TurnTimeoutHoursValue
 } from "../shared/turn-timeouts.cjs";
 import type { SupportedMap } from "../shared/maps/index.cjs";
+import type { AuthoredVictoryModuleRuntime } from "../shared/runtime-validation.cjs";
 const { secureRandom } = require("./random.cjs");
 import { createLocalizedError, type LocalizedError } from "../shared/messages.cjs";
 import type { GameState } from "../shared/models.cjs";
@@ -217,7 +218,8 @@ function buildResolvedGameConfig(
   config: ValidatedNewGameConfig,
   moduleSelection: NetRiskGameModuleSelection,
   resolvedSetup: NetRiskResolvedModuleSetup | null | undefined,
-  hydratedConfigInput: NewGameConfigInput
+  hydratedConfigInput: NewGameConfigInput,
+  authoredVictoryRuntime: AuthoredVictoryModuleRuntime | null = null
 ): ExtensionAwareGameConfig {
   const clonedModuleSelection = cloneModuleSelection(moduleSelection);
 
@@ -253,6 +255,9 @@ function buildResolvedGameConfig(
     uiProfileId: clonedModuleSelection.uiProfileId || null,
     gameplayEffects: resolvedSetup?.gameplayEffects || null,
     scenarioSetup: resolvedSetup?.scenarioSetup || null,
+    victoryObjectiveModule: authoredVictoryRuntime
+      ? (JSON.parse(JSON.stringify(authoredVictoryRuntime)) as AuthoredVictoryModuleRuntime)
+      : null,
     turnTimeoutHours: config.turnTimeoutHours,
     totalPlayers: config.totalPlayers,
     players: config.players.map((player) => ({
@@ -377,6 +382,22 @@ export function validateNewGameConfig(
     throw createLocalizedError(
       "La regola vittoria selezionata non e supportata.",
       "newGame.invalidVictoryRuleSet"
+    );
+  }
+
+  if (
+    typeof selectedVictoryRuleSet.mapId === "string" &&
+    selectedVictoryRuleSet.mapId &&
+    selectedVictoryRuleSet.mapId !== selectedMap.id
+  ) {
+    throw createLocalizedError(
+      `La regola vittoria selezionata richiede la mappa "${selectedVictoryRuleSet.mapId}".`,
+      "newGame.invalidVictoryRuleSetMap",
+      {
+        requiredMapId: selectedVictoryRuleSet.mapId,
+        selectedMapId: selectedMap.id,
+        victoryRuleSetId: selectedVictoryRuleSet.id
+      }
     );
   }
 
@@ -516,6 +537,7 @@ export function createConfiguredInitialState(
     resolvePlayerPieceSet?: (pieceSetId: string) => PlayerPieceSet | null;
     resolveSupportedMap?: (mapId: string) => SupportedMap | null;
     resolveVictoryRuleSet?: (victoryRuleSetId: string) => VictoryRuleSet | null;
+    resolveVictoryRuleRuntime?: (victoryRuleSetId: string) => AuthoredVictoryModuleRuntime | null;
     resolveTheme?: (themeId: string) => VisualTheme | null;
     resolvePieceSkin?: (pieceSkinId: string) => PieceSkin | null;
     resolveGamePreset?: (input: {
@@ -737,6 +759,10 @@ export function createConfiguredInitialState(
           : config.moduleSelection;
 
       const finalizeConfiguredState = (moduleSelection: NetRiskGameModuleSelection) => {
+        const authoredVictoryRuntime =
+          typeof options.resolveVictoryRuleRuntime === "function"
+            ? options.resolveVictoryRuleRuntime(config.victoryRuleSetId)
+            : null;
         const state = createInitialState(config.selectedMap);
         state.contentPackId = config.contentPackId;
         state.diceRuleSetId = config.diceRuleSetId;
@@ -746,7 +772,8 @@ export function createConfiguredInitialState(
           config,
           moduleSelection,
           resolvedSetup || null,
-          hydratedConfigInput
+          hydratedConfigInput,
+          authoredVictoryRuntime
         );
 
         config.players.forEach((player) => {

--- a/backend/routes/admin-content-studio.cts
+++ b/backend/routes/admin-content-studio.cts
@@ -1,0 +1,551 @@
+const {
+  adminAuthoredModuleDetailResponseSchema,
+  adminAuthoredModuleEditorOptionsResponseSchema,
+  adminAuthoredModuleMutationResponseSchema,
+  adminAuthoredModulesListResponseSchema,
+  adminAuthoredModuleUpsertRequestSchema,
+  adminAuthoredModuleValidateResponseSchema
+} = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+
+type SendJson = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  payload: unknown,
+  headers?: Record<string, string>
+) => void;
+
+type SendLocalizedError = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  input: Record<string, unknown> | null,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams?: Record<string, unknown>,
+  code?: string | null,
+  extra?: Record<string, unknown>
+) => void;
+
+type RequireAuth = (
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  url?: URL | null
+) => Promise<{ user: { id: string; username: string; role?: string } } | null>;
+
+type Authorize = (action: string, context: Record<string, unknown>) => unknown;
+
+type AdminConsole = {
+  getAuthoredModuleEditorOptions(): Promise<unknown>;
+  listAuthoredModules(): Promise<unknown>;
+  getAuthoredModule(moduleId: string): Promise<unknown>;
+  validateAuthoredModuleDraft(input: Record<string, unknown>): Promise<unknown>;
+  saveAuthoredModuleDraft(
+    actor: { id: string; username: string; role?: string },
+    input: Record<string, unknown>
+  ): Promise<unknown>;
+  publishAuthoredModule(
+    actor: { id: string; username: string; role?: string },
+    moduleId: string
+  ): Promise<unknown>;
+  enableAuthoredModule(
+    actor: { id: string; username: string; role?: string },
+    moduleId: string
+  ): Promise<unknown>;
+  disableAuthoredModule(
+    actor: { id: string; username: string; role?: string },
+    moduleId: string
+  ): Promise<unknown>;
+  recordAudit?(input: {
+    actor: { id: string; username: string; role?: string };
+    action: string;
+    targetType: string;
+    targetId?: string | null;
+    targetLabel?: string | null;
+    result: "success" | "failure";
+    details?: Record<string, unknown> | null;
+  }): Promise<unknown>;
+};
+
+async function requireAdminAccess(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  url?: URL | null
+) {
+  const authContext = await requireAuth(req, res, body, url);
+  if (!authContext) {
+    return null;
+  }
+
+  authorize("admin:manage", { user: authContext.user });
+  return authContext;
+}
+
+async function tryRecordFailureAudit(
+  adminConsole: AdminConsole,
+  authContext: { user: { id: string; username: string; role?: string } } | null,
+  action: string,
+  targetId: string | null,
+  error: unknown
+) {
+  if (!authContext || typeof adminConsole.recordAudit !== "function") {
+    return;
+  }
+
+  try {
+    await adminConsole.recordAudit({
+      actor: authContext.user,
+      action,
+      targetType: "authored-module",
+      targetId,
+      targetLabel: null,
+      result: "failure",
+      details: {
+        error:
+          error && typeof error === "object" && "message" in error
+            ? String((error as { message?: unknown }).message || "")
+            : "unknown"
+      }
+    });
+  } catch {
+    // Audit persistence must not hide the primary failure.
+  }
+}
+
+function sendAuthoredModuleError(
+  res: import("node:http").ServerResponse,
+  sendLocalizedError: SendLocalizedError,
+  error: unknown,
+  fallbackMessage: string,
+  fallbackKey: string
+) {
+  const validation =
+    error && typeof error === "object" && "validation" in error
+      ? ((error as { validation?: unknown }).validation ?? null)
+      : null;
+
+  sendLocalizedError(
+    res,
+    error && typeof error === "object" && "statusCode" in error
+      ? Number((error as { statusCode?: unknown }).statusCode || 400)
+      : 400,
+    error as Record<string, unknown> | null,
+    fallbackMessage,
+    fallbackKey,
+    {},
+    null,
+    validation ? { validation } : {}
+  );
+}
+
+function ensureModuleIdMatchesPath(routeModuleId: string, bodyModuleId: string) {
+  if (routeModuleId !== bodyModuleId) {
+    throw new Error(`Request body module id "${bodyModuleId}" does not match route id "${routeModuleId}".`);
+  }
+}
+
+async function handleAdminContentStudioOptionsRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.getAuthoredModuleEditorOptions(),
+      adminAuthoredModuleEditorOptionsResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Content Studio options are unavailable.",
+      "server.admin.contentStudio.optionsUnavailable"
+    );
+  }
+}
+
+async function handleAdminContentStudioModulesRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.listAuthoredModules(),
+      adminAuthoredModulesListResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Content Studio modules are unavailable.",
+      "server.admin.contentStudio.modulesUnavailable"
+    );
+  }
+}
+
+async function handleAdminContentStudioModuleDetailRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  moduleId: string,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.getAuthoredModule(moduleId),
+      adminAuthoredModuleDetailResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 404,
+      error,
+      "Content Studio module not available.",
+      "server.admin.contentStudio.moduleUnavailable"
+    );
+  }
+}
+
+async function handleAdminContentStudioValidateRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminAuthoredModuleUpsertRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.validateAuthoredModuleDraft(parsedBody),
+      adminAuthoredModuleValidateResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendAuthoredModuleError(
+      res,
+      sendLocalizedError,
+      error,
+      "Module validation failed.",
+      "server.admin.contentStudio.validationFailed"
+    );
+  }
+}
+
+async function handleAdminContentStudioCreateRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminAuthoredModuleUpsertRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      201,
+      await adminConsole.saveAuthoredModuleDraft(authContext.user, parsedBody),
+      adminAuthoredModuleMutationResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "content-studio.module.save-draft",
+      typeof body.id === "string" ? body.id : null,
+      error
+    );
+    sendAuthoredModuleError(
+      res,
+      sendLocalizedError,
+      error,
+      "Unable to save the module draft.",
+      "server.admin.contentStudio.saveFailed"
+    );
+  }
+}
+
+async function handleAdminContentStudioUpdateRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  moduleId: string,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminAuthoredModuleUpsertRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    ensureModuleIdMatchesPath(moduleId, parsedBody.id);
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.saveAuthoredModuleDraft(authContext.user, parsedBody),
+      adminAuthoredModuleMutationResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "content-studio.module.save-draft",
+      moduleId,
+      error
+    );
+    sendAuthoredModuleError(
+      res,
+      sendLocalizedError,
+      error,
+      "Unable to update the module draft.",
+      "server.admin.contentStudio.updateFailed"
+    );
+  }
+}
+
+async function handleAdminContentStudioPublishRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  moduleId: string,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.publishAuthoredModule(authContext.user, moduleId),
+      adminAuthoredModuleMutationResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "content-studio.module.publish",
+      moduleId,
+      error
+    );
+    sendAuthoredModuleError(
+      res,
+      sendLocalizedError,
+      error,
+      "Unable to publish the module.",
+      "server.admin.contentStudio.publishFailed"
+    );
+  }
+}
+
+async function handleAdminContentStudioEnableRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  moduleId: string,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.enableAuthoredModule(authContext.user, moduleId),
+      adminAuthoredModuleMutationResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "content-studio.module.enable",
+      moduleId,
+      error
+    );
+    sendAuthoredModuleError(
+      res,
+      sendLocalizedError,
+      error,
+      "Unable to enable the module.",
+      "server.admin.contentStudio.enableFailed"
+    );
+  }
+}
+
+async function handleAdminContentStudioDisableRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  moduleId: string,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.disableAuthoredModule(authContext.user, moduleId),
+      adminAuthoredModuleMutationResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "content-studio.module.disable",
+      moduleId,
+      error
+    );
+    sendAuthoredModuleError(
+      res,
+      sendLocalizedError,
+      error,
+      "Unable to disable the module.",
+      "server.admin.contentStudio.disableFailed"
+    );
+  }
+}
+
+module.exports = {
+  handleAdminContentStudioCreateRoute,
+  handleAdminContentStudioModuleDetailRoute,
+  handleAdminContentStudioDisableRoute,
+  handleAdminContentStudioEnableRoute,
+  handleAdminContentStudioModulesRoute,
+  handleAdminContentStudioOptionsRoute,
+  handleAdminContentStudioPublishRoute,
+  handleAdminContentStudioUpdateRoute,
+  handleAdminContentStudioValidateRoute
+};

--- a/backend/routes/admin-content-studio.cts
+++ b/backend/routes/admin-content-studio.cts
@@ -143,7 +143,9 @@ function sendAuthoredModuleError(
 
 function ensureModuleIdMatchesPath(routeModuleId: string, bodyModuleId: string) {
   if (routeModuleId !== bodyModuleId) {
-    throw new Error(`Request body module id "${bodyModuleId}" does not match route id "${routeModuleId}".`);
+    throw new Error(
+      `Request body module id "${bodyModuleId}" does not match route id "${routeModuleId}".`
+    );
   }
 }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -5,6 +5,7 @@ const path = require("path");
 const { createAdminConsole } = require("./admin-console.cjs");
 const { loadLocalEnv } = require("./load-local-env.cjs");
 const { createDatastore } = require("./datastore.cjs");
+const { createAuthoredModulesService } = require("./authored-modules.cjs");
 const { createModuleRuntime } = require("./module-runtime.cjs");
 const { createAuthStore } = require("./auth.cjs");
 const { authorize } = require("./authorization.cjs");
@@ -60,6 +61,17 @@ const {
   handleModuleOptionsRoute,
   handleRescanModulesRoute
 } = require("./routes/modules.cjs");
+const {
+  handleAdminContentStudioCreateRoute,
+  handleAdminContentStudioModuleDetailRoute,
+  handleAdminContentStudioDisableRoute,
+  handleAdminContentStudioEnableRoute,
+  handleAdminContentStudioModulesRoute,
+  handleAdminContentStudioOptionsRoute,
+  handleAdminContentStudioPublishRoute,
+  handleAdminContentStudioUpdateRoute,
+  handleAdminContentStudioValidateRoute
+} = require("./routes/admin-content-studio.cjs");
 const {
   handleAdminAuditRoute,
   handleAdminConfigRoute,
@@ -297,9 +309,17 @@ function createApp(options: CreateAppOptions = {}) {
     legacySessionsFile:
       options.sessionsFile || path.join(runtimeProjectRoot, "data", "sessions.json")
   });
+  const authoredModules = createAuthoredModulesService({
+    datastore
+  });
   const moduleRuntime = createModuleRuntime({
     projectRoot: runtimeProjectRoot,
-    datastore
+    datastore,
+    authoredModules
+  });
+  authoredModules.setMapCatalog({
+    listMaps: () => moduleRuntime.listSupportedMaps(),
+    resolveMap: (mapId: string) => moduleRuntime.findSupportedMap(mapId)
   });
   const resolveCatalogMapName = (mapId: string | null | undefined) => {
     if (typeof mapId !== "string" || !mapId.trim()) {
@@ -333,7 +353,8 @@ function createApp(options: CreateAppOptions = {}) {
     persistGameContext,
     broadcastGame,
     createConfiguredInitialState,
-    moduleRuntime
+    moduleRuntime,
+    authoredModules
   });
 
   async function getSafeAdminDefaults() {
@@ -1059,6 +1080,146 @@ function createApp(options: CreateAppOptions = {}) {
       return;
     }
 
+    if (req.method === "GET" && url.pathname === "/api/admin/content-studio/options") {
+      await handleAdminContentStudioOptionsRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/content-studio/modules") {
+      await handleAdminContentStudioModulesRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/admin/content-studio/modules/validate") {
+      const body = await parseBody(req);
+      await handleAdminContentStudioValidateRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/admin/content-studio/modules") {
+      const body = await parseBody(req);
+      await handleAdminContentStudioCreateRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    const adminContentStudioDetailMatch = url.pathname.match(
+      /^\/api\/admin\/content-studio\/modules\/([^/]+)$/
+    );
+    if (req.method === "GET" && adminContentStudioDetailMatch) {
+      await handleAdminContentStudioModuleDetailRoute(
+        req,
+        res,
+        decodeURIComponent(adminContentStudioDetailMatch[1] || ""),
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "PUT" && adminContentStudioDetailMatch) {
+      const body = await parseBody(req);
+      await handleAdminContentStudioUpdateRoute(
+        req,
+        res,
+        decodeURIComponent(adminContentStudioDetailMatch[1] || ""),
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    const adminContentStudioPublishMatch = url.pathname.match(
+      /^\/api\/admin\/content-studio\/modules\/([^/]+)\/publish$/
+    );
+    if (req.method === "POST" && adminContentStudioPublishMatch) {
+      await handleAdminContentStudioPublishRoute(
+        req,
+        res,
+        decodeURIComponent(adminContentStudioPublishMatch[1] || ""),
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    const adminContentStudioEnableMatch = url.pathname.match(
+      /^\/api\/admin\/content-studio\/modules\/([^/]+)\/enable$/
+    );
+    if (req.method === "POST" && adminContentStudioEnableMatch) {
+      await handleAdminContentStudioEnableRoute(
+        req,
+        res,
+        decodeURIComponent(adminContentStudioEnableMatch[1] || ""),
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    const adminContentStudioDisableMatch = url.pathname.match(
+      /^\/api\/admin\/content-studio\/modules\/([^/]+)\/disable$/
+    );
+    if (req.method === "POST" && adminContentStudioDisableMatch) {
+      await handleAdminContentStudioDisableRoute(
+        req,
+        res,
+        decodeURIComponent(adminContentStudioDisableMatch[1] || ""),
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
     if (req.method === "GET" && url.pathname === "/api/cron/scheduled-jobs") {
       await handleScheduledJobsRoute(
         req,
@@ -1143,6 +1304,8 @@ function createApp(options: CreateAppOptions = {}) {
               resolvedCatalog.victoryRuleSets.find(
                 (entry: { id: string }) => entry.id === victoryRuleSetId
               ) || null,
+            resolveVictoryRuleRuntime: (victoryRuleSetId: string) =>
+              moduleRuntime.findVictoryRuleSetRuntime(victoryRuleSetId),
             resolveTheme: (themeId: string) =>
               resolvedCatalog.themes.find((entry: { id: string }) => entry.id === themeId) || null,
             resolvePieceSkin: (pieceSkinId: string) =>
@@ -1633,9 +1796,11 @@ function createApp(options: CreateAppOptions = {}) {
   return {
     adminConsole,
     auth,
+    authoredModules,
     datastore,
     handleApi,
     handleRequest,
+    moduleRuntime,
     parseBody,
     sendJson,
     server,

--- a/docs/codex-pr-readiness-gate.md
+++ b/docs/codex-pr-readiness-gate.md
@@ -1,0 +1,102 @@
+# Codex PR Readiness Gate
+
+## Scope
+
+This repository includes an automated readiness gate for draft pull requests created through the Codex workflow.
+
+The gate targets:
+
+- draft PRs whose head branch starts with `codex/`
+- draft PRs labeled `codex`
+- draft PRs authored directly by the Codex GitHub actor when that actor is the PR author
+
+It does not post noisy comments on unrelated pull requests.
+
+## Workflow
+
+The automation lives in [`.github/workflows/codex-pr-readiness.yml`](/D:/Andre/Documents/Playground/.github/workflows/codex-pr-readiness.yml) and runs on:
+
+- Codex-relevant draft PR events
+- Codex-relevant review activity
+- Codex-relevant comments that may contain a greenlight
+- completion of the main CI workflows (`Quality`, `Coverage`, `E2E Smoke`, `CodeQL Advanced`)
+- a recurring schedule every 30 minutes
+- manual dispatch
+
+The heavy logic is centralized in [`scripts/evaluate-codex-pr-readiness.cts`](/D:/Andre/Documents/Playground/scripts/evaluate-codex-pr-readiness.cts).
+
+## Hard blockers
+
+The gate keeps the PR in draft when any of these remain true:
+
+- a required GitHub check is missing, pending, or failed
+- the `quality` workflow cannot prove the required step-level requirements:
+  - repository typecheck
+  - React shell typecheck
+  - build
+  - lint
+  - format check
+  - React shell tests
+- the coverage job is not green
+- the E2E smoke job is not green
+- CodeQL is not green
+- the PR has unresolved review threads
+- the latest Codex signal after the current head commit is not an explicit greenlight
+- the PR branch is behind the base branch
+- GitHub reports the PR as not mergeable
+- newly introduced skipped tests are detected in changed test files
+- newly introduced `console.log`, `debugger`, `TODO`, `FIXME`, `temporary`, `placeholder`, or comment-style mock markers are detected in changed files unless allowlisted
+- required generated outputs are out of sync
+
+## Codex greenlight detection
+
+The gate treats Codex greenlight as one of:
+
+- an `APPROVED` review from `chatgpt-codex-connector`
+- a Codex-authored review or issue comment containing one of:
+  - `Codex greenlight`
+  - `Codex PR readiness: greenlight`
+  - `Codex final approval`
+
+The greenlight must be newer than the latest PR head commit. If a later Codex comment appears after that commit and it is not a greenlight, the gate blocks readiness.
+
+## Soft advisories
+
+The gate warns, but does not block, when it detects:
+
+- coverage risk from production changes without matching tests
+- significant production changes without docs updates
+- suspiciously large diffs
+- unusually low test additions relative to production additions
+
+## Sticky summary comment
+
+The gate maintains a single reusable PR summary comment marked with:
+
+`<!-- codex-pr-readiness-summary -->`
+
+It updates that comment in place and avoids duplicate status comments. If the body is unchanged, it does not patch the comment again.
+
+## Allowlists and tuning
+
+Behavior is tuned in [`.github/codex-pr-readiness.json`](/D:/Andre/Documents/Playground/.github/codex-pr-readiness.json), including:
+
+- target label and branch prefix
+- Codex actor list
+- greenlight phrases
+- required check names
+- required `quality` step names
+- freshness rule
+- allowlists for skipped tests and temporary markers
+- generated artifact sync requirements
+- advisory thresholds
+
+## Safety against false positives
+
+The evaluator reduces false positives by:
+
+- scanning only added diff lines for skipped tests and leftovers
+- allowing explicit per-path marker allowlists
+- checking generated sync only through explicit pair rules
+- requiring the latest Codex signal after the current head commit to be a greenlight
+- skipping unrelated PRs entirely

--- a/docs/content-studio-victory-objectives.md
+++ b/docs/content-studio-victory-objectives.md
@@ -1,0 +1,165 @@
+# Content Studio Victory Objectives
+
+This document describes the first authored gameplay-module flow shipped through the admin console.
+
+## Scope
+
+The new `Content Studio` admin area is the first constrained authoring surface for gameplay modules.
+In this phase it supports one module type:
+
+- `victory-objectives`
+
+The system is intentionally schema-driven. Admins can author validated objective modules without
+editing source files, but they cannot execute arbitrary code or upload scripts.
+
+## Authoring lifecycle
+
+Victory objective modules move through three states:
+
+- `draft`: editable and saveable even when validation errors still exist
+- `published`: validated and available in runtime victory-rule catalogs
+- `disabled`: previously published content that is hidden from runtime selection
+
+The admin UI supports:
+
+- listing existing authored modules
+- starting a new draft
+- editing an existing draft
+- validating the current draft continuously
+- publishing a valid draft
+- disabling or re-enabling a published module
+- inspecting the generated runtime JSON
+
+Published or disabled modules are read-only in this phase. If later revisioning is needed, the
+next step should introduce explicit draft-from-published versioning rather than in-place mutation.
+
+## Data model
+
+Shared transport and validation contracts live in `shared/runtime-validation.cts`.
+
+The authored module shape includes:
+
+- `id`
+- `name`
+- `description`
+- `version`
+- `status`
+- `moduleType`
+- `createdAt`
+- `updatedAt`
+- `content`
+
+For `victory-objectives`, `content` currently contains:
+
+- `mapId`
+- `objectives[]`
+
+Supported objective types in this phase:
+
+- `control-continents`
+- `control-territory-count`
+
+## Persistence
+
+Authored modules are persisted through the existing datastore app-state mechanism under the
+`authoredGameplayModules` key.
+
+That keeps the feature aligned with current NetRisk persistence patterns:
+
+- no hardcoded gameplay content in source files
+- no manual file editing by admins
+- no new persistence stack introduced just for authoring
+
+The service entry point is `backend/authored-modules.cts`.
+
+## Validation rules
+
+Validation happens on the backend and is exposed to the UI for live feedback.
+
+Current rules include:
+
+- required module id, name, description, version, and map
+- supported module type only
+- objective id uniqueness within a module
+- supported objective type only
+- valid continent ids for the selected map
+- valid territory count bounds for the selected map
+- at least one objective
+- at least one enabled objective before publish
+
+Drafts may remain invalid. Publishing and enabling require a clean validation result.
+
+## Runtime integration
+
+Published authored victory modules are merged into the runtime catalog by `backend/module-runtime.cts`.
+
+That means they now appear in:
+
+- `GET /api/game/options`
+- admin default selection flows
+- runtime victory-rule catalogs used during game creation
+
+When a game is created with an authored victory module:
+
+- the selected authored module id is stored in `gameConfig.victoryRuleSetId`
+- the resolved authored runtime payload is stored in `gameConfig.victoryObjectiveModule`
+
+The engine uses that persisted runtime payload in `backend/engine/victory-detection.cts` to
+evaluate authored objectives without needing an admin lookup at turn time.
+
+## Admin API
+
+The admin routes live in `backend/routes/admin-content-studio.cts`.
+
+Current endpoints:
+
+- `GET /api/admin/content-studio/options`
+- `GET /api/admin/content-studio/modules`
+- `GET /api/admin/content-studio/modules/:id`
+- `POST /api/admin/content-studio/modules/validate`
+- `POST /api/admin/content-studio/modules`
+- `PUT /api/admin/content-studio/modules/:id`
+- `POST /api/admin/content-studio/modules/:id/publish`
+- `POST /api/admin/content-studio/modules/:id/enable`
+- `POST /api/admin/content-studio/modules/:id/disable`
+
+These routes reuse the existing admin authorization and audit flow through `backend/admin-console.cts`.
+
+## UI structure
+
+The React screen is extracted into `frontend/react-shell/src/admin-content-studio.tsx`.
+
+The monolithic admin route only owns:
+
+- navigation
+- section selection
+- shell framing
+
+The authoring screen owns:
+
+- module list
+- draft editor
+- objective editor
+- live validation
+- player-facing preview
+- generated runtime JSON
+
+## Extension path for future module types
+
+The current model is intentionally narrow but extendable.
+
+The next constrained authoring types should follow the same pattern:
+
+1. add a shared schema and runtime payload
+2. add backend validation and persistence rules
+3. add an editor surface in Content Studio
+4. merge published output into the runtime catalog
+5. persist resolved runtime data into `gameConfig` when selected
+6. let the engine consume the resolved payload directly
+
+Good next candidates:
+
+- reinforcement modifiers
+- alternate combat rule selections
+- scenario start bonuses
+- map-specific setup constraints

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -1,6 +1,11 @@
 import { screen, waitFor } from "@testing-library/react";
 
 import type {
+  AdminAuthoredModuleDetailResponse,
+  AdminAuthoredModuleEditorOptionsResponse,
+  AdminAuthoredModuleMutationResponse,
+  AdminAuthoredModulesListResponse,
+  AdminAuthoredModuleValidateResponse,
   AdminConfigResponse,
   AdminGameDetailsResponse,
   AdminGamesResponse,
@@ -13,19 +18,28 @@ import type {
 } from "@frontend-generated/shared-runtime-validation.mts";
 
 import {
+  createAdminAuthoredModule,
+  disableAdminAuthoredModule,
+  enableAdminAuthoredModule,
+  getAdminAuthoredModule,
+  getAdminContentStudioOptions,
   getAdminConfig,
   getAdminGameDetails,
   getAdminMaintenanceReport,
   getAdminOverview,
   getGameOptions,
+  listAdminAuthoredModules,
   getModuleOptions,
+  publishAdminAuthoredModule,
   getSession,
   listAdminGames,
   listAdminUsers,
   runAdminGameAction,
   runAdminMaintenanceAction,
+  updateAdminAuthoredModule,
   updateAdminConfig,
-  updateAdminUserRole
+  updateAdminUserRole,
+  validateAdminAuthoredModule
 } from "@frontend-core/api/client.mts";
 
 import { renderReactShell } from "../../test/render-react-shell";
@@ -46,6 +60,15 @@ vi.mock("@frontend-core/api/client.mts", () => ({
   openGame: vi.fn(),
   joinGame: vi.fn(),
   getAdminOverview: vi.fn(),
+  getAdminContentStudioOptions: vi.fn(),
+  listAdminAuthoredModules: vi.fn(),
+  getAdminAuthoredModule: vi.fn(),
+  validateAdminAuthoredModule: vi.fn(),
+  createAdminAuthoredModule: vi.fn(),
+  updateAdminAuthoredModule: vi.fn(),
+  publishAdminAuthoredModule: vi.fn(),
+  enableAdminAuthoredModule: vi.fn(),
+  disableAdminAuthoredModule: vi.fn(),
   listAdminUsers: vi.fn(),
   updateAdminUserRole: vi.fn(),
   listAdminGames: vi.fn(),
@@ -59,6 +82,15 @@ vi.mock("@frontend-core/api/client.mts", () => ({
 }));
 
 const getAdminOverviewMock = vi.mocked(getAdminOverview);
+const getAdminContentStudioOptionsMock = vi.mocked(getAdminContentStudioOptions);
+const listAdminAuthoredModulesMock = vi.mocked(listAdminAuthoredModules);
+const getAdminAuthoredModuleMock = vi.mocked(getAdminAuthoredModule);
+const validateAdminAuthoredModuleMock = vi.mocked(validateAdminAuthoredModule);
+const createAdminAuthoredModuleMock = vi.mocked(createAdminAuthoredModule);
+const updateAdminAuthoredModuleMock = vi.mocked(updateAdminAuthoredModule);
+const publishAdminAuthoredModuleMock = vi.mocked(publishAdminAuthoredModule);
+const enableAdminAuthoredModuleMock = vi.mocked(enableAdminAuthoredModule);
+const disableAdminAuthoredModuleMock = vi.mocked(disableAdminAuthoredModule);
 const getAdminConfigMock = vi.mocked(getAdminConfig);
 const getAdminGameDetailsMock = vi.mocked(getAdminGameDetails);
 const getAdminMaintenanceReportMock = vi.mocked(getAdminMaintenanceReport);
@@ -502,10 +534,181 @@ function createMaintenanceReport(): AdminMaintenanceReport {
   };
 }
 
+function createContentStudioOptionsResponse(): AdminAuthoredModuleEditorOptionsResponse {
+  return {
+    moduleTypes: ["victory-objectives"],
+    maps: [
+      {
+        id: "classic-mini",
+        name: "Classic Mini",
+        territoryCount: 42,
+        continentCount: 6,
+        continents: [
+          {
+            id: "north_america",
+            name: "North America",
+            bonus: 5,
+            territoryCount: 9
+          },
+          {
+            id: "asia",
+            name: "Asia",
+            bonus: 7,
+            territoryCount: 12
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function createAuthoredModuleDetail(
+  overrides: Partial<AdminAuthoredModuleDetailResponse["module"]> = {}
+): AdminAuthoredModuleDetailResponse {
+  return {
+    module: {
+      id: "victory.na-asia",
+      name: "North America and Asia",
+      description: "Control both continents simultaneously.",
+      version: "1.0.0",
+      status: "draft",
+      moduleType: "victory-objectives",
+      createdAt: "2026-04-21T09:00:00.000Z",
+      updatedAt: "2026-04-21T10:00:00.000Z",
+      content: {
+        mapId: "classic-mini",
+        objectives: [
+          {
+            id: "hold-na-asia",
+            title: "Hold North America and Asia",
+            description: "Control North America and Asia at the same time.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america", "asia"]
+          }
+        ]
+      },
+      ...overrides
+    },
+    validation: {
+      valid: true,
+      errors: [],
+      warnings: []
+    },
+    preview: {
+      summary: "Win condition: Control North America and Asia simultaneously.",
+      objectiveSummaries: ["Control North America and Asia simultaneously."]
+    },
+    runtime: {
+      id: "victory.na-asia",
+      name: "North America and Asia",
+      description: "Control both continents simultaneously.",
+      version: "1.0.0",
+      moduleType: "victory-objectives",
+      kind: "authored-victory-objectives",
+      map: {
+        id: "classic-mini",
+        name: "Classic Mini",
+        territoryCount: 42,
+        continentCount: 6
+      },
+      objectives: [
+        {
+          id: "hold-na-asia",
+          title: "Hold North America and Asia",
+          description: "Control North America and Asia at the same time.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america", "asia"],
+          continentNames: ["North America", "Asia"],
+          summary: "Control North America and Asia simultaneously."
+        }
+      ],
+      preview: {
+        summary: "Win condition: Control North America and Asia simultaneously.",
+        objectiveSummaries: ["Control North America and Asia simultaneously."]
+      }
+    }
+  };
+}
+
+function createAuthoredModulesResponse(): AdminAuthoredModulesListResponse {
+  const detail = createAuthoredModuleDetail();
+
+  return {
+    modules: [
+      {
+        ...detail.module,
+        validation: detail.validation,
+        preview: detail.preview,
+        map: {
+          id: "classic-mini",
+          name: "Classic Mini",
+          territoryCount: 42,
+          continentCount: 6
+        },
+        objectiveCount: 1,
+        enabledObjectiveCount: 1
+      }
+    ]
+  };
+}
+
+function createAuthoredValidationResponse(): AdminAuthoredModuleValidateResponse {
+  const detail = createAuthoredModuleDetail();
+
+  return {
+    validation: detail.validation,
+    preview: detail.preview,
+    runtime: detail.runtime
+  };
+}
+
+function createAuthoredMutationResponse(
+  overrides: Partial<AdminAuthoredModuleDetailResponse["module"]> = {}
+): AdminAuthoredModuleMutationResponse {
+  const detail = createAuthoredModuleDetail(overrides);
+
+  return {
+    ok: true,
+    module: detail.module,
+    validation: detail.validation,
+    preview: detail.preview,
+    runtime: detail.runtime,
+    audit: createAuditEntry({
+      action: "content-studio.module.save-draft",
+      targetType: "authored-module",
+      targetId: detail.module.id,
+      targetLabel: detail.module.name
+    })
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   getModuleOptionsMock.mockResolvedValue(emptyModuleOptions());
   getAdminOverviewMock.mockResolvedValue(createOverviewResponse());
+  getAdminContentStudioOptionsMock.mockResolvedValue(createContentStudioOptionsResponse());
+  listAdminAuthoredModulesMock.mockResolvedValue(createAuthoredModulesResponse());
+  getAdminAuthoredModuleMock.mockResolvedValue(createAuthoredModuleDetail());
+  validateAdminAuthoredModuleMock.mockResolvedValue(createAuthoredValidationResponse());
+  createAdminAuthoredModuleMock.mockResolvedValue(createAuthoredMutationResponse());
+  updateAdminAuthoredModuleMock.mockResolvedValue(createAuthoredMutationResponse());
+  publishAdminAuthoredModuleMock.mockResolvedValue(
+    createAuthoredMutationResponse({
+      status: "published"
+    })
+  );
+  enableAdminAuthoredModuleMock.mockResolvedValue(
+    createAuthoredMutationResponse({
+      status: "published"
+    })
+  );
+  disableAdminAuthoredModuleMock.mockResolvedValue(
+    createAuthoredMutationResponse({
+      status: "disabled"
+    })
+  );
   getSessionMock.mockResolvedValue(createSession("ember", "admin"));
 });
 
@@ -742,5 +945,53 @@ describe("Admin route integration", () => {
         expect.anything()
       );
     });
+  });
+
+  it("loads the content studio editor, shows preview data, and saves a draft", async () => {
+    const { user } = renderReactShell("/react/admin/content-studio");
+
+    expect(await screen.findByText("Author victory objective modules")).toBeInTheDocument();
+    expect(await screen.findByText("North America and Asia")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Win condition: Control North America and Asia simultaneously.")
+    ).toBeInTheDocument();
+
+    const nameField = (await screen.findByRole("textbox", {
+      name: "Name"
+    })) as HTMLInputElement;
+    expect(nameField.value).toBe("North America and Asia");
+
+    await user.clear(nameField);
+    await user.type(nameField, "Updated objective module");
+
+    await waitFor(() => {
+      expect(validateAdminAuthoredModuleMock).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save draft" }));
+
+    await waitFor(() => {
+      expect(updateAdminAuthoredModuleMock).toHaveBeenCalledWith(
+        "victory.na-asia",
+        expect.objectContaining({
+          id: "victory.na-asia",
+          name: "Updated objective module",
+          moduleType: "victory-objectives"
+        }),
+        expect.anything()
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+
+    await waitFor(() => {
+      expect(publishAdminAuthoredModuleMock).toHaveBeenCalledWith(
+        "victory.na-asia",
+        expect.anything()
+      );
+    });
+
+    expect(screen.getByText("Engine-ready JSON")).toBeInTheDocument();
+    expect(screen.getByText(/authored-victory-objectives/)).toBeInTheDocument();
   });
 });

--- a/frontend/react-shell/src/admin-content-studio.tsx
+++ b/frontend/react-shell/src/admin-content-studio.tsx
@@ -133,9 +133,7 @@ function createObjective(
   };
 }
 
-function createEmptyDraft(
-  mapOption: AuthoredMapOption | null
-): EditorDraft {
+function createEmptyDraft(mapOption: AuthoredMapOption | null): EditorDraft {
   return {
     id: "",
     name: "",
@@ -218,7 +216,10 @@ function ValidationPanel({ inspection }: { inspection: ContentStudioInspection |
       ) : (
         <ul className="content-studio-validation-list">
           {errors.map((entry) => (
-            <li key={`${entry.path}-${entry.code}`} className="content-studio-validation-item is-error">
+            <li
+              key={`${entry.path}-${entry.code}`}
+              className="content-studio-validation-item is-error"
+            >
               <strong>{entry.code}</strong>
               <p>{entry.message}</p>
               <span>{entry.path}</span>
@@ -275,11 +276,7 @@ function RuntimePanel({ inspection }: { inspection: ContentStudioInspection | nu
   );
 }
 
-export function AdminContentStudioSection({
-  frameContext
-}: {
-  frameContext: AdminFrameContext;
-}) {
+export function AdminContentStudioSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const queryClient = useQueryClient();
   const [selectedEditorKey, setSelectedEditorKey] = useState<string | null>(null);
   const [draft, setDraft] = useState<EditorDraft | null>(null);
@@ -350,7 +347,10 @@ export function AdminContentStudioSection({
       return;
     }
 
-    if (!activeObjectiveId || !draft.content.objectives.some((entry) => entry.id === activeObjectiveId)) {
+    if (
+      !activeObjectiveId ||
+      !draft.content.objectives.some((entry) => entry.id === activeObjectiveId)
+    ) {
       setActiveObjectiveId(draft.content.objectives[0]?.id || null);
     }
   }, [activeObjectiveId, draft]);
@@ -466,10 +466,7 @@ export function AdminContentStudioSection({
     setDraft(nextDraft);
   }
 
-  function updateModuleField<K extends keyof EditorDraft>(
-    key: K,
-    value: EditorDraft[K]
-  ) {
+  function updateModuleField<K extends keyof EditorDraft>(key: K, value: EditorDraft[K]) {
     if (!draft) {
       return;
     }
@@ -527,7 +524,9 @@ export function AdminContentStudioSection({
       return;
     }
 
-    const nextObjectives = draft.content.objectives.filter((objective) => objective.id !== objectiveId);
+    const nextObjectives = draft.content.objectives.filter(
+      (objective) => objective.id !== objectiveId
+    );
     updateDraft({
       ...draft,
       content: {
@@ -583,7 +582,9 @@ export function AdminContentStudioSection({
     draft?.content.objectives.find((objective) => objective.id === activeObjectiveId) || null;
   const latestInspection = currentInspection(detailQuery.data, inspection);
   const modules = modulesQuery.data?.modules || [];
-  const isEditableDraft = Boolean(draft && (isNewDraft || detailQuery.data?.module.status === "draft"));
+  const isEditableDraft = Boolean(
+    draft && (isNewDraft || detailQuery.data?.module.status === "draft")
+  );
   const isBusy =
     validateMutation.isPending ||
     saveMutation.isPending ||
@@ -657,7 +658,9 @@ export function AdminContentStudioSection({
       <section className="card-panel admin-toolbar-panel admin-toolbar-panel-sticky">
         <div className="admin-toolbar admin-toolbar-dense">
           <div className="admin-toolbar-summary">
-            <span className={`chip ${moduleStatusTone(draft?.status || detailQuery.data?.module.status)}`}>
+            <span
+              className={`chip ${moduleStatusTone(draft?.status || detailQuery.data?.module.status)}`}
+            >
               {moduleStatusLabel(draft?.status || detailQuery.data?.module.status)}
             </span>
             <span className={`chip ${validationTone(latestInspection?.validation.valid)}`}>
@@ -711,7 +714,10 @@ export function AdminContentStudioSection({
         </div>
       </section>
 
-      {saveMutation.isError || publishMutation.isError || enableMutation.isError || disableMutation.isError ? (
+      {saveMutation.isError ||
+      publishMutation.isError ||
+      enableMutation.isError ||
+      disableMutation.isError ? (
         <section className="status-panel status-panel-error">
           <p className="status-label">Content Studio</p>
           <h2>Last mutation failed</h2>
@@ -920,7 +926,9 @@ export function AdminContentStudioSection({
                         >
                           <div className="admin-list-copy">
                             <strong>{objective.title || `Objective ${index + 1}`}</strong>
-                            <span>{objective.description || "No player-facing description yet."}</span>
+                            <span>
+                              {objective.description || "No player-facing description yet."}
+                            </span>
                             <span className="admin-item-meta">
                               {objective.id || "missing-id"} · {objectiveTypeLabel(objective.type)}
                             </span>
@@ -984,7 +992,9 @@ export function AdminContentStudioSection({
                               }
                               disabled={!isEditableDraft}
                             >
-                              <option value="control-continents">Control specific continents</option>
+                              <option value="control-continents">
+                                Control specific continents
+                              </option>
                               <option value="control-territory-count">
                                 Control minimum territory count
                               </option>
@@ -1042,7 +1052,9 @@ export function AdminContentStudioSection({
                             </p>
                             <div className="content-studio-chip-row">
                               {(selectedMap?.continents || []).map((continent) => {
-                                const selected = activeObjective.continentIds.includes(continent.id);
+                                const selected = activeObjective.continentIds.includes(
+                                  continent.id
+                                );
                                 return (
                                   <button
                                     key={continent.id}
@@ -1068,7 +1080,8 @@ export function AdminContentStudioSection({
                                   >
                                     <strong>{continent.name}</strong>
                                     <span>
-                                      {continent.territoryCount} territories · bonus {continent.bonus}
+                                      {continent.territoryCount} territories · bonus{" "}
+                                      {continent.bonus}
                                     </span>
                                   </button>
                                 );
@@ -1096,7 +1109,8 @@ export function AdminContentStudioSection({
                               disabled={!isEditableDraft}
                             />
                             <small>
-                              Must be between 1 and {selectedMap?.territoryCount || "the map limit"}.
+                              Must be between 1 and {selectedMap?.territoryCount || "the map limit"}
+                              .
                             </small>
                           </label>
                         )}

--- a/frontend/react-shell/src/admin-content-studio.tsx
+++ b/frontend/react-shell/src/admin-content-studio.tsx
@@ -1049,14 +1049,20 @@ export function AdminContentStudioSection({
                                     type="button"
                                     className={`content-studio-chip${selected ? " is-selected" : ""}`}
                                     onClick={() =>
-                                      updateObjective(activeObjective.id, (objective) => ({
-                                        ...objective,
-                                        continentIds: selected
-                                          ? objective.continentIds.filter(
-                                              (entry) => entry !== continent.id
-                                            )
-                                          : [...objective.continentIds, continent.id]
-                                      }))
+                                      updateObjective(activeObjective.id, (objective) => {
+                                        if (objective.type !== "control-continents") {
+                                          return objective;
+                                        }
+
+                                        return {
+                                          ...objective,
+                                          continentIds: selected
+                                            ? objective.continentIds.filter(
+                                                (entry) => entry !== continent.id
+                                              )
+                                            : [...objective.continentIds, continent.id]
+                                        };
+                                      })
                                     }
                                     disabled={!isEditableDraft}
                                   >
@@ -1078,10 +1084,14 @@ export function AdminContentStudioSection({
                               max={selectedMap?.territoryCount || 42}
                               value={String(activeObjective.territoryCount)}
                               onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) => ({
-                                  ...objective,
-                                  territoryCount: Number(event.target.value || "0")
-                                }))
+                                updateObjective(activeObjective.id, (objective) =>
+                                  objective.type !== "control-territory-count"
+                                    ? objective
+                                    : {
+                                        ...objective,
+                                        territoryCount: Number(event.target.value || "0")
+                                      }
+                                )
                               }
                               disabled={!isEditableDraft}
                             />

--- a/frontend/react-shell/src/admin-content-studio.tsx
+++ b/frontend/react-shell/src/admin-content-studio.tsx
@@ -1,0 +1,1132 @@
+import { useDeferredValue, useEffect, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+  AdminAuthoredModuleDetailResponse,
+  AdminAuthoredModuleUpsertRequest,
+  AuthoredMapOption,
+  AuthoredVictoryObjective
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+import {
+  createAdminAuthoredModule,
+  disableAdminAuthoredModule,
+  enableAdminAuthoredModule,
+  getAdminAuthoredModule,
+  getAdminContentStudioOptions,
+  listAdminAuthoredModules,
+  publishAdminAuthoredModule,
+  updateAdminAuthoredModule,
+  validateAdminAuthoredModule
+} from "@frontend-core/api/client.mts";
+import { messageFromError } from "@frontend-core/errors.mts";
+import { formatDate } from "@frontend-i18n";
+
+import {
+  adminContentStudioModuleDetailQueryKey,
+  adminContentStudioModulesQueryKey,
+  adminContentStudioOptionsQueryKey,
+  gameOptionsQueryKey
+} from "@react-shell/react-query";
+
+type AdminFrameContext = {
+  basePath: string;
+  currentUser: {
+    id: string;
+    username: string;
+    role?: string | null;
+  };
+  environmentLabel: string;
+  hostLabel: string;
+  sectionLabel: string;
+};
+
+type ContentStudioInspection = Pick<
+  AdminAuthoredModuleDetailResponse,
+  "validation" | "preview" | "runtime"
+>;
+
+type EditorDraft = AdminAuthoredModuleUpsertRequest & {
+  status?: "draft" | "published" | "disabled";
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+const NEW_MODULE_KEY = "__content-studio-new__";
+
+function requestMessages(scope: string) {
+  return {
+    errorMessage: `Unable to load ${scope}.`,
+    fallbackMessage: `Unable to validate ${scope}.`
+  };
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return "n/a";
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "n/a";
+  }
+
+  return formatDate(parsed, {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function moduleStatusTone(status: string | null | undefined): "accent" | "danger" | "muted" {
+  if (status === "published") {
+    return "accent";
+  }
+
+  if (status === "disabled") {
+    return "danger";
+  }
+
+  return "muted";
+}
+
+function validationTone(valid: boolean | null | undefined): "success" | "warning" {
+  return valid ? "success" : "warning";
+}
+
+function firstMap(options: { maps: AuthoredMapOption[] } | undefined): AuthoredMapOption | null {
+  return options?.maps?.[0] || null;
+}
+
+function createObjectiveId(index: number): string {
+  return `objective-${index + 1}`;
+}
+
+function createObjective(
+  index: number,
+  type: AuthoredVictoryObjective["type"]
+): AuthoredVictoryObjective {
+  if (type === "control-territory-count") {
+    return {
+      id: createObjectiveId(index),
+      title: `Territory control ${index + 1}`,
+      description: "Own the configured number of territories.",
+      enabled: true,
+      type,
+      territoryCount: 24
+    };
+  }
+
+  return {
+    id: createObjectiveId(index),
+    title: `Continent control ${index + 1}`,
+    description: "Control the selected continents at the same time.",
+    enabled: true,
+    type,
+    continentIds: []
+  };
+}
+
+function createEmptyDraft(
+  mapOption: AuthoredMapOption | null
+): EditorDraft {
+  return {
+    id: "",
+    name: "",
+    description: "",
+    version: "1.0.0",
+    moduleType: "victory-objectives",
+    content: {
+      mapId: mapOption?.id || "",
+      objectives: [createObjective(0, "control-continents")]
+    }
+  };
+}
+
+function toUpsertRequest(draft: EditorDraft): AdminAuthoredModuleUpsertRequest {
+  return {
+    id: draft.id,
+    name: draft.name,
+    description: draft.description,
+    version: draft.version,
+    moduleType: draft.moduleType,
+    content: {
+      mapId: draft.content.mapId,
+      objectives: draft.content.objectives.map((objective) => clone(objective))
+    }
+  };
+}
+
+function currentInspection(
+  detail: AdminAuthoredModuleDetailResponse | undefined,
+  inspection: ContentStudioInspection | null
+): ContentStudioInspection | null {
+  if (inspection) {
+    return inspection;
+  }
+
+  if (!detail) {
+    return null;
+  }
+
+  return {
+    validation: detail.validation,
+    preview: detail.preview,
+    runtime: detail.runtime
+  };
+}
+
+function moduleStatusLabel(status: string | null | undefined): string {
+  if (status === "published") {
+    return "Published";
+  }
+
+  if (status === "disabled") {
+    return "Disabled";
+  }
+
+  return "Draft";
+}
+
+function objectiveTypeLabel(type: AuthoredVictoryObjective["type"]): string {
+  return type === "control-territory-count" ? "Territory count" : "Specific continents";
+}
+
+function ValidationPanel({ inspection }: { inspection: ContentStudioInspection | null }) {
+  const errors = inspection?.validation.errors || [];
+  const warnings = inspection?.validation.warnings || [];
+
+  return (
+    <section className="card-panel content-studio-side-panel">
+      <div className="card-header">
+        <div>
+          <p className="status-label">Validation</p>
+          <h3>Publish gate</h3>
+        </div>
+        <span className={`badge ${inspection?.validation.valid ? "success" : "warning"}`}>
+          {inspection?.validation.valid ? "Ready to publish" : "Needs fixes"}
+        </span>
+      </div>
+      {!errors.length && !warnings.length ? (
+        <p className="admin-item-meta">No validation issues detected for the current draft.</p>
+      ) : (
+        <ul className="content-studio-validation-list">
+          {errors.map((entry) => (
+            <li key={`${entry.path}-${entry.code}`} className="content-studio-validation-item is-error">
+              <strong>{entry.code}</strong>
+              <p>{entry.message}</p>
+              <span>{entry.path}</span>
+            </li>
+          ))}
+          {warnings.map((entry) => (
+            <li
+              key={`${entry.path}-${entry.code}`}
+              className="content-studio-validation-item is-warning"
+            >
+              <strong>{entry.code}</strong>
+              <p>{entry.message}</p>
+              <span>{entry.path}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function PreviewPanel({ inspection }: { inspection: ContentStudioInspection | null }) {
+  return (
+    <section className="card-panel content-studio-side-panel">
+      <div className="card-header">
+        <div>
+          <p className="status-label">Live preview</p>
+          <h3>Player-facing summary</h3>
+        </div>
+      </div>
+      <p className="content-studio-summary">{inspection?.preview.summary || "No preview yet."}</p>
+      <ul className="content-studio-preview-list">
+        {(inspection?.preview.objectiveSummaries || []).map((entry, index) => (
+          <li key={`${entry}-${index}`}>{entry}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function RuntimePanel({ inspection }: { inspection: ContentStudioInspection | null }) {
+  return (
+    <section className="card-panel content-studio-side-panel">
+      <div className="card-header">
+        <div>
+          <p className="status-label">Generated runtime</p>
+          <h3>Engine-ready JSON</h3>
+        </div>
+      </div>
+      <pre className="content-studio-runtime-json">
+        {JSON.stringify(inspection?.runtime || {}, null, 2)}
+      </pre>
+    </section>
+  );
+}
+
+export function AdminContentStudioSection({
+  frameContext
+}: {
+  frameContext: AdminFrameContext;
+}) {
+  const queryClient = useQueryClient();
+  const [selectedEditorKey, setSelectedEditorKey] = useState<string | null>(null);
+  const [draft, setDraft] = useState<EditorDraft | null>(null);
+  const [inspection, setInspection] = useState<ContentStudioInspection | null>(null);
+  const [activeObjectiveId, setActiveObjectiveId] = useState<string | null>(null);
+  const selectedModuleId =
+    selectedEditorKey && selectedEditorKey !== NEW_MODULE_KEY ? selectedEditorKey : null;
+  const isNewDraft = selectedEditorKey === NEW_MODULE_KEY;
+
+  const optionsQuery = useQuery({
+    queryKey: adminContentStudioOptionsQueryKey(),
+    queryFn: () => getAdminContentStudioOptions(requestMessages("Content Studio options"))
+  });
+
+  const modulesQuery = useQuery({
+    queryKey: adminContentStudioModulesQueryKey(),
+    queryFn: () => listAdminAuthoredModules(requestMessages("Content Studio modules"))
+  });
+
+  const detailQuery = useQuery({
+    queryKey: adminContentStudioModuleDetailQueryKey(selectedModuleId),
+    queryFn: () =>
+      getAdminAuthoredModule(
+        selectedModuleId as string,
+        requestMessages(`module ${selectedModuleId || ""}`)
+      ),
+    enabled: Boolean(selectedModuleId)
+  });
+
+  const deferredDraft = useDeferredValue(draft);
+
+  useEffect(() => {
+    if (selectedEditorKey !== null || !modulesQuery.data) {
+      return;
+    }
+
+    setSelectedEditorKey(modulesQuery.data.modules[0]?.id || NEW_MODULE_KEY);
+  }, [modulesQuery.data, selectedEditorKey]);
+
+  useEffect(() => {
+    if (!isNewDraft || !optionsQuery.data) {
+      return;
+    }
+
+    const nextDraft = createEmptyDraft(firstMap(optionsQuery.data));
+    setDraft(nextDraft);
+    setInspection(null);
+    setActiveObjectiveId(nextDraft.content.objectives[0]?.id || null);
+  }, [isNewDraft, optionsQuery.data]);
+
+  useEffect(() => {
+    if (!detailQuery.data || !selectedModuleId) {
+      return;
+    }
+
+    setDraft(clone(detailQuery.data.module));
+    setInspection({
+      validation: detailQuery.data.validation,
+      preview: detailQuery.data.preview,
+      runtime: detailQuery.data.runtime
+    });
+    setActiveObjectiveId(detailQuery.data.module.content.objectives[0]?.id || null);
+  }, [detailQuery.data, selectedModuleId]);
+
+  useEffect(() => {
+    if (!draft?.content.objectives.length) {
+      setActiveObjectiveId(null);
+      return;
+    }
+
+    if (!activeObjectiveId || !draft.content.objectives.some((entry) => entry.id === activeObjectiveId)) {
+      setActiveObjectiveId(draft.content.objectives[0]?.id || null);
+    }
+  }, [activeObjectiveId, draft]);
+
+  const listMutationKeys = [
+    adminContentStudioModulesQueryKey(),
+    adminContentStudioModuleDetailQueryKey(selectedModuleId),
+    gameOptionsQueryKey()
+  ];
+
+  const validateMutation = useMutation({
+    mutationFn: (request: AdminAuthoredModuleUpsertRequest) =>
+      validateAdminAuthoredModule(request, requestMessages("module draft")),
+    onSuccess(payload) {
+      setInspection(payload);
+    }
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (request: AdminAuthoredModuleUpsertRequest) =>
+      selectedModuleId
+        ? updateAdminAuthoredModule(selectedModuleId, request, requestMessages("module draft"))
+        : createAdminAuthoredModule(request, requestMessages("module draft")),
+    onSuccess(payload) {
+      setSelectedEditorKey(payload.module.id);
+      setDraft(clone(payload.module));
+      setInspection({
+        validation: payload.validation,
+        preview: payload.preview,
+        runtime: payload.runtime
+      });
+      setActiveObjectiveId(payload.module.content.objectives[0]?.id || null);
+      listMutationKeys.forEach((queryKey) => {
+        void queryClient.invalidateQueries({ queryKey });
+      });
+    }
+  });
+
+  const publishMutation = useMutation({
+    mutationFn: (moduleId: string) =>
+      publishAdminAuthoredModule(moduleId, requestMessages(`module ${moduleId}`)),
+    onSuccess(payload) {
+      setDraft(clone(payload.module));
+      setInspection({
+        validation: payload.validation,
+        preview: payload.preview,
+        runtime: payload.runtime
+      });
+      listMutationKeys.forEach((queryKey) => {
+        void queryClient.invalidateQueries({ queryKey });
+      });
+    }
+  });
+
+  const enableMutation = useMutation({
+    mutationFn: (moduleId: string) =>
+      enableAdminAuthoredModule(moduleId, requestMessages(`module ${moduleId}`)),
+    onSuccess(payload) {
+      setDraft(clone(payload.module));
+      setInspection({
+        validation: payload.validation,
+        preview: payload.preview,
+        runtime: payload.runtime
+      });
+      listMutationKeys.forEach((queryKey) => {
+        void queryClient.invalidateQueries({ queryKey });
+      });
+    }
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: (moduleId: string) =>
+      disableAdminAuthoredModule(moduleId, requestMessages(`module ${moduleId}`)),
+    onSuccess(payload) {
+      setDraft(clone(payload.module));
+      setInspection({
+        validation: payload.validation,
+        preview: payload.preview,
+        runtime: payload.runtime
+      });
+      listMutationKeys.forEach((queryKey) => {
+        void queryClient.invalidateQueries({ queryKey });
+      });
+    }
+  });
+
+  useEffect(() => {
+    if (!deferredDraft) {
+      return;
+    }
+
+    const isEditableDraft = isNewDraft || detailQuery.data?.module.status === "draft";
+    if (!isEditableDraft) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      validateMutation.mutate(toUpsertRequest(clone(deferredDraft)));
+    }, 220);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [deferredDraft, detailQuery.data?.module.status, isNewDraft]);
+
+  function startNewDraft() {
+    const nextDraft = createEmptyDraft(firstMap(optionsQuery.data));
+    setSelectedEditorKey(NEW_MODULE_KEY);
+    setDraft(nextDraft);
+    setInspection(null);
+    setActiveObjectiveId(nextDraft.content.objectives[0]?.id || null);
+  }
+
+  function updateDraft(nextDraft: EditorDraft) {
+    setDraft(nextDraft);
+  }
+
+  function updateModuleField<K extends keyof EditorDraft>(
+    key: K,
+    value: EditorDraft[K]
+  ) {
+    if (!draft) {
+      return;
+    }
+
+    updateDraft({
+      ...draft,
+      [key]: value
+    });
+  }
+
+  function updateObjective(
+    objectiveId: string,
+    transform: (objective: AuthoredVictoryObjective) => AuthoredVictoryObjective
+  ) {
+    if (!draft) {
+      return;
+    }
+
+    updateDraft({
+      ...draft,
+      content: {
+        ...draft.content,
+        objectives: draft.content.objectives.map((objective) =>
+          objective.id === objectiveId ? transform(objective) : objective
+        )
+      }
+    });
+  }
+
+  function addObjective(type: AuthoredVictoryObjective["type"]) {
+    if (!draft) {
+      return;
+    }
+
+    const nextObjective = createObjective(draft.content.objectives.length, type);
+    updateDraft({
+      ...draft,
+      content: {
+        ...draft.content,
+        objectives: [...draft.content.objectives, nextObjective]
+      }
+    });
+    setActiveObjectiveId(nextObjective.id);
+  }
+
+  function removeObjective(objectiveId: string) {
+    if (!draft) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Remove objective "${objectiveId}" from this draft? This change is not reversible.`
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    const nextObjectives = draft.content.objectives.filter((objective) => objective.id !== objectiveId);
+    updateDraft({
+      ...draft,
+      content: {
+        ...draft.content,
+        objectives: nextObjectives
+      }
+    });
+    setActiveObjectiveId(nextObjectives[0]?.id || null);
+  }
+
+  function handleSaveDraft() {
+    if (!draft) {
+      return;
+    }
+
+    saveMutation.mutate(toUpsertRequest(clone(draft)));
+  }
+
+  function handlePublish() {
+    if (!selectedModuleId) {
+      return;
+    }
+
+    publishMutation.mutate(selectedModuleId);
+  }
+
+  function handleDisable() {
+    if (!selectedModuleId || !draft) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Disable published module "${draft.name || draft.id}"? Active games and admin defaults will be checked before the change is applied.`
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    disableMutation.mutate(selectedModuleId);
+  }
+
+  function handleEnable() {
+    if (!selectedModuleId) {
+      return;
+    }
+
+    enableMutation.mutate(selectedModuleId);
+  }
+
+  const selectedMap =
+    optionsQuery.data?.maps.find((entry) => entry.id === draft?.content.mapId) || null;
+  const activeObjective =
+    draft?.content.objectives.find((objective) => objective.id === activeObjectiveId) || null;
+  const latestInspection = currentInspection(detailQuery.data, inspection);
+  const modules = modulesQuery.data?.modules || [];
+  const isEditableDraft = Boolean(draft && (isNewDraft || detailQuery.data?.module.status === "draft"));
+  const isBusy =
+    validateMutation.isPending ||
+    saveMutation.isPending ||
+    publishMutation.isPending ||
+    enableMutation.isPending ||
+    disableMutation.isPending;
+  const moduleIdLocked = Boolean(selectedModuleId);
+
+  if (optionsQuery.isLoading || modulesQuery.isLoading || selectedEditorKey === null) {
+    return (
+      <section className="status-panel">
+        <p className="status-label">Content Studio</p>
+        <h2>Loading authoring workspace</h2>
+        <p className="status-copy">
+          Reading published modules, draft metadata, and map authoring options.
+        </p>
+      </section>
+    );
+  }
+
+  if (optionsQuery.isError || modulesQuery.isError) {
+    return (
+      <section className="status-panel status-panel-error">
+        <p className="status-label">Content Studio</p>
+        <h2>Authoring workspace unavailable</h2>
+        <p className="status-copy">
+          {messageFromError(
+            optionsQuery.error || modulesQuery.error,
+            "Unable to load the Content Studio workspace."
+          )}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="admin-section-stack" data-testid="admin-content-studio">
+      <section className="hero-panel admin-hero-panel admin-page-header">
+        <div className="admin-hero-copy">
+          <div className="admin-breadcrumbs" aria-label="Breadcrumb">
+            <span>Admin</span>
+            <span>Content Studio</span>
+          </div>
+          <p className="status-label">Content Studio</p>
+          <h1>Author victory objective modules</h1>
+          <p className="status-copy">
+            Create validated, publishable objective packs without editing source files. Published
+            modules flow into the runtime victory-rule catalog and are stored for engine use.
+          </p>
+        </div>
+        <div className="admin-hero-side">
+          <section className="admin-context-panel" aria-label="Operator session">
+            <p className="status-label">Operator</p>
+            <p className="admin-context-copy">
+              {frameContext.currentUser.username} · {frameContext.environmentLabel}
+            </p>
+            <div className="admin-toolbar-summary">
+              <span className="chip">Maps {optionsQuery.data?.maps.length || 0}</span>
+              <span className="chip">Modules {modules.length}</span>
+              <span className="chip">Type victory-objectives</span>
+            </div>
+          </section>
+          <div className="hero-actions admin-hero-actions">
+            <button type="button" className="refresh-button" onClick={startNewDraft}>
+              New draft
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="card-panel admin-toolbar-panel admin-toolbar-panel-sticky">
+        <div className="admin-toolbar admin-toolbar-dense">
+          <div className="admin-toolbar-summary">
+            <span className={`chip ${moduleStatusTone(draft?.status || detailQuery.data?.module.status)}`}>
+              {moduleStatusLabel(draft?.status || detailQuery.data?.module.status)}
+            </span>
+            <span className={`chip ${validationTone(latestInspection?.validation.valid)}`}>
+              {latestInspection?.validation.valid ? "Valid" : "Validation pending"}
+            </span>
+            <span className="chip">Objectives {draft?.content.objectives.length || 0}</span>
+            <span className="chip">
+              Updated {formatTimestamp((detailQuery.data?.module || null)?.updatedAt)}
+            </span>
+          </div>
+          <div className="admin-inline-actions">
+            <button
+              type="button"
+              className="refresh-button"
+              onClick={handleSaveDraft}
+              disabled={!draft || !isEditableDraft || isBusy}
+            >
+              {saveMutation.isPending ? "Saving…" : "Save draft"}
+            </button>
+            <button
+              type="button"
+              className="ghost-action"
+              onClick={handlePublish}
+              disabled={
+                !selectedModuleId ||
+                !draft ||
+                draft.status !== "draft" ||
+                !latestInspection?.validation.valid ||
+                isBusy
+              }
+            >
+              {publishMutation.isPending ? "Publishing…" : "Publish"}
+            </button>
+            <button
+              type="button"
+              className="ghost-action"
+              onClick={handleEnable}
+              disabled={!selectedModuleId || draft?.status !== "disabled" || isBusy}
+            >
+              {enableMutation.isPending ? "Enabling…" : "Enable"}
+            </button>
+            <button
+              type="button"
+              className="ghost-action"
+              onClick={handleDisable}
+              disabled={!selectedModuleId || draft?.status !== "published" || isBusy}
+            >
+              {disableMutation.isPending ? "Disabling…" : "Disable"}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {saveMutation.isError || publishMutation.isError || enableMutation.isError || disableMutation.isError ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Content Studio</p>
+          <h2>Last mutation failed</h2>
+          <p className="status-copy">
+            {messageFromError(
+              saveMutation.error ||
+                publishMutation.error ||
+                enableMutation.error ||
+                disableMutation.error,
+              "Unable to apply the requested module change."
+            )}
+          </p>
+        </section>
+      ) : null}
+
+      <div className="content-studio-grid">
+        <section className="card-panel content-studio-list-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Catalog</p>
+              <h2>Authored modules</h2>
+            </div>
+          </div>
+          <div className="content-studio-list">
+            {modules.length ? (
+              modules.map((moduleEntry) => (
+                <button
+                  key={moduleEntry.id}
+                  type="button"
+                  className={`admin-list-button${
+                    selectedModuleId === moduleEntry.id ? " is-selected" : ""
+                  }`}
+                  onClick={() => setSelectedEditorKey(moduleEntry.id)}
+                >
+                  <div className="admin-list-copy">
+                    <strong>{moduleEntry.name}</strong>
+                    <span>{moduleEntry.description}</span>
+                    <span className="admin-item-meta">
+                      {moduleEntry.id} · {moduleStatusLabel(moduleEntry.status)} · updated{" "}
+                      {formatTimestamp(moduleEntry.updatedAt)}
+                    </span>
+                  </div>
+                  <div className="content-studio-list-meta">
+                    <span className={`badge ${moduleStatusTone(moduleEntry.status)}`}>
+                      {moduleStatusLabel(moduleEntry.status)}
+                    </span>
+                    <span className={`badge ${validationTone(moduleEntry.validation.valid)}`}>
+                      {moduleEntry.validation.valid ? "valid" : "draft"}
+                    </span>
+                    <span className="badge">{moduleEntry.enabledObjectiveCount} enabled</span>
+                  </div>
+                </button>
+              ))
+            ) : (
+              <section className="status-panel admin-empty-state">
+                <p className="status-label">Content Studio</p>
+                <h2>No authored modules yet</h2>
+                <p className="status-copy">
+                  Start with a draft victory-objective module and publish it when validation is
+                  clean.
+                </p>
+              </section>
+            )}
+          </div>
+        </section>
+
+        <section className="content-studio-editor-shell">
+          {detailQuery.isLoading && selectedModuleId ? (
+            <section className="status-panel">
+              <p className="status-label">Content Studio</p>
+              <h2>Loading module</h2>
+              <p className="status-copy">Fetching the selected draft and runtime preview.</p>
+            </section>
+          ) : detailQuery.isError && selectedModuleId ? (
+            <section className="status-panel status-panel-error">
+              <p className="status-label">Content Studio</p>
+              <h2>Module unavailable</h2>
+              <p className="status-copy">
+                {messageFromError(detailQuery.error, "Unable to load the selected module.")}
+              </p>
+            </section>
+          ) : !draft ? (
+            <section className="status-panel">
+              <p className="status-label">Content Studio</p>
+              <h2>Select or create a module</h2>
+              <p className="status-copy">
+                Choose an authored module from the list or start a fresh draft.
+              </p>
+            </section>
+          ) : (
+            <div className="content-studio-editor-grid">
+              <div className="content-studio-main-panel">
+                <section className="card-panel content-studio-form-panel">
+                  <div className="card-header">
+                    <div>
+                      <p className="status-label">Module</p>
+                      <h2>Definition</h2>
+                    </div>
+                  </div>
+                  <div className="admin-form-grid admin-form-grid-2">
+                    <label className="shell-field admin-field">
+                      <span>Module id</span>
+                      <input
+                        value={draft.id}
+                        onChange={(event) => updateModuleField("id", event.target.value)}
+                        disabled={moduleIdLocked}
+                      />
+                      <small>
+                        {moduleIdLocked
+                          ? "Module id is locked after the first saved draft in this phase."
+                          : "Stable runtime identifier."}
+                      </small>
+                    </label>
+                    <label className="shell-field admin-field">
+                      <span>Version</span>
+                      <input
+                        value={draft.version}
+                        onChange={(event) => updateModuleField("version", event.target.value)}
+                        disabled={!isEditableDraft}
+                      />
+                    </label>
+                    <label className="shell-field admin-field">
+                      <span>Name</span>
+                      <input
+                        value={draft.name}
+                        onChange={(event) => updateModuleField("name", event.target.value)}
+                        disabled={!isEditableDraft}
+                      />
+                    </label>
+                    <label className="shell-field admin-field">
+                      <span>Target map</span>
+                      <select
+                        value={draft.content.mapId}
+                        onChange={(event) =>
+                          updateDraft({
+                            ...draft,
+                            content: {
+                              ...draft.content,
+                              mapId: event.target.value
+                            }
+                          })
+                        }
+                        disabled={!isEditableDraft}
+                      >
+                        <option value="">Select a map</option>
+                        {optionsQuery.data?.maps.map((entry) => (
+                          <option key={entry.id} value={entry.id}>
+                            {entry.name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="shell-field admin-field admin-card-span">
+                      <span>Description</span>
+                      <textarea
+                        rows={3}
+                        value={draft.description}
+                        onChange={(event) => updateModuleField("description", event.target.value)}
+                        disabled={!isEditableDraft}
+                      />
+                    </label>
+                  </div>
+                  <div className="content-studio-map-meta">
+                    <span className="chip">{selectedMap?.name || "No map selected"}</span>
+                    <span className="chip">Territories {selectedMap?.territoryCount || 0}</span>
+                    <span className="chip">Continents {selectedMap?.continentCount || 0}</span>
+                  </div>
+                </section>
+
+                <section className="card-panel content-studio-form-panel">
+                  <div className="card-header">
+                    <div>
+                      <p className="status-label">Objectives</p>
+                      <h2>Victory conditions</h2>
+                    </div>
+                    <div className="admin-inline-actions">
+                      <button
+                        type="button"
+                        className="ghost-action"
+                        onClick={() => addObjective("control-continents")}
+                        disabled={!isEditableDraft}
+                      >
+                        Add continent objective
+                      </button>
+                      <button
+                        type="button"
+                        className="ghost-action"
+                        onClick={() => addObjective("control-territory-count")}
+                        disabled={!isEditableDraft}
+                      >
+                        Add territory objective
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="content-studio-objective-layout">
+                    <div className="content-studio-objective-list">
+                      {draft.content.objectives.map((objective, index) => (
+                        <button
+                          key={objective.id}
+                          type="button"
+                          className={`admin-list-button${
+                            activeObjectiveId === objective.id ? " is-selected" : ""
+                          }`}
+                          onClick={() => setActiveObjectiveId(objective.id)}
+                        >
+                          <div className="admin-list-copy">
+                            <strong>{objective.title || `Objective ${index + 1}`}</strong>
+                            <span>{objective.description || "No player-facing description yet."}</span>
+                            <span className="admin-item-meta">
+                              {objective.id || "missing-id"} · {objectiveTypeLabel(objective.type)}
+                            </span>
+                          </div>
+                          <div className="content-studio-list-meta">
+                            <span className={`badge ${objective.enabled ? "success" : "muted"}`}>
+                              {objective.enabled ? "Enabled" : "Off"}
+                            </span>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+
+                    {activeObjective ? (
+                      <div className="content-studio-objective-editor">
+                        <div className="admin-form-grid admin-form-grid-2">
+                          <label className="shell-field admin-field">
+                            <span>Objective id</span>
+                            <input
+                              value={activeObjective.id}
+                              onChange={(event) =>
+                                updateObjective(activeObjective.id, (objective) => ({
+                                  ...objective,
+                                  id: event.target.value
+                                }))
+                              }
+                              disabled={!isEditableDraft}
+                            />
+                          </label>
+                          <label className="shell-field admin-field">
+                            <span>Objective type</span>
+                            <select
+                              value={activeObjective.type}
+                              onChange={(event) =>
+                                updateObjective(activeObjective.id, (objective) => {
+                                  const baseObjective = {
+                                    id: objective.id,
+                                    title: objective.title,
+                                    description: objective.description,
+                                    enabled: objective.enabled
+                                  };
+
+                                  return event.target.value === "control-territory-count"
+                                    ? {
+                                        ...baseObjective,
+                                        type: "control-territory-count",
+                                        territoryCount:
+                                          objective.type === "control-territory-count"
+                                            ? objective.territoryCount
+                                            : 24
+                                      }
+                                    : {
+                                        ...baseObjective,
+                                        type: "control-continents",
+                                        continentIds:
+                                          objective.type === "control-continents"
+                                            ? objective.continentIds
+                                            : []
+                                      };
+                                })
+                              }
+                              disabled={!isEditableDraft}
+                            >
+                              <option value="control-continents">Control specific continents</option>
+                              <option value="control-territory-count">
+                                Control minimum territory count
+                              </option>
+                            </select>
+                          </label>
+                          <label className="shell-field admin-field">
+                            <span>Title</span>
+                            <input
+                              value={activeObjective.title}
+                              onChange={(event) =>
+                                updateObjective(activeObjective.id, (objective) => ({
+                                  ...objective,
+                                  title: event.target.value
+                                }))
+                              }
+                              disabled={!isEditableDraft}
+                            />
+                          </label>
+                          <label className="shell-field admin-field">
+                            <span>Enabled</span>
+                            <select
+                              value={activeObjective.enabled ? "true" : "false"}
+                              onChange={(event) =>
+                                updateObjective(activeObjective.id, (objective) => ({
+                                  ...objective,
+                                  enabled: event.target.value === "true"
+                                }))
+                              }
+                              disabled={!isEditableDraft}
+                            >
+                              <option value="true">Enabled</option>
+                              <option value="false">Disabled</option>
+                            </select>
+                          </label>
+                          <label className="shell-field admin-field admin-card-span">
+                            <span>Player-facing description</span>
+                            <textarea
+                              rows={3}
+                              value={activeObjective.description}
+                              onChange={(event) =>
+                                updateObjective(activeObjective.id, (objective) => ({
+                                  ...objective,
+                                  description: event.target.value
+                                }))
+                              }
+                              disabled={!isEditableDraft}
+                            />
+                          </label>
+                        </div>
+
+                        {activeObjective.type === "control-continents" ? (
+                          <div className="content-studio-chip-group">
+                            <p className="admin-item-meta">
+                              Select one or more continents from the active map.
+                            </p>
+                            <div className="content-studio-chip-row">
+                              {(selectedMap?.continents || []).map((continent) => {
+                                const selected = activeObjective.continentIds.includes(continent.id);
+                                return (
+                                  <button
+                                    key={continent.id}
+                                    type="button"
+                                    className={`content-studio-chip${selected ? " is-selected" : ""}`}
+                                    onClick={() =>
+                                      updateObjective(activeObjective.id, (objective) => ({
+                                        ...objective,
+                                        continentIds: selected
+                                          ? objective.continentIds.filter(
+                                              (entry) => entry !== continent.id
+                                            )
+                                          : [...objective.continentIds, continent.id]
+                                      }))
+                                    }
+                                    disabled={!isEditableDraft}
+                                  >
+                                    <strong>{continent.name}</strong>
+                                    <span>
+                                      {continent.territoryCount} territories · bonus {continent.bonus}
+                                    </span>
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ) : (
+                          <label className="shell-field admin-field">
+                            <span>Minimum territory count</span>
+                            <input
+                              type="number"
+                              min={1}
+                              max={selectedMap?.territoryCount || 42}
+                              value={String(activeObjective.territoryCount)}
+                              onChange={(event) =>
+                                updateObjective(activeObjective.id, (objective) => ({
+                                  ...objective,
+                                  territoryCount: Number(event.target.value || "0")
+                                }))
+                              }
+                              disabled={!isEditableDraft}
+                            />
+                            <small>
+                              Must be between 1 and {selectedMap?.territoryCount || "the map limit"}.
+                            </small>
+                          </label>
+                        )}
+
+                        <div className="admin-inline-actions">
+                          <button
+                            type="button"
+                            className="ghost-action"
+                            onClick={() => removeObjective(activeObjective.id)}
+                            disabled={!isEditableDraft}
+                          >
+                            Remove objective
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </section>
+
+                {!isEditableDraft && selectedModuleId ? (
+                  <section className="status-panel">
+                    <p className="status-label">Read only</p>
+                    <h2>Published modules are locked</h2>
+                    <p className="status-copy">
+                      This phase allows editing saved drafts. Published or disabled modules can be
+                      reviewed, enabled, or disabled, but not rewritten in place.
+                    </p>
+                  </section>
+                ) : null}
+              </div>
+
+              <div className="content-studio-side-stack">
+                <PreviewPanel inspection={latestInspection} />
+                <ValidationPanel inspection={latestInspection} />
+                <RuntimePanel inspection={latestInspection} />
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -27,6 +27,7 @@ import { messageFromError } from "@frontend-core/errors.mts";
 import { formatDate } from "@frontend-i18n";
 
 import { useAuth } from "@react-shell/auth";
+import { AdminContentStudioSection } from "@react-shell/admin-content-studio";
 import { ProfileAdminModules } from "@react-shell/profile-admin-modules";
 import {
   buildAdminPath,
@@ -43,7 +44,15 @@ import {
   adminUsersQueryKey
 } from "@react-shell/react-query";
 
-type AdminSection = "audit" | "config" | "games" | "maintenance" | "modules" | "overview" | "users";
+type AdminSection =
+  | "audit"
+  | "config"
+  | "content-studio"
+  | "games"
+  | "maintenance"
+  | "modules"
+  | "overview"
+  | "users";
 
 type AdminNavItem = {
   id: AdminSection;
@@ -121,6 +130,10 @@ function resolveAdminSection(pathname: string): AdminSection {
 
   if (pathname.endsWith("/config")) {
     return "config";
+  }
+
+  if (pathname.endsWith("/content-studio")) {
+    return "content-studio";
   }
 
   if (pathname.endsWith("/modules")) {
@@ -2330,6 +2343,13 @@ export function AdminRoute() {
       description: "Gameplay, visual, and maintenance defaults."
     },
     {
+      id: "content-studio",
+      group: "Operate",
+      label: "Content Studio",
+      path: `${basePath}/content-studio`,
+      description: "Author victory objective modules from the UI."
+    },
+    {
       id: "modules",
       group: "Operate",
       label: "Runtime modules",
@@ -2475,6 +2495,9 @@ export function AdminRoute() {
           {section === "users" ? <UsersSection frameContext={frameContext} /> : null}
           {section === "games" ? <GamesSection frameContext={frameContext} /> : null}
           {section === "config" ? <ConfigSection frameContext={frameContext} /> : null}
+          {section === "content-studio" ? (
+            <AdminContentStudioSection frameContext={frameContext} />
+          ) : null}
           {section === "modules" ? (
             <ModulesSection userId={currentUser.id} frameContext={frameContext} />
           ) : null}

--- a/frontend/react-shell/src/react-query.ts
+++ b/frontend/react-shell/src/react-query.ts
@@ -65,3 +65,15 @@ export function adminMaintenanceQueryKey() {
 export function adminAuditQueryKey() {
   return ["admin", "audit"] as const;
 }
+
+export function adminContentStudioOptionsQueryKey() {
+  return ["admin", "content-studio", "options"] as const;
+}
+
+export function adminContentStudioModulesQueryKey() {
+  return ["admin", "content-studio", "modules"] as const;
+}
+
+export function adminContentStudioModuleDetailQueryKey(moduleId: string | null) {
+  return ["admin", "content-studio", "module-detail", moduleId || "new"] as const;
+}

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -1755,10 +1755,180 @@ button.ghost-action {
   appearance: none;
 }
 
+.content-studio-grid {
+  display: grid;
+  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.content-studio-list,
+.content-studio-side-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.content-studio-list-panel,
+.content-studio-form-panel,
+.content-studio-side-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.content-studio-editor-shell,
+.content-studio-main-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.content-studio-editor-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 0.9fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.content-studio-list-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.content-studio-map-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.content-studio-objective-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.content-studio-objective-list,
+.content-studio-objective-editor {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.content-studio-chip-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.content-studio-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.content-studio-chip {
+  min-width: 180px;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-card-radius);
+  background: var(--shell-card-bg);
+  color: var(--shell-copy);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    transform 120ms ease;
+}
+
+.content-studio-chip:hover,
+.content-studio-chip.is-selected {
+  border-color: var(--shell-border-hi);
+  background: var(--shell-card-bg-hover);
+  transform: translateY(-1px);
+}
+
+.content-studio-chip strong {
+  font-size: 0.95rem;
+}
+
+.content-studio-chip span {
+  color: var(--shell-muted);
+  font-size: 0.82rem;
+}
+
+.content-studio-summary {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.55;
+}
+
+.content-studio-preview-list,
+.content-studio-validation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.content-studio-preview-list li {
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-card-radius);
+  background: var(--shell-card-bg);
+}
+
+.content-studio-validation-item {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-card-radius);
+  background: var(--shell-card-bg);
+}
+
+.content-studio-validation-item.is-error {
+  border-color: var(--shell-danger-border);
+  background: var(--shell-danger-bg);
+}
+
+.content-studio-validation-item.is-warning {
+  border-color: var(--shell-warning-border);
+  background: var(--shell-warning-bg);
+}
+
+.content-studio-validation-item p,
+.content-studio-validation-item span {
+  margin: 0;
+}
+
+.content-studio-validation-item span {
+  color: var(--shell-muted);
+  font-size: 0.8rem;
+}
+
+.content-studio-runtime-json {
+  margin: 0;
+  max-height: 420px;
+  overflow: auto;
+  padding: 1rem;
+  border: 1px solid var(--shell-border);
+  border-radius: var(--campaign-card-radius);
+  background: color-mix(in srgb, var(--shell-panel-bg) 78%, black 22%);
+  color: var(--shell-heading);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
 @media (max-width: 1180px) {
   .admin-page-header,
   .admin-users-grid,
   .admin-games-grid,
+  .content-studio-grid,
+  .content-studio-editor-grid,
+  .content-studio-objective-layout,
   .admin-kpi-layout,
   .admin-detail-grid,
   .admin-form-grid-3,
@@ -1842,6 +2012,9 @@ button.ghost-action {
   .profile-metric-grid,
   .lobby-summary-grid,
   .lobby-shell-grid,
+  .content-studio-grid,
+  .content-studio-editor-grid,
+  .content-studio-objective-layout,
   .admin-page-header,
   .admin-kpi-layout,
   .admin-users-grid,

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -1,6 +1,12 @@
 import {
   accountSettingsRequestSchema,
   accountSettingsResponseSchema,
+  adminAuthoredModuleDetailResponseSchema,
+  adminAuthoredModuleEditorOptionsResponseSchema,
+  adminAuthoredModuleMutationResponseSchema,
+  adminAuthoredModulesListResponseSchema,
+  adminAuthoredModuleUpsertRequestSchema,
+  adminAuthoredModuleValidateResponseSchema,
   adminAuditResponseSchema,
   adminConfigResponseSchema,
   adminConfigUpdateRequestSchema,
@@ -42,6 +48,12 @@ import {
 import type {
   AccountSettingsRequest,
   AccountSettingsResponse,
+  AdminAuthoredModuleDetailResponse,
+  AdminAuthoredModuleEditorOptionsResponse,
+  AdminAuthoredModuleMutationResponse,
+  AdminAuthoredModulesListResponse,
+  AdminAuthoredModuleUpsertRequest,
+  AdminAuthoredModuleValidateResponse,
   AdminAuditResponse,
   AdminConfigResponse,
   AdminConfigUpdateRequest,
@@ -429,6 +441,131 @@ export function getAdminAudit(messages: ClientMessages): Promise<AdminAuditRespo
     path: "/api/admin/audit",
     responseSchema: adminAuditResponseSchema,
     responseSchemaName: "AdminAuditResponse",
+    ...messages
+  });
+}
+
+export function getAdminContentStudioOptions(
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleEditorOptionsResponse> {
+  return requestJson({
+    path: "/api/admin/content-studio/options",
+    responseSchema: adminAuthoredModuleEditorOptionsResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleEditorOptionsResponse",
+    ...messages
+  });
+}
+
+export function listAdminAuthoredModules(
+  messages: ClientMessages
+): Promise<AdminAuthoredModulesListResponse> {
+  return requestJson({
+    path: "/api/admin/content-studio/modules",
+    responseSchema: adminAuthoredModulesListResponseSchema,
+    responseSchemaName: "AdminAuthoredModulesListResponse",
+    ...messages
+  });
+}
+
+export function getAdminAuthoredModule(
+  moduleId: string,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleDetailResponse> {
+  return requestJson({
+    path: `/api/admin/content-studio/modules/${encodeURIComponent(moduleId)}`,
+    responseSchema: adminAuthoredModuleDetailResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleDetailResponse",
+    ...messages
+  });
+}
+
+export function validateAdminAuthoredModule(
+  request: AdminAuthoredModuleUpsertRequest,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleValidateResponse> {
+  return requestJson({
+    path: "/api/admin/content-studio/modules/validate",
+    method: "POST",
+    body: request,
+    requestSchema: adminAuthoredModuleUpsertRequestSchema,
+    requestSchemaName: "AdminAuthoredModuleUpsertRequest",
+    responseSchema: adminAuthoredModuleValidateResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleValidateResponse",
+    ...messages
+  });
+}
+
+export function createAdminAuthoredModule(
+  request: AdminAuthoredModuleUpsertRequest,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleMutationResponse> {
+  return requestJson({
+    path: "/api/admin/content-studio/modules",
+    method: "POST",
+    body: request,
+    requestSchema: adminAuthoredModuleUpsertRequestSchema,
+    requestSchemaName: "AdminAuthoredModuleUpsertRequest",
+    responseSchema: adminAuthoredModuleMutationResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleMutationResponse",
+    ...messages
+  });
+}
+
+export function updateAdminAuthoredModule(
+  moduleId: string,
+  request: AdminAuthoredModuleUpsertRequest,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleMutationResponse> {
+  return requestJson({
+    path: `/api/admin/content-studio/modules/${encodeURIComponent(moduleId)}`,
+    method: "PUT",
+    body: request,
+    requestSchema: adminAuthoredModuleUpsertRequestSchema,
+    requestSchemaName: "AdminAuthoredModuleUpsertRequest",
+    responseSchema: adminAuthoredModuleMutationResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleMutationResponse",
+    ...messages
+  });
+}
+
+export function publishAdminAuthoredModule(
+  moduleId: string,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleMutationResponse> {
+  return requestJson({
+    path: `/api/admin/content-studio/modules/${encodeURIComponent(moduleId)}/publish`,
+    method: "POST",
+    body: {},
+    responseSchema: adminAuthoredModuleMutationResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleMutationResponse",
+    ...messages
+  });
+}
+
+export function enableAdminAuthoredModule(
+  moduleId: string,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleMutationResponse> {
+  return requestJson({
+    path: `/api/admin/content-studio/modules/${encodeURIComponent(moduleId)}/enable`,
+    method: "POST",
+    body: {},
+    responseSchema: adminAuthoredModuleMutationResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleMutationResponse",
+    ...messages
+  });
+}
+
+export function disableAdminAuthoredModule(
+  moduleId: string,
+  messages: ClientMessages
+): Promise<AdminAuthoredModuleMutationResponse> {
+  return requestJson({
+    path: `/api/admin/content-studio/modules/${encodeURIComponent(moduleId)}/disable`,
+    method: "POST",
+    body: {},
+    responseSchema: adminAuthoredModuleMutationResponseSchema,
+    responseSchemaName: "AdminAuthoredModuleMutationResponse",
     ...messages
   });
 }

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -1134,7 +1134,7 @@ export const authoredVictoryModuleContentSchema = objectSchema({
 export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
 
 export const authoredModuleInputSchema = objectSchema({
-  id: z.string(),
+  id: z.string().trim().min(1),
   name: z.string(),
   description: z.string(),
   version: z.string(),

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -1099,23 +1099,21 @@ export const authoredVictoryObjectiveBaseSchema = objectSchema({
   type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
 });
 
-export const authoredVictoryControlContinentsObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
-  {
+export const authoredVictoryControlContinentsObjectiveSchema =
+  authoredVictoryObjectiveBaseSchema.extend({
     type: z.literal("control-continents"),
     continentIds: z.array(z.string())
-  }
-);
+  });
 
 export type AuthoredVictoryControlContinentsObjective = z.infer<
   typeof authoredVictoryControlContinentsObjectiveSchema
 >;
 
-export const authoredVictoryTerritoryCountObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
-  {
+export const authoredVictoryTerritoryCountObjectiveSchema =
+  authoredVictoryObjectiveBaseSchema.extend({
     type: z.literal("control-territory-count"),
     territoryCount: z.number().int().nullable().optional()
-  }
-);
+  });
 
 export type AuthoredVictoryTerritoryCountObjective = z.infer<
   typeof authoredVictoryTerritoryCountObjectiveSchema
@@ -1194,9 +1192,7 @@ export const authoredVictoryRuntimeObjectiveSchema = z.discriminatedUnion("type"
   authoredVictoryRuntimeTerritoryCountObjectiveSchema
 ]);
 
-export type AuthoredVictoryRuntimeObjective = z.infer<
-  typeof authoredVictoryRuntimeObjectiveSchema
->;
+export type AuthoredVictoryRuntimeObjective = z.infer<typeof authoredVictoryRuntimeObjectiveSchema>;
 
 export const authoredVictoryModuleRuntimeSchema = objectSchema({
   id: z.string(),
@@ -1210,9 +1206,7 @@ export const authoredVictoryModuleRuntimeSchema = objectSchema({
   preview: authoredModulePreviewSchema
 });
 
-export type AuthoredVictoryModuleRuntime = z.infer<
-  typeof authoredVictoryModuleRuntimeSchema
->;
+export type AuthoredVictoryModuleRuntime = z.infer<typeof authoredVictoryModuleRuntimeSchema>;
 
 export const authoredModuleRuntimeSchema = authoredVictoryModuleRuntimeSchema;
 

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -21,6 +21,13 @@ const NETRISK_UI_SLOT_ID_VALUES = [
   "new-game.sidebar",
   "top-nav-bar"
 ] as const;
+const AUTHORED_MODULE_STATUS_VALUES = ["draft", "published", "disabled"] as const;
+const AUTHORED_MODULE_TYPE_VALUES = ["victory-objectives"] as const;
+const AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES = [
+  "control-continents",
+  "control-territory-count"
+] as const;
+const AUTHORED_MODULE_VALIDATION_SEVERITY_VALUES = ["warning", "error"] as const;
 
 type IssuePathSegment = string | number;
 
@@ -210,7 +217,11 @@ export type LogoutResponse = z.infer<typeof logoutResponseSchema>;
 export const victoryRuleSetSchema = objectSchema({
   id: z.string().min(1),
   name: z.string().min(1),
-  description: z.string().min(1)
+  description: z.string().min(1),
+  source: z.enum(["built-in", "authored"]).optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  objectiveCount: z.number().int().optional(),
+  moduleType: z.string().min(1).nullable().optional()
 });
 
 export type VictoryRuleSet = z.infer<typeof victoryRuleSetSchema>;
@@ -1063,6 +1074,179 @@ export const adminAuditEntrySchema = objectSchema({
 
 export type AdminAuditEntry = z.infer<typeof adminAuditEntrySchema>;
 
+export const authoredModuleValidationIssueSchema = objectSchema({
+  code: z.string().min(1),
+  path: z.string().min(1),
+  severity: z.enum(AUTHORED_MODULE_VALIDATION_SEVERITY_VALUES),
+  message: z.string().min(1)
+});
+
+export type AuthoredModuleValidationIssue = z.infer<typeof authoredModuleValidationIssueSchema>;
+
+export const authoredModuleValidationSchema = objectSchema({
+  valid: z.boolean(),
+  errors: z.array(authoredModuleValidationIssueSchema),
+  warnings: z.array(authoredModuleValidationIssueSchema)
+});
+
+export type AuthoredModuleValidation = z.infer<typeof authoredModuleValidationSchema>;
+
+export const authoredVictoryObjectiveBaseSchema = objectSchema({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  enabled: z.boolean(),
+  type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
+});
+
+export const authoredVictoryControlContinentsObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
+  {
+    type: z.literal("control-continents"),
+    continentIds: z.array(z.string())
+  }
+);
+
+export type AuthoredVictoryControlContinentsObjective = z.infer<
+  typeof authoredVictoryControlContinentsObjectiveSchema
+>;
+
+export const authoredVictoryTerritoryCountObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
+  {
+    type: z.literal("control-territory-count"),
+    territoryCount: z.number().int().nullable().optional()
+  }
+);
+
+export type AuthoredVictoryTerritoryCountObjective = z.infer<
+  typeof authoredVictoryTerritoryCountObjectiveSchema
+>;
+
+export const authoredVictoryObjectiveSchema = z.discriminatedUnion("type", [
+  authoredVictoryControlContinentsObjectiveSchema,
+  authoredVictoryTerritoryCountObjectiveSchema
+]);
+
+export type AuthoredVictoryObjective = z.infer<typeof authoredVictoryObjectiveSchema>;
+
+export const authoredVictoryModuleContentSchema = objectSchema({
+  mapId: z.string(),
+  objectives: z.array(authoredVictoryObjectiveSchema)
+});
+
+export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
+
+export const authoredModuleInputSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  content: authoredVictoryModuleContentSchema
+});
+
+export type AuthoredModuleInput = z.infer<typeof authoredModuleInputSchema>;
+
+export const authoredModuleSchema = authoredModuleInputSchema.extend({
+  status: z.enum(AUTHORED_MODULE_STATUS_VALUES),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1)
+});
+
+export type AuthoredModule = z.infer<typeof authoredModuleSchema>;
+
+export const authoredModulePreviewSchema = objectSchema({
+  summary: z.string(),
+  objectiveSummaries: z.array(z.string())
+});
+
+export type AuthoredModulePreview = z.infer<typeof authoredModulePreviewSchema>;
+
+export const authoredVictoryRuntimeMapSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  territoryCount: z.number().int().nonnegative(),
+  continentCount: z.number().int().nonnegative()
+});
+
+export type AuthoredVictoryRuntimeMap = z.infer<typeof authoredVictoryRuntimeMapSchema>;
+
+export const authoredVictoryRuntimeControlContinentsObjectiveSchema =
+  authoredVictoryControlContinentsObjectiveSchema.extend({
+    continentNames: z.array(z.string()),
+    summary: z.string()
+  });
+
+export type AuthoredVictoryRuntimeControlContinentsObjective = z.infer<
+  typeof authoredVictoryRuntimeControlContinentsObjectiveSchema
+>;
+
+export const authoredVictoryRuntimeTerritoryCountObjectiveSchema =
+  authoredVictoryTerritoryCountObjectiveSchema.extend({
+    summary: z.string()
+  });
+
+export type AuthoredVictoryRuntimeTerritoryCountObjective = z.infer<
+  typeof authoredVictoryRuntimeTerritoryCountObjectiveSchema
+>;
+
+export const authoredVictoryRuntimeObjectiveSchema = z.discriminatedUnion("type", [
+  authoredVictoryRuntimeControlContinentsObjectiveSchema,
+  authoredVictoryRuntimeTerritoryCountObjectiveSchema
+]);
+
+export type AuthoredVictoryRuntimeObjective = z.infer<
+  typeof authoredVictoryRuntimeObjectiveSchema
+>;
+
+export const authoredVictoryModuleRuntimeSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  moduleType: z.literal("victory-objectives"),
+  kind: z.literal("authored-victory-objectives"),
+  map: authoredVictoryRuntimeMapSchema,
+  objectives: z.array(authoredVictoryRuntimeObjectiveSchema),
+  preview: authoredModulePreviewSchema
+});
+
+export type AuthoredVictoryModuleRuntime = z.infer<
+  typeof authoredVictoryModuleRuntimeSchema
+>;
+
+export const authoredModuleRuntimeSchema = authoredVictoryModuleRuntimeSchema;
+
+export type AuthoredModuleRuntime = z.infer<typeof authoredModuleRuntimeSchema>;
+
+export const authoredMapContinentOptionSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  bonus: z.number(),
+  territoryCount: z.number().int()
+});
+
+export type AuthoredMapContinentOption = z.infer<typeof authoredMapContinentOptionSchema>;
+
+export const authoredMapOptionSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  territoryCount: z.number().int(),
+  continentCount: z.number().int(),
+  continents: z.array(authoredMapContinentOptionSchema)
+});
+
+export type AuthoredMapOption = z.infer<typeof authoredMapOptionSchema>;
+
+export const authoredModuleSummarySchema = authoredModuleSchema.extend({
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  map: authoredMapOptionSchema.omit({ continents: true }).nullable().optional(),
+  objectiveCount: z.number().int(),
+  enabledObjectiveCount: z.number().int()
+});
+
+export type AuthoredModuleSummary = z.infer<typeof authoredModuleSummarySchema>;
+
 export const adminConfigSchema = objectSchema({
   defaults: adminGameDefaultsSchema,
   maintenance: objectSchema({
@@ -1241,3 +1425,60 @@ export const adminAuditResponseSchema = objectSchema({
 });
 
 export type AdminAuditResponse = z.infer<typeof adminAuditResponseSchema>;
+
+export const adminAuthoredModuleEditorOptionsResponseSchema = objectSchema({
+  moduleTypes: z.array(z.enum(AUTHORED_MODULE_TYPE_VALUES)),
+  maps: z.array(authoredMapOptionSchema)
+});
+
+export type AdminAuthoredModuleEditorOptionsResponse = z.infer<
+  typeof adminAuthoredModuleEditorOptionsResponseSchema
+>;
+
+export const adminAuthoredModulesListResponseSchema = objectSchema({
+  modules: z.array(authoredModuleSummarySchema)
+});
+
+export type AdminAuthoredModulesListResponse = z.infer<
+  typeof adminAuthoredModulesListResponseSchema
+>;
+
+export const adminAuthoredModuleDetailResponseSchema = objectSchema({
+  module: authoredModuleSchema,
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  runtime: authoredModuleRuntimeSchema
+});
+
+export type AdminAuthoredModuleDetailResponse = z.infer<
+  typeof adminAuthoredModuleDetailResponseSchema
+>;
+
+export const adminAuthoredModuleUpsertRequestSchema = authoredModuleInputSchema;
+
+export type AdminAuthoredModuleUpsertRequest = z.infer<
+  typeof adminAuthoredModuleUpsertRequestSchema
+>;
+
+export const adminAuthoredModuleValidateResponseSchema = objectSchema({
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  runtime: authoredModuleRuntimeSchema
+});
+
+export type AdminAuthoredModuleValidateResponse = z.infer<
+  typeof adminAuthoredModuleValidateResponseSchema
+>;
+
+export const adminAuthoredModuleMutationResponseSchema = objectSchema({
+  ok: z.literal(true),
+  module: authoredModuleSchema,
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  runtime: authoredModuleRuntimeSchema,
+  audit: adminAuditEntrySchema.nullable().optional()
+});
+
+export type AdminAuthoredModuleMutationResponse = z.infer<
+  typeof adminAuthoredModuleMutationResponseSchema
+>;

--- a/scripts/check-no-js-sources.cts
+++ b/scripts/check-no-js-sources.cts
@@ -32,6 +32,7 @@ const allowedPathPatterns = [
   /^\.vercelignore$/,
   /^\.githooks\/.+$/,
   /^\.github\/.+\.yml$/,
+  /^\.github\/.+\.json$/,
   /^\.prettierignore$/,
   /^\.prettierrc\.json$/,
   /^LICENSE$/,

--- a/scripts/evaluate-codex-pr-readiness.cts
+++ b/scripts/evaluate-codex-pr-readiness.cts
@@ -1,0 +1,1588 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+type QualityStepGroupName = "typecheck" | "build" | "lint" | "format" | "reactTests";
+type PullRequestDecision = "ready" | "blocked" | "skipped";
+type ApplyCommentStatus = "created" | "updated" | "unchanged" | "skipped";
+type AllowlistEntry = {
+  pattern: string;
+  markers?: string[];
+};
+
+type SyncRequirement = {
+  ifChanged: string[];
+  mustAlsoChange: string[];
+  message: string;
+};
+
+type GateConfig = {
+  targetLabel: string;
+  branchPrefix: string;
+  codexActors: string[];
+  codexGreenlightPhrases: string[];
+  requiredCheckNames: string[];
+  requiredQualitySteps: Record<QualityStepGroupName, string[]>;
+  maxCommitsBehindBase: number;
+  summaryCommentMarker: string;
+  skipTestAllowlist: AllowlistEntry[];
+  temporaryMarkerAllowlist: AllowlistEntry[];
+  syncRequirements: SyncRequirement[];
+  productionFileGlobs: string[];
+  testFileGlobs: string[];
+  docFileGlobs: string[];
+  largeDiffChangeThreshold: number;
+  significantChangeThreshold: number;
+  lowTestAdditionsMinProductionAdditions: number;
+  lowTestAdditionsRatio: number;
+};
+
+type GitHubRepositoryRef = {
+  owner: string;
+  repo: string;
+};
+
+type PullRequestSummary = {
+  number: number;
+  nodeId: string;
+  title: string;
+  url: string;
+  state: string;
+  isDraft: boolean;
+  authorLogin: string;
+  baseRefName: string;
+  headRefName: string;
+  headSha: string;
+  headCommitAt: string;
+  labels: string[];
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  mergeable: boolean | null;
+  mergeableState: string | null;
+};
+
+type WorkflowJobStep = {
+  name: string;
+  status: string | null;
+  conclusion: string | null;
+};
+
+type WorkflowJob = {
+  id: number;
+  name: string;
+  htmlUrl: string;
+  status: string | null;
+  conclusion: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  workflowName: string;
+  steps: WorkflowJobStep[];
+};
+
+type ReviewThreadComment = {
+  authorLogin: string;
+  body: string;
+  createdAt: string;
+  url: string;
+};
+
+type ReviewThread = {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  updatedAt: string;
+  comments: ReviewThreadComment[];
+};
+
+type ReviewSignal = {
+  actorLogin: string;
+  state: string | null;
+  body: string;
+  submittedAt: string;
+  url: string;
+  kind: "review" | "issue-comment";
+};
+
+type ChangedFile = {
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch: string | null;
+};
+
+type BranchFreshness = {
+  behindBy: number;
+  aheadBy: number;
+  status: string;
+  url: string;
+};
+
+type Snapshot = {
+  pr: PullRequestSummary;
+  branchFreshness: BranchFreshness;
+  workflowJobs: WorkflowJob[];
+  reviewThreads: ReviewThread[];
+  codexSignals: ReviewSignal[];
+  changedFiles: ChangedFile[];
+};
+
+type ReviewThreadsQueryData = {
+  repository?: {
+    pullRequest?: {
+      reviewThreads?: {
+        pageInfo?: ReviewThreadsPageInfo;
+        nodes?: any[];
+      };
+    };
+  };
+};
+
+type ReviewThreadsPageInfo = {
+  hasNextPage?: boolean;
+  endCursor?: string | null;
+};
+
+type GateMessage = {
+  code: string;
+  message: string;
+};
+
+type CheckStatusRow = {
+  name: string;
+  status: string;
+  details: string;
+};
+
+type QualityGroupStatus = {
+  name: QualityStepGroupName;
+  status: "pass" | "fail" | "pending" | "missing";
+  details: string;
+};
+
+type ReadinessEvaluation = {
+  decision: PullRequestDecision;
+  targeted: boolean;
+  targetReason: string | null;
+  blockers: GateMessage[];
+  advisories: GateMessage[];
+  checkStatuses: CheckStatusRow[];
+  qualityStatuses: QualityGroupStatus[];
+  unresolvedReviewThreads: number;
+  unresolvedCodexThreads: number;
+  branchFreshness: BranchFreshness;
+  codexGreenlight: ReviewSignal | null;
+  latestCodexSignal: ReviewSignal | null;
+  summary: string;
+};
+
+type ApplyResult = {
+  commentStatus: ApplyCommentStatus;
+  markedReady: boolean;
+};
+
+type EvaluationResult = {
+  pr: PullRequestSummary;
+  evaluation: ReadinessEvaluation;
+  applyResult: ApplyResult;
+};
+
+type GitHubPullRequestListItem = {
+  number: number;
+  draft: boolean;
+  state: string;
+  labels?: Array<{ name?: string }>;
+  user?: { login?: string };
+  base?: { ref?: string };
+  head?: { ref?: string; sha?: string };
+};
+
+type CommandOptions = {
+  apply: boolean;
+  configPath: string | null;
+  eventPath: string | null;
+  repository: string | null;
+  prNumbers: number[];
+  jsonOutputPath: string | null;
+  summaryOutputPath: string | null;
+};
+
+const READY_COMMENT_HEADING = "## Codex PR Readiness Gate";
+const DEFAULT_CONFIG_PATH = path.join(process.cwd(), ".github", "codex-pr-readiness.json");
+const SUCCESS_CONCLUSION = "success";
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const normalized = pattern.replace(/\\/g, "/");
+  let source = "";
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index];
+    if (character === "*") {
+      if (normalized[index + 1] === "*") {
+        source += ".*";
+        index += 1;
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+
+    source += escapeRegExp(character);
+  }
+
+  return new RegExp(`^${source}$`);
+}
+
+function matchesAnyGlob(filePath: string, patterns: string[]): boolean {
+  const normalizedPath = String(filePath || "").replace(/\\/g, "/");
+  return patterns.some((pattern) => globToRegExp(pattern).test(normalizedPath));
+}
+
+function loadGateConfig(configPath: string = DEFAULT_CONFIG_PATH): GateConfig {
+  return readJsonFile<GateConfig>(configPath);
+}
+
+function normalizeBody(body: string): string {
+  return String(body || "")
+    .trim()
+    .toLowerCase();
+}
+
+function isCodexActor(login: string, config: GateConfig): boolean {
+  return config.codexActors.includes(String(login || "").trim());
+}
+
+function isTargetPullRequest(
+  pr: PullRequestSummary,
+  config: GateConfig
+): {
+  targeted: boolean;
+  reason: string | null;
+} {
+  if (pr.state !== "open") {
+    return { targeted: false, reason: null };
+  }
+
+  if (!pr.isDraft) {
+    return { targeted: false, reason: null };
+  }
+
+  if (pr.labels.includes(config.targetLabel)) {
+    return { targeted: true, reason: `label \`${config.targetLabel}\`` };
+  }
+
+  if (pr.headRefName.startsWith(config.branchPrefix)) {
+    return { targeted: true, reason: `branch prefix \`${config.branchPrefix}\`` };
+  }
+
+  if (isCodexActor(pr.authorLogin, config)) {
+    return { targeted: true, reason: `author \`${pr.authorLogin}\`` };
+  }
+
+  return { targeted: false, reason: null };
+}
+
+function parseAddedLines(patch: string | null): string[] {
+  if (!patch) {
+    return [];
+  }
+
+  return String(patch)
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+}
+
+function isAllowlisted(filePath: string, marker: string, entries: AllowlistEntry[]): boolean {
+  return entries.some((entry) => {
+    if (!matchesAnyGlob(filePath, [entry.pattern])) {
+      return false;
+    }
+
+    const markers = asArray(entry.markers);
+    if (!markers.length) {
+      return true;
+    }
+
+    return markers.includes(marker);
+  });
+}
+
+function summarizeFileMatches(
+  prefix: string,
+  matches: Array<{ path: string; marker: string }>
+): string {
+  const grouped = new Map<string, Set<string>>();
+  matches.forEach((match) => {
+    if (!grouped.has(match.path)) {
+      grouped.set(match.path, new Set<string>());
+    }
+    grouped.get(match.path)?.add(match.marker);
+  });
+
+  const parts = Array.from(grouped.entries()).map(
+    ([filePath, markers]) => `\`${filePath}\` (${Array.from(markers).join(", ")})`
+  );
+  return `${prefix}: ${parts.join("; ")}`;
+}
+
+function collectSkippedTestMatches(changedFiles: ChangedFile[], config: GateConfig) {
+  const skipPattern = /\b(?:it|test|describe)\.skip\s*\(/;
+  const matches: Array<{ path: string; marker: string }> = [];
+
+  changedFiles.forEach((file) => {
+    if (!matchesAnyGlob(file.path, config.testFileGlobs)) {
+      return;
+    }
+
+    parseAddedLines(file.patch).forEach((line) => {
+      if (!skipPattern.test(line)) {
+        return;
+      }
+
+      const marker = line.match(/\b(?:it|test|describe)\.skip\b/)?.[0] || "skip";
+      if (isAllowlisted(file.path, marker, config.skipTestAllowlist)) {
+        return;
+      }
+
+      matches.push({ path: file.path, marker });
+    });
+  });
+
+  return matches;
+}
+
+function collectTemporaryMarkerMatches(changedFiles: ChangedFile[], config: GateConfig) {
+  const markerRules: Array<{ marker: string; regex: RegExp }> = [
+    { marker: "console.log", regex: /\bconsole\.log\s*\(/ },
+    { marker: "debugger", regex: /\bdebugger\b/ },
+    { marker: "TODO", regex: /\bTODO\b/i },
+    { marker: "FIXME", regex: /\bFIXME\b/i },
+    { marker: "temporary", regex: /\btemporary\b/i },
+    { marker: "placeholder", regex: /\bplaceholder\b/i },
+    { marker: "mock-marker", regex: /(?:\/\/|\/\*|\*|#).*\bmock\b/i }
+  ];
+  const matches: Array<{ path: string; marker: string }> = [];
+
+  changedFiles.forEach((file) => {
+    parseAddedLines(file.patch).forEach((line) => {
+      markerRules.forEach((rule) => {
+        if (!rule.regex.test(line)) {
+          return;
+        }
+
+        if (isAllowlisted(file.path, rule.marker, config.temporaryMarkerAllowlist)) {
+          return;
+        }
+
+        matches.push({ path: file.path, marker: rule.marker });
+      });
+    });
+  });
+
+  return matches;
+}
+
+function collectSyncBlockers(changedFiles: ChangedFile[], config: GateConfig): GateMessage[] {
+  return config.syncRequirements
+    .filter((requirement) =>
+      changedFiles.some((file) => matchesAnyGlob(file.path, requirement.ifChanged))
+    )
+    .filter(
+      (requirement) =>
+        !requirement.mustAlsoChange.every((expected) =>
+          changedFiles.some((file) => matchesAnyGlob(file.path, [expected]))
+        )
+    )
+    .map((requirement, index) => ({
+      code: `sync-requirement-${index + 1}`,
+      message: requirement.message
+    }));
+}
+
+function latestWorkflowJobByName(workflowJobs: WorkflowJob[], jobName: string): WorkflowJob | null {
+  return (
+    workflowJobs
+      .filter((job) => job.name === jobName)
+      .sort((left, right) => {
+        const leftDate = Date.parse(left.completedAt || left.startedAt || "");
+        const rightDate = Date.parse(right.completedAt || right.startedAt || "");
+        return rightDate - leftDate;
+      })[0] || null
+  );
+}
+
+function describeJobStatus(job: WorkflowJob | null): CheckStatusRow {
+  if (!job) {
+    return {
+      name: "missing",
+      status: "missing",
+      details: "No matching workflow job was found for the current head SHA."
+    };
+  }
+
+  if (job.status !== "completed") {
+    return {
+      name: job.name,
+      status: "pending",
+      details: "The job is still running or queued."
+    };
+  }
+
+  return {
+    name: job.name,
+    status: job.conclusion === SUCCESS_CONCLUSION ? "pass" : "fail",
+    details: `Conclusion: ${String(job.conclusion || "unknown")}.`
+  };
+}
+
+function evaluateCheckStatuses(
+  snapshot: Snapshot,
+  config: GateConfig
+): {
+  blockers: GateMessage[];
+  checkStatuses: CheckStatusRow[];
+} {
+  const blockers: GateMessage[] = [];
+  const checkStatuses: CheckStatusRow[] = [];
+
+  config.requiredCheckNames.forEach((checkName) => {
+    const job = latestWorkflowJobByName(snapshot.workflowJobs, checkName);
+    const statusRow = describeJobStatus(job);
+    statusRow.name = checkName;
+    checkStatuses.push(statusRow);
+
+    if (!job) {
+      blockers.push({
+        code: `required-check-missing:${checkName}`,
+        message: `Required check \`${checkName}\` is missing for the current head SHA.`
+      });
+      return;
+    }
+
+    if (job.status !== "completed") {
+      blockers.push({
+        code: `required-check-pending:${checkName}`,
+        message: `Required check \`${checkName}\` is still pending.`
+      });
+      return;
+    }
+
+    if (job.conclusion !== SUCCESS_CONCLUSION) {
+      blockers.push({
+        code: `required-check-failed:${checkName}`,
+        message: `Required check \`${checkName}\` finished with \`${String(
+          job.conclusion || "unknown"
+        )}\`.`
+      });
+    }
+  });
+
+  return { blockers, checkStatuses };
+}
+
+function evaluateQualitySteps(
+  snapshot: Snapshot,
+  config: GateConfig
+): {
+  blockers: GateMessage[];
+  qualityStatuses: QualityGroupStatus[];
+} {
+  const blockers: GateMessage[] = [];
+  const qualityStatuses: QualityGroupStatus[] = [];
+  const qualityJob = latestWorkflowJobByName(snapshot.workflowJobs, "quality");
+
+  (Object.keys(config.requiredQualitySteps) as QualityStepGroupName[]).forEach((groupName) => {
+    const expectedSteps = config.requiredQualitySteps[groupName];
+
+    if (!qualityJob) {
+      qualityStatuses.push({
+        name: groupName,
+        status: "missing",
+        details: "The quality job is missing, so this requirement could not be verified."
+      });
+      blockers.push({
+        code: `quality-group-missing:${groupName}`,
+        message: `Cannot verify the \`${groupName}\` readiness requirement because the \`quality\` job is missing.`
+      });
+      return;
+    }
+
+    const matchingSteps = expectedSteps.map(
+      (stepName) => qualityJob.steps.find((step) => step.name === stepName) || null
+    );
+    if (matchingSteps.some((step) => !step)) {
+      qualityStatuses.push({
+        name: groupName,
+        status: "missing",
+        details: `Expected quality steps not found: ${expectedSteps.join(", ")}.`
+      });
+      blockers.push({
+        code: `quality-step-missing:${groupName}`,
+        message: `Cannot verify \`${groupName}\` because one or more expected quality steps are missing: ${expectedSteps.join(
+          ", "
+        )}.`
+      });
+      return;
+    }
+
+    const pendingStep = matchingSteps.find((step) => step?.status !== "completed");
+    if (pendingStep) {
+      qualityStatuses.push({
+        name: groupName,
+        status: "pending",
+        details: `Quality step \`${pendingStep.name}\` is still pending.`
+      });
+      blockers.push({
+        code: `quality-step-pending:${groupName}`,
+        message: `Quality step \`${pendingStep.name}\` is still pending.`
+      });
+      return;
+    }
+
+    const failedSteps = matchingSteps.filter((step) => step?.conclusion !== SUCCESS_CONCLUSION);
+    if (failedSteps.length > 0) {
+      qualityStatuses.push({
+        name: groupName,
+        status: "fail",
+        details: `Failing quality steps: ${failedSteps
+          .map((step) => `${step?.name} (${String(step?.conclusion || "unknown")})`)
+          .join(", ")}.`
+      });
+      blockers.push({
+        code: `quality-step-failed:${groupName}`,
+        message: `The \`${groupName}\` readiness requirement failed in ${failedSteps
+          .map((step) => `\`${step?.name}\``)
+          .join(", ")}.`
+      });
+      return;
+    }
+
+    qualityStatuses.push({
+      name: groupName,
+      status: "pass",
+      details: `Verified via ${expectedSteps.join(", ")}.`
+    });
+  });
+
+  return { blockers, qualityStatuses };
+}
+
+function latestSignal(signals: ReviewSignal[]): ReviewSignal | null {
+  return (
+    [...signals].sort(
+      (left, right) => Date.parse(right.submittedAt || "") - Date.parse(left.submittedAt || "")
+    )[0] || null
+  );
+}
+
+function isGreenlightSignal(signal: ReviewSignal, config: GateConfig): boolean {
+  if (signal.kind === "review" && signal.state === "APPROVED") {
+    return true;
+  }
+
+  const body = normalizeBody(signal.body);
+  return config.codexGreenlightPhrases.some((phrase) => body.includes(normalizeBody(phrase)));
+}
+
+function evaluateCodexSignals(
+  snapshot: Snapshot,
+  config: GateConfig
+): {
+  blockers: GateMessage[];
+  unresolvedReviewThreads: number;
+  unresolvedCodexThreads: number;
+  codexGreenlight: ReviewSignal | null;
+  latestCodexSignal: ReviewSignal | null;
+} {
+  const blockers: GateMessage[] = [];
+  const unresolvedThreads = snapshot.reviewThreads.filter((thread) => !thread.isResolved);
+  const unresolvedReviewThreads = unresolvedThreads.length;
+  const unresolvedCodexThreads = unresolvedThreads.filter((thread) =>
+    thread.comments.some((comment) => isCodexActor(comment.authorLogin, config))
+  ).length;
+  const postHeadSignals = snapshot.codexSignals.filter(
+    (signal) => Date.parse(signal.submittedAt || "") >= Date.parse(snapshot.pr.headCommitAt || "")
+  );
+  const latestCodexSignal = latestSignal(postHeadSignals);
+  const codexGreenlight =
+    postHeadSignals
+      .filter((signal) => isGreenlightSignal(signal, config))
+      .sort(
+        (left, right) => Date.parse(right.submittedAt || "") - Date.parse(left.submittedAt || "")
+      )[0] || null;
+
+  if (unresolvedReviewThreads > 0) {
+    blockers.push({
+      code: "unresolved-review-threads",
+      message: `${unresolvedReviewThreads} unresolved review thread(s) remain.`
+    });
+  }
+
+  if (!latestCodexSignal) {
+    blockers.push({
+      code: "missing-codex-greenlight",
+      message: `No explicit Codex greenlight was found after head commit \`${snapshot.pr.headSha.slice(
+        0,
+        12
+      )}\`.`
+    });
+  } else if (!isGreenlightSignal(latestCodexSignal, config)) {
+    blockers.push({
+      code: "stale-codex-greenlight",
+      message: "The latest Codex signal after the current head commit is not a final greenlight."
+    });
+  }
+
+  return {
+    blockers,
+    unresolvedReviewThreads,
+    unresolvedCodexThreads,
+    codexGreenlight,
+    latestCodexSignal
+  };
+}
+
+function evaluateBranchFreshness(snapshot: Snapshot, config: GateConfig): GateMessage[] {
+  if (snapshot.branchFreshness.behindBy <= config.maxCommitsBehindBase) {
+    return [];
+  }
+
+  return [
+    {
+      code: "branch-stale",
+      message: `The PR branch is ${snapshot.branchFreshness.behindBy} commit(s) behind \`${snapshot.pr.baseRefName}\`, which exceeds the freshness limit of ${config.maxCommitsBehindBase}.`
+    }
+  ];
+}
+
+function evaluateMergeability(snapshot: Snapshot): GateMessage[] {
+  if (snapshot.pr.mergeable === true) {
+    return [];
+  }
+
+  return [
+    {
+      code: "not-mergeable",
+      message: `GitHub reports the PR as not mergeable (${String(
+        snapshot.pr.mergeableState || "unknown"
+      )}).`
+    }
+  ];
+}
+
+function buildAdvisories(snapshot: Snapshot, config: GateConfig): GateMessage[] {
+  const advisories: GateMessage[] = [];
+  const changedFiles = snapshot.changedFiles.filter((file) => file.status !== "removed");
+  const productionFiles = changedFiles.filter((file) =>
+    matchesAnyGlob(file.path, config.productionFileGlobs)
+  );
+  const testFiles = changedFiles.filter((file) => matchesAnyGlob(file.path, config.testFileGlobs));
+  const docFiles = changedFiles.filter((file) => matchesAnyGlob(file.path, config.docFileGlobs));
+  const totalChanges = changedFiles.reduce((sum, file) => sum + Number(file.changes || 0), 0);
+  const productionAdditions = productionFiles.reduce(
+    (sum, file) => sum + Number(file.additions || 0),
+    0
+  );
+  const testAdditions = testFiles.reduce((sum, file) => sum + Number(file.additions || 0), 0);
+
+  if (totalChanges >= config.largeDiffChangeThreshold) {
+    advisories.push({
+      code: "large-diff",
+      message: `The diff is large (${totalChanges} changed lines across ${changedFiles.length} files).`
+    });
+  }
+
+  if (productionAdditions >= config.significantChangeThreshold && docFiles.length === 0) {
+    advisories.push({
+      code: "missing-docs",
+      message: "Significant production changes were detected without corresponding docs updates."
+    });
+  }
+
+  const backendOrSharedTouched = productionFiles.some((file) =>
+    matchesAnyGlob(file.path, ["backend/**", "shared/**", "scripts/**", "api/**", "supabase/**"])
+  );
+  const frontendTouched = productionFiles.some((file) =>
+    matchesAnyGlob(file.path, ["frontend/**", "frontend/react-shell/**"])
+  );
+
+  if (
+    backendOrSharedTouched &&
+    !testFiles.some((file) => matchesAnyGlob(file.path, ["tests/**"]))
+  ) {
+    advisories.push({
+      code: "coverage-risk-backend",
+      message:
+        "Backend/shared production changes were detected without matching automated test file updates."
+    });
+  }
+
+  if (
+    frontendTouched &&
+    !testFiles.some((file) =>
+      matchesAnyGlob(file.path, ["frontend/react-shell/src/__tests__/**", "e2e/**", "tests/**"])
+    )
+  ) {
+    advisories.push({
+      code: "coverage-risk-frontend",
+      message:
+        "Frontend production changes were detected without matching React or E2E test updates."
+    });
+  }
+
+  if (
+    productionAdditions >= config.lowTestAdditionsMinProductionAdditions &&
+    testAdditions < Math.max(1, Math.floor(productionAdditions * config.lowTestAdditionsRatio))
+  ) {
+    advisories.push({
+      code: "low-test-additions",
+      message: `Production additions (${productionAdditions}) substantially exceed new test additions (${testAdditions}).`
+    });
+  }
+
+  return advisories;
+}
+
+function buildSummary(
+  pr: PullRequestSummary,
+  evaluation: ReadinessEvaluation,
+  config: GateConfig
+): string {
+  const lines = [
+    config.summaryCommentMarker,
+    READY_COMMENT_HEADING,
+    "",
+    `Decision: **${evaluation.decision === "ready" ? "READY" : "BLOCKED"}**`,
+    "",
+    `- PR: #${pr.number} - ${pr.title}`,
+    `- Target reason: ${evaluation.targetReason || "n/a"}`,
+    `- Head branch: \`${pr.headRefName}\``,
+    `- Base branch: \`${pr.baseRefName}\``,
+    `- Mergeable: ${pr.mergeable === true ? "yes" : `no (${String(pr.mergeableState || "unknown")})`}`,
+    `- Branch freshness: ${evaluation.branchFreshness.behindBy} commit(s) behind \`${pr.baseRefName}\``,
+    `- Unresolved review threads: ${evaluation.unresolvedReviewThreads}`,
+    `- Unresolved Codex review threads: ${evaluation.unresolvedCodexThreads}`,
+    `- Codex greenlight: ${
+      evaluation.codexGreenlight
+        ? `yes (${evaluation.codexGreenlight.kind} by \`${evaluation.codexGreenlight.actorLogin}\`)`
+        : "missing"
+    }`,
+    "",
+    "### Hard blockers",
+    ...(evaluation.blockers.length
+      ? evaluation.blockers.map((blocker) => `- ${blocker.message}`)
+      : ["- None."]),
+    "",
+    "### Soft advisories",
+    ...(evaluation.advisories.length
+      ? evaluation.advisories.map((advisory) => `- ${advisory.message}`)
+      : ["- None."]),
+    "",
+    "### Required checks",
+    ...evaluation.checkStatuses.map(
+      (status) => `- \`${status.name}\`: ${status.status.toUpperCase()} - ${status.details}`
+    ),
+    "",
+    "### Quality gate details",
+    ...evaluation.qualityStatuses.map(
+      (status) => `- \`${status.name}\`: ${status.status.toUpperCase()} - ${status.details}`
+    ),
+    "",
+    evaluation.decision === "ready"
+      ? "Final decision: **Ready for review.** The automation will mark this draft PR as ready."
+      : "Final decision: **Keep in draft.** The automation will not mark this PR ready until every hard blocker is cleared."
+  ];
+
+  return lines.join("\n");
+}
+
+function evaluateReadinessFromSnapshot(
+  snapshot: Snapshot,
+  config: GateConfig
+): ReadinessEvaluation {
+  const targetInfo = isTargetPullRequest(snapshot.pr, config);
+  if (!targetInfo.targeted) {
+    return {
+      decision: "skipped",
+      targeted: false,
+      targetReason: null,
+      blockers: [],
+      advisories: [],
+      checkStatuses: [],
+      qualityStatuses: [],
+      unresolvedReviewThreads: 0,
+      unresolvedCodexThreads: 0,
+      branchFreshness: snapshot.branchFreshness,
+      codexGreenlight: null,
+      latestCodexSignal: null,
+      summary: ""
+    };
+  }
+
+  const blockers: GateMessage[] = [];
+  const advisories = buildAdvisories(snapshot, config);
+  const checkEvaluation = evaluateCheckStatuses(snapshot, config);
+  const qualityEvaluation = evaluateQualitySteps(snapshot, config);
+  const codexEvaluation = evaluateCodexSignals(snapshot, config);
+
+  blockers.push(...checkEvaluation.blockers);
+  blockers.push(...qualityEvaluation.blockers);
+  blockers.push(...evaluateBranchFreshness(snapshot, config));
+  blockers.push(...evaluateMergeability(snapshot));
+  blockers.push(...codexEvaluation.blockers);
+
+  const skippedTests = collectSkippedTestMatches(snapshot.changedFiles, config);
+  if (skippedTests.length > 0) {
+    blockers.push({
+      code: "skipped-tests-introduced",
+      message: summarizeFileMatches("New skipped tests were introduced", skippedTests)
+    });
+  }
+
+  const temporaryMatches = collectTemporaryMarkerMatches(snapshot.changedFiles, config);
+  if (temporaryMatches.length > 0) {
+    blockers.push({
+      code: "temporary-leftovers",
+      message: summarizeFileMatches(
+        "Temporary or debug leftovers were introduced",
+        temporaryMatches
+      )
+    });
+  }
+
+  blockers.push(...collectSyncBlockers(snapshot.changedFiles, config));
+
+  const decision: PullRequestDecision = blockers.length === 0 ? "ready" : "blocked";
+  const evaluation: ReadinessEvaluation = {
+    decision,
+    targeted: true,
+    targetReason: targetInfo.reason,
+    blockers,
+    advisories,
+    checkStatuses: checkEvaluation.checkStatuses,
+    qualityStatuses: qualityEvaluation.qualityStatuses,
+    unresolvedReviewThreads: codexEvaluation.unresolvedReviewThreads,
+    unresolvedCodexThreads: codexEvaluation.unresolvedCodexThreads,
+    branchFreshness: snapshot.branchFreshness,
+    codexGreenlight: codexEvaluation.codexGreenlight,
+    latestCodexSignal: codexEvaluation.latestCodexSignal,
+    summary: ""
+  };
+
+  evaluation.summary = buildSummary(snapshot.pr, evaluation, config);
+  return evaluation;
+}
+
+function parseRepository(input: string): GitHubRepositoryRef {
+  const [owner, repo] = String(input || "").split("/");
+  if (!owner || !repo) {
+    throw new Error(`Invalid repository value "${input}". Expected owner/name.`);
+  }
+
+  return { owner, repo };
+}
+
+class GitHubApiClient {
+  owner: string;
+  repo: string;
+  token: string;
+
+  constructor(repository: string, token: string) {
+    const parsed = parseRepository(repository);
+    this.owner = parsed.owner;
+    this.repo = parsed.repo;
+    this.token = token;
+  }
+
+  async requestJson(method: string, requestPath: string, body?: Record<string, unknown>) {
+    const response = await fetch(`https://api.github.com${requestPath}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "netrisk-codex-pr-readiness"
+      },
+      body: body ? JSON.stringify(body) : undefined
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`${method} ${requestPath} failed (${response.status}): ${text}`);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    return response.json();
+  }
+
+  async graphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    const response = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "netrisk-codex-pr-readiness"
+      },
+      body: JSON.stringify({ query, variables })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GraphQL request failed (${response.status}): ${text}`);
+    }
+
+    const payload = (await response.json()) as {
+      data?: T;
+      errors?: Array<{ message?: string }>;
+    };
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+      throw new Error(
+        `GraphQL returned errors: ${payload.errors.map((entry) => entry.message || "unknown").join("; ")}`
+      );
+    }
+
+    return payload.data as T;
+  }
+}
+
+async function paginateRest<T>(client: GitHubApiClient, requestPath: string): Promise<T[]> {
+  const results: T[] = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const pagePath = `${requestPath}${requestPath.includes("?") ? "&" : "?"}per_page=100&page=${page}`;
+    const pageResults = (await client.requestJson("GET", pagePath)) as T[];
+    results.push(...asArray(pageResults));
+    if (asArray(pageResults).length < 100) {
+      break;
+    }
+  }
+  return results;
+}
+
+function toPullRequestSummary(raw: any): PullRequestSummary {
+  return {
+    number: Number(raw.number || 0),
+    nodeId: String(raw.node_id || ""),
+    title: String(raw.title || ""),
+    url: String(raw.html_url || ""),
+    state: String(raw.state || ""),
+    isDraft: Boolean(raw.draft),
+    authorLogin: String(raw.user?.login || ""),
+    baseRefName: String(raw.base?.ref || ""),
+    headRefName: String(raw.head?.ref || ""),
+    headSha: String(raw.head?.sha || ""),
+    headCommitAt: "",
+    labels: asArray(raw.labels)
+      .map((label: any) => String(label?.name || ""))
+      .filter(Boolean),
+    additions: Number(raw.additions || 0),
+    deletions: Number(raw.deletions || 0),
+    changedFiles: Number(raw.changed_files || 0),
+    mergeable: typeof raw.mergeable === "boolean" ? raw.mergeable : null,
+    mergeableState: raw.mergeable_state ? String(raw.mergeable_state) : null
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getPullRequest(
+  client: GitHubApiClient,
+  prNumber: number
+): Promise<PullRequestSummary> {
+  let attempt = 0;
+  while (attempt < 4) {
+    const raw = await client.requestJson(
+      "GET",
+      `/repos/${client.owner}/${client.repo}/pulls/${prNumber}`
+    );
+    const summary = toPullRequestSummary(raw);
+    if (summary.mergeable !== null || attempt === 3) {
+      return summary;
+    }
+    attempt += 1;
+    await sleep(1500);
+  }
+
+  throw new Error(`Unable to load pull request #${prNumber}.`);
+}
+
+async function getHeadCommitTimestamp(client: GitHubApiClient, headSha: string): Promise<string> {
+  const raw = (await client.requestJson(
+    "GET",
+    `/repos/${client.owner}/${client.repo}/commits/${headSha}`
+  )) as any;
+  return String(raw.commit?.committer?.date || raw.commit?.author?.date || "");
+}
+
+async function getBranchFreshness(
+  client: GitHubApiClient,
+  pr: PullRequestSummary
+): Promise<BranchFreshness> {
+  const raw = (await client.requestJson(
+    "GET",
+    `/repos/${client.owner}/${client.repo}/compare/${encodeURIComponent(pr.baseRefName)}...${encodeURIComponent(
+      pr.headSha
+    )}`
+  )) as any;
+
+  return {
+    behindBy: Number(raw.behind_by || 0),
+    aheadBy: Number(raw.ahead_by || 0),
+    status: String(raw.status || "unknown"),
+    url: String(raw.html_url || "")
+  };
+}
+
+async function getWorkflowJobs(client: GitHubApiClient, headSha: string): Promise<WorkflowJob[]> {
+  const runs: any[] = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const raw = (await client.requestJson(
+      "GET",
+      `/repos/${client.owner}/${client.repo}/actions/runs?head_sha=${encodeURIComponent(
+        headSha
+      )}&per_page=100&page=${page}`
+    )) as { workflow_runs?: any[] };
+    const pageRuns = asArray(raw.workflow_runs).filter(
+      (run) => String(run.head_sha || "") === headSha
+    );
+    runs.push(...pageRuns);
+    if (pageRuns.length < 100) {
+      break;
+    }
+  }
+  const jobs: WorkflowJob[] = [];
+
+  for (const run of runs) {
+    const jobsResponse = (await client.requestJson(
+      "GET",
+      `/repos/${client.owner}/${client.repo}/actions/runs/${run.id}/jobs?per_page=100`
+    )) as { jobs?: any[] };
+    asArray(jobsResponse.jobs).forEach((job) => {
+      jobs.push({
+        id: Number(job.id || 0),
+        name: String(job.name || ""),
+        htmlUrl: String(job.html_url || ""),
+        status: job.status ? String(job.status) : null,
+        conclusion: job.conclusion ? String(job.conclusion) : null,
+        startedAt: job.started_at ? String(job.started_at) : null,
+        completedAt: job.completed_at ? String(job.completed_at) : null,
+        workflowName: String(run.name || ""),
+        steps: asArray(job.steps).map((step: any) => ({
+          name: String(step.name || ""),
+          status: step.status ? String(step.status) : null,
+          conclusion: step.conclusion ? String(step.conclusion) : null
+        }))
+      });
+    });
+  }
+
+  const latestByName = new Map<string, WorkflowJob>();
+  jobs.forEach((job) => {
+    const existing = latestByName.get(job.name);
+    if (!existing) {
+      latestByName.set(job.name, job);
+      return;
+    }
+
+    const existingTime = Date.parse(existing.completedAt || existing.startedAt || "");
+    const nextTime = Date.parse(job.completedAt || job.startedAt || "");
+    if (nextTime >= existingTime) {
+      latestByName.set(job.name, job);
+    }
+  });
+
+  return Array.from(latestByName.values());
+}
+
+async function getReviewThreads(
+  client: GitHubApiClient,
+  prNumber: number
+): Promise<ReviewThread[]> {
+  const threads: ReviewThread[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const payload: ReviewThreadsQueryData = await client.graphql<ReviewThreadsQueryData>(
+      `
+        query ReviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  updatedAt
+                  comments(first: 20) {
+                    nodes {
+                      author {
+                        login
+                      }
+                      body
+                      createdAt
+                      url
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner: client.owner,
+        repo: client.repo,
+        number: prNumber,
+        cursor
+      }
+    );
+
+    const reviewThreads = asArray(payload.repository?.pullRequest?.reviewThreads?.nodes).map(
+      (thread: any) => ({
+        id: String(thread.id || ""),
+        isResolved: Boolean(thread.isResolved),
+        isOutdated: Boolean(thread.isOutdated),
+        updatedAt: String(thread.updatedAt || ""),
+        comments: asArray(thread.comments?.nodes).map((comment: any) => ({
+          authorLogin: String(comment.author?.login || ""),
+          body: String(comment.body || ""),
+          createdAt: String(comment.createdAt || ""),
+          url: String(comment.url || "")
+        }))
+      })
+    );
+
+    threads.push(...reviewThreads);
+    const pageInfo: ReviewThreadsPageInfo | undefined =
+      payload.repository?.pullRequest?.reviewThreads?.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) {
+      break;
+    }
+    cursor = String(pageInfo.endCursor);
+  }
+
+  return threads;
+}
+
+async function getCodexSignals(client: GitHubApiClient, prNumber: number, config: GateConfig) {
+  const reviewSignals = (
+    await paginateRest<any>(
+      client,
+      `/repos/${client.owner}/${client.repo}/pulls/${prNumber}/reviews`
+    )
+  )
+    .filter((review) => isCodexActor(String(review.user?.login || ""), config))
+    .map((review) => ({
+      actorLogin: String(review.user?.login || ""),
+      state: review.state ? String(review.state) : null,
+      body: String(review.body || ""),
+      submittedAt: String(review.submitted_at || review.submittedAt || ""),
+      url: String(review.html_url || ""),
+      kind: "review" as const
+    }));
+  const issueCommentSignals = (
+    await paginateRest<any>(
+      client,
+      `/repos/${client.owner}/${client.repo}/issues/${prNumber}/comments`
+    )
+  )
+    .filter((comment) => isCodexActor(String(comment.user?.login || ""), config))
+    .map((comment) => ({
+      actorLogin: String(comment.user?.login || ""),
+      state: null,
+      body: String(comment.body || ""),
+      submittedAt: String(comment.created_at || ""),
+      url: String(comment.html_url || ""),
+      kind: "issue-comment" as const
+    }));
+
+  return [...reviewSignals, ...issueCommentSignals];
+}
+
+async function getChangedFiles(client: GitHubApiClient, prNumber: number): Promise<ChangedFile[]> {
+  return (
+    await paginateRest<any>(client, `/repos/${client.owner}/${client.repo}/pulls/${prNumber}/files`)
+  ).map((file) => ({
+    path: String(file.filename || ""),
+    status: String(file.status || ""),
+    additions: Number(file.additions || 0),
+    deletions: Number(file.deletions || 0),
+    changes: Number(file.changes || 0),
+    patch: typeof file.patch === "string" ? file.patch : null
+  }));
+}
+
+async function getSnapshot(
+  client: GitHubApiClient,
+  prNumber: number,
+  config: GateConfig
+): Promise<Snapshot> {
+  const pr = await getPullRequest(client, prNumber);
+  pr.headCommitAt = await getHeadCommitTimestamp(client, pr.headSha);
+
+  return {
+    pr,
+    branchFreshness: await getBranchFreshness(client, pr),
+    workflowJobs: await getWorkflowJobs(client, pr.headSha),
+    reviewThreads: await getReviewThreads(client, prNumber),
+    codexSignals: await getCodexSignals(client, prNumber, config),
+    changedFiles: await getChangedFiles(client, prNumber)
+  };
+}
+
+async function upsertSummaryComment(
+  client: GitHubApiClient,
+  prNumber: number,
+  body: string,
+  marker: string
+): Promise<ApplyCommentStatus> {
+  const comments = await paginateRest<any>(
+    client,
+    `/repos/${client.owner}/${client.repo}/issues/${prNumber}/comments`
+  );
+  const existing = comments.find(
+    (comment) =>
+      String(comment.user?.login || "") === "github-actions[bot]" &&
+      String(comment.body || "").includes(marker)
+  );
+
+  if (!existing) {
+    await client.requestJson(
+      "POST",
+      `/repos/${client.owner}/${client.repo}/issues/${prNumber}/comments`,
+      {
+        body
+      }
+    );
+    return "created";
+  }
+
+  if (String(existing.body || "") === body) {
+    return "unchanged";
+  }
+
+  await client.requestJson(
+    "PATCH",
+    `/repos/${client.owner}/${client.repo}/issues/comments/${existing.id}`,
+    { body }
+  );
+  return "updated";
+}
+
+async function markReadyForReview(
+  client: GitHubApiClient,
+  pullRequestNodeId: string
+): Promise<boolean> {
+  await client.graphql(
+    `
+      mutation MarkReady($pullRequestId: ID!) {
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+          pullRequest {
+            id
+            isDraft
+          }
+        }
+      }
+    `,
+    {
+      pullRequestId: pullRequestNodeId
+    }
+  );
+  return true;
+}
+
+async function applyEvaluation(
+  client: GitHubApiClient,
+  snapshot: Snapshot,
+  evaluation: ReadinessEvaluation,
+  config: GateConfig,
+  apply: boolean
+): Promise<ApplyResult> {
+  if (!apply || !evaluation.targeted || evaluation.decision === "skipped") {
+    return {
+      commentStatus: "skipped",
+      markedReady: false
+    };
+  }
+
+  const commentStatus = await upsertSummaryComment(
+    client,
+    snapshot.pr.number,
+    evaluation.summary,
+    config.summaryCommentMarker
+  );
+
+  if (evaluation.decision !== "ready" || !snapshot.pr.isDraft) {
+    return {
+      commentStatus,
+      markedReady: false
+    };
+  }
+
+  await markReadyForReview(client, snapshot.pr.nodeId);
+  return {
+    commentStatus,
+    markedReady: true
+  };
+}
+
+function buildBatchSummary(results: EvaluationResult[]): string {
+  if (results.length === 0) {
+    return ["# Codex PR Readiness", "", "No targeted draft PRs were evaluated in this run."].join(
+      "\n"
+    );
+  }
+
+  const lines = ["# Codex PR Readiness", ""];
+  results.forEach((result) => {
+    const blockerCount = result.evaluation.blockers.length;
+    const advisoryCount = result.evaluation.advisories.length;
+    lines.push(
+      `- PR #${result.pr.number}: ${result.evaluation.decision.toUpperCase()} ` +
+        `(${blockerCount} blocker(s), ${advisoryCount} advisory/advisories, comment ${result.applyResult.commentStatus}, marked ready ${result.applyResult.markedReady ? "yes" : "no"})`
+    );
+  });
+
+  return lines.join("\n");
+}
+
+function parseArgs(argv: string[]): CommandOptions {
+  const options: CommandOptions = {
+    apply: false,
+    configPath: null,
+    eventPath: null,
+    repository: null,
+    prNumbers: [],
+    jsonOutputPath: null,
+    summaryOutputPath: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (arg === "--config" && next) {
+      options.configPath = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--event-path" && next) {
+      options.eventPath = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--repository" && next) {
+      options.repository = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--pr-number" && next) {
+      options.prNumbers.push(Number(next));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--json-output" && next) {
+      options.jsonOutputPath = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--summary-output" && next) {
+      options.summaryOutputPath = next;
+      index += 1;
+      continue;
+    }
+  }
+
+  return options;
+}
+
+function parseEventPrNumbers(eventPath: string | null): number[] {
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    return [];
+  }
+
+  const payload = readJsonFile<any>(eventPath);
+  const eventName = String(process.env.GITHUB_EVENT_NAME || payload.action || "");
+
+  if (payload.pull_request?.number) {
+    return [Number(payload.pull_request.number)];
+  }
+
+  if (
+    eventName === "pull_request_review" &&
+    payload.pull_request?.number &&
+    Number.isInteger(Number(payload.pull_request.number))
+  ) {
+    return [Number(payload.pull_request.number)];
+  }
+
+  if (eventName === "issue_comment" && payload.issue?.pull_request && payload.issue?.number) {
+    return [Number(payload.issue.number)];
+  }
+
+  if (eventName === "workflow_run") {
+    return asArray(payload.workflow_run?.pull_requests)
+      .map((entry: any) => Number(entry?.number || 0))
+      .filter((value) => Number.isInteger(value) && value > 0);
+  }
+
+  if (eventName === "workflow_dispatch" && payload.inputs?.pr_number) {
+    const value = Number(payload.inputs.pr_number);
+    return Number.isInteger(value) && value > 0 ? [value] : [];
+  }
+
+  return [];
+}
+
+async function resolveTargetPrNumbers(
+  client: GitHubApiClient,
+  options: CommandOptions,
+  config: GateConfig
+): Promise<number[]> {
+  const explicitPrNumbers = options.prNumbers.filter(
+    (value) => Number.isInteger(value) && value > 0
+  );
+  if (explicitPrNumbers.length > 0) {
+    return Array.from(new Set(explicitPrNumbers));
+  }
+
+  const eventPrNumbers = parseEventPrNumbers(options.eventPath);
+  if (eventPrNumbers.length > 0) {
+    return Array.from(new Set(eventPrNumbers));
+  }
+
+  const openPullRequests = (
+    await paginateRest<GitHubPullRequestListItem>(
+      client,
+      `/repos/${client.owner}/${client.repo}/pulls?state=open`
+    )
+  )
+    .map((raw) =>
+      toPullRequestSummary({
+        ...raw,
+        html_url: "",
+        node_id: "",
+        additions: 0,
+        deletions: 0,
+        changed_files: 0,
+        mergeable: null,
+        mergeable_state: null
+      })
+    )
+    .filter((pr) => isTargetPullRequest(pr, config).targeted);
+
+  return openPullRequests.map((pr) => pr.number);
+}
+
+async function run(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const config = loadGateConfig(options.configPath || DEFAULT_CONFIG_PATH);
+  const token = String(process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "");
+  const repository = options.repository || process.env.GITHUB_REPOSITORY || "";
+
+  if (!token) {
+    throw new Error("GITHUB_TOKEN (or GH_TOKEN) is required.");
+  }
+
+  if (!repository) {
+    throw new Error("GitHub repository could not be resolved. Pass --repository owner/name.");
+  }
+
+  const client = new GitHubApiClient(repository, token);
+  const prNumbers = await resolveTargetPrNumbers(client, options, config);
+  const results: EvaluationResult[] = [];
+
+  for (const prNumber of prNumbers) {
+    const snapshot = await getSnapshot(client, prNumber, config);
+    const evaluation = evaluateReadinessFromSnapshot(snapshot, config);
+    if (!evaluation.targeted) {
+      continue;
+    }
+
+    const applyResult = await applyEvaluation(client, snapshot, evaluation, config, options.apply);
+    results.push({
+      pr: snapshot.pr,
+      evaluation,
+      applyResult
+    });
+  }
+
+  const output = {
+    evaluatedPullRequests: results.map((result) => ({
+      number: result.pr.number,
+      url: result.pr.url,
+      decision: result.evaluation.decision,
+      blockers: result.evaluation.blockers,
+      advisories: result.evaluation.advisories,
+      commentStatus: result.applyResult.commentStatus,
+      markedReady: result.applyResult.markedReady
+    }))
+  };
+
+  if (options.jsonOutputPath) {
+    fs.writeFileSync(options.jsonOutputPath, JSON.stringify(output, null, 2));
+  }
+
+  const batchSummary = buildBatchSummary(results);
+  if (options.summaryOutputPath) {
+    fs.writeFileSync(options.summaryOutputPath, batchSummary);
+  }
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+if (require.main === module) {
+  void run();
+}
+
+module.exports = {
+  READY_COMMENT_HEADING,
+  buildSummary,
+  evaluateReadinessFromSnapshot,
+  isTargetPullRequest,
+  loadGateConfig,
+  parseAddedLines,
+  __testables: {
+    GitHubApiClient,
+    applyEvaluation,
+    buildBatchSummary,
+    getSnapshot,
+    markReadyForReview,
+    parseArgs,
+    parseEventPrNumbers,
+    resolveTargetPrNumbers,
+    upsertSummaryComment
+  }
+};

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -42,6 +42,8 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/game-summary-stores.test.cjs",
   "../tests/gameplay/regression/module-runtime.test.cjs",
   "../tests/gameplay/regression/admin-console-routes.test.cjs",
+  "../tests/gameplay/regression/admin-content-studio-routes.test.cjs",
+  "../tests/gameplay/regression/authored-modules.test.cjs",
   "../tests/gameplay/regression/startup-init-error.test.cjs",
   "../tests/gameplay/regression/tooling-and-supabase-regressions.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -44,6 +44,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/admin-console-routes.test.cjs",
   "../tests/gameplay/regression/admin-content-studio-routes.test.cjs",
   "../tests/gameplay/regression/authored-modules.test.cjs",
+  "../tests/gameplay/regression/codex-pr-readiness.test.cjs",
   "../tests/gameplay/regression/startup-init-error.test.cjs",
   "../tests/gameplay/regression/tooling-and-supabase-regressions.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",

--- a/shared/extensions.cts
+++ b/shared/extensions.cts
@@ -30,6 +30,10 @@ export interface VictoryRuleSet {
   id: string;
   name: string;
   description: string;
+  source?: "built-in" | "authored";
+  mapId?: string | null;
+  objectiveCount?: number;
+  moduleType?: string | null;
 }
 
 export interface VisualTheme {
@@ -515,6 +519,20 @@ export function migrateGameConfigExtensions(
   const sourceMapId = typeof source.mapId === "string" ? source.mapId.trim() : "";
   const fallbackMapId = typeof fallback.mapId === "string" ? fallback.mapId.trim() : "";
   const runtimeMapId = sourceMapId || fallbackMapId;
+  const sourceVictoryRuleSetId =
+    typeof source.victoryRuleSetId === "string" ? source.victoryRuleSetId.trim() : "";
+  const authoredVictoryModuleId =
+    source.victoryObjectiveModule &&
+    typeof source.victoryObjectiveModule === "object" &&
+    typeof (source.victoryObjectiveModule as { id?: unknown }).id === "string"
+      ? String((source.victoryObjectiveModule as { id?: unknown }).id || "").trim()
+      : "";
+  const resolvedVictoryRuleSetId =
+    sourceVictoryRuleSetId &&
+    !findVictoryRuleSet(sourceVictoryRuleSetId) &&
+    authoredVictoryModuleId === sourceVictoryRuleSetId
+      ? sourceVictoryRuleSetId
+      : selection.victoryRuleSetId;
   const sourceMapName = typeof source.mapName === "string" ? source.mapName.trim() : "";
   const fallbackMapName = typeof fallback.mapName === "string" ? fallback.mapName.trim() : "";
   const resolvedMapId = sourceMapId
@@ -600,7 +618,7 @@ export function migrateGameConfigExtensions(
         : typeof fallback.diceRuleSetDefenderWinsTies === "boolean"
           ? fallback.diceRuleSetDefenderWinsTies
           : null,
-    victoryRuleSetId: selection.victoryRuleSetId,
+    victoryRuleSetId: resolvedVictoryRuleSetId,
     themeId: selection.themeId,
     pieceSkinId: selection.pieceSkinId,
     activeModules: moduleSelection.activeModules,

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -1133,7 +1133,7 @@ export const authoredVictoryModuleContentSchema = objectSchema({
 export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
 
 export const authoredModuleInputSchema = objectSchema({
-  id: z.string(),
+  id: z.string().trim().min(1),
   name: z.string(),
   description: z.string(),
   version: z.string(),

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -20,6 +20,13 @@ const NETRISK_UI_SLOT_ID_VALUES = [
   "new-game.sidebar",
   "top-nav-bar"
 ] as const;
+const AUTHORED_MODULE_STATUS_VALUES = ["draft", "published", "disabled"] as const;
+const AUTHORED_MODULE_TYPE_VALUES = ["victory-objectives"] as const;
+const AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES = [
+  "control-continents",
+  "control-territory-count"
+] as const;
+const AUTHORED_MODULE_VALIDATION_SEVERITY_VALUES = ["warning", "error"] as const;
 
 type IssuePathSegment = string | number;
 
@@ -209,7 +216,11 @@ export type LogoutResponse = z.infer<typeof logoutResponseSchema>;
 export const victoryRuleSetSchema = objectSchema({
   id: z.string().min(1),
   name: z.string().min(1),
-  description: z.string().min(1)
+  description: z.string().min(1),
+  source: z.enum(["built-in", "authored"]).optional(),
+  mapId: z.string().min(1).nullable().optional(),
+  objectiveCount: z.number().int().optional(),
+  moduleType: z.string().min(1).nullable().optional()
 });
 
 export type VictoryRuleSet = z.infer<typeof victoryRuleSetSchema>;
@@ -1062,6 +1073,179 @@ export const adminAuditEntrySchema = objectSchema({
 
 export type AdminAuditEntry = z.infer<typeof adminAuditEntrySchema>;
 
+export const authoredModuleValidationIssueSchema = objectSchema({
+  code: z.string().min(1),
+  path: z.string().min(1),
+  severity: z.enum(AUTHORED_MODULE_VALIDATION_SEVERITY_VALUES),
+  message: z.string().min(1)
+});
+
+export type AuthoredModuleValidationIssue = z.infer<typeof authoredModuleValidationIssueSchema>;
+
+export const authoredModuleValidationSchema = objectSchema({
+  valid: z.boolean(),
+  errors: z.array(authoredModuleValidationIssueSchema),
+  warnings: z.array(authoredModuleValidationIssueSchema)
+});
+
+export type AuthoredModuleValidation = z.infer<typeof authoredModuleValidationSchema>;
+
+export const authoredVictoryObjectiveBaseSchema = objectSchema({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  enabled: z.boolean(),
+  type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
+});
+
+export const authoredVictoryControlContinentsObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
+  {
+    type: z.literal("control-continents"),
+    continentIds: z.array(z.string())
+  }
+);
+
+export type AuthoredVictoryControlContinentsObjective = z.infer<
+  typeof authoredVictoryControlContinentsObjectiveSchema
+>;
+
+export const authoredVictoryTerritoryCountObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
+  {
+    type: z.literal("control-territory-count"),
+    territoryCount: z.number().int().nullable().optional()
+  }
+);
+
+export type AuthoredVictoryTerritoryCountObjective = z.infer<
+  typeof authoredVictoryTerritoryCountObjectiveSchema
+>;
+
+export const authoredVictoryObjectiveSchema = z.discriminatedUnion("type", [
+  authoredVictoryControlContinentsObjectiveSchema,
+  authoredVictoryTerritoryCountObjectiveSchema
+]);
+
+export type AuthoredVictoryObjective = z.infer<typeof authoredVictoryObjectiveSchema>;
+
+export const authoredVictoryModuleContentSchema = objectSchema({
+  mapId: z.string(),
+  objectives: z.array(authoredVictoryObjectiveSchema)
+});
+
+export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
+
+export const authoredModuleInputSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  content: authoredVictoryModuleContentSchema
+});
+
+export type AuthoredModuleInput = z.infer<typeof authoredModuleInputSchema>;
+
+export const authoredModuleSchema = authoredModuleInputSchema.extend({
+  status: z.enum(AUTHORED_MODULE_STATUS_VALUES),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1)
+});
+
+export type AuthoredModule = z.infer<typeof authoredModuleSchema>;
+
+export const authoredModulePreviewSchema = objectSchema({
+  summary: z.string(),
+  objectiveSummaries: z.array(z.string())
+});
+
+export type AuthoredModulePreview = z.infer<typeof authoredModulePreviewSchema>;
+
+export const authoredVictoryRuntimeMapSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  territoryCount: z.number().int().nonnegative(),
+  continentCount: z.number().int().nonnegative()
+});
+
+export type AuthoredVictoryRuntimeMap = z.infer<typeof authoredVictoryRuntimeMapSchema>;
+
+export const authoredVictoryRuntimeControlContinentsObjectiveSchema =
+  authoredVictoryControlContinentsObjectiveSchema.extend({
+    continentNames: z.array(z.string()),
+    summary: z.string()
+  });
+
+export type AuthoredVictoryRuntimeControlContinentsObjective = z.infer<
+  typeof authoredVictoryRuntimeControlContinentsObjectiveSchema
+>;
+
+export const authoredVictoryRuntimeTerritoryCountObjectiveSchema =
+  authoredVictoryTerritoryCountObjectiveSchema.extend({
+    summary: z.string()
+  });
+
+export type AuthoredVictoryRuntimeTerritoryCountObjective = z.infer<
+  typeof authoredVictoryRuntimeTerritoryCountObjectiveSchema
+>;
+
+export const authoredVictoryRuntimeObjectiveSchema = z.discriminatedUnion("type", [
+  authoredVictoryRuntimeControlContinentsObjectiveSchema,
+  authoredVictoryRuntimeTerritoryCountObjectiveSchema
+]);
+
+export type AuthoredVictoryRuntimeObjective = z.infer<
+  typeof authoredVictoryRuntimeObjectiveSchema
+>;
+
+export const authoredVictoryModuleRuntimeSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  moduleType: z.literal("victory-objectives"),
+  kind: z.literal("authored-victory-objectives"),
+  map: authoredVictoryRuntimeMapSchema,
+  objectives: z.array(authoredVictoryRuntimeObjectiveSchema),
+  preview: authoredModulePreviewSchema
+});
+
+export type AuthoredVictoryModuleRuntime = z.infer<
+  typeof authoredVictoryModuleRuntimeSchema
+>;
+
+export const authoredModuleRuntimeSchema = authoredVictoryModuleRuntimeSchema;
+
+export type AuthoredModuleRuntime = z.infer<typeof authoredModuleRuntimeSchema>;
+
+export const authoredMapContinentOptionSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  bonus: z.number(),
+  territoryCount: z.number().int()
+});
+
+export type AuthoredMapContinentOption = z.infer<typeof authoredMapContinentOptionSchema>;
+
+export const authoredMapOptionSchema = objectSchema({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  territoryCount: z.number().int(),
+  continentCount: z.number().int(),
+  continents: z.array(authoredMapContinentOptionSchema)
+});
+
+export type AuthoredMapOption = z.infer<typeof authoredMapOptionSchema>;
+
+export const authoredModuleSummarySchema = authoredModuleSchema.extend({
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  map: authoredMapOptionSchema.omit({ continents: true }).nullable().optional(),
+  objectiveCount: z.number().int(),
+  enabledObjectiveCount: z.number().int()
+});
+
+export type AuthoredModuleSummary = z.infer<typeof authoredModuleSummarySchema>;
+
 export const adminConfigSchema = objectSchema({
   defaults: adminGameDefaultsSchema,
   maintenance: objectSchema({
@@ -1240,3 +1424,60 @@ export const adminAuditResponseSchema = objectSchema({
 });
 
 export type AdminAuditResponse = z.infer<typeof adminAuditResponseSchema>;
+
+export const adminAuthoredModuleEditorOptionsResponseSchema = objectSchema({
+  moduleTypes: z.array(z.enum(AUTHORED_MODULE_TYPE_VALUES)),
+  maps: z.array(authoredMapOptionSchema)
+});
+
+export type AdminAuthoredModuleEditorOptionsResponse = z.infer<
+  typeof adminAuthoredModuleEditorOptionsResponseSchema
+>;
+
+export const adminAuthoredModulesListResponseSchema = objectSchema({
+  modules: z.array(authoredModuleSummarySchema)
+});
+
+export type AdminAuthoredModulesListResponse = z.infer<
+  typeof adminAuthoredModulesListResponseSchema
+>;
+
+export const adminAuthoredModuleDetailResponseSchema = objectSchema({
+  module: authoredModuleSchema,
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  runtime: authoredModuleRuntimeSchema
+});
+
+export type AdminAuthoredModuleDetailResponse = z.infer<
+  typeof adminAuthoredModuleDetailResponseSchema
+>;
+
+export const adminAuthoredModuleUpsertRequestSchema = authoredModuleInputSchema;
+
+export type AdminAuthoredModuleUpsertRequest = z.infer<
+  typeof adminAuthoredModuleUpsertRequestSchema
+>;
+
+export const adminAuthoredModuleValidateResponseSchema = objectSchema({
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  runtime: authoredModuleRuntimeSchema
+});
+
+export type AdminAuthoredModuleValidateResponse = z.infer<
+  typeof adminAuthoredModuleValidateResponseSchema
+>;
+
+export const adminAuthoredModuleMutationResponseSchema = objectSchema({
+  ok: z.literal(true),
+  module: authoredModuleSchema,
+  validation: authoredModuleValidationSchema,
+  preview: authoredModulePreviewSchema,
+  runtime: authoredModuleRuntimeSchema,
+  audit: adminAuditEntrySchema.nullable().optional()
+});
+
+export type AdminAuthoredModuleMutationResponse = z.infer<
+  typeof adminAuthoredModuleMutationResponseSchema
+>;

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -1098,23 +1098,21 @@ export const authoredVictoryObjectiveBaseSchema = objectSchema({
   type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
 });
 
-export const authoredVictoryControlContinentsObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
-  {
+export const authoredVictoryControlContinentsObjectiveSchema =
+  authoredVictoryObjectiveBaseSchema.extend({
     type: z.literal("control-continents"),
     continentIds: z.array(z.string())
-  }
-);
+  });
 
 export type AuthoredVictoryControlContinentsObjective = z.infer<
   typeof authoredVictoryControlContinentsObjectiveSchema
 >;
 
-export const authoredVictoryTerritoryCountObjectiveSchema = authoredVictoryObjectiveBaseSchema.extend(
-  {
+export const authoredVictoryTerritoryCountObjectiveSchema =
+  authoredVictoryObjectiveBaseSchema.extend({
     type: z.literal("control-territory-count"),
     territoryCount: z.number().int().nullable().optional()
-  }
-);
+  });
 
 export type AuthoredVictoryTerritoryCountObjective = z.infer<
   typeof authoredVictoryTerritoryCountObjectiveSchema
@@ -1193,9 +1191,7 @@ export const authoredVictoryRuntimeObjectiveSchema = z.discriminatedUnion("type"
   authoredVictoryRuntimeTerritoryCountObjectiveSchema
 ]);
 
-export type AuthoredVictoryRuntimeObjective = z.infer<
-  typeof authoredVictoryRuntimeObjectiveSchema
->;
+export type AuthoredVictoryRuntimeObjective = z.infer<typeof authoredVictoryRuntimeObjectiveSchema>;
 
 export const authoredVictoryModuleRuntimeSchema = objectSchema({
   id: z.string(),
@@ -1209,9 +1205,7 @@ export const authoredVictoryModuleRuntimeSchema = objectSchema({
   preview: authoredModulePreviewSchema
 });
 
-export type AuthoredVictoryModuleRuntime = z.infer<
-  typeof authoredVictoryModuleRuntimeSchema
->;
+export type AuthoredVictoryModuleRuntime = z.infer<typeof authoredVictoryModuleRuntimeSchema>;
 
 export const authoredModuleRuntimeSchema = authoredVictoryModuleRuntimeSchema;
 

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -213,6 +213,40 @@ async function withModuleAdminApp(
   }
 }
 
+function createAuthoredVictoryDraft(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    mapId: string;
+    objectives: unknown[];
+  }> = {}
+) {
+  return {
+    id: overrides.id || "victory.na-asia",
+    name: overrides.name || "North America and Asia",
+    description:
+      overrides.description || "Author a custom victory objective that spans two continents.",
+    version: overrides.version || "1.0.0",
+    moduleType: "victory-objectives",
+    content: {
+      mapId: overrides.mapId || "classic-mini",
+      objectives:
+        overrides.objectives || [
+          {
+            id: "hold-na-asia",
+            title: "Hold North America and Asia",
+            description: "Control North America and Asia at the same time.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america", "asia"]
+          }
+        ]
+    }
+  };
+}
+
 register("admin console overview rejects anonymous and non-admin access", async () => {
   await withAdminApp(async ({ app }) => {
     const anonymousResponse = await callApp(app, "GET", "/api/admin/overview");
@@ -302,8 +336,161 @@ register("admin mutation routes reject anonymous and non-admin access", async ()
     );
     assert.equal(nonAdminConfigResponse.statusCode, 403);
     assert.equal(nonAdminConfigResponse.payload.code, "ADMIN_ONLY");
+
+    const authoredDraftPayload = createAuthoredVictoryDraft();
+    const anonymousAuthoredModuleResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules",
+      authoredDraftPayload
+    );
+    assert.equal(anonymousAuthoredModuleResponse.statusCode, 401);
+    assert.equal(anonymousAuthoredModuleResponse.payload.code, "AUTH_REQUIRED");
+
+    const nonAdminAuthoredModuleResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules",
+      authoredDraftPayload,
+      authHeaders(login.sessionToken)
+    );
+    assert.equal(nonAdminAuthoredModuleResponse.statusCode, 403);
+    assert.equal(nonAdminAuthoredModuleResponse.payload.code, "ADMIN_ONLY");
   });
 });
+
+register("content studio saves invalid drafts but blocks publishing until validation passes", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const draft = createAuthoredVictoryDraft({
+      id: "victory.too-many-territories",
+      objectives: [
+        {
+          id: "hold-999",
+          title: "Hold 999 territories",
+          description: "Impossible validation target for a classic map.",
+          enabled: true,
+          type: "control-territory-count",
+          territoryCount: 999
+        }
+      ]
+    });
+
+    const saveResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules",
+      draft,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(saveResponse.statusCode, 201);
+    assert.equal(saveResponse.payload.module.status, "draft");
+    assert.equal(saveResponse.payload.validation.valid, false);
+    assert.equal(
+      saveResponse.payload.validation.errors.some(
+        (entry: { code?: string }) => entry.code === "territory-count-out-of-range"
+      ),
+      true
+    );
+
+    const publishResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(publishResponse.statusCode, 400);
+    assert.equal(
+      publishResponse.payload.validation.errors.some(
+        (entry: { code?: string }) => entry.code === "territory-count-out-of-range"
+      ),
+      true
+    );
+  });
+});
+
+register(
+  "content studio publishes authored victory modules into runtime options and persists engine data",
+  async () => {
+    await withAdminApp(async ({ app, adminSessionToken }) => {
+      const draft = createAuthoredVictoryDraft({
+        id: "victory.hold-four",
+        name: "Own four territories",
+        objectives: [
+          {
+            id: "hold-four",
+            title: "Own four territories",
+            description: "Reach four territories before any rival objective resolves.",
+            enabled: true,
+            type: "control-territory-count",
+            territoryCount: 4
+          }
+        ]
+      });
+
+      const saveResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/content-studio/modules",
+        draft,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(saveResponse.statusCode, 201);
+      assert.equal(saveResponse.payload.validation.valid, true);
+
+      const publishResponse = await callApp(
+        app,
+        "POST",
+        `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(publishResponse.statusCode, 200);
+      assert.equal(publishResponse.payload.module.status, "published");
+
+      const optionsResponse = await callApp(app, "GET", "/api/game/options");
+      assert.equal(optionsResponse.statusCode, 200);
+      const authoredRule = optionsResponse.payload.victoryRuleSets.find(
+        (entry: { id?: string }) => entry.id === draft.id
+      );
+      assert.ok(authoredRule);
+      assert.equal(authoredRule.source, "authored");
+      assert.equal(authoredRule.mapId, "classic-mini");
+
+      const createGameResponse = await callApp(
+        app,
+        "POST",
+        "/api/games",
+        {
+          name: "Authored Objective Match",
+          mapId: "classic-mini",
+          victoryRuleSetId: draft.id
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(createGameResponse.statusCode, 201);
+      assert.equal(createGameResponse.payload.state.gameConfig.victoryRuleSetId, draft.id);
+      assert.equal(
+        createGameResponse.payload.state.gameConfig.victoryObjectiveModule.id,
+        draft.id
+      );
+      assert.equal(
+        createGameResponse.payload.state.gameConfig.victoryObjectiveModule.objectives[0].type,
+        "control-territory-count"
+      );
+
+      const disableResponse = await callApp(
+        app,
+        "POST",
+        `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/disable`,
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(disableResponse.statusCode, 400);
+      assert.match(String(disableResponse.payload.error || ""), /active game/i);
+    });
+  }
+);
 
 register("admin console can promote a user and grant admin access", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -232,17 +232,16 @@ function createAuthoredVictoryDraft(
     moduleType: "victory-objectives",
     content: {
       mapId: overrides.mapId || "classic-mini",
-      objectives:
-        overrides.objectives || [
-          {
-            id: "hold-na-asia",
-            title: "Hold North America and Asia",
-            description: "Control North America and Asia at the same time.",
-            enabled: true,
-            type: "control-continents",
-            continentIds: ["north_america", "asia"]
-          }
-        ]
+      objectives: overrides.objectives || [
+        {
+          id: "hold-na-asia",
+          title: "Hold North America and Asia",
+          description: "Control North America and Asia at the same time.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america", "asia"]
+        }
+      ]
     }
   };
 }
@@ -359,55 +358,58 @@ register("admin mutation routes reject anonymous and non-admin access", async ()
   });
 });
 
-register("content studio saves invalid drafts but blocks publishing until validation passes", async () => {
-  await withAdminApp(async ({ app, adminSessionToken }) => {
-    const draft = createAuthoredVictoryDraft({
-      id: "victory.too-many-territories",
-      objectives: [
-        {
-          id: "hold-999",
-          title: "Hold 999 territories",
-          description: "Impossible validation target for a classic map.",
-          enabled: true,
-          type: "control-territory-count",
-          territoryCount: 999
-        }
-      ]
+register(
+  "content studio saves invalid drafts but blocks publishing until validation passes",
+  async () => {
+    await withAdminApp(async ({ app, adminSessionToken }) => {
+      const draft = createAuthoredVictoryDraft({
+        id: "victory.too-many-territories",
+        objectives: [
+          {
+            id: "hold-999",
+            title: "Hold 999 territories",
+            description: "Impossible validation target for a classic map.",
+            enabled: true,
+            type: "control-territory-count",
+            territoryCount: 999
+          }
+        ]
+      });
+
+      const saveResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/content-studio/modules",
+        draft,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(saveResponse.statusCode, 201);
+      assert.equal(saveResponse.payload.module.status, "draft");
+      assert.equal(saveResponse.payload.validation.valid, false);
+      assert.equal(
+        saveResponse.payload.validation.errors.some(
+          (entry: { code?: string }) => entry.code === "territory-count-out-of-range"
+        ),
+        true
+      );
+
+      const publishResponse = await callApp(
+        app,
+        "POST",
+        `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(publishResponse.statusCode, 400);
+      assert.equal(
+        publishResponse.payload.validation.errors.some(
+          (entry: { code?: string }) => entry.code === "territory-count-out-of-range"
+        ),
+        true
+      );
     });
-
-    const saveResponse = await callApp(
-      app,
-      "POST",
-      "/api/admin/content-studio/modules",
-      draft,
-      authHeaders(adminSessionToken)
-    );
-    assert.equal(saveResponse.statusCode, 201);
-    assert.equal(saveResponse.payload.module.status, "draft");
-    assert.equal(saveResponse.payload.validation.valid, false);
-    assert.equal(
-      saveResponse.payload.validation.errors.some(
-        (entry: { code?: string }) => entry.code === "territory-count-out-of-range"
-      ),
-      true
-    );
-
-    const publishResponse = await callApp(
-      app,
-      "POST",
-      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
-      {},
-      authHeaders(adminSessionToken)
-    );
-    assert.equal(publishResponse.statusCode, 400);
-    assert.equal(
-      publishResponse.payload.validation.errors.some(
-        (entry: { code?: string }) => entry.code === "territory-count-out-of-range"
-      ),
-      true
-    );
-  });
-});
+  }
+);
 
 register(
   "content studio publishes authored victory modules into runtime options and persists engine data",
@@ -470,10 +472,7 @@ register(
       );
       assert.equal(createGameResponse.statusCode, 201);
       assert.equal(createGameResponse.payload.state.gameConfig.victoryRuleSetId, draft.id);
-      assert.equal(
-        createGameResponse.payload.state.gameConfig.victoryObjectiveModule.id,
-        draft.id
-      );
+      assert.equal(createGameResponse.payload.state.gameConfig.victoryObjectiveModule.id, draft.id);
       assert.equal(
         createGameResponse.payload.state.gameConfig.victoryObjectiveModule.objectives[0].type,
         "control-territory-count"

--- a/tests/gameplay/regression/admin-content-studio-routes.test.cts
+++ b/tests/gameplay/regression/admin-content-studio-routes.test.cts
@@ -138,7 +138,7 @@ function createVictoryDraft(
   }> = {}
 ) {
   return {
-    id: overrides.id || "victory.world.na-asia",
+    id: typeof overrides.id === "string" ? overrides.id : "victory.world.na-asia",
     name: overrides.name || "North America and Asia",
     description:
       overrides.description ||
@@ -320,6 +320,21 @@ register("content studio update route rejects body and path id mismatches", asyn
 
     assert.equal(response.statusCode, 400);
     assert.match(String(response.payload.error || ""), /does not match route id/i);
+  });
+});
+
+register("content studio rejects empty module ids at the API boundary", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const response = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules/validate",
+      createVictoryDraft({ id: "" }),
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(response.statusCode, 400);
+    assert.match(String(response.payload.error || ""), /id/i);
   });
 });
 

--- a/tests/gameplay/regression/admin-content-studio-routes.test.cts
+++ b/tests/gameplay/regression/admin-content-studio-routes.test.cts
@@ -1,0 +1,355 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { createApp } = require("../../../backend/server.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type HeaderMap = Record<string, string>;
+
+type MockResponse = {
+  statusCode: number;
+  headers: HeaderMap;
+  body: string;
+  setHeader(name: string, value: string): void;
+  writeHead(statusCode: number, nextHeaders?: HeaderMap): void;
+  end(chunk?: string): void;
+};
+
+function makeMockResponse(): MockResponse {
+  const headers: HeaderMap = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: "",
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
+    writeHead(statusCode: number, nextHeaders: HeaderMap = {}) {
+      this.statusCode = statusCode;
+      Object.assign(headers, nextHeaders);
+    },
+    end(chunk = "") {
+      this.body += chunk || "";
+    }
+  };
+}
+
+async function callApp(
+  app: any,
+  method: string,
+  pathname: string,
+  body?: any,
+  headers: HeaderMap = {}
+): Promise<{ statusCode: number; payload: any }> {
+  const req = new (require("events").EventEmitter)();
+  req.method = method;
+  req.headers = { "content-type": "application/json", ...headers };
+  req.destroy = () => {};
+  const res = makeMockResponse();
+  const promise = app.handleApi(req, res, new URL(`http://127.0.0.1${pathname}`));
+
+  process.nextTick(() => {
+    if (body !== undefined) {
+      req.emit("data", JSON.stringify(body));
+    }
+    req.emit("end");
+  });
+
+  await promise;
+  return {
+    statusCode: res.statusCode,
+    payload: res.body ? JSON.parse(res.body) : null
+  };
+}
+
+function authHeaders(sessionToken: string): HeaderMap {
+  return {
+    cookie: `netrisk_session=${encodeURIComponent(sessionToken)}`
+  };
+}
+
+function cleanupSqliteFiles(baseFile: string): void {
+  [baseFile, `${baseFile}-shm`, `${baseFile}-wal`].forEach((target) => {
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { force: true });
+    }
+  });
+}
+
+async function withAdminApp(
+  run: (context: { app: any; adminSessionToken: string; tempRoot: string }) => Promise<void>
+) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-content-studio-"));
+  const dataDir = path.join(tempRoot, "data");
+  const frontendDir = path.join(tempRoot, "frontend", "src");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(frontendDir, { recursive: true });
+
+  const originalProjectRoot = process.env.NETRISK_PROJECT_ROOT;
+  process.env.NETRISK_PROJECT_ROOT = tempRoot;
+
+  const tempDbFile = path.join(tempRoot, "data", "admin.sqlite");
+  const tempUsersFile = path.join(tempRoot, "data", "users.json");
+  const tempGamesFile = path.join(tempRoot, "data", "games.json");
+  const tempSessionsFile = path.join(tempRoot, "data", "sessions.json");
+  const app = createApp({
+    projectRoot: tempRoot,
+    dbFile: tempDbFile,
+    dataFile: tempUsersFile,
+    gamesFile: tempGamesFile,
+    sessionsFile: tempSessionsFile
+  });
+
+  try {
+    const registered = await app.auth.registerPasswordUser("studio_admin", "secret123");
+    assert.equal(registered.ok, true);
+    await app.datastore.updateUserRoleByUsername("studio_admin", "admin");
+    const login = await app.auth.loginWithPassword("studio_admin", "secret123");
+    assert.equal(login.ok, true);
+
+    await run({
+      app,
+      adminSessionToken: login.sessionToken,
+      tempRoot
+    });
+  } finally {
+    app.datastore.close();
+    cleanupSqliteFiles(tempDbFile);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    if (typeof originalProjectRoot === "undefined") {
+      delete process.env.NETRISK_PROJECT_ROOT;
+    } else {
+      process.env.NETRISK_PROJECT_ROOT = originalProjectRoot;
+    }
+  }
+}
+
+function createVictoryDraft(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    mapId: string;
+    objectives: unknown[];
+  }> = {}
+) {
+  return {
+    id: overrides.id || "victory.world.na-asia",
+    name: overrides.name || "North America and Asia",
+    description:
+      overrides.description || "Author a world-classic objective that spans two strategic continents.",
+    version: overrides.version || "1.0.0",
+    moduleType: "victory-objectives",
+    content: {
+      mapId: overrides.mapId || "world-classic",
+      objectives:
+        overrides.objectives || [
+          {
+            id: "hold-na-asia",
+            title: "Hold North America and Asia",
+            description: "Control North America and Asia at the same time.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america", "asia"]
+          }
+        ]
+    }
+  };
+}
+
+register("content studio routes expose CRUD, validation, and enable toggles", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const draft = createVictoryDraft();
+
+    const optionsResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/content-studio/options",
+      undefined,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(optionsResponse.statusCode, 200);
+    assert.equal(
+      optionsResponse.payload.maps.some((entry: { id?: string }) => entry.id === "world-classic"),
+      true
+    );
+
+    const validateResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules/validate",
+      draft,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(validateResponse.statusCode, 200);
+    assert.equal(validateResponse.payload.validation.valid, true);
+    assert.match(validateResponse.payload.preview.summary, /North America and Asia/i);
+
+    const createResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules",
+      draft,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createResponse.statusCode, 201);
+    assert.equal(createResponse.payload.module.status, "draft");
+
+    const listResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/content-studio/modules",
+      undefined,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(listResponse.statusCode, 200);
+    assert.equal(
+      listResponse.payload.modules.some((entry: { id?: string }) => entry.id === draft.id),
+      true
+    );
+
+    const detailResponse = await callApp(
+      app,
+      "GET",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}`,
+      undefined,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(detailResponse.statusCode, 200);
+    assert.equal(detailResponse.payload.module.id, draft.id);
+
+    const updatedDraft = createVictoryDraft({
+      id: draft.id,
+      description: "Updated objective copy for runtime exposure.",
+      objectives: [
+        ...draft.content.objectives,
+        {
+          id: "hold-europe-south-america",
+          title: "Hold Europe and South America",
+          description: "Control Europe and South America at the same time.",
+          enabled: false,
+          type: "control-continents",
+          continentIds: ["europe", "south_america"]
+        }
+      ]
+    });
+
+    const updateResponse = await callApp(
+      app,
+      "PUT",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}`,
+      updatedDraft,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(updateResponse.statusCode, 200);
+    assert.equal(updateResponse.payload.module.description, updatedDraft.description);
+    assert.equal(updateResponse.payload.module.content.objectives.length, 2);
+
+    const publishResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(publishResponse.statusCode, 200);
+    assert.equal(publishResponse.payload.module.status, "published");
+
+    const enabledOptionsResponse = await callApp(app, "GET", "/api/game/options");
+    assert.equal(enabledOptionsResponse.statusCode, 200);
+    assert.equal(
+      enabledOptionsResponse.payload.victoryRuleSets.some((entry: { id?: string }) => entry.id === draft.id),
+      true
+    );
+
+    const disableResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/disable`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(disableResponse.statusCode, 200);
+    assert.equal(disableResponse.payload.module.status, "disabled");
+
+    const disabledOptionsResponse = await callApp(app, "GET", "/api/game/options");
+    assert.equal(disabledOptionsResponse.statusCode, 200);
+    assert.equal(
+      disabledOptionsResponse.payload.victoryRuleSets.some((entry: { id?: string }) => entry.id === draft.id),
+      false
+    );
+
+    const enableResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/enable`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(enableResponse.statusCode, 200);
+    assert.equal(enableResponse.payload.module.status, "published");
+
+    const reenabledOptionsResponse = await callApp(app, "GET", "/api/game/options");
+    assert.equal(reenabledOptionsResponse.statusCode, 200);
+    assert.equal(
+      reenabledOptionsResponse.payload.victoryRuleSets.some((entry: { id?: string }) => entry.id === draft.id),
+      true
+    );
+  });
+});
+
+register("content studio update route rejects body and path id mismatches", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const response = await callApp(
+      app,
+      "PUT",
+      "/api/admin/content-studio/modules/victory.route-id",
+      createVictoryDraft({ id: "victory.body-id" }),
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(response.statusCode, 400);
+    assert.match(String(response.payload.error || ""), /does not match route id/i);
+  });
+});
+
+register("content studio blocks draft edits after a module is published", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const draft = createVictoryDraft({ id: "victory.published-edit-lock" });
+
+    const createResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules",
+      draft,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createResponse.statusCode, 201);
+
+    const publishResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(publishResponse.statusCode, 200);
+
+    const updateResponse = await callApp(
+      app,
+      "PUT",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}`,
+      createVictoryDraft({
+        id: draft.id,
+        description: "Attempt to edit a published module."
+      }),
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(updateResponse.statusCode, 409);
+    assert.match(String(updateResponse.payload.error || ""), /only draft modules are editable/i);
+  });
+});

--- a/tests/gameplay/regression/admin-content-studio-routes.test.cts
+++ b/tests/gameplay/regression/admin-content-studio-routes.test.cts
@@ -141,22 +141,22 @@ function createVictoryDraft(
     id: overrides.id || "victory.world.na-asia",
     name: overrides.name || "North America and Asia",
     description:
-      overrides.description || "Author a world-classic objective that spans two strategic continents.",
+      overrides.description ||
+      "Author a world-classic objective that spans two strategic continents.",
     version: overrides.version || "1.0.0",
     moduleType: "victory-objectives",
     content: {
       mapId: overrides.mapId || "world-classic",
-      objectives:
-        overrides.objectives || [
-          {
-            id: "hold-na-asia",
-            title: "Hold North America and Asia",
-            description: "Control North America and Asia at the same time.",
-            enabled: true,
-            type: "control-continents",
-            continentIds: ["north_america", "asia"]
-          }
-        ]
+      objectives: overrides.objectives || [
+        {
+          id: "hold-na-asia",
+          title: "Hold North America and Asia",
+          description: "Control North America and Asia at the same time.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america", "asia"]
+        }
+      ]
     }
   };
 }
@@ -262,7 +262,9 @@ register("content studio routes expose CRUD, validation, and enable toggles", as
     const enabledOptionsResponse = await callApp(app, "GET", "/api/game/options");
     assert.equal(enabledOptionsResponse.statusCode, 200);
     assert.equal(
-      enabledOptionsResponse.payload.victoryRuleSets.some((entry: { id?: string }) => entry.id === draft.id),
+      enabledOptionsResponse.payload.victoryRuleSets.some(
+        (entry: { id?: string }) => entry.id === draft.id
+      ),
       true
     );
 
@@ -279,7 +281,9 @@ register("content studio routes expose CRUD, validation, and enable toggles", as
     const disabledOptionsResponse = await callApp(app, "GET", "/api/game/options");
     assert.equal(disabledOptionsResponse.statusCode, 200);
     assert.equal(
-      disabledOptionsResponse.payload.victoryRuleSets.some((entry: { id?: string }) => entry.id === draft.id),
+      disabledOptionsResponse.payload.victoryRuleSets.some(
+        (entry: { id?: string }) => entry.id === draft.id
+      ),
       false
     );
 
@@ -296,7 +300,9 @@ register("content studio routes expose CRUD, validation, and enable toggles", as
     const reenabledOptionsResponse = await callApp(app, "GET", "/api/game/options");
     assert.equal(reenabledOptionsResponse.statusCode, 200);
     assert.equal(
-      reenabledOptionsResponse.payload.victoryRuleSets.some((entry: { id?: string }) => entry.id === draft.id),
+      reenabledOptionsResponse.payload.victoryRuleSets.some(
+        (entry: { id?: string }) => entry.id === draft.id
+      ),
       true
     );
   });

--- a/tests/gameplay/regression/authored-modules.test.cts
+++ b/tests/gameplay/regression/authored-modules.test.cts
@@ -135,6 +135,15 @@ register(
     const datastore = createMemoryDatastore();
     const service = createAuthoredModulesService({ datastore });
 
+    const builtInIdValidation = await service.validateDraft(createVictoryDraft({ id: "conquest" }));
+    assert.equal(builtInIdValidation.validation.valid, false);
+    assert.equal(
+      builtInIdValidation.validation.errors.some(
+        (entry: { code?: string }) => entry.code === "reserved-module-id"
+      ),
+      true
+    );
+
     const invalidValidation = await service.validateDraft(
       createVictoryDraft({
         id: "victory.invalid-validation",

--- a/tests/gameplay/regression/authored-modules.test.cts
+++ b/tests/gameplay/regression/authored-modules.test.cts
@@ -42,27 +42,30 @@ function createVictoryDraft(
     id: overrides.id || "victory.world.na-asia",
     name: overrides.name || "North America and Asia",
     description:
-      overrides.description || "Author a world-classic objective that spans two strategic continents.",
+      overrides.description ||
+      "Author a world-classic objective that spans two strategic continents.",
     version: overrides.version || "1.0.0",
     moduleType: "victory-objectives",
     content: {
       mapId: overrides.mapId || "world-classic",
-      objectives:
-        overrides.objectives || [
-          {
-            id: "hold-na-asia",
-            title: "Hold North America and Asia",
-            description: "Control North America and Asia at the same time.",
-            enabled: true,
-            type: "control-continents",
-            continentIds: ["north_america", "asia"]
-          }
-        ]
+      objectives: overrides.objectives || [
+        {
+          id: "hold-na-asia",
+          title: "Hold North America and Asia",
+          description: "Control North America and Asia at the same time.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america", "asia"]
+        }
+      ]
     }
   };
 }
 
-function toStoredModule(input: ReturnType<typeof createVictoryDraft>, overrides: Record<string, unknown> = {}) {
+function toStoredModule(
+  input: ReturnType<typeof createVictoryDraft>,
+  overrides: Record<string, unknown> = {}
+) {
   return {
     ...clone(input),
     status: "draft",
@@ -105,7 +108,10 @@ register("authored modules service filters stored modules and exposes editor opt
 
   const options = await service.listEditorOptions();
   assert.deepEqual(options.moduleTypes, ["victory-objectives"]);
-  assert.equal(options.maps.some((entry: { id?: string }) => entry.id === "world-classic"), true);
+  assert.equal(
+    options.maps.some((entry: { id?: string }) => entry.id === "world-classic"),
+    true
+  );
 
   const modules = await service.listModules();
   assert.deepEqual(
@@ -123,60 +129,70 @@ register("authored modules service filters stored modules and exposes editor opt
   assert.equal(await service.isModuleStored("missing-module"), false);
 });
 
-register("authored modules service validates drafts and manages the publish lifecycle", async () => {
-  const datastore = createMemoryDatastore();
-  const service = createAuthoredModulesService({ datastore });
+register(
+  "authored modules service validates drafts and manages the publish lifecycle",
+  async () => {
+    const datastore = createMemoryDatastore();
+    const service = createAuthoredModulesService({ datastore });
 
-  const invalidValidation = await service.validateDraft(
-    createVictoryDraft({
-      id: "victory.invalid-validation",
-      objectives: [
-        {
-          id: "duplicate-objective",
-          title: "Broken continent objective",
-          description: "Select the same and an invalid continent.",
-          enabled: true,
-          type: "control-continents",
-          continentIds: ["north_america", "north_america", "atlantis"]
-        },
-        {
-          id: "duplicate-objective",
-          title: "Broken territory objective",
-          description: "Set an impossible territory count.",
-          enabled: true,
-          type: "control-territory-count",
-          territoryCount: 0
-        }
-      ]
-    })
-  );
-  const invalidCodes = invalidValidation.validation.errors.map((entry: { code: string }) => entry.code);
-  assert.equal(invalidValidation.validation.valid, false);
-  assert.equal(invalidCodes.includes("duplicate-objective-id"), true);
-  assert.equal(invalidCodes.includes("duplicate-continent-id"), true);
-  assert.equal(invalidCodes.includes("invalid-continent-id"), true);
-  assert.equal(invalidCodes.includes("invalid-territory-count"), true);
+    const invalidValidation = await service.validateDraft(
+      createVictoryDraft({
+        id: "victory.invalid-validation",
+        objectives: [
+          {
+            id: "duplicate-objective",
+            title: "Broken continent objective",
+            description: "Select the same and an invalid continent.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america", "north_america", "atlantis"]
+          },
+          {
+            id: "duplicate-objective",
+            title: "Broken territory objective",
+            description: "Set an impossible territory count.",
+            enabled: true,
+            type: "control-territory-count",
+            territoryCount: 0
+          }
+        ]
+      })
+    );
+    const invalidCodes = invalidValidation.validation.errors.map(
+      (entry: { code: string }) => entry.code
+    );
+    assert.equal(invalidValidation.validation.valid, false);
+    assert.equal(invalidCodes.includes("duplicate-objective-id"), true);
+    assert.equal(invalidCodes.includes("duplicate-continent-id"), true);
+    assert.equal(invalidCodes.includes("invalid-continent-id"), true);
+    assert.equal(invalidCodes.includes("invalid-territory-count"), true);
 
-  const savedDraft = await service.saveDraft(createVictoryDraft({ id: "victory.lifecycle" }));
-  assert.equal(savedDraft.module.status, "draft");
+    const savedDraft = await service.saveDraft(createVictoryDraft({ id: "victory.lifecycle" }));
+    assert.equal(savedDraft.module.status, "draft");
 
-  const published = await service.publishModule("victory.lifecycle");
-  assert.equal(published.module.status, "published");
+    const published = await service.publishModule("victory.lifecycle");
+    assert.equal(published.module.status, "published");
 
-  const publishedRuleSets = await service.listPublishedVictoryRuleSets();
-  const publishedRule = publishedRuleSets.find((entry: { id: string }) => entry.id === "victory.lifecycle");
-  assert.ok(publishedRule);
-  assert.equal(publishedRule.source, "authored");
-  assert.equal(publishedRule.objectiveCount, 1);
+    const publishedRuleSets = await service.listPublishedVictoryRuleSets();
+    const publishedRule = publishedRuleSets.find(
+      (entry: { id: string }) => entry.id === "victory.lifecycle"
+    );
+    assert.ok(publishedRule);
+    assert.equal(publishedRule.source, "authored");
+    assert.equal(publishedRule.objectiveCount, 1);
 
-  const disabled = await service.disableModule("victory.lifecycle");
-  assert.equal(disabled.module.status, "disabled");
-  assert.equal(await service.findPublishedVictoryRuleSetRuntime("victory.lifecycle"), null);
+    const disabled = await service.disableModule("victory.lifecycle");
+    assert.equal(disabled.module.status, "disabled");
+    assert.equal(await service.findPublishedVictoryRuleSetRuntime("victory.lifecycle"), null);
 
-  const enabled = await service.enableModule("victory.lifecycle");
-  assert.equal(enabled.module.status, "published");
-  assert.equal((await service.findPublishedVictoryRuleSetRuntime("victory.lifecycle"))?.id, "victory.lifecycle");
-});
+    const enabled = await service.enableModule("victory.lifecycle");
+    assert.equal(enabled.module.status, "published");
+    assert.equal(
+      (await service.findPublishedVictoryRuleSetRuntime("victory.lifecycle"))?.id,
+      "victory.lifecycle"
+    );
+  }
+);
 
 register("authored modules service blocks published edits and invalid re-enabling", async () => {
   const datastore = createMemoryDatastore();

--- a/tests/gameplay/regression/authored-modules.test.cts
+++ b/tests/gameplay/regression/authored-modules.test.cts
@@ -1,0 +1,217 @@
+const assert = require("node:assert/strict");
+
+const {
+  AUTHORED_MODULES_STATE_KEY,
+  createAuthoredModulesService
+} = require("../../../backend/authored-modules.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value ?? null)) as T;
+}
+
+function createMemoryDatastore(initialState?: unknown) {
+  let state = clone(initialState);
+  return {
+    getAppState(key: string) {
+      assert.equal(key, AUTHORED_MODULES_STATE_KEY);
+      return clone(state);
+    },
+    setAppState(key: string, value: unknown) {
+      assert.equal(key, AUTHORED_MODULES_STATE_KEY);
+      state = clone(value);
+    },
+    readState() {
+      return clone(state);
+    }
+  };
+}
+
+function createVictoryDraft(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    mapId: string;
+    objectives: unknown[];
+  }> = {}
+) {
+  return {
+    id: overrides.id || "victory.world.na-asia",
+    name: overrides.name || "North America and Asia",
+    description:
+      overrides.description || "Author a world-classic objective that spans two strategic continents.",
+    version: overrides.version || "1.0.0",
+    moduleType: "victory-objectives",
+    content: {
+      mapId: overrides.mapId || "world-classic",
+      objectives:
+        overrides.objectives || [
+          {
+            id: "hold-na-asia",
+            title: "Hold North America and Asia",
+            description: "Control North America and Asia at the same time.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america", "asia"]
+          }
+        ]
+    }
+  };
+}
+
+function toStoredModule(input: ReturnType<typeof createVictoryDraft>, overrides: Record<string, unknown> = {}) {
+  return {
+    ...clone(input),
+    status: "draft",
+    createdAt: "2026-04-20T10:00:00.000Z",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    ...overrides
+  };
+}
+
+register("authored modules service filters stored modules and exposes editor options", async () => {
+  const datastore = createMemoryDatastore({
+    modules: [
+      { id: "" },
+      toStoredModule(createVictoryDraft({ id: "victory.older", name: "Older Module" }), {
+        updatedAt: "2026-04-20T10:00:00.000Z"
+      }),
+      toStoredModule(
+        createVictoryDraft({
+          id: "victory.newer",
+          name: "Newer Module",
+          objectives: [
+            {
+              id: "hold-twelve",
+              title: "Own twelve territories",
+              description: "Reach twelve territories on the world map.",
+              enabled: true,
+              type: "control-territory-count",
+              territoryCount: 12
+            }
+          ]
+        }),
+        {
+          status: "published",
+          updatedAt: "2026-04-21T10:00:00.000Z"
+        }
+      )
+    ]
+  });
+  const service = createAuthoredModulesService({ datastore });
+
+  const options = await service.listEditorOptions();
+  assert.deepEqual(options.moduleTypes, ["victory-objectives"]);
+  assert.equal(options.maps.some((entry: { id?: string }) => entry.id === "world-classic"), true);
+
+  const modules = await service.listModules();
+  assert.deepEqual(
+    modules.map((entry: { id: string }) => entry.id),
+    ["victory.newer", "victory.older"]
+  );
+  assert.equal(modules[0].map?.id, "world-classic");
+
+  const detail = await service.getModule("victory.older");
+  assert.equal(detail.module.id, "victory.older");
+  assert.equal(detail.validation.valid, true);
+  assert.match(detail.preview.summary, /North America and Asia/i);
+
+  assert.equal(await service.isModuleStored("victory.newer"), true);
+  assert.equal(await service.isModuleStored("missing-module"), false);
+});
+
+register("authored modules service validates drafts and manages the publish lifecycle", async () => {
+  const datastore = createMemoryDatastore();
+  const service = createAuthoredModulesService({ datastore });
+
+  const invalidValidation = await service.validateDraft(
+    createVictoryDraft({
+      id: "victory.invalid-validation",
+      objectives: [
+        {
+          id: "duplicate-objective",
+          title: "Broken continent objective",
+          description: "Select the same and an invalid continent.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america", "north_america", "atlantis"]
+        },
+        {
+          id: "duplicate-objective",
+          title: "Broken territory objective",
+          description: "Set an impossible territory count.",
+          enabled: true,
+          type: "control-territory-count",
+          territoryCount: 0
+        }
+      ]
+    })
+  );
+  const invalidCodes = invalidValidation.validation.errors.map((entry: { code: string }) => entry.code);
+  assert.equal(invalidValidation.validation.valid, false);
+  assert.equal(invalidCodes.includes("duplicate-objective-id"), true);
+  assert.equal(invalidCodes.includes("duplicate-continent-id"), true);
+  assert.equal(invalidCodes.includes("invalid-continent-id"), true);
+  assert.equal(invalidCodes.includes("invalid-territory-count"), true);
+
+  const savedDraft = await service.saveDraft(createVictoryDraft({ id: "victory.lifecycle" }));
+  assert.equal(savedDraft.module.status, "draft");
+
+  const published = await service.publishModule("victory.lifecycle");
+  assert.equal(published.module.status, "published");
+
+  const publishedRuleSets = await service.listPublishedVictoryRuleSets();
+  const publishedRule = publishedRuleSets.find((entry: { id: string }) => entry.id === "victory.lifecycle");
+  assert.ok(publishedRule);
+  assert.equal(publishedRule.source, "authored");
+  assert.equal(publishedRule.objectiveCount, 1);
+
+  const disabled = await service.disableModule("victory.lifecycle");
+  assert.equal(disabled.module.status, "disabled");
+  assert.equal(await service.findPublishedVictoryRuleSetRuntime("victory.lifecycle"), null);
+
+  const enabled = await service.enableModule("victory.lifecycle");
+  assert.equal(enabled.module.status, "published");
+  assert.equal((await service.findPublishedVictoryRuleSetRuntime("victory.lifecycle"))?.id, "victory.lifecycle");
+});
+
+register("authored modules service blocks published edits and invalid re-enabling", async () => {
+  const datastore = createMemoryDatastore();
+  const service = createAuthoredModulesService({ datastore });
+  const draft = createVictoryDraft({ id: "victory.map-bound" });
+
+  await service.saveDraft(draft);
+  await service.publishModule(draft.id);
+
+  await assert.rejects(
+    () =>
+      service.saveDraft(
+        createVictoryDraft({
+          id: draft.id,
+          description: "Attempt to revise a published module in place."
+        })
+      ),
+    /Only draft modules are editable/i
+  );
+
+  await service.disableModule(draft.id);
+  service.setMapCatalog({
+    listMaps: () => [],
+    resolveMap: () => null
+  });
+
+  await assert.rejects(
+    () => service.enableModule(draft.id),
+    (error: any) => {
+      assert.equal(error.statusCode, 400);
+      assert.equal(
+        error.validation.errors.some((entry: { code?: string }) => entry.code === "invalid-map"),
+        true
+      );
+      return true;
+    }
+  );
+});

--- a/tests/gameplay/regression/check-no-js-sources.test.cts
+++ b/tests/gameplay/regression/check-no-js-sources.test.cts
@@ -90,6 +90,34 @@ register("check-no-js-sources consente docs/openapi.json nel repo tracciato", ()
   });
 });
 
+register("check-no-js-sources consente config JSON in .github nel repo tracciato", () => {
+  withTrackedTempRepo((repoDir) => {
+    writeFile(
+      repoDir,
+      "package.json",
+      JSON.stringify({
+        name: "allowlist-github-json",
+        private: true
+      })
+    );
+    writeFile(
+      repoDir,
+      ".github/codex-pr-readiness.json",
+      JSON.stringify({
+        targetLabel: "codex"
+      })
+    );
+    runGit(["add", "."], repoDir);
+
+    const output = execFileSync(process.execPath, [builtScriptPath], {
+      cwd: repoDir,
+      encoding: "utf8"
+    });
+
+    assert.match(output, /Tracked repository sources satisfy the TS-complete allowlist\./);
+  });
+});
+
 register("check-no-js-sources rifiuta file js tracciati fuori allowlist", () => {
   withTrackedTempRepo((repoDir) => {
     writeFile(

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -222,6 +222,17 @@ register("codex PR readiness targets only draft Codex PRs", () => {
   assert.equal(skipped.targeted, false);
 });
 
+register("codex PR readiness workflow listens to all pull_request workflow_run completions", () => {
+  const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /github\.event_name == 'workflow_run' &&\s+github\.event\.workflow_run\.event == 'pull_request'\) \|\|/
+  );
+  assert.doesNotMatch(workflow, /github\.event\.workflow_run\.head_branch/);
+});
+
 register(
   "codex PR readiness blocks pending checks, stale Codex feedback, stale branches, and conflicts",
   () => {

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -1,0 +1,1044 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  READY_COMMENT_HEADING,
+  evaluateReadinessFromSnapshot,
+  isTargetPullRequest,
+  loadGateConfig,
+  parseAddedLines,
+  __testables: {
+    GitHubApiClient,
+    applyEvaluation,
+    buildBatchSummary,
+    getSnapshot,
+    parseArgs,
+    parseEventPrNumbers,
+    resolveTargetPrNumbers,
+    upsertSummaryComment
+  }
+} = require("../../../scripts/evaluate-codex-pr-readiness.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+const config = loadGateConfig(path.join(process.cwd(), ".github", "codex-pr-readiness.json"));
+
+function createQualityJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    name: "quality",
+    htmlUrl: "https://example.test/quality",
+    status: "completed",
+    conclusion: "success",
+    startedAt: "2026-04-23T10:01:00.000Z",
+    completedAt: "2026-04-23T10:05:00.000Z",
+    workflowName: "Quality",
+    steps: [
+      { name: "Run repository typecheck", status: "completed", conclusion: "success" },
+      { name: "Run React shell typecheck", status: "completed", conclusion: "success" },
+      { name: "Run build", status: "completed", conclusion: "success" },
+      { name: "Run lint", status: "completed", conclusion: "success" },
+      { name: "Run format check", status: "completed", conclusion: "success" },
+      { name: "Run React shell tests", status: "completed", conclusion: "success" }
+    ],
+    ...overrides
+  };
+}
+
+function createSnapshot(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    pr: {
+      number: 146,
+      nodeId: "PR_node",
+      title: "Codex draft",
+      url: "https://example.test/pr/146",
+      state: "open",
+      isDraft: true,
+      authorLogin: "andreame-code",
+      baseRefName: "main",
+      headRefName: "codex/pr-readiness-gate-20260423",
+      headSha: "abcdef1234567890abcdef1234567890abcdef12",
+      headCommitAt: "2026-04-23T10:00:00.000Z",
+      labels: [],
+      additions: 24,
+      deletions: 4,
+      changedFiles: 3,
+      mergeable: true,
+      mergeableState: "clean"
+    },
+    branchFreshness: {
+      behindBy: 0,
+      aheadBy: 2,
+      status: "ahead",
+      url: "https://example.test/compare"
+    },
+    workflowJobs: [
+      createQualityJob(),
+      {
+        id: 20,
+        name: "coverage",
+        htmlUrl: "https://example.test/coverage",
+        status: "completed",
+        conclusion: "success",
+        startedAt: "2026-04-23T10:01:00.000Z",
+        completedAt: "2026-04-23T10:05:00.000Z",
+        workflowName: "Coverage",
+        steps: []
+      },
+      {
+        id: 30,
+        name: "e2e-smoke",
+        htmlUrl: "https://example.test/e2e",
+        status: "completed",
+        conclusion: "success",
+        startedAt: "2026-04-23T10:01:00.000Z",
+        completedAt: "2026-04-23T10:05:00.000Z",
+        workflowName: "E2E Smoke",
+        steps: []
+      },
+      {
+        id: 40,
+        name: "Analyze (javascript-typescript)",
+        htmlUrl: "https://example.test/codeql",
+        status: "completed",
+        conclusion: "success",
+        startedAt: "2026-04-23T10:01:00.000Z",
+        completedAt: "2026-04-23T10:05:00.000Z",
+        workflowName: "CodeQL Advanced",
+        steps: []
+      }
+    ],
+    reviewThreads: [],
+    codexSignals: [
+      {
+        actorLogin: "chatgpt-codex-connector",
+        state: "APPROVED",
+        body: "Codex greenlight",
+        submittedAt: "2026-04-23T10:10:00.000Z",
+        url: "https://example.test/review",
+        kind: "review"
+      }
+    ],
+    changedFiles: [
+      {
+        path: "backend/readiness-gate.cts",
+        status: "modified",
+        additions: 18,
+        deletions: 2,
+        changes: 20,
+        patch: "@@ -1,1 +1,2 @@\n+const ready = true;\n+export { ready };"
+      },
+      {
+        path: "tests/gameplay/regression/codex-pr-readiness.test.cts",
+        status: "modified",
+        additions: 12,
+        deletions: 0,
+        changes: 12,
+        patch: "@@ -1,1 +1,2 @@\n+register('ready gate', () => {});\n+assert.equal(true, true);"
+      },
+      {
+        path: "docs/codex-pr-readiness-gate.md",
+        status: "modified",
+        additions: 6,
+        deletions: 0,
+        changes: 6,
+        patch: "@@ -1,1 +1,2 @@\n+# Readiness gate\n+Updated docs."
+      }
+    ],
+    ...overrides
+  };
+}
+
+function createTempJsonFile(name: string, payload: unknown) {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), "codex-pr-readiness-"));
+  const filePath = path.join(dirPath, name);
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+  return {
+    dirPath,
+    filePath
+  };
+}
+
+function createFakeClient(
+  routes: Record<string, unknown>,
+  graphqlHandler?: (query: string, variables: Record<string, unknown>) => unknown | Promise<unknown>
+) {
+  const calls: Array<Record<string, unknown>> = [];
+
+  return {
+    owner: "andreame-code",
+    repo: "netrisk",
+    calls,
+    async requestJson(method: string, requestPath: string, body?: Record<string, unknown>) {
+      calls.push({
+        kind: "rest",
+        method,
+        requestPath,
+        body: body || null
+      });
+      const key = `${method} ${requestPath}`;
+      if (!(key in routes)) {
+        throw new Error(`Unexpected route ${key}`);
+      }
+
+      const response = routes[key];
+      return typeof response === "function" ? await response(body) : response;
+    },
+    async graphql(query: string, variables: Record<string, unknown>) {
+      calls.push({
+        kind: "graphql",
+        query,
+        variables
+      });
+      return graphqlHandler ? await graphqlHandler(query, variables) : {};
+    }
+  };
+}
+
+register("codex PR readiness targets only draft Codex PRs", () => {
+  const branchTarget = isTargetPullRequest(createSnapshot().pr, config);
+  assert.equal(branchTarget.targeted, true);
+
+  const labelTarget = isTargetPullRequest(
+    {
+      ...createSnapshot().pr,
+      headRefName: "feature/plain-branch",
+      labels: ["codex"]
+    },
+    config
+  );
+  assert.equal(labelTarget.targeted, true);
+
+  const skipped = isTargetPullRequest(
+    {
+      ...createSnapshot().pr,
+      isDraft: false,
+      labels: ["codex"]
+    },
+    config
+  );
+  assert.equal(skipped.targeted, false);
+});
+
+register(
+  "codex PR readiness blocks pending checks, stale Codex feedback, stale branches, and conflicts",
+  () => {
+    const evaluation = evaluateReadinessFromSnapshot(
+      createSnapshot({
+        pr: {
+          ...createSnapshot().pr,
+          mergeable: false,
+          mergeableState: "dirty"
+        },
+        branchFreshness: {
+          behindBy: 3,
+          aheadBy: 2,
+          status: "behind",
+          url: "https://example.test/compare"
+        },
+        workflowJobs: [
+          createQualityJob({
+            status: "in_progress",
+            conclusion: null,
+            steps: [
+              { name: "Run repository typecheck", status: "completed", conclusion: "success" },
+              { name: "Run React shell typecheck", status: "completed", conclusion: "success" },
+              { name: "Run build", status: "in_progress", conclusion: null },
+              { name: "Run lint", status: "queued", conclusion: null },
+              { name: "Run format check", status: "queued", conclusion: null },
+              { name: "Run React shell tests", status: "queued", conclusion: null }
+            ]
+          }),
+          {
+            id: 20,
+            name: "coverage",
+            htmlUrl: "https://example.test/coverage",
+            status: "completed",
+            conclusion: "success",
+            startedAt: "2026-04-23T10:01:00.000Z",
+            completedAt: "2026-04-23T10:05:00.000Z",
+            workflowName: "Coverage",
+            steps: []
+          },
+          {
+            id: 30,
+            name: "e2e-smoke",
+            htmlUrl: "https://example.test/e2e",
+            status: "completed",
+            conclusion: "success",
+            startedAt: "2026-04-23T10:01:00.000Z",
+            completedAt: "2026-04-23T10:05:00.000Z",
+            workflowName: "E2E Smoke",
+            steps: []
+          },
+          {
+            id: 40,
+            name: "Analyze (javascript-typescript)",
+            htmlUrl: "https://example.test/codeql",
+            status: "completed",
+            conclusion: "success",
+            startedAt: "2026-04-23T10:01:00.000Z",
+            completedAt: "2026-04-23T10:05:00.000Z",
+            workflowName: "CodeQL Advanced",
+            steps: []
+          }
+        ],
+        reviewThreads: [
+          {
+            id: "thread-1",
+            isResolved: false,
+            isOutdated: false,
+            updatedAt: "2026-04-23T10:12:00.000Z",
+            comments: [
+              {
+                authorLogin: "chatgpt-codex-connector",
+                body: "Please fix this before merge.",
+                createdAt: "2026-04-23T10:12:00.000Z",
+                url: "https://example.test/thread-1"
+              }
+            ]
+          }
+        ],
+        codexSignals: [
+          {
+            actorLogin: "chatgpt-codex-connector",
+            state: "COMMENTED",
+            body: "Need follow-up changes.",
+            submittedAt: "2026-04-23T10:11:00.000Z",
+            url: "https://example.test/review",
+            kind: "review"
+          }
+        ]
+      }),
+      config
+    );
+
+    const blockerCodes = evaluation.blockers.map((blocker: { code: string }) => blocker.code);
+    assert.equal(evaluation.decision, "blocked");
+    assert.equal(blockerCodes.includes("required-check-pending:quality"), true);
+    assert.equal(blockerCodes.includes("quality-step-pending:build"), true);
+    assert.equal(blockerCodes.includes("unresolved-review-threads"), true);
+    assert.equal(blockerCodes.includes("stale-codex-greenlight"), true);
+    assert.equal(blockerCodes.includes("branch-stale"), true);
+    assert.equal(blockerCodes.includes("not-mergeable"), true);
+  }
+);
+
+register("codex PR readiness returns READY only when all hard blockers clear", () => {
+  const evaluation = evaluateReadinessFromSnapshot(createSnapshot(), config);
+
+  assert.equal(evaluation.decision, "ready");
+  assert.equal(evaluation.blockers.length, 0);
+  assert.equal(evaluation.advisories.length, 0);
+  assert.match(evaluation.summary, new RegExp(escapeForRegExp(READY_COMMENT_HEADING)));
+  assert.match(evaluation.summary, /Ready for review/i);
+});
+
+register(
+  "codex PR readiness blocks skipped tests, temporary leftovers, and missing generated sync",
+  () => {
+    const evaluation = evaluateReadinessFromSnapshot(
+      createSnapshot({
+        changedFiles: [
+          {
+            path: "shared/runtime-validation.cts",
+            status: "modified",
+            additions: 4,
+            deletions: 1,
+            changes: 5,
+            patch: "@@ -1,1 +1,2 @@\n+export const x = 1;\n+// TODO sync runtime"
+          },
+          {
+            path: "backend/readiness-gate.cts",
+            status: "modified",
+            additions: 2,
+            deletions: 0,
+            changes: 2,
+            patch: "@@ -1,1 +1,2 @@\n+console.log('debug');\n+export const y = 2;"
+          },
+          {
+            path: "tests/gameplay/regression/readiness.test.cts",
+            status: "modified",
+            additions: 2,
+            deletions: 0,
+            changes: 2,
+            patch: "@@ -1,1 +1,2 @@\n+it.skip('not ready', () => {});\n+assert.equal(true, true);"
+          }
+        ]
+      }),
+      config
+    );
+
+    const blockerCodes = evaluation.blockers.map((blocker: { code: string }) => blocker.code);
+    assert.equal(evaluation.decision, "blocked");
+    assert.equal(blockerCodes.includes("skipped-tests-introduced"), true);
+    assert.equal(blockerCodes.includes("temporary-leftovers"), true);
+    assert.equal(blockerCodes.includes("sync-requirement-1"), true);
+  }
+);
+
+register(
+  "codex PR readiness emits soft advisories for coverage risk, missing docs, and large diffs",
+  () => {
+    const evaluation = evaluateReadinessFromSnapshot(
+      createSnapshot({
+        changedFiles: [
+          {
+            path: "backend/heavy-change.cts",
+            status: "modified",
+            additions: 420,
+            deletions: 20,
+            changes: 440,
+            patch: "@@ -1,1 +1,2 @@\n+export const heavy = true;\n+export const stillHeavy = true;"
+          },
+          {
+            path: "frontend/react-shell/src/admin-route.tsx",
+            status: "modified",
+            additions: 300,
+            deletions: 10,
+            changes: 310,
+            patch:
+              "@@ -1,1 +1,2 @@\n+export function Ready() { return null; }\n+export const mode = 'ready';"
+          }
+        ]
+      }),
+      config
+    );
+
+    const advisoryCodes = evaluation.advisories.map((advisory: { code: string }) => advisory.code);
+    assert.equal(evaluation.decision, "ready");
+    assert.equal(advisoryCodes.includes("large-diff"), true);
+    assert.equal(advisoryCodes.includes("missing-docs"), true);
+    assert.equal(advisoryCodes.includes("coverage-risk-backend"), true);
+    assert.equal(advisoryCodes.includes("coverage-risk-frontend"), true);
+    assert.equal(advisoryCodes.includes("low-test-additions"), true);
+  }
+);
+
+register("codex PR readiness parses added diff lines only", () => {
+  assert.deepEqual(parseAddedLines("@@ -1,1 +1,3 @@\n line\n+added\n+++ ignore\n+also added"), [
+    "added",
+    "also added"
+  ]);
+});
+
+register("codex PR readiness parses CLI args and GitHub event payloads", () => {
+  assert.deepEqual(
+    parseArgs([
+      "--apply",
+      "--config",
+      "config.json",
+      "--event-path",
+      "event.json",
+      "--repository",
+      "andreame-code/netrisk",
+      "--pr-number",
+      "42",
+      "--pr-number",
+      "43",
+      "--json-output",
+      "out.json",
+      "--summary-output",
+      "summary.md"
+    ]),
+    {
+      apply: true,
+      configPath: "config.json",
+      eventPath: "event.json",
+      repository: "andreame-code/netrisk",
+      prNumbers: [42, 43],
+      jsonOutputPath: "out.json",
+      summaryOutputPath: "summary.md"
+    }
+  );
+
+  assert.deepEqual(parseEventPrNumbers(null), []);
+
+  const previousEventName = process.env.GITHUB_EVENT_NAME;
+  const pullRequestEvent = createTempJsonFile("pull-request.json", {
+    pull_request: { number: 71 }
+  });
+  const issueCommentEvent = createTempJsonFile("issue-comment.json", {
+    issue: {
+      number: 72,
+      pull_request: {
+        url: "https://example.test/pr/72"
+      }
+    }
+  });
+  const workflowRunEvent = createTempJsonFile("workflow-run.json", {
+    workflow_run: {
+      pull_requests: [{ number: 73 }, { number: 0 }, { number: "74" }]
+    }
+  });
+  const workflowDispatchEvent = createTempJsonFile("workflow-dispatch.json", {
+    inputs: {
+      pr_number: "75"
+    }
+  });
+
+  try {
+    delete process.env.GITHUB_EVENT_NAME;
+    assert.deepEqual(parseEventPrNumbers(pullRequestEvent.filePath), [71]);
+
+    process.env.GITHUB_EVENT_NAME = "issue_comment";
+    assert.deepEqual(parseEventPrNumbers(issueCommentEvent.filePath), [72]);
+
+    process.env.GITHUB_EVENT_NAME = "workflow_run";
+    assert.deepEqual(parseEventPrNumbers(workflowRunEvent.filePath), [73, 74]);
+
+    process.env.GITHUB_EVENT_NAME = "workflow_dispatch";
+    assert.deepEqual(parseEventPrNumbers(workflowDispatchEvent.filePath), [75]);
+  } finally {
+    if (typeof previousEventName === "string") {
+      process.env.GITHUB_EVENT_NAME = previousEventName;
+    } else {
+      delete process.env.GITHUB_EVENT_NAME;
+    }
+    fs.rmSync(pullRequestEvent.dirPath, { recursive: true, force: true });
+    fs.rmSync(issueCommentEvent.dirPath, { recursive: true, force: true });
+    fs.rmSync(workflowRunEvent.dirPath, { recursive: true, force: true });
+    fs.rmSync(workflowDispatchEvent.dirPath, { recursive: true, force: true });
+  }
+});
+
+register(
+  "codex PR readiness resolves explicit, event, and scheduled target PR numbers",
+  async () => {
+    const eventPayload = createTempJsonFile("workflow-run.json", {
+      workflow_run: {
+        pull_requests: [{ number: 81 }, { number: 82 }]
+      }
+    });
+    const previousEventName = process.env.GITHUB_EVENT_NAME;
+    const client = createFakeClient({
+      "GET /repos/andreame-code/netrisk/pulls?state=open&per_page=100&page=1": [
+        {
+          number: 10,
+          draft: true,
+          state: "open",
+          labels: [{ name: "codex" }],
+          user: { login: "developer" },
+          base: { ref: "main" },
+          head: { ref: "feature/content-studio", sha: "sha-10" }
+        },
+        {
+          number: 11,
+          draft: true,
+          state: "open",
+          labels: [],
+          user: { login: "developer" },
+          base: { ref: "main" },
+          head: { ref: "codex/quality-gate", sha: "sha-11" }
+        },
+        {
+          number: 12,
+          draft: false,
+          state: "open",
+          labels: [{ name: "codex" }],
+          user: { login: "developer" },
+          base: { ref: "main" },
+          head: { ref: "feature/not-targeted", sha: "sha-12" }
+        },
+        {
+          number: 13,
+          draft: true,
+          state: "open",
+          labels: [],
+          user: { login: "chatgpt-codex-connector" },
+          base: { ref: "main" },
+          head: { ref: "feature/codex-author", sha: "sha-13" }
+        }
+      ],
+      "GET /repos/andreame-code/netrisk/pulls?state=open&per_page=100&page=2": []
+    });
+
+    try {
+      assert.deepEqual(
+        await resolveTargetPrNumbers(
+          client,
+          {
+            apply: false,
+            configPath: null,
+            eventPath: null,
+            repository: null,
+            prNumbers: [99, 99, 0],
+            jsonOutputPath: null,
+            summaryOutputPath: null
+          },
+          config
+        ),
+        [99]
+      );
+
+      process.env.GITHUB_EVENT_NAME = "workflow_run";
+      assert.deepEqual(
+        await resolveTargetPrNumbers(
+          client,
+          {
+            apply: false,
+            configPath: null,
+            eventPath: eventPayload.filePath,
+            repository: null,
+            prNumbers: [],
+            jsonOutputPath: null,
+            summaryOutputPath: null
+          },
+          config
+        ),
+        [81, 82]
+      );
+
+      delete process.env.GITHUB_EVENT_NAME;
+      assert.deepEqual(
+        await resolveTargetPrNumbers(
+          client,
+          {
+            apply: false,
+            configPath: null,
+            eventPath: null,
+            repository: null,
+            prNumbers: [],
+            jsonOutputPath: null,
+            summaryOutputPath: null
+          },
+          config
+        ),
+        [10, 11, 13]
+      );
+    } finally {
+      if (typeof previousEventName === "string") {
+        process.env.GITHUB_EVENT_NAME = previousEventName;
+      } else {
+        delete process.env.GITHUB_EVENT_NAME;
+      }
+      fs.rmSync(eventPayload.dirPath, { recursive: true, force: true });
+    }
+  }
+);
+
+register("codex PR readiness snapshots GitHub metadata into the evaluation input", async () => {
+  const client = createFakeClient(
+    {
+      "GET /repos/andreame-code/netrisk/pulls/146": {
+        number: 146,
+        node_id: "PR_node",
+        title: "Codex readiness gate",
+        html_url: "https://example.test/pr/146",
+        state: "open",
+        draft: true,
+        user: { login: "andreame-code" },
+        base: { ref: "main" },
+        head: { ref: "codex/pr-readiness-gate-20260423", sha: "sha-146" },
+        labels: [{ name: "codex" }],
+        additions: 24,
+        deletions: 4,
+        changed_files: 2,
+        mergeable: true,
+        mergeable_state: "clean"
+      },
+      "GET /repos/andreame-code/netrisk/commits/sha-146": {
+        commit: {
+          committer: {
+            date: "2026-04-23T10:09:00.000Z"
+          }
+        }
+      },
+      "GET /repos/andreame-code/netrisk/compare/main...sha-146": {
+        behind_by: 0,
+        ahead_by: 2,
+        status: "ahead",
+        html_url: "https://example.test/compare"
+      },
+      "GET /repos/andreame-code/netrisk/actions/runs?head_sha=sha-146&per_page=100&page=1": {
+        workflow_runs: [
+          { id: 900, name: "Quality", head_sha: "sha-146" },
+          { id: 901, name: "Coverage", head_sha: "sha-146" }
+        ]
+      },
+      "GET /repos/andreame-code/netrisk/actions/runs?head_sha=sha-146&per_page=100&page=2": {
+        workflow_runs: []
+      },
+      "GET /repos/andreame-code/netrisk/actions/runs/900/jobs?per_page=100": {
+        jobs: [
+          {
+            id: 9001,
+            name: "quality",
+            html_url: "https://example.test/jobs/9001",
+            status: "completed",
+            conclusion: "success",
+            started_at: "2026-04-23T10:10:00.000Z",
+            completed_at: "2026-04-23T10:12:00.000Z",
+            steps: [{ name: "Run build", status: "completed", conclusion: "success" }]
+          }
+        ]
+      },
+      "GET /repos/andreame-code/netrisk/actions/runs/901/jobs?per_page=100": {
+        jobs: [
+          {
+            id: 9002,
+            name: "coverage",
+            html_url: "https://example.test/jobs/9002",
+            status: "completed",
+            conclusion: "success",
+            started_at: "2026-04-23T10:12:00.000Z",
+            completed_at: "2026-04-23T10:14:00.000Z",
+            steps: []
+          }
+        ]
+      },
+      "GET /repos/andreame-code/netrisk/pulls/146/reviews?per_page=100&page=1": [
+        {
+          user: { login: "chatgpt-codex-connector" },
+          state: "APPROVED",
+          body: "Codex greenlight",
+          submitted_at: "2026-04-23T10:15:00.000Z",
+          html_url: "https://example.test/reviews/1"
+        }
+      ],
+      "GET /repos/andreame-code/netrisk/pulls/146/reviews?per_page=100&page=2": [],
+      "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [
+        {
+          user: { login: "chatgpt-codex-connector" },
+          body: "Codex PR readiness: greenlight",
+          created_at: "2026-04-23T10:16:00.000Z",
+          html_url: "https://example.test/comments/1"
+        }
+      ],
+      "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=2": [],
+      "GET /repos/andreame-code/netrisk/pulls/146/files?per_page=100&page=1": [
+        {
+          filename: "scripts/evaluate-codex-pr-readiness.cts",
+          status: "modified",
+          additions: 12,
+          deletions: 1,
+          changes: 13,
+          patch: "@@ -1,1 +1,2 @@\n+export const ready = true;\n+export const applied = true;"
+        }
+      ],
+      "GET /repos/andreame-code/netrisk/pulls/146/files?per_page=100&page=2": []
+    },
+    async () => ({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null
+            },
+            nodes: [
+              {
+                id: "thread-1",
+                isResolved: false,
+                isOutdated: false,
+                updatedAt: "2026-04-23T10:17:00.000Z",
+                comments: {
+                  nodes: [
+                    {
+                      author: { login: "chatgpt-codex-connector" },
+                      body: "Please rerun coverage after the last push.",
+                      createdAt: "2026-04-23T10:17:00.000Z",
+                      url: "https://example.test/thread/1"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    })
+  );
+
+  const snapshot = await getSnapshot(client, 146, config);
+
+  assert.equal(snapshot.pr.headCommitAt, "2026-04-23T10:09:00.000Z");
+  assert.equal(snapshot.branchFreshness.behindBy, 0);
+  assert.equal(snapshot.workflowJobs.length, 2);
+  assert.equal(snapshot.workflowJobs[0].workflowName, "Quality");
+  assert.equal(snapshot.reviewThreads[0].comments[0].authorLogin, "chatgpt-codex-connector");
+  assert.equal(snapshot.codexSignals.length, 2);
+  assert.equal(snapshot.changedFiles[0].path, "scripts/evaluate-codex-pr-readiness.cts");
+});
+
+register("codex PR readiness upserts a single sticky summary comment", async () => {
+  const createdClient = createFakeClient({
+    "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [],
+    "POST /repos/andreame-code/netrisk/issues/146/comments": {}
+  });
+  assert.equal(
+    await upsertSummaryComment(
+      createdClient,
+      146,
+      `${config.summaryCommentMarker}\nCreated summary`,
+      config.summaryCommentMarker
+    ),
+    "created"
+  );
+
+  const updatedClient = createFakeClient({
+    "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [
+      {
+        id: 7,
+        user: { login: "github-actions[bot]" },
+        body: `${config.summaryCommentMarker}\nOld summary`
+      }
+    ],
+    "PATCH /repos/andreame-code/netrisk/issues/comments/7": {}
+  });
+  assert.equal(
+    await upsertSummaryComment(
+      updatedClient,
+      146,
+      `${config.summaryCommentMarker}\nUpdated summary`,
+      config.summaryCommentMarker
+    ),
+    "updated"
+  );
+
+  const unchangedClient = createFakeClient({
+    "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [
+      {
+        id: 8,
+        user: { login: "github-actions[bot]" },
+        body: `${config.summaryCommentMarker}\nSame summary`
+      }
+    ]
+  });
+  assert.equal(
+    await upsertSummaryComment(
+      unchangedClient,
+      146,
+      `${config.summaryCommentMarker}\nSame summary`,
+      config.summaryCommentMarker
+    ),
+    "unchanged"
+  );
+});
+
+register("codex PR readiness applies draft transitions only for fully ready PRs", async () => {
+  const readySnapshot = createSnapshot();
+  const readyEvaluation = evaluateReadinessFromSnapshot(readySnapshot, config);
+  const readyClient = createFakeClient(
+    {
+      "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [
+        {
+          id: 9,
+          user: { login: "github-actions[bot]" },
+          body: readyEvaluation.summary
+        }
+      ]
+    },
+    async () => ({
+      markPullRequestReadyForReview: {
+        pullRequest: {
+          id: readySnapshot.pr.nodeId,
+          isDraft: false
+        }
+      }
+    })
+  );
+
+  assert.deepEqual(
+    await applyEvaluation(readyClient, readySnapshot, readyEvaluation, config, true),
+    {
+      commentStatus: "unchanged",
+      markedReady: true
+    }
+  );
+
+  const blockedSnapshot = createSnapshot({
+    reviewThreads: [
+      {
+        id: "thread-blocking",
+        isResolved: false,
+        isOutdated: false,
+        updatedAt: "2026-04-23T10:30:00.000Z",
+        comments: [
+          {
+            authorLogin: "chatgpt-codex-connector",
+            body: "Still blocked",
+            createdAt: "2026-04-23T10:30:00.000Z",
+            url: "https://example.test/thread/blocking"
+          }
+        ]
+      }
+    ]
+  });
+  const blockedEvaluation = evaluateReadinessFromSnapshot(blockedSnapshot, config);
+  const blockedClient = createFakeClient({
+    "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [],
+    "POST /repos/andreame-code/netrisk/issues/146/comments": {}
+  });
+
+  assert.deepEqual(
+    await applyEvaluation(blockedClient, blockedSnapshot, blockedEvaluation, config, true),
+    {
+      commentStatus: "created",
+      markedReady: false
+    }
+  );
+
+  assert.deepEqual(
+    await applyEvaluation(readyClient, readySnapshot, readyEvaluation, config, false),
+    {
+      commentStatus: "skipped",
+      markedReady: false
+    }
+  );
+});
+
+register("codex PR readiness builds batch summaries for empty and populated runs", () => {
+  assert.match(
+    buildBatchSummary([]),
+    new RegExp(escapeForRegExp("No targeted draft PRs were evaluated in this run."))
+  );
+
+  assert.match(
+    buildBatchSummary([
+      {
+        pr: createSnapshot().pr,
+        evaluation: {
+          ...evaluateReadinessFromSnapshot(createSnapshot(), config),
+          blockers: [],
+          advisories: [{ code: "large-diff", message: "Large diff." }]
+        },
+        applyResult: {
+          commentStatus: "updated",
+          markedReady: true
+        }
+      }
+    ]),
+    new RegExp(
+      escapeForRegExp(
+        "PR #146: READY (0 blocker(s), 1 advisory/advisories, comment updated, marked ready yes)"
+      )
+    )
+  );
+});
+
+register(
+  "codex PR readiness GitHub client handles REST and GraphQL success and failures",
+  async () => {
+    assert.throws(
+      () => new GitHubApiClient("invalid-repo-value", "token"),
+      /Invalid repository value/
+    );
+
+    const originalFetch = global.fetch;
+    const calls: Array<Record<string, unknown>> = [];
+
+    try {
+      global.fetch = (async (url: string, init: Record<string, unknown>) => {
+        calls.push({
+          url,
+          method: init.method
+        });
+
+        if (String(url).endsWith("/ok")) {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return { ok: true };
+            },
+            async text() {
+              return "";
+            }
+          } as any;
+        }
+
+        if (String(url).endsWith("/empty")) {
+          return {
+            ok: true,
+            status: 204,
+            async json() {
+              return null;
+            },
+            async text() {
+              return "";
+            }
+          } as any;
+        }
+
+        if (String(url).endsWith("/graphql")) {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                data: {
+                  viewer: {
+                    login: "chatgpt-codex-connector"
+                  }
+                }
+              };
+            },
+            async text() {
+              return "";
+            }
+          } as any;
+        }
+
+        return {
+          ok: false,
+          status: 500,
+          async json() {
+            return {};
+          },
+          async text() {
+            return "boom";
+          }
+        } as any;
+      }) as typeof global.fetch;
+
+      const client = new GitHubApiClient("andreame-code/netrisk", "token");
+      assert.deepEqual(await client.requestJson("GET", "/ok"), { ok: true });
+      assert.equal(await client.requestJson("POST", "/empty"), null);
+      assert.deepEqual(await client.graphql("query Viewer { viewer { login } }", {}), {
+        viewer: {
+          login: "chatgpt-codex-connector"
+        }
+      });
+      await assert.rejects(
+        async () => client.requestJson("GET", "/fail"),
+        /GET \/fail failed \(500\): boom/
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    const graphqlFailureFetch = global.fetch;
+    try {
+      global.fetch = (async () =>
+        ({
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              errors: [{ message: "GraphQL exploded" }]
+            };
+          },
+          async text() {
+            return "";
+          }
+        }) as any) as typeof global.fetch;
+
+      const client = new GitHubApiClient("andreame-code/netrisk", "token");
+      await assert.rejects(
+        async () => client.graphql("query Viewer { viewer { login } }", {}),
+        /GraphQL returned errors: GraphQL exploded/
+      );
+    } finally {
+      global.fetch = graphqlFailureFetch;
+    }
+
+    assert.equal(calls.length >= 4, true);
+  }
+);
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}

--- a/tests/gameplay/victory/victory-detection.test.cts
+++ b/tests/gameplay/victory/victory-detection.test.cts
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const { detectVictory } = require("../../../backend/engine/victory-detection.cjs");
 const { MAJORITY_CONTROL_VICTORY_RULE_SET_ID } = require("../../../shared/models.cjs");
 const {
+  makeContinent,
   makePlayers,
   makeState,
   territoryStates,
@@ -193,4 +194,127 @@ register("detectVictory majority control usa la soglia modulare persistita nel g
   assert.equal(result.victory?.winnerId, "p1");
   assert.equal(result.victory?.summaryParams?.majorityControlThresholdPercent, 60);
   assert.equal(result.victory?.summaryParams?.requiredTerritoryCount, 6);
+});
+
+register("detectVictory resolves authored continent objectives from the persisted gameConfig", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "alaska", ownerId: "p1", armies: 1 },
+      { id: "ontario", ownerId: "p1", armies: 1 },
+      { id: "india", ownerId: "p1", armies: 1 },
+      { id: "china", ownerId: "p1", armies: 1 },
+      { id: "brazil", ownerId: "p2", armies: 1 }
+    ]),
+    continents: [
+      makeContinent("north_america", ["alaska", "ontario"], 5, {
+        name: "North America"
+      }),
+      makeContinent("asia", ["india", "china"], 7, {
+        name: "Asia"
+      }),
+      makeContinent("south_america", ["brazil"], 2, {
+        name: "South America"
+      })
+    ],
+    currentTurnIndex: 0,
+    turnPhase: TurnPhase.ATTACK
+  });
+  state.gameConfig = {
+    ...(state.gameConfig || {}),
+    victoryRuleSetId: "victory.na-asia",
+    victoryObjectiveModule: {
+      id: "victory.na-asia",
+      name: "North America and Asia",
+      description: "Control both continents simultaneously.",
+      version: "1.0.0",
+      moduleType: "victory-objectives",
+      kind: "authored-victory-objectives",
+      map: {
+        id: "classic-mini",
+        name: "Classic Mini",
+        territoryCount: 5,
+        continentCount: 3
+      },
+      objectives: [
+        {
+          id: "hold-na-asia",
+          title: "Hold North America and Asia",
+          description: "Control North America and Asia at the same time.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america", "asia"],
+          continentNames: ["North America", "Asia"],
+          summary: "Control North America and Asia simultaneously."
+        }
+      ],
+      preview: {
+        summary: "Win condition: control North America and Asia simultaneously.",
+        objectiveSummaries: ["Control North America and Asia simultaneously."]
+      }
+    }
+  };
+
+  const result = detectVictory(state);
+
+  assert.equal(result.code, "VICTORY_DECLARED");
+  assert.equal(result.victory?.winnerId, "p1");
+  assert.equal(result.victory?.summaryKey, "game.log.victoryAuthoredObjective");
+  assert.equal(result.victory?.summaryParams?.objectiveId, "hold-na-asia");
+  assert.equal(result.victory?.summaryParams?.victoryModuleId, "victory.na-asia");
+});
+
+register("detectVictory resolves authored territory-count objectives from the persisted gameConfig", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 1 },
+      { id: "b", ownerId: "p1", armies: 1 },
+      { id: "c", ownerId: "p1", armies: 1 },
+      { id: "d", ownerId: "p1", armies: 1 },
+      { id: "e", ownerId: "p2", armies: 1 }
+    ]),
+    currentTurnIndex: 0,
+    turnPhase: TurnPhase.ATTACK
+  });
+  state.gameConfig = {
+    ...(state.gameConfig || {}),
+    victoryRuleSetId: "victory.territory-count",
+    victoryObjectiveModule: {
+      id: "victory.territory-count",
+      name: "Territory Control",
+      description: "Reach the configured number of territories.",
+      version: "1.0.0",
+      moduleType: "victory-objectives",
+      kind: "authored-victory-objectives",
+      map: {
+        id: "classic-mini",
+        name: "Classic Mini",
+        territoryCount: 5,
+        continentCount: 0
+      },
+      objectives: [
+        {
+          id: "hold-four",
+          title: "Own four territories",
+          description: "Reach four territories.",
+          enabled: true,
+          type: "control-territory-count",
+          territoryCount: 4,
+          summary: "Own at least 4 territories."
+        }
+      ],
+      preview: {
+        summary: "Win condition: own at least 4 territories.",
+        objectiveSummaries: ["Own at least 4 territories."]
+      }
+    }
+  };
+
+  const result = detectVictory(state);
+
+  assert.equal(result.code, "VICTORY_DECLARED");
+  assert.equal(result.victory?.winnerId, "p1");
+  assert.equal(result.victory?.summaryParams?.objectiveType, "control-territory-count");
+  assert.equal(result.victory?.summaryParams?.objectiveTitle, "Own four territories");
 });

--- a/tests/gameplay/victory/victory-detection.test.cts
+++ b/tests/gameplay/victory/victory-detection.test.cts
@@ -196,125 +196,131 @@ register("detectVictory majority control usa la soglia modulare persistita nel g
   assert.equal(result.victory?.summaryParams?.requiredTerritoryCount, 6);
 });
 
-register("detectVictory resolves authored continent objectives from the persisted gameConfig", () => {
-  const state = makeState({
-    players: makePlayers(["Alice", "Bob"]),
-    territories: territoryStates([
-      { id: "alaska", ownerId: "p1", armies: 1 },
-      { id: "ontario", ownerId: "p1", armies: 1 },
-      { id: "india", ownerId: "p1", armies: 1 },
-      { id: "china", ownerId: "p1", armies: 1 },
-      { id: "brazil", ownerId: "p2", armies: 1 }
-    ]),
-    continents: [
-      makeContinent("north_america", ["alaska", "ontario"], 5, {
-        name: "North America"
-      }),
-      makeContinent("asia", ["india", "china"], 7, {
-        name: "Asia"
-      }),
-      makeContinent("south_america", ["brazil"], 2, {
-        name: "South America"
-      })
-    ],
-    currentTurnIndex: 0,
-    turnPhase: TurnPhase.ATTACK
-  });
-  state.gameConfig = {
-    ...(state.gameConfig || {}),
-    victoryRuleSetId: "victory.na-asia",
-    victoryObjectiveModule: {
-      id: "victory.na-asia",
-      name: "North America and Asia",
-      description: "Control both continents simultaneously.",
-      version: "1.0.0",
-      moduleType: "victory-objectives",
-      kind: "authored-victory-objectives",
-      map: {
-        id: "classic-mini",
-        name: "Classic Mini",
-        territoryCount: 5,
-        continentCount: 3
-      },
-      objectives: [
-        {
-          id: "hold-na-asia",
-          title: "Hold North America and Asia",
-          description: "Control North America and Asia at the same time.",
-          enabled: true,
-          type: "control-continents",
-          continentIds: ["north_america", "asia"],
-          continentNames: ["North America", "Asia"],
-          summary: "Control North America and Asia simultaneously."
-        }
+register(
+  "detectVictory resolves authored continent objectives from the persisted gameConfig",
+  () => {
+    const state = makeState({
+      players: makePlayers(["Alice", "Bob"]),
+      territories: territoryStates([
+        { id: "alaska", ownerId: "p1", armies: 1 },
+        { id: "ontario", ownerId: "p1", armies: 1 },
+        { id: "india", ownerId: "p1", armies: 1 },
+        { id: "china", ownerId: "p1", armies: 1 },
+        { id: "brazil", ownerId: "p2", armies: 1 }
+      ]),
+      continents: [
+        makeContinent("north_america", ["alaska", "ontario"], 5, {
+          name: "North America"
+        }),
+        makeContinent("asia", ["india", "china"], 7, {
+          name: "Asia"
+        }),
+        makeContinent("south_america", ["brazil"], 2, {
+          name: "South America"
+        })
       ],
-      preview: {
-        summary: "Win condition: control North America and Asia simultaneously.",
-        objectiveSummaries: ["Control North America and Asia simultaneously."]
-      }
-    }
-  };
-
-  const result = detectVictory(state);
-
-  assert.equal(result.code, "VICTORY_DECLARED");
-  assert.equal(result.victory?.winnerId, "p1");
-  assert.equal(result.victory?.summaryKey, "game.log.victoryAuthoredObjective");
-  assert.equal(result.victory?.summaryParams?.objectiveId, "hold-na-asia");
-  assert.equal(result.victory?.summaryParams?.victoryModuleId, "victory.na-asia");
-});
-
-register("detectVictory resolves authored territory-count objectives from the persisted gameConfig", () => {
-  const state = makeState({
-    players: makePlayers(["Alice", "Bob"]),
-    territories: territoryStates([
-      { id: "a", ownerId: "p1", armies: 1 },
-      { id: "b", ownerId: "p1", armies: 1 },
-      { id: "c", ownerId: "p1", armies: 1 },
-      { id: "d", ownerId: "p1", armies: 1 },
-      { id: "e", ownerId: "p2", armies: 1 }
-    ]),
-    currentTurnIndex: 0,
-    turnPhase: TurnPhase.ATTACK
-  });
-  state.gameConfig = {
-    ...(state.gameConfig || {}),
-    victoryRuleSetId: "victory.territory-count",
-    victoryObjectiveModule: {
-      id: "victory.territory-count",
-      name: "Territory Control",
-      description: "Reach the configured number of territories.",
-      version: "1.0.0",
-      moduleType: "victory-objectives",
-      kind: "authored-victory-objectives",
-      map: {
-        id: "classic-mini",
-        name: "Classic Mini",
-        territoryCount: 5,
-        continentCount: 0
-      },
-      objectives: [
-        {
-          id: "hold-four",
-          title: "Own four territories",
-          description: "Reach four territories.",
-          enabled: true,
-          type: "control-territory-count",
-          territoryCount: 4,
-          summary: "Own at least 4 territories."
+      currentTurnIndex: 0,
+      turnPhase: TurnPhase.ATTACK
+    });
+    state.gameConfig = {
+      ...(state.gameConfig || {}),
+      victoryRuleSetId: "victory.na-asia",
+      victoryObjectiveModule: {
+        id: "victory.na-asia",
+        name: "North America and Asia",
+        description: "Control both continents simultaneously.",
+        version: "1.0.0",
+        moduleType: "victory-objectives",
+        kind: "authored-victory-objectives",
+        map: {
+          id: "classic-mini",
+          name: "Classic Mini",
+          territoryCount: 5,
+          continentCount: 3
+        },
+        objectives: [
+          {
+            id: "hold-na-asia",
+            title: "Hold North America and Asia",
+            description: "Control North America and Asia at the same time.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america", "asia"],
+            continentNames: ["North America", "Asia"],
+            summary: "Control North America and Asia simultaneously."
+          }
+        ],
+        preview: {
+          summary: "Win condition: control North America and Asia simultaneously.",
+          objectiveSummaries: ["Control North America and Asia simultaneously."]
         }
-      ],
-      preview: {
-        summary: "Win condition: own at least 4 territories.",
-        objectiveSummaries: ["Own at least 4 territories."]
       }
-    }
-  };
+    };
 
-  const result = detectVictory(state);
+    const result = detectVictory(state);
 
-  assert.equal(result.code, "VICTORY_DECLARED");
-  assert.equal(result.victory?.winnerId, "p1");
-  assert.equal(result.victory?.summaryParams?.objectiveType, "control-territory-count");
-  assert.equal(result.victory?.summaryParams?.objectiveTitle, "Own four territories");
-});
+    assert.equal(result.code, "VICTORY_DECLARED");
+    assert.equal(result.victory?.winnerId, "p1");
+    assert.equal(result.victory?.summaryKey, "game.log.victoryAuthoredObjective");
+    assert.equal(result.victory?.summaryParams?.objectiveId, "hold-na-asia");
+    assert.equal(result.victory?.summaryParams?.victoryModuleId, "victory.na-asia");
+  }
+);
+
+register(
+  "detectVictory resolves authored territory-count objectives from the persisted gameConfig",
+  () => {
+    const state = makeState({
+      players: makePlayers(["Alice", "Bob"]),
+      territories: territoryStates([
+        { id: "a", ownerId: "p1", armies: 1 },
+        { id: "b", ownerId: "p1", armies: 1 },
+        { id: "c", ownerId: "p1", armies: 1 },
+        { id: "d", ownerId: "p1", armies: 1 },
+        { id: "e", ownerId: "p2", armies: 1 }
+      ]),
+      currentTurnIndex: 0,
+      turnPhase: TurnPhase.ATTACK
+    });
+    state.gameConfig = {
+      ...(state.gameConfig || {}),
+      victoryRuleSetId: "victory.territory-count",
+      victoryObjectiveModule: {
+        id: "victory.territory-count",
+        name: "Territory Control",
+        description: "Reach the configured number of territories.",
+        version: "1.0.0",
+        moduleType: "victory-objectives",
+        kind: "authored-victory-objectives",
+        map: {
+          id: "classic-mini",
+          name: "Classic Mini",
+          territoryCount: 5,
+          continentCount: 0
+        },
+        objectives: [
+          {
+            id: "hold-four",
+            title: "Own four territories",
+            description: "Reach four territories.",
+            enabled: true,
+            type: "control-territory-count",
+            territoryCount: 4,
+            summary: "Own at least 4 territories."
+          }
+        ],
+        preview: {
+          summary: "Win condition: own at least 4 territories.",
+          objectiveSummaries: ["Own at least 4 territories."]
+        }
+      }
+    };
+
+    const result = detectVictory(state);
+
+    assert.equal(result.code, "VICTORY_DECLARED");
+    assert.equal(result.victory?.winnerId, "p1");
+    assert.equal(result.victory?.summaryParams?.objectiveType, "control-territory-count");
+    assert.equal(result.victory?.summaryParams?.objectiveTitle, "Own four territories");
+  }
+);


### PR DESCRIPTION
## Summary
- add a dedicated Codex PR readiness workflow that evaluates only Codex-authored/labelled draft PRs on relevant events and on a schedule
- add a central readiness evaluator script with hard blockers, soft advisories, sticky summary comment upserts, and automatic draft-to-ready transitions
- add regression coverage and docs for the readiness gate, including GitHub API shape handling for workflow runs

## Validation
- npm run test:gameplay
- npm run test:react
- npm run lint
- npm run format:check
- npm run coverage && npm run coverage:check
