### PR TITLE
Restore gameplay action panel fallbacks

### DIFF
--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -174,6 +174,7 @@ function createGameplayState(overrides: Partial<GameStateResponse> = {}): GameSt
 describe("GameRoute integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
 
     closeStreamMock = vi.fn();
     streamHandlers = null;
@@ -203,6 +204,33 @@ describe("GameRoute integration", () => {
 
   afterEach(() => {
     streamHandlers = null;
+    window.localStorage.clear();
+  });
+
+  it("keeps reinforcement actions visible when the session user matches the current player", async () => {
+    getGameStateMock.mockResolvedValue(createGameplayState({ playerId: null }));
+
+    renderReactShell("/react/game/g-1");
+
+    expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.getElementById("reinforce-group")).toBeVisible();
+    });
+  });
+
+  it("restores reinforcement actions from the legacy stored player id format", async () => {
+    getSessionMock.mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), { code: "AUTH_REQUIRED" })
+    );
+    getGameStateMock.mockResolvedValue(createGameplayState({ playerId: null }));
+    window.localStorage.setItem("frontline-player-id", "p1");
+
+    renderReactShell("/react/game/g-1");
+
+    expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.getElementById("reinforce-group")).toBeVisible();
+    });
   });
 
   it("falls back to polling after an invalid stream payload and returns to live updates after recovery", async () => {

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 
 import type {
   AuthSessionResponse,
@@ -9,6 +9,7 @@ import type {
 import {
   getGameState,
   getModuleOptions,
+  sendGameAction,
   getSession,
   subscribeToGameEvents
 } from "@frontend-core/api/client.mts";
@@ -45,6 +46,7 @@ vi.mock("@react-shell/gameplay-map-viewport", () => ({
 const getGameStateMock = vi.mocked(getGameState);
 const getModuleOptionsMock = vi.mocked(getModuleOptions);
 const getSessionMock = vi.mocked(getSession);
+const sendGameActionMock = vi.mocked(sendGameAction);
 const subscribeToGameEventsMock = vi.mocked(subscribeToGameEvents);
 
 type StreamHandlers = Parameters<typeof subscribeToGameEvents>[0];
@@ -182,6 +184,35 @@ describe("GameRoute integration", () => {
     getSessionMock.mockResolvedValue(createSession());
     getModuleOptionsMock.mockResolvedValue(emptyModuleOptions());
     getGameStateMock.mockResolvedValue(createGameplayState());
+    sendGameActionMock.mockResolvedValue({
+      ok: true,
+      state: createGameplayState({
+        reinforcementPool: 2,
+        version: 5,
+        map: [
+          {
+            id: "aurora",
+            name: "Aurora",
+            neighbors: ["bastion"],
+            continentId: "north",
+            ownerId: "p1",
+            armies: 4,
+            x: 0.2,
+            y: 0.3
+          },
+          {
+            id: "bastion",
+            name: "Bastion",
+            neighbors: ["aurora"],
+            continentId: "north",
+            ownerId: "p2",
+            armies: 1,
+            x: 0.65,
+            y: 0.45
+          }
+        ]
+      })
+    });
     subscribeToGameEventsMock.mockImplementation((handlers) => {
       streamHandlers = handlers;
       return {
@@ -230,6 +261,30 @@ describe("GameRoute integration", () => {
     expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
     await waitFor(() => {
       expect(document.getElementById("reinforce-group")).toBeVisible();
+    });
+  });
+
+  it("submits reinforce without expectedVersion when the player id is inferred", async () => {
+    getGameStateMock.mockResolvedValue(createGameplayState({ playerId: null }));
+
+    renderReactShell("/react/game/g-1");
+
+    expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.getElementById("reinforce-group")).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Aggiungi" }));
+
+    await waitFor(() => {
+      expect(sendGameActionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(sendGameActionMock.mock.calls[0]?.[0]).toEqual({
+      gameId: "g-1",
+      playerId: "p1",
+      type: "reinforce",
+      territoryId: "aurora",
+      amount: 1
     });
   });
 

--- a/frontend/react-shell/src/__tests__/player-session.test.ts
+++ b/frontend/react-shell/src/__tests__/player-session.test.ts
@@ -15,4 +15,10 @@ describe("player session storage", () => {
 
     expect(readCurrentPlayerId("g-1")).toBeNull();
   });
+
+  it("reads legacy digit-only player ids", () => {
+    window.localStorage.setItem("frontline-player-id", "00123");
+
+    expect(readCurrentPlayerId("g-1")).toBe("00123");
+  });
 });

--- a/frontend/react-shell/src/__tests__/player-session.test.ts
+++ b/frontend/react-shell/src/__tests__/player-session.test.ts
@@ -1,0 +1,18 @@
+import { readCurrentPlayerId } from "@react-shell/player-session";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("player session storage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("returns null when storage access throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Blocked", "SecurityError");
+    });
+
+    expect(readCurrentPlayerId("g-1")).toBeNull();
+  });
+});

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -261,7 +261,21 @@ export function GameRoute() {
   }
 
   const storedPlayerId = readCurrentPlayerId(resolvedGameId || null);
-  const myPlayerId = snapshot?.playerId || storedPlayerId || null;
+  const authenticatedPlayer =
+    authenticatedUser && Array.isArray(snapshot?.players)
+      ? snapshot.players.find(
+          (player) => !player.isAi && player.name === authenticatedUser.username
+        ) || null
+      : null;
+  const storedPlayer =
+    storedPlayerId && playersById[storedPlayerId] ? playersById[storedPlayerId] : null;
+  const myPlayerId =
+    snapshot?.playerId ||
+    authenticatedPlayer?.id ||
+    (storedPlayer && (!authenticatedUser || storedPlayer.name === authenticatedUser.username)
+      ? storedPlayer.id
+      : null) ||
+    null;
   const me = myPlayerId ? playersById[myPlayerId] || null : null;
   const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
   const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -285,6 +285,8 @@ export function GameRoute() {
   );
   const currentVersion =
     snapshot && Number.isInteger(snapshot.version) ? snapshot.version : undefined;
+  const actionExpectedVersion =
+    snapshot?.playerId && snapshot.playerId === myPlayerId ? currentVersion : undefined;
   const isMyTurn = Boolean(
     snapshot?.phase === "active" && myPlayerId && snapshot.currentPlayerId === myPlayerId
   );
@@ -500,7 +502,7 @@ export function GameRoute() {
         {
           gameId: resolvedGameId,
           playerId: myPlayerId,
-          ...(currentVersion ? { expectedVersion: currentVersion } : {})
+          ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
         },
         {
           errorMessage: t("errors.requestFailed"),
@@ -592,7 +594,7 @@ export function GameRoute() {
       type: "reinforce",
       territoryId: reinforceTerritoryId,
       amount,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -607,7 +609,7 @@ export function GameRoute() {
       type: "reinforce",
       territoryId: reinforceTerritoryId,
       amount: Math.max(1, Number(snapshot?.reinforcementPool || 1)),
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -623,7 +625,7 @@ export function GameRoute() {
       fromId: attackFromId,
       toId: attackToId,
       attackDice: Number(attackDiceCount),
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -642,7 +644,7 @@ export function GameRoute() {
       playerId: myPlayerId,
       type: "moveAfterConquest",
       armies,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -656,7 +658,7 @@ export function GameRoute() {
       playerId: myPlayerId,
       type: "moveAfterConquest",
       armies: pendingConquestMax,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -673,7 +675,7 @@ export function GameRoute() {
       fromId: fortifyFromId,
       toId: fortifyToId,
       armies,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -686,7 +688,7 @@ export function GameRoute() {
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "endTurn",
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -699,7 +701,7 @@ export function GameRoute() {
       gameId: resolvedGameId,
       playerId: myPlayerId,
       cardIds: selectedTradeCardIds,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 
@@ -743,7 +745,7 @@ export function GameRoute() {
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "surrender",
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      ...(actionExpectedVersion ? { expectedVersion: actionExpectedVersion } : {})
     });
   }
 

--- a/frontend/react-shell/src/player-session.ts
+++ b/frontend/react-shell/src/player-session.ts
@@ -33,7 +33,16 @@ export function readCurrentPlayerId(gameId?: string | null): string | null {
       return null;
     }
 
-    const parsedValue = JSON.parse(rawValue) as Partial<StoredPlayerSession> | null;
+    const normalizedValue = rawValue.trim();
+    if (!normalizedValue) {
+      return null;
+    }
+
+    const parsedValue = JSON.parse(normalizedValue) as Partial<StoredPlayerSession> | string | null;
+    if (typeof parsedValue === "string") {
+      return parsedValue.trim() || null;
+    }
+
     if (
       !parsedValue ||
       typeof parsedValue.playerId !== "string" ||
@@ -48,7 +57,22 @@ export function readCurrentPlayerId(gameId?: string | null): string | null {
 
     return parsedValue.playerId;
   } catch {
-    return null;
+    const rawValue = window.localStorage.getItem(PLAYER_ID_STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const normalizedValue = rawValue.trim();
+    if (
+      !normalizedValue ||
+      normalizedValue.startsWith("{") ||
+      normalizedValue.startsWith("[") ||
+      normalizedValue.startsWith('"')
+    ) {
+      return null;
+    }
+
+    return normalizedValue;
   }
 }
 

--- a/frontend/react-shell/src/player-session.ts
+++ b/frontend/react-shell/src/player-session.ts
@@ -4,6 +4,44 @@ type StoredPlayerSession = {
   playerId: string;
 };
 
+function parseStoredPlayerId(rawValue: string, gameId?: string | null): string | null {
+  const normalizedValue = rawValue.trim();
+  if (!normalizedValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(normalizedValue) as Partial<StoredPlayerSession> | string | null;
+    if (typeof parsedValue === "string") {
+      return parsedValue.trim() || null;
+    }
+
+    if (
+      !parsedValue ||
+      typeof parsedValue.playerId !== "string" ||
+      typeof parsedValue.gameId !== "string"
+    ) {
+      return null;
+    }
+
+    if (gameId && parsedValue.gameId !== gameId) {
+      return null;
+    }
+
+    return parsedValue.playerId;
+  } catch {
+    if (
+      normalizedValue.startsWith("{") ||
+      normalizedValue.startsWith("[") ||
+      normalizedValue.startsWith('"')
+    ) {
+      return null;
+    }
+
+    return normalizedValue;
+  }
+}
+
 export function storeCurrentPlayerId(
   playerId: string | null | undefined,
   gameId?: string | null
@@ -33,46 +71,9 @@ export function readCurrentPlayerId(gameId?: string | null): string | null {
       return null;
     }
 
-    const normalizedValue = rawValue.trim();
-    if (!normalizedValue) {
-      return null;
-    }
-
-    const parsedValue = JSON.parse(normalizedValue) as Partial<StoredPlayerSession> | string | null;
-    if (typeof parsedValue === "string") {
-      return parsedValue.trim() || null;
-    }
-
-    if (
-      !parsedValue ||
-      typeof parsedValue.playerId !== "string" ||
-      typeof parsedValue.gameId !== "string"
-    ) {
-      return null;
-    }
-
-    if (gameId && parsedValue.gameId !== gameId) {
-      return null;
-    }
-
-    return parsedValue.playerId;
+    return parseStoredPlayerId(rawValue, gameId);
   } catch {
-    const rawValue = window.localStorage.getItem(PLAYER_ID_STORAGE_KEY);
-    if (!rawValue) {
-      return null;
-    }
-
-    const normalizedValue = rawValue.trim();
-    if (
-      !normalizedValue ||
-      normalizedValue.startsWith("{") ||
-      normalizedValue.startsWith("[") ||
-      normalizedValue.startsWith('"')
-    ) {
-      return null;
-    }
-
-    return normalizedValue;
+    return null;
   }
 }
 

--- a/frontend/react-shell/src/player-session.ts
+++ b/frontend/react-shell/src/player-session.ts
@@ -16,6 +16,10 @@ function parseStoredPlayerId(rawValue: string, gameId?: string | null): string |
       return parsedValue.trim() || null;
     }
 
+    if (typeof parsedValue === "number" && /^\d+$/.test(normalizedValue)) {
+      return normalizedValue;
+    }
+
     if (
       !parsedValue ||
       typeof parsedValue.playerId !== "string" ||


### PR DESCRIPTION
## Summary
- restore action-panel visibility when the gameplay snapshot is missing playerId but the signed-in user still matches the active player
- accept the legacy localStorage player-id format so existing sessions still recover reinforcement/attack controls
- add gameplay route regression coverage for both fallback paths

## Validation
- npm run typecheck:react-shell
- vitest gameplay-route integration: keeps reinforcement actions visible when the session user matches the current player
- vitest gameplay-route integration: restores reinforcement actions from the legacy stored player id format