### PR TITLE
[codex] Cover header-only map CSVs

### DIFF
--- a/tests/gameplay/shared/map-loader.test.cts
+++ b/tests/gameplay/shared/map-loader.test.cts
@@ -52,6 +52,12 @@ register("loadMapDefinitionFromCsv rejects CSV files with missing headers", () =
   });
 });
 
+register("loadMapDefinitionFromCsv rejects header-only CSV files", () => {
+  withCsvFile("id,name,continentId,x,y,neighbors", (filePath) => {
+    assert.throws(() => loadMapDefinitionFromCsv(filePath), /at least one territory row/i);
+  });
+});
+
 register("loadMapDefinitionFromCsv rejects rows that do not match header length", () => {
   withCsvFile(
     ["id,name,continentId,x,y,neighbors", "alpha,Alpha,north,0.1,0.2"].join("\n"),


### PR DESCRIPTION
## Summary
- add regression coverage for map CSV files that contain only headers
- keeps the loader boundary explicit when no territory rows are present

## Validation
- npm run test:gameplay