### PR TITLE
[codex] Ignore non-actionable triage signals

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -194,6 +194,17 @@ jobs:
               return isAfter(createdAt(item), headDate);
             }
 
+            function reviewCommentUrl(item) {
+              return String(item?.html_url || item?.url || "");
+            }
+
+            function reviewCommentIsForCurrentHead(item, sha, headDate, staleReviewCommentUrls = new Set()) {
+              const url = reviewCommentUrl(item);
+              if (url && staleReviewCommentUrls.has(url)) return false;
+              if (bodyHasCurrentSha(item?.body, sha)) return true;
+              return itemIsForCurrentHead(item, sha, headDate);
+            }
+
             function actionMarker(type, sha) {
               return `${ACTION_MARKER_PREFIX}:${type}:${sha} -->`;
             }
@@ -227,9 +238,36 @@ jobs:
                 explicitNoSeverityFinding ||
                 body.includes("codex greenlight") ||
                 body.includes("codex pr readiness: greenlight") ||
-                body.includes("codex final approval") ||
-                body.includes("all tests are passing") ||
-                body.includes("all tests passed")
+                body.includes("codex final approval")
+              );
+            }
+
+            function hasNegatedRegressionRiskSignal(text) {
+              const body = normalize(text);
+              if (!body || isCodexUsageError(body)) return false;
+
+              return (
+                /\b(?:did not|didn't)\s+find\s+any\s+regression\s+risk\b/i.test(body) ||
+                /\bno\s+regression\s+risk\b/i.test(body)
+              );
+            }
+
+            function stripNegatedRegressionRiskPhrases(text) {
+              return normalize(text)
+                .replace(/\b(?:did not|didn't)\s+find\s+any\s+regression\s+risk\b/gi, "")
+                .replace(/\bno\s+regression\s+risk\b/gi, "");
+            }
+
+            function isNegativeNonProblemCodexSignal(text) {
+              const body = normalize(text);
+              if (!body || isCodexUsageError(body)) return false;
+
+              return (
+                body.includes("no failing checks or requested code updates") ||
+                body.includes("no actionable blocking defect") ||
+                body.includes("no real code issue") ||
+                (hasNegatedRegressionRiskSignal(body) &&
+                  !hasGenericProblemSignal(stripNegatedRegressionRiskPhrases(body)))
               );
             }
 
@@ -238,32 +276,94 @@ jobs:
               if (!body || isCodexUsageError(body)) return false;
 
               return (
+                body.includes("this trigger is non-actionable right now") ||
+                body.includes("this trigger is non actionable right now") ||
+                body.includes("non-actionable triage note") ||
+                body.includes("non actionable triage note") ||
+                body.includes("wait for ci") ||
+                body.includes("waiting for ci") ||
                 body.includes("nothing to fix yet") ||
                 body.includes("there is nothing to fix yet") ||
                 body.includes("there's nothing to fix yet") ||
-                body.includes("no failing checks or requested code updates") ||
+                body.includes("nothing to patch") ||
+                body.includes("no code-change action") ||
+                body.includes("no code changes are needed") ||
                 body.includes("no code changes were made") ||
                 body.includes("no new pr was created") ||
-                body.includes("no actionable blocking defect") ||
-                body.includes("no real code issue") ||
-                body.includes("did not find any regression risk") ||
-                body.includes("didn't find any regression risk")
+                body.includes("not opening a follow-up pr") ||
+                body.includes("all tests are passing") ||
+                body.includes("all tests passed")
               );
             }
 
-            function hasProblemSignal(text, state) {
+            function isCodexExecutionSummary(text) {
               const body = normalize(text);
-              const reviewState = normalize(state);
+              if (!body || isCodexUsageError(body)) return false;
+              if (hasBlockingCodexMarker(body)) return false;
 
-              if (!body && !reviewState) return false;
-              if (reviewState === "changes_requested") return true;
-              if (isCleanCodexSignal(body)) return false;
-              if (isNonActionableCodexSignal(body)) return false;
+              const hasUnresolvedWorkSignal =
+                /\b(?:not|never)\s+(?:fixed|addressed|resolved)\b/i.test(body) ||
+                /\b(?:could not|cannot|can't|couldn't)\s+(?:fix|address|resolve)\b/i.test(body) ||
+                /\b(?:could not|cannot|can't|couldn't)\s+be\s+(?:fixed|addressed|resolved)\b/i.test(body);
+              const hasResolvedWorkSignal =
+                /\b(?:fixed|addressed|resolved)\b/i.test(body) &&
+                !hasUnresolvedWorkSignal;
+              const hasCompletedActionSignal =
+                hasResolvedWorkSignal ||
+                body.includes("no code changes are needed") ||
+                body.includes("created commit") ||
+                body.includes("opened a follow-up pr");
 
               return (
-                /\bp0\b/.test(body) ||
-                /\bp1\b/.test(body) ||
+                body.includes("### summary") &&
+                (body.includes("**testing**") || body.includes("### checks")) &&
+                !hasUnresolvedWorkSignal &&
+                hasCompletedActionSignal
+              );
+            }
+
+            function isCodexExecutionPlan(text) {
+              const body = normalize(text);
+              if (!body || isCodexUsageError(body)) return false;
+              if (hasBlockingCodexMarker(body)) return false;
+
+              return body.includes("implementation plan:") && body.includes("view task");
+            }
+
+            function isSkippableCodexExecutionSignal(text) {
+              const body = normalize(text);
+              if (!body || isCodexUsageError(body)) return false;
+              if (hasBlockingCodexMarker(body)) return false;
+
+              return isCodexExecutionSummary(body) || isCodexExecutionPlan(body);
+            }
+
+            function hasBlockingCodexMarker(text) {
+              const body = normalize(text);
+              if (!body || isCodexUsageError(body)) return false;
+
+              const hasRegressionMarker =
+                /\bregression\s+(?:found|detected|introduced|issue|bug)\b/i.test(body) ||
+                (/\bregression\s+risk\b/i.test(body) && !hasNegatedRegressionRiskSignal(body));
+
+              return (
+                body.includes("changes requested") ||
+                body.includes("p0 badge") ||
                 body.includes("p1 badge") ||
+                /\[\s*p0\s*\]/i.test(body) ||
+                /\[\s*p1\s*\]/i.test(body) ||
+                /\bp0\b\s+(?:finding|issue|blocker|blocking|critical|severity)/i.test(body) ||
+                /\bp1\b\s+(?:finding|issue|blocker|blocking|critical|severity)/i.test(body) ||
+                hasRegressionMarker ||
+                body.includes("must fix") ||
+                body.includes("needs fix")
+              );
+            }
+
+            function hasGenericProblemSignal(text) {
+              const body = normalize(text);
+
+              return (
                 body.includes("changes requested") ||
                 body.includes("regression") ||
                 body.includes("bug") ||
@@ -288,6 +388,22 @@ jobs:
                 body.includes("timing attack") ||
                 body.includes("avoid hashing raw input")
               );
+            }
+
+            function hasProblemSignal(text, state) {
+              const body = normalize(text);
+              const reviewState = normalize(state);
+
+              if (!body && !reviewState) return false;
+              if (reviewState === "changes_requested") return true;
+              if (isCleanCodexSignal(body)) return false;
+              if (hasBlockingCodexMarker(body)) return true;
+              if (isSkippableCodexExecutionSignal(body)) return false;
+              if (isNegativeNonProblemCodexSignal(body)) return false;
+              if (isNonActionableCodexSignal(body)) return false;
+              if (hasGenericProblemSignal(body)) return true;
+
+              return false;
             }
 
             function hasCodexReviewPromptForHead(issueComments, sha, headDate) {
@@ -386,8 +502,112 @@ jobs:
               }
             }
 
+            async function getReviewThreads(prNumber) {
+              const threads = [];
+              let cursor = null;
+
+              while (true) {
+                const response = await github.graphql(
+                  `
+                    query ReviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                      repository(owner: $owner, name: $repo) {
+                        pullRequest(number: $number) {
+                          reviewThreads(first: 100, after: $cursor) {
+                            pageInfo {
+                              hasNextPage
+                              endCursor
+                            }
+                            nodes {
+                              id
+                              isResolved
+                              isOutdated
+                              comments(first: 100) {
+                                pageInfo {
+                                  hasNextPage
+                                  endCursor
+                                }
+                                nodes {
+                                  url
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `,
+                  { owner, repo, number: prNumber, cursor }
+                );
+
+                const reviewThreads = response.repository?.pullRequest?.reviewThreads;
+                const nodes = reviewThreads?.nodes || [];
+                for (const thread of nodes) {
+                  await hydrateReviewThreadComments(thread);
+                }
+                threads.push(...nodes);
+
+                if (!reviewThreads?.pageInfo?.hasNextPage || !reviewThreads.pageInfo.endCursor) {
+                  break;
+                }
+                cursor = reviewThreads.pageInfo.endCursor;
+              }
+
+              return threads;
+            }
+
+            async function hydrateReviewThreadComments(thread) {
+              if (!thread?.id || !thread?.comments?.pageInfo?.hasNextPage) return;
+
+              let cursor = thread.comments.pageInfo.endCursor;
+
+              while (cursor) {
+                const response = await github.graphql(
+                  `
+                    query ReviewThreadComments($threadId: ID!, $cursor: String) {
+                      node(id: $threadId) {
+                        ... on PullRequestReviewThread {
+                          comments(first: 100, after: $cursor) {
+                            pageInfo {
+                              hasNextPage
+                              endCursor
+                            }
+                            nodes {
+                              url
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `,
+                  { threadId: thread.id, cursor }
+                );
+
+                const comments = response.node?.comments;
+                thread.comments.nodes.push(...(comments?.nodes || []));
+
+                if (!comments?.pageInfo?.hasNextPage || !comments.pageInfo.endCursor) {
+                  break;
+                }
+                cursor = comments.pageInfo.endCursor;
+              }
+            }
+
+            function buildStaleReviewCommentUrls(reviewThreads) {
+              const urls = new Set();
+
+              for (const thread of reviewThreads || []) {
+                if (!thread?.isResolved && !thread?.isOutdated) continue;
+
+                for (const comment of thread?.comments?.nodes || []) {
+                  if (comment?.url) urls.add(String(comment.url));
+                }
+              }
+
+              return urls;
+            }
+
             async function getPrContext(prNumber) {
-              const [issueComments, reviews, reviewComments] = await Promise.all([
+              const [issueComments, reviews, reviewComments, reviewThreads] = await Promise.all([
                 github.paginate(github.rest.issues.listComments, {
                   owner,
                   repo,
@@ -406,9 +626,10 @@ jobs:
                   pull_number: prNumber,
                   per_page: 100,
                 }),
+                getReviewThreads(prNumber),
               ]);
 
-              return { issueComments, reviews, reviewComments };
+              return { issueComments, reviews, reviewComments, reviewThreads };
             }
 
             async function getCheckState(sha) {
@@ -629,12 +850,15 @@ jobs:
               const headDate = await getCommitDate(sha);
               const freshness = await getBranchFreshness(pr);
               const prContext = await getPrContext(pr.number);
+              const staleReviewCommentUrls = buildStaleReviewCommentUrls(prContext.reviewThreads);
               const checkState = await getCheckState(sha);
 
               const currentReviewItems = [
-                ...prContext.reviews,
-                ...prContext.reviewComments,
-              ].filter((item) => isReviewBotActor(item) && itemIsForCurrentHead(item, sha, headDate));
+                ...prContext.reviews.filter((item) => itemIsForCurrentHead(item, sha, headDate)),
+                ...prContext.reviewComments.filter((item) =>
+                  reviewCommentIsForCurrentHead(item, sha, headDate, staleReviewCommentUrls)
+                ),
+              ].filter((item) => isReviewBotActor(item));
 
               const currentCodexIssueComments = prContext.issueComments.filter((item) =>
                 isCodexActor(item) &&
@@ -643,10 +867,12 @@ jobs:
               );
 
               const currentCodexSignals = [
-                ...prContext.reviews,
-                ...prContext.reviewComments,
+                ...prContext.reviews.filter((item) => itemIsForCurrentHead(item, sha, headDate)),
+                ...prContext.reviewComments.filter((item) =>
+                  reviewCommentIsForCurrentHead(item, sha, headDate, staleReviewCommentUrls)
+                ),
                 ...currentCodexIssueComments,
-              ].filter((item) => isCodexActor(item) && itemIsForCurrentHead(item, sha, headDate) && !isCodexUsageError(item.body));
+              ].filter((item) => isCodexActor(item) && !isCodexUsageError(item.body));
 
               const problemItems = [
                 ...currentReviewItems,

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -238,13 +238,101 @@ register("codex PR readiness watchdog ignores non-actionable Codex status commen
   const workflow = fs.readFileSync(workflowPath, "utf8");
 
   assert.match(workflow, /function isNonActionableCodexSignal\(text\)/);
-  assert.match(workflow, /body\.includes\("nothing to fix yet"\)/);
-  assert.match(workflow, /body\.includes\("no failing checks or requested code updates"\)/);
-  assert.match(workflow, /body\.includes\("did not find any regression risk"\)/);
+  assert.match(workflow, /function isNegativeNonProblemCodexSignal\(text\)/);
+  assert.match(workflow, /function isCodexExecutionSummary\(text\)/);
+  assert.match(workflow, /function isSkippableCodexExecutionSignal\(text\)/);
+  assert.match(workflow, /function hasBlockingCodexMarker\(text\)/);
+  assert.match(workflow, /function hasNegatedRegressionRiskSignal\(text\)/);
+  assert.match(workflow, /function stripNegatedRegressionRiskPhrases\(text\)/);
   assert.match(
     workflow,
-    /if \(isCleanCodexSignal\(body\)\) return false;\s+if \(isNonActionableCodexSignal\(body\)\) return false;/
+    /function reviewCommentIsForCurrentHead\(item, sha, headDate, staleReviewCommentUrls = new Set\(\)\)/
   );
+  assert.match(workflow, /function getReviewThreads\(prNumber\)/);
+  assert.match(workflow, /function hydrateReviewThreadComments\(thread\)/);
+  assert.match(workflow, /function buildStaleReviewCommentUrls\(reviewThreads\)/);
+  assert.match(workflow, /comments\(first: 100, after: \$cursor\)/);
+  assert.match(workflow, /await hydrateReviewThreadComments\(thread\)/);
+  assert.doesNotMatch(workflow, /item\?\.original_commit_id && item\.original_commit_id !== sha/);
+  assert.match(workflow, /staleReviewCommentUrls\.has\(url\)/);
+  assert.match(
+    workflow,
+    /reviewCommentIsForCurrentHead\(item, sha, headDate, staleReviewCommentUrls\)/
+  );
+  const reviewCommentFreshnessBody = workflow.match(
+    /function reviewCommentIsForCurrentHead[\s\S]+?return itemIsForCurrentHead\(item, sha, headDate\);\s+}/
+  )?.[0];
+  assert.ok(reviewCommentFreshnessBody);
+  const staleReviewUrlIndex = reviewCommentFreshnessBody.indexOf(
+    "if (url && staleReviewCommentUrls.has(url)) return false;"
+  );
+  const bodyShaIndex = reviewCommentFreshnessBody.indexOf(
+    "if (bodyHasCurrentSha(item?.body, sha)) return true;"
+  );
+  assert.equal(staleReviewUrlIndex >= 0, true);
+  assert.equal(bodyShaIndex > staleReviewUrlIndex, true);
+  assert.match(workflow, /if \(hasBlockingCodexMarker\(body\)\) return false;/);
+  assert.match(
+    workflow,
+    /return isCodexExecutionSummary\(body\) \|\| isCodexExecutionPlan\(body\);/
+  );
+  assert.match(workflow, /hasUnresolvedWorkSignal/);
+  assert.match(workflow, /hasResolvedWorkSignal/);
+  assert.match(workflow, /hasCompletedActionSignal/);
+  assert.match(workflow, /\(\?:not\|never\)\\s\+\(\?:fixed\|addressed\|resolved\)/);
+  assert.match(workflow, /!hasUnresolvedWorkSignal &&/);
+  assert.match(workflow, /!hasUnresolvedWorkSignal &&\s+hasCompletedActionSignal/);
+  assert.doesNotMatch(workflow, /body\.includes\("non-actionable"\) \|\|/);
+  assert.match(workflow, /body\.includes\("this trigger is non-actionable right now"\)/);
+  assert.match(workflow, /body\.includes\("non-actionable triage note"\)/);
+  assert.match(workflow, /body\.includes\("wait for ci"\)/);
+  assert.doesNotMatch(workflow, /body\.includes\("checks are pending"\)/);
+  assert.doesNotMatch(workflow, /body\.includes\("checks still pending"\)/);
+  assert.match(workflow, /body\.includes\("nothing to fix yet"\)/);
+  assert.match(workflow, /body\.includes\("no code-change action"\)/);
+  assert.match(workflow, /body\.includes\("no code changes are needed"\)/);
+  assert.match(workflow, /body\.includes\("not opening a follow-up pr"\)/);
+  assert.match(workflow, /body\.includes\("all tests are passing"\)/);
+  assert.match(workflow, /body\.includes\("all tests passed"\)/);
+  assert.match(workflow, /body\.includes\("no failing checks or requested code updates"\)/);
+  assert.match(workflow, /hasNegatedRegressionRiskSignal\(body\)/);
+  assert.match(workflow, /stripNegatedRegressionRiskPhrases\(body\)/);
+  assert.match(
+    workflow,
+    /hasNegatedRegressionRiskSignal\(body\) &&\s+!hasGenericProblemSignal\(stripNegatedRegressionRiskPhrases\(body\)\)/
+  );
+  assert.match(workflow, /\\bno\\s\+regression\\s\+risk\\b/);
+  assert.match(
+    workflow,
+    /\\bregression\\s\+risk\\b\/i\.test\(body\) && !hasNegatedRegressionRiskSignal\(body\)/
+  );
+  const cleanFunctionBlock = workflow.slice(
+    workflow.indexOf("function isCleanCodexSignal(text)"),
+    workflow.indexOf("function isNegativeNonProblemCodexSignal(text)")
+  );
+  assert.doesNotMatch(cleanFunctionBlock, /no failing checks or requested code updates/);
+  assert.doesNotMatch(cleanFunctionBlock, /did not find any regression risk/);
+  assert.doesNotMatch(cleanFunctionBlock, /no actionable blocking defect/);
+  assert.doesNotMatch(cleanFunctionBlock, /all tests are passing/);
+  assert.doesNotMatch(cleanFunctionBlock, /all tests passed/);
+  const cleanIndex = workflow.indexOf("if (isCleanCodexSignal(body)) return false;");
+  const blockingMarkerIndex = workflow.indexOf("if (hasBlockingCodexMarker(body)) return true;");
+  const skippableExecutionIndex = workflow.indexOf(
+    "if (isSkippableCodexExecutionSignal(body)) return false;"
+  );
+  const negativeNonProblemIndex = workflow.indexOf(
+    "if (isNegativeNonProblemCodexSignal(body)) return false;"
+  );
+  const nonActionableIndex = workflow.indexOf(
+    "if (isNonActionableCodexSignal(body)) return false;"
+  );
+  const genericProblemIndex = workflow.indexOf("if (hasGenericProblemSignal(body)) return true;");
+  assert.equal(cleanIndex >= 0, true);
+  assert.equal(blockingMarkerIndex > cleanIndex, true);
+  assert.equal(skippableExecutionIndex > blockingMarkerIndex, true);
+  assert.equal(negativeNonProblemIndex > skippableExecutionIndex, true);
+  assert.equal(nonActionableIndex > negativeNonProblemIndex, true);
+  assert.equal(genericProblemIndex > nonActionableIndex, true);
 });
 
 register(


### PR DESCRIPTION
## Summary
- expand the readiness watchdog non-actionable signal filter for Codex triage comments discovered by dummy PR #170
- cover wait-for-CI, pending-check, no-code-change, and no-follow-up-PR wording
- extend the regression assertion for the workflow filter

## Validation
- npx prettier --check .github/workflows/codex-pr-readiness.yml tests/gameplay/regression/codex-pr-readiness.test.cts
- npm run build:ts
- node .tsbuild/scripts/run-gameplay-tests.cjs
- npm run lint
- npm run format:check
- npm run test:react