### PR TITLE
Harden GitHub automation permissions

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -38,15 +38,16 @@ jobs:
         (startsWith(github.event.pull_request.head.ref, 'codex/') ||
           contains(github.event.pull_request.labels.*.name, 'codex'))) ||
       (github.event_name == 'pull_request_review' &&
+        github.event.review.user.login == 'chatgpt-codex-connector' &&
         github.event.pull_request.draft == true &&
         (startsWith(github.event.pull_request.head.ref, 'codex/') ||
           contains(github.event.pull_request.labels.*.name, 'codex'))) ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        (contains(github.event.comment.body, 'codex') ||
-          contains(github.event.comment.body, 'Codex') ||
-          contains(github.event.comment.body, 'greenlight') ||
-          contains(github.event.comment.body, 'Greenlight')))
+        github.event.comment.user.login == 'chatgpt-codex-connector' &&
+        (contains(github.event.comment.body, 'codex greenlight') ||
+          contains(github.event.comment.body, 'codex pr readiness: greenlight') ||
+          contains(github.event.comment.body, 'codex final approval')))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -43,9 +46,11 @@ jobs:
         run: npm run test:react
 
       - name: Install Vercel CLI
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
         run: npm install --global vercel@50.39.0
 
       - name: Verify Vercel auth for env parity
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
         id: vercel_auth
         continue-on-error: true
         env:
@@ -60,12 +65,12 @@ jobs:
           vercel whoami --token "$VERCEL_TOKEN"
 
       - name: Note skipped Vercel env parity check
-        if: ${{ steps.vercel_auth.outcome != 'success' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.vercel_auth.outcome != 'success' }}
         run: |
           echo "Skipping Vercel env parity check because VERCEL_TOKEN is missing or invalid for this run." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Vercel env parity check
-        if: ${{ steps.vercel_auth.outcome == 'success' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.vercel_auth.outcome == 'success' }}
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: team_KZLHaqyM8HI03cxJQzg1e9Wz


### PR DESCRIPTION
## Summary
- prevent `VERCEL_TOKEN` from being exposed to pull request workflow runs
- add explicit read-only workflow permissions to Quality, Coverage, and E2E Smoke
- narrow Codex readiness comment/review triggers to the Codex connector actor and final approval phrases
- restrict repository GitHub Actions policy to GitHub-owned actions only

## Validation
- `npx prettier --check ".github/workflows/*.yml"`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with existing warnings)
- `npm run format:check`
- `npm run test:react`
- `npm run build:ts`