### PR TITLE
[codex] Cover empty typed map definitions

### DIFF
--- a/tests/gameplay/shared/typed-map-data.test.cts
+++ b/tests/gameplay/shared/typed-map-data.test.cts
@@ -3,6 +3,10 @@ const { buildMapDefinition } = require("../../../shared/typed-map-data.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
+register("buildMapDefinition rejects empty territory records", () => {
+  assert.throws(() => buildMapDefinition("empty-map", []), /at least one territory/i);
+});
+
 register("buildMapDefinition rejects non-bidirectional adjacency", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary
- add regression coverage for empty typed map definitions
- documents the existing boundary error before map graph construction

## Validation
- npm run test:gameplay