### PR TITLE
[codex] Cover runtime validation root paths

### DIFF
--- a/tests/gameplay/shared/runtime-validation.test.cts
+++ b/tests/gameplay/shared/runtime-validation.test.cts
@@ -3,6 +3,7 @@ const {
   accountSettingsRequestSchema,
   accountSettingsResponseSchema,
   authSessionResponseSchema,
+  formatValidationPath,
   gameIdRequestSchema,
   gameListResponseSchema,
   gameMutationResponseSchema,
@@ -216,6 +217,11 @@ register("shared runtime validation exposes deterministic validation issue paths
       (entry: { message: string }) => typeof entry.message === "string" && entry.message.length > 0
     )
   );
+});
+
+register("shared runtime validation formats root issue paths deterministically", () => {
+  assert.equal(formatValidationPath([]), "$");
+  assert.equal(formatValidationPath(undefined), "$");
 });
 
 register("shared runtime validation validates lobby route payload shapes", () => {


### PR DESCRIPTION
## Summary
- add regression coverage for root validation path formatting
- protects API-boundary error rendering for whole-payload validation failures

## Validation
- npm run test:gameplay