### PR TITLE
[codex] Fix open game user snapshot

### DIFF
--- a/backend/routes/game-management.cts
+++ b/backend/routes/game-management.cts
@@ -37,11 +37,12 @@ type OpenGame = (gameId: string) => Promise<any>;
 type ReplaceState = (state: any) => void;
 type BroadcastGame = (gameContext: any) => void;
 type Snapshot = () => unknown;
-type SnapshotForState = (
+type SnapshotForUser = (
   state: any,
   gameId: string | null,
   version: number | null,
-  gameName: string | null
+  gameName: string | null,
+  user: unknown
 ) => unknown;
 type ResumeAiTurnsForRead = (gameContext: any) => Promise<any>;
 type ResolvePlayerForUser = (state: any, user: unknown) => any;
@@ -152,7 +153,7 @@ async function handleOpenGameRoute(
   listGames: ListGames,
   resumeAiTurnsForRead: ResumeAiTurnsForRead,
   resolvePlayerForUser: ResolvePlayerForUser,
-  snapshotForState: SnapshotForState,
+  snapshotForUser: SnapshotForUser,
   sendJson: SendJson,
   sendLocalizedError: SendLocalizedError
 ): Promise<void> {
@@ -189,11 +190,12 @@ async function handleOpenGameRoute(
         game: opened.game,
         games: await listGames(),
         activeGameId: opened.game.id,
-        state: snapshotForState(
+        state: snapshotForUser(
           opened.state,
           opened.game.id,
           opened.game.version,
-          opened.game.name
+          opened.game.name,
+          authContext.user
         ),
         playerId: resolvedPlayer ? resolvedPlayer.id : null
       },

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1375,7 +1375,7 @@ function createApp(options: CreateAppOptions = {}) {
         () => gameSessions.listGames(),
         resumeAiTurnsForRead,
         resolvePlayerForUser,
-        snapshotForState,
+        snapshotForUser,
         sendJson,
         sendLocalizedError
       );

--- a/scripts/evaluate-codex-pr-readiness.cts
+++ b/scripts/evaluate-codex-pr-readiness.cts
@@ -90,7 +90,6 @@ type ReviewThread = {
   id: string;
   isResolved: boolean;
   isOutdated: boolean;
-  updatedAt: string;
   comments: ReviewThreadComment[];
 };
 
@@ -1135,7 +1134,6 @@ async function getReviewThreads(
                   id
                   isResolved
                   isOutdated
-                  updatedAt
                   comments(first: 20) {
                     nodes {
                       author {
@@ -1165,7 +1163,6 @@ async function getReviewThreads(
         id: String(thread.id || ""),
         isResolved: Boolean(thread.isResolved),
         isOutdated: Boolean(thread.isOutdated),
-        updatedAt: String(thread.updatedAt || ""),
         comments: asArray(thread.comments?.nodes).map((comment: any) => ({
           authorLogin: String(comment.author?.login || ""),
           body: String(comment.body || ""),

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -478,6 +478,48 @@ register(
         "control-territory-count"
       );
 
+      const registered = await app.auth.registerPasswordUser("objective_guest", "secret123");
+      assert.equal(registered.ok, true);
+      const guestLogin = await app.auth.loginWithPassword("objective_guest", "secret123");
+      assert.equal(guestLogin.ok, true);
+
+      const joinResponse = await callApp(
+        app,
+        "POST",
+        "/api/join",
+        {
+          gameId: createGameResponse.payload.game.id
+        },
+        authHeaders(guestLogin.sessionToken)
+      );
+      assert.equal(joinResponse.statusCode, 201);
+
+      const startResponse = await callApp(
+        app,
+        "POST",
+        "/api/start",
+        {
+          gameId: createGameResponse.payload.game.id,
+          playerId: createGameResponse.payload.playerId
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(startResponse.statusCode, 200);
+
+      const openGameResponse = await callApp(
+        app,
+        "POST",
+        "/api/games/open",
+        {
+          gameId: createGameResponse.payload.game.id
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(openGameResponse.statusCode, 200);
+      assert.equal(openGameResponse.payload.state.assignedVictoryObjective?.moduleId, draft.id);
+      assert.equal(typeof openGameResponse.payload.state.assignedVictoryObjective?.id, "string");
+      assert.deepEqual(openGameResponse.payload.state.playerHand, []);
+
       const disableResponse = await callApp(
         app,
         "POST",

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -301,7 +301,6 @@ register(
             id: "thread-1",
             isResolved: false,
             isOutdated: false,
-            updatedAt: "2026-04-23T10:12:00.000Z",
             comments: [
               {
                 authorLogin: "chatgpt-codex-connector",
@@ -744,7 +743,6 @@ register("codex PR readiness snapshots GitHub metadata into the evaluation input
                 id: "thread-1",
                 isResolved: false,
                 isOutdated: false,
-                updatedAt: "2026-04-23T10:17:00.000Z",
                 comments: {
                   nodes: [
                     {
@@ -866,7 +864,6 @@ register("codex PR readiness applies draft transitions only for fully ready PRs"
         id: "thread-blocking",
         isResolved: false,
         isOutdated: false,
-        updatedAt: "2026-04-23T10:30:00.000Z",
         comments: [
           {
             authorLogin: "chatgpt-codex-connector",

--- a/tests/gameplay/regression/game-management-routes.test.cts
+++ b/tests/gameplay/regression/game-management-routes.test.cts
@@ -1,0 +1,99 @@
+const assert = require("node:assert/strict");
+const {
+  handleOpenGameRoute
+} = require("../../../backend/routes/game-management.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("handleOpenGameRoute returns the per-user snapshot for the opener", async () => {
+  let sentPayload: Record<string, unknown> | null = null;
+
+  await handleOpenGameRoute(
+    { headers: {} },
+    {},
+    {
+      gameId: "g-1"
+    },
+    async () => ({
+      user: {
+        id: "u-1",
+        username: "Commander"
+      }
+    }),
+    () => ({ actor: { id: "u-1" } }),
+    async () => ({
+      game: {
+        id: "g-1",
+        name: "Open Route"
+      },
+      state: {
+        phase: "active"
+      }
+    }),
+    async () => ({
+      game: {
+        id: "g-1",
+        name: "Open Route",
+        version: 5
+      },
+      state: {
+        phase: "active"
+      }
+    }),
+    async () => [],
+    () => ({
+      id: "p-1"
+    }),
+    (
+      state: Record<string, unknown>,
+      gameId: string | null,
+      version: number | null,
+      gameName: string | null,
+      user: unknown
+    ) => ({
+      state,
+      gameId,
+      version,
+      gameName,
+      playerId: "p-1",
+      assignedVictoryObjective: {
+        id: "mission-a"
+      },
+      user
+    }),
+    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+      sentPayload = payload;
+    },
+    () => {
+      throw new Error("sendLocalizedError should not run for a successful open route.");
+    }
+  );
+
+  assert.deepEqual(sentPayload, {
+    ok: true,
+    game: {
+      id: "g-1",
+      name: "Open Route",
+      version: 5
+    },
+    games: [],
+    activeGameId: "g-1",
+    state: {
+      state: {
+        phase: "active"
+      },
+      gameId: "g-1",
+      version: 5,
+      gameName: "Open Route",
+      playerId: "p-1",
+      assignedVictoryObjective: {
+        id: "mission-a"
+      },
+      user: {
+        id: "u-1",
+        username: "Commander"
+      }
+    },
+    playerId: "p-1"
+  });
+});

--- a/tests/gameplay/regression/game-management-routes.test.cts
+++ b/tests/gameplay/regression/game-management-routes.test.cts
@@ -1,7 +1,5 @@
 const assert = require("node:assert/strict");
-const {
-  handleOpenGameRoute
-} = require("../../../backend/routes/game-management.cjs");
+const { handleOpenGameRoute } = require("../../../backend/routes/game-management.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 


### PR DESCRIPTION
## What changed

- Route `/api/games/open` now returns the opener-specific game snapshot via `snapshotForUser`.
- Added regression coverage for the open-game route to ensure user-scoped snapshot data is preserved.
- Removed an unsupported `updatedAt` field from the Codex PR readiness review-thread GraphQL query, which was blocking the PR checks.

## Why

Recent victory-objective work moved private assigned objectives onto per-user snapshots. The open-game route still used the public state snapshot, so reopening an active game could omit `assignedVictoryObjective` from the immediate response.

The readiness workflow failure was a separate CI blocker exposed after opening this PR: GitHub's `PullRequestReviewThread` schema does not expose `updatedAt`, and the field was unused by the evaluator.

## Validation

- `npm run test:gameplay -- tests/gameplay/regression/game-management-routes.test.cts`
- `npm run test:gameplay -- tests/gameplay/regression/game-management-routes.test.cts tests/gameplay/regression/codex-pr-readiness.test.cts`
- `npm run format:check -- tests/gameplay/regression/game-management-routes.test.cts scripts/evaluate-codex-pr-readiness.cts tests/gameplay/regression/codex-pr-readiness.test.cts`
