### PR TITLE
Handle pull_request_target workflow_run in Codex PR readiness gate

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -32,7 +32,8 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request') ||
+        (github.event.workflow_run.event == 'pull_request' ||
+          github.event.workflow_run.event == 'pull_request_target')) ||
       (github.event_name == 'pull_request_target' &&
         github.event.pull_request.draft == true &&
         (startsWith(github.event.pull_request.head.ref, 'codex/') ||

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -228,7 +228,7 @@ register("codex PR readiness workflow listens to all pull_request workflow_run c
 
   assert.match(
     workflow,
-    /github\.event_name == 'workflow_run' &&\s+github\.event\.workflow_run\.event == 'pull_request'\) \|\|/
+    /github\.event_name == 'workflow_run' &&\s+\(github\.event\.workflow_run\.event == 'pull_request' \|\|\s+github\.event\.workflow_run\.event == 'pull_request_target'\)\) \|\|/
   );
   assert.doesNotMatch(workflow, /github\.event\.workflow_run\.head_branch/);
 });


### PR DESCRIPTION
### Motivation
- The readiness gate missed some workflow_run events that originate from `pull_request_target`, causing the automation to skip evaluations for PR-target workflows.

### Description
- Updated the workflow condition in `.github/workflows/codex-pr-readiness.yml` to also treat `workflow_run` events where `workflow_run.event == 'pull_request_target'` as a trigger for the readiness job.
- Updated the regression assertion in `tests/gameplay/regression/codex-pr-readiness.test.cts` to match the expanded `workflow_run` condition pattern.

### Testing
- Ran `npm run lint`, which completed successfully (repository has pre-existing warnings but no new lint errors).
- Verified the workflow file contains the new `pull_request_target` condition using a targeted Node check that confirmed the change.
- Attempted the targeted gameplay regression test run (`npm test -- tests/gameplay/regression/codex-pr-readiness.test.cts`), but full execution could not complete locally due to the environment's Node runtime missing the built-in `node:sqlite` module; CI runs on Node 22 where the module is available and will perform full validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb027390f0832ca2efdbec8e7c43dc)