### PR TITLE
[codex] Tighten readiness promotion gate

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -885,8 +885,7 @@ jobs:
                 codexReviewedCurrentHead &&
                 problemItems.length === 0 &&
                 (normalize(latestCodexSignal?.state) === "approved" ||
-                  isCleanCodexSignal(latestCodexSignal?.body || "") ||
-                  currentCodexSignals.some((signal) => bodyHasCurrentSha(signal.body, sha)));
+                  isCleanCodexSignal(latestCodexSignal?.body || ""));
 
               const reviewPromptForHead = hasCodexReviewPromptForHead(prContext.issueComments, sha, headDate);
 

--- a/scripts/evaluate-codex-pr-readiness.cts
+++ b/scripts/evaluate-codex-pr-readiness.cts
@@ -1311,6 +1311,18 @@ async function markReadyForReview(
   return true;
 }
 
+function canPromoteDraftToReady(evaluation: ReadinessEvaluation, config: GateConfig): boolean {
+  return (
+    evaluation.decision === "ready" &&
+    evaluation.blockers.length === 0 &&
+    evaluation.checkStatuses.every((status) => status.status === "pass") &&
+    evaluation.qualityStatuses.every((status) => status.status === "pass") &&
+    !!evaluation.latestCodexSignal &&
+    !!evaluation.codexGreenlight &&
+    isGreenlightSignal(evaluation.latestCodexSignal, config)
+  );
+}
+
 async function applyEvaluation(
   client: GitHubApiClient,
   snapshot: Snapshot,
@@ -1332,7 +1344,7 @@ async function applyEvaluation(
     config.summaryCommentMarker
   );
 
-  if (evaluation.decision !== "ready" || !snapshot.pr.isDraft) {
+  if (!canPromoteDraftToReady(evaluation, config) || !snapshot.pr.isDraft) {
     return {
       commentStatus,
       markedReady: false

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -301,6 +301,11 @@ register("codex PR readiness watchdog ignores non-actionable Codex status commen
     workflow,
     /hasNegatedRegressionRiskSignal\(body\) &&\s+!hasGenericProblemSignal\(stripNegatedRegressionRiskPhrases\(body\)\)/
   );
+  assert.doesNotMatch(
+    workflow,
+    /currentCodexSignals\.some\(\(signal\) => bodyHasCurrentSha\(signal\.body, sha\)\)/
+  );
+  assert.match(workflow, /isCleanCodexSignal\(latestCodexSignal\?\.body \|\| ""\)/);
   assert.match(workflow, /\\bno\\s\+regression\\s\+risk\\b/);
   assert.match(
     workflow,
@@ -957,6 +962,40 @@ register("codex PR readiness applies draft transitions only for fully ready PRs"
     {
       commentStatus: "unchanged",
       markedReady: true
+    }
+  );
+
+  const pendingChecksEvaluation = {
+    ...readyEvaluation,
+    checkStatuses: readyEvaluation.checkStatuses.map((status: { status: string }, index: number) =>
+      index === 0 ? { ...status, status: "pending", details: "Still running." } : status
+    )
+  };
+  assert.deepEqual(
+    await applyEvaluation(readyClient, readySnapshot, pendingChecksEvaluation, config, true),
+    {
+      commentStatus: "unchanged",
+      markedReady: false
+    }
+  );
+
+  const missingCodexOkEvaluation = {
+    ...readyEvaluation,
+    codexGreenlight: null,
+    latestCodexSignal: {
+      actorLogin: "chatgpt-codex-connector",
+      state: "COMMENTED",
+      body: `Implementation plan for ${readySnapshot.pr.headSha}`,
+      submittedAt: "2026-04-23T10:11:00.000Z",
+      url: "https://example.test/codex-plan",
+      kind: "issue-comment"
+    }
+  };
+  assert.deepEqual(
+    await applyEvaluation(readyClient, readySnapshot, missingCodexOkEvaluation, config, true),
+    {
+      commentStatus: "unchanged",
+      markedReady: false
     }
   );
 


### PR DESCRIPTION
## Summary
- require explicit latest Codex OK signal instead of treating any SHA mention as OK
- add a final promotion guard before markPullRequestReadyForReview requiring pass checks, pass quality steps, and Codex greenlight
- cover pending-check and missing-Codex-OK promotion cases in regression tests

## Validation
- npm run build:ts
- node .tsbuild/scripts/run-gameplay-tests.cjs
- npm run format:check
- npm run lint (139 existing warnings, 0 errors)
- npm run test:react
- git diff --check