### PR TITLE
[codex] Cover map graph neighbor copies

### DIFF
--- a/tests/gameplay/shared/map-graph.test.cts
+++ b/tests/gameplay/shared/map-graph.test.cts
@@ -77,6 +77,16 @@ register("buildMapGraph rejects non-bidirectional adjacency", () => {
   );
 });
 
+register("buildMapGraph returns neighbor copies from getNeighbors", () => {
+  const graph = buildMapGraph([makeTerritory("a", ["b"]), makeTerritory("b", ["a"])]);
+  const neighbors = graph.getNeighbors("a");
+
+  neighbors.push("mutated");
+
+  assert.deepEqual(graph.getNeighbors("a"), ["b"]);
+  assert.equal(graph.hasTerritory("mutated"), false);
+});
+
 register("buildMapGraph rejects unknown territories in getNeighbors and areAdjacent", () => {
   const graph = buildMapGraph([makeTerritory("a", ["b"]), makeTerritory("b", ["a"])]);
 


### PR DESCRIPTION
## Summary
- add regression coverage that map graph neighbor reads are defensive copies
- protects the graph boundary from accidental caller-side array mutation

## Validation
- npm run test:gameplay