### PR TITLE
[codex] Fix readiness false positives

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -233,6 +233,24 @@ jobs:
               );
             }
 
+            function isNonActionableCodexSignal(text) {
+              const body = normalize(text);
+              if (!body || isCodexUsageError(body)) return false;
+
+              return (
+                body.includes("nothing to fix yet") ||
+                body.includes("there is nothing to fix yet") ||
+                body.includes("there's nothing to fix yet") ||
+                body.includes("no failing checks or requested code updates") ||
+                body.includes("no code changes were made") ||
+                body.includes("no new pr was created") ||
+                body.includes("no actionable blocking defect") ||
+                body.includes("no real code issue") ||
+                body.includes("did not find any regression risk") ||
+                body.includes("didn't find any regression risk")
+              );
+            }
+
             function hasProblemSignal(text, state) {
               const body = normalize(text);
               const reviewState = normalize(state);
@@ -240,6 +258,7 @@ jobs:
               if (!body && !reviewState) return false;
               if (reviewState === "changes_requested") return true;
               if (isCleanCodexSignal(body)) return false;
+              if (isNonActionableCodexSignal(body)) return false;
 
               return (
                 /\bp0\b/.test(body) ||

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -233,6 +233,20 @@ register("codex PR readiness workflow listens to all pull_request workflow_run c
   assert.doesNotMatch(workflow, /github\.event\.workflow_run\.head_branch/);
 });
 
+register("codex PR readiness watchdog ignores non-actionable Codex status comments", () => {
+  const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /function isNonActionableCodexSignal\(text\)/);
+  assert.match(workflow, /body\.includes\("nothing to fix yet"\)/);
+  assert.match(workflow, /body\.includes\("no failing checks or requested code updates"\)/);
+  assert.match(workflow, /body\.includes\("did not find any regression risk"\)/);
+  assert.match(
+    workflow,
+    /if \(isCleanCodexSignal\(body\)\) return false;\s+if \(isNonActionableCodexSignal\(body\)\) return false;/
+  );
+});
+
 register(
   "codex PR readiness blocks pending checks, stale Codex feedback, stale branches, and conflicts",
   () => {


### PR DESCRIPTION
## Summary
- ignore non-actionable Codex status comments in the readiness watchdog before keyword-based problem matching
- add regression coverage that the workflow keeps those neutral patterns filtered

## Validation
- npx prettier --check .github/workflows/codex-pr-readiness.yml tests/gameplay/regression/codex-pr-readiness.test.cts
- npm run build:ts
- node .tsbuild/scripts/run-gameplay-tests.cjs
- npm run lint
- npm run format:check
- npm run test:react