### PR TITLE
[codex] Harden workflow permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -43,9 +46,11 @@ jobs:
         run: npm run test:react
 
       - name: Install Vercel CLI
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
         run: npm install --global vercel@50.39.0
 
       - name: Verify Vercel auth for env parity
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
         id: vercel_auth
         continue-on-error: true
         env:
@@ -60,12 +65,12 @@ jobs:
           vercel whoami --token "$VERCEL_TOKEN"
 
       - name: Note skipped Vercel env parity check
-        if: ${{ steps.vercel_auth.outcome != 'success' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.vercel_auth.outcome != 'success' }}
         run: |
           echo "Skipping Vercel env parity check because VERCEL_TOKEN is missing or invalid for this run." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Vercel env parity check
-        if: ${{ steps.vercel_auth.outcome == 'success' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.vercel_auth.outcome == 'success' }}
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: team_KZLHaqyM8HI03cxJQzg1e9Wz


### PR DESCRIPTION
## Summary
- add explicit read-only workflow permissions to Quality, Coverage, and E2E Smoke
- skip Vercel env parity auth/check steps on pull request workflow runs
- replace the older conflicting #155 with a smaller clean workflow-only change

## Validation
- npx prettier --check ".github/workflows/*.yml"
- npm run format:check