### PR TITLE
[codex] Cover missing core.base lookups

### DIFF
--- a/tests/gameplay/shared/core-base-catalog.test.cts
+++ b/tests/gameplay/shared/core-base-catalog.test.cts
@@ -51,3 +51,8 @@ register("core.base catalog centralizes the built-in new-game rule sets", () => 
   assert.equal(classicDefense3.defaults.mapId, "classic-mini");
   assert.equal(classicDefense3.defaults.diceRuleSetId, "defense-3");
 });
+
+register("core.base catalog returns null for unknown map and rule set ids", () => {
+  assert.equal(findCoreBaseSupportedMap("missing-map"), null);
+  assert.equal(findCoreBaseNewGameRuleSet("missing-rule-set"), null);
+});


### PR DESCRIPTION
## Summary
- add regression coverage for unknown core.base map and rule-set lookups
- makes the null-return contract explicit for catalog consumers

## Validation
- npm run test:gameplay