### PR TITLE
[codex] Cover attacker tie-win combat dice

### DIFF
--- a/tests/gameplay/combat/combat-resolution.test.cts
+++ b/tests/gameplay/combat/combat-resolution.test.cts
@@ -184,3 +184,12 @@ register("combat dice helpers tirano ordinato e confrontano in modo puro", () =>
     ["attacker", "attacker"]
   );
 });
+
+register("combat dice helpers let attackers win ties when configured", () => {
+  const compared = compareCombatDice([5, 3], [5, 2], { defenderWinsTies: false });
+
+  assert.deepEqual(
+    compared.comparisons.map((entry: CombatComparison) => entry.winner),
+    ["attacker", "attacker"]
+  );
+});


### PR DESCRIPTION
## Summary
- add regression coverage for combat dice comparisons when attackers win ties
- documents the configurable tie-break behavior in the pure dice helper

## Validation
- npm run test:gameplay