### PR TITLE
[codex] Strengthen map adjacency validation

### DIFF
--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -20,6 +20,7 @@ const tests: GameplayTest[] = [];
 const gameplayTestModules = [
   "../tests/gameplay/shared/map-graph.test.cjs",
   "../tests/gameplay/shared/map-loader.test.cjs",
+  "../tests/gameplay/shared/typed-map-data.test.cjs",
   "../tests/gameplay/shared/continent-loader.test.cjs",
   "../tests/gameplay/shared/extensions.test.cjs",
   "../tests/gameplay/shared/core-base-catalog.test.cjs",

--- a/shared/map-loader.cts
+++ b/shared/map-loader.cts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createTerritory, type MapPosition, type Territory } from "./core-domain.cjs";
+import { buildMapGraph } from "./map-graph.cjs";
 
 const REQUIRED_HEADERS = ["id", "name", "continentId", "x", "y", "neighbors"] as const;
 
@@ -99,13 +100,7 @@ function buildTerritoryRecord(record: Record<string, string>): TerritoryRecord {
 }
 
 function validateAdjacency(territoriesById: Record<string, MapDefinitionTerritoryEntry>): void {
-  Object.values(territoriesById).forEach(({ territory }) => {
-    territory.neighbors.forEach((neighborId) => {
-      if (!territoriesById[neighborId]) {
-        throw new Error(`Territory "${territory.id}" references unknown neighbor "${neighborId}".`);
-      }
-    });
-  });
+  buildMapGraph(Object.values(territoriesById));
 }
 
 export function loadMapDefinitionFromCsv(csvPath: string): MapDefinition {

--- a/shared/typed-map-data.cts
+++ b/shared/typed-map-data.cts
@@ -5,6 +5,7 @@ import {
   type MapPosition,
   type Territory
 } from "./core-domain.cjs";
+import { buildMapGraph } from "./map-graph.cjs";
 
 export interface MapDefinitionTerritoryEntry {
   territory: Territory;
@@ -57,13 +58,7 @@ function normalizeCoordinate(rawValue: number, fieldName: string, territoryId: s
 }
 
 function validateAdjacency(territoriesById: Record<string, MapDefinitionTerritoryEntry>): void {
-  Object.values(territoriesById).forEach(({ territory }) => {
-    territory.neighbors.forEach((neighborId) => {
-      if (!territoriesById[neighborId]) {
-        throw new Error(`Territory "${territory.id}" references unknown neighbor "${neighborId}".`);
-      }
-    });
-  });
+  buildMapGraph(Object.values(territoriesById));
 }
 
 function validateTerritoryReferences(

--- a/tests/gameplay/all.test.cts
+++ b/tests/gameplay/all.test.cts
@@ -2,6 +2,7 @@ const gameplayTestModules = [
   "./shared/runtime-validation.test.cjs",
   "./shared/map-graph.test.cjs",
   "./shared/map-loader.test.cjs",
+  "./shared/typed-map-data.test.cjs",
   "./shared/continent-loader.test.cjs",
   "./shared/extensions.test.cjs",
   "./setup/game-setup.test.cjs",

--- a/tests/gameplay/shared/map-loader.test.cts
+++ b/tests/gameplay/shared/map-loader.test.cts
@@ -25,7 +25,7 @@ register(
       [
         "# comment",
         " id , name , continentId , x , y , neighbors ",
-        " alpha , Alpha , north , 0.10 , 0.20 , beta | gamma ",
+        " alpha , Alpha , north , 0.10 , 0.20 , beta ",
         " beta , Beta , north , 0.30 , 0.40 , alpha ",
         " gamma , Gamma , south , 0.50 , 0.60 , "
       ].join("\n"),
@@ -37,7 +37,7 @@ register(
           map.territories.map((entry: any) => entry.territory.id),
           ["alpha", "beta", "gamma"]
         );
-        assert.deepEqual(map.territories[0].territory.neighbors, ["beta", "gamma"]);
+        assert.deepEqual(map.territories[0].territory.neighbors, ["beta"]);
         assert.deepEqual(map.territories[2].territory.neighbors, []);
         assert.deepEqual(map.positions.alpha, { x: 0.1, y: 0.2 });
         assert.deepEqual(map.positions.gamma, { x: 0.5, y: 0.6 });
@@ -118,6 +118,19 @@ register("loadMapDefinitionFromCsv rejects unknown neighbors", () => {
     ["id,name,continentId,x,y,neighbors", "alpha,Alpha,north,0.1,0.2,missing"].join("\n"),
     (filePath) => {
       assert.throws(() => loadMapDefinitionFromCsv(filePath), /unknown neighbor "missing"/i);
+    }
+  );
+});
+
+register("loadMapDefinitionFromCsv rejects non-bidirectional adjacency", () => {
+  withCsvFile(
+    [
+      "id,name,continentId,x,y,neighbors",
+      "alpha,Alpha,north,0.1,0.2,beta",
+      "beta,Beta,north,0.3,0.4,"
+    ].join("\n"),
+    (filePath) => {
+      assert.throws(() => loadMapDefinitionFromCsv(filePath), /must be bidirectional/i);
     }
   );
 });

--- a/tests/gameplay/shared/typed-map-data.test.cts
+++ b/tests/gameplay/shared/typed-map-data.test.cts
@@ -1,0 +1,29 @@
+const assert = require("node:assert/strict");
+const { buildMapDefinition } = require("../../../shared/typed-map-data.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("buildMapDefinition rejects non-bidirectional adjacency", () => {
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "alpha",
+          name: "Alpha",
+          continentId: "north",
+          x: 0.1,
+          y: 0.2,
+          neighbors: ["beta"]
+        },
+        {
+          id: "beta",
+          name: "Beta",
+          continentId: "north",
+          x: 0.3,
+          y: 0.4,
+          neighbors: []
+        }
+      ]),
+    /must be bidirectional/i
+  );
+});

--- a/tests/gameplay/shared/typed-map-data.test.cts
+++ b/tests/gameplay/shared/typed-map-data.test.cts
@@ -27,3 +27,20 @@ register("buildMapDefinition rejects non-bidirectional adjacency", () => {
     /must be bidirectional/i
   );
 });
+
+register("buildMapDefinition rejects unknown neighbors", () => {
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "alpha",
+          name: "Alpha",
+          continentId: "north",
+          x: 0.1,
+          y: 0.2,
+          neighbors: ["missing"]
+        }
+      ]),
+    /unknown neighbor "missing"/i
+  );
+});


### PR DESCRIPTION
## Summary
- reuse the shared map graph validator for CSV and typed map definitions
- reject one-way map adjacency during map loading, not only during graph construction
- add gameplay tests covering CSV and typed map definition validation

## Validation
- npm run test:gameplay
- npm run test:all
- npm run lint
- npm run format:check