### PR TITLE
[codex] Dummy readiness automation smoke

### DIFF
--- a/TEST_GAPS.md
+++ b/TEST_GAPS.md
@@ -40,6 +40,7 @@
 - Gameplay E2E: granular rendering reinforcement flow stabilized against async control population
 - React shell routes: bootstrap, auth redirects, lobby/profile/new game, and gameplay route rendering
 - TS-complete allowlist regression: React shell sources are allowed and tracked stray `.js` sources are rejected
+- Codex PR readiness automation smoke coverage via temporary dummy PR
 
 ## Missing
 


### PR DESCRIPTION
## Summary
- add a temporary docs-only marker to exercise the Codex PR readiness automation
- intended as a smoke PR to verify non-actionable Codex/status comments do not become false positive fix requests

## Validation
- npx prettier --check TEST_GAPS.md

## Notes
- This PR is intentionally low-impact and can be closed or reverted after the automation test.