### PR TITLE
[codex] Cover header-only continent CSVs

### DIFF
--- a/tests/gameplay/shared/continent-loader.test.cts
+++ b/tests/gameplay/shared/continent-loader.test.cts
@@ -47,6 +47,12 @@ register("loadContinentsFromCsv rejects CSV files with missing headers", () => {
   });
 });
 
+register("loadContinentsFromCsv rejects header-only CSV files", () => {
+  withCsvFile("id,name,bonus,territoryIds", (filePath) => {
+    assert.throws(() => loadContinentsFromCsv(filePath), /at least one continent row/i);
+  });
+});
+
 register("loadContinentsFromCsv rejects invalid bonus values", () => {
   withCsvFile(["id,name,bonus,territoryIds", "north,North,nope,alpha"].join("\n"), (filePath) => {
     assert.throws(() => loadContinentsFromCsv(filePath), /invalid bonus value/i);


### PR DESCRIPTION
## Summary
- add regression coverage for continent CSV files with no continent rows
- keeps continent import failures explicit at the loader boundary

## Validation
- npm run test:gameplay