### PR TITLE
[codex] Cover invalid new game maps

### DIFF
--- a/tests/gameplay/setup/new-game-config.test.cts
+++ b/tests/gameplay/setup/new-game-config.test.cts
@@ -331,3 +331,13 @@ register("validateNewGameConfig rejects unsupported victory rules", () => {
     /regola vittoria/i
   );
 });
+
+register("validateNewGameConfig rejects unsupported maps", () => {
+  assert.throws(
+    () =>
+      validateNewGameConfig({
+        mapId: "unknown-map"
+      }),
+    /mappa selezionata/i
+  );
+});


### PR DESCRIPTION
## Summary
- add direct regression coverage for unsupported map ids in new game config validation
- keeps the setup boundary explicit for invalid map selection

## Validation
- npm run test:gameplay