### PR TITLE
Fix Codex readiness PR targeting

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -138,6 +138,9 @@ jobs:
               "chatgpt-codex-connector[bot]",
             ];
 
+            const TARGET_LABEL = "codex";
+            const BRANCH_PREFIX = "codex/";
+
             const REVIEW_BOT_ACTORS = [
               ...CODEX_ACTORS,
               "github-advanced-security",
@@ -444,7 +447,19 @@ jobs:
             }
 
             function isAutomationTargetPr(pr) {
-              return pr.state === "open";
+              if (!pr || pr.state !== "open" || pr.draft !== true) return false;
+
+              const labels = (pr.labels || []).map((label) =>
+                normalize(label?.name || label)
+              );
+              const headRef = String(pr.head?.ref || "");
+              const author = normalize(pr.user?.login || "");
+
+              return (
+                labels.includes(TARGET_LABEL) ||
+                headRef.startsWith(BRANCH_PREFIX) ||
+                CODEX_ACTORS.some((actor) => author === normalize(actor))
+              );
             }
 
             async function getPr(prNumber) {
@@ -841,8 +856,10 @@ jobs:
             async function evaluatePr(prNumber) {
               const pr = await getPr(prNumber);
 
-              if (pr.state !== "open") {
-                core.info(`Skipping PR #${prNumber}: state=${pr.state}`);
+              if (!isAutomationTargetPr(pr)) {
+                core.info(
+                  `Skipping PR #${prNumber}: not a targeted draft Codex PR.`
+                );
                 return;
               }
 
@@ -1029,7 +1046,8 @@ jobs:
               if (manualPrNumber > 0) return [manualPrNumber];
 
               if (context.eventName === "pull_request_target" && context.payload.pull_request?.number) {
-                return [context.payload.pull_request.number];
+                const pr = context.payload.pull_request;
+                return isAutomationTargetPr(pr) ? [pr.number] : [];
               }
 
               if (
@@ -1037,7 +1055,8 @@ jobs:
                   context.eventName === "pull_request_review_comment") &&
                 context.payload.pull_request?.number
               ) {
-                return [context.payload.pull_request.number];
+                const pr = context.payload.pull_request;
+                return isAutomationTargetPr(pr) ? [pr.number] : [];
               }
 
               if (context.eventName === "issue_comment") {

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -233,6 +233,27 @@ register("codex PR readiness workflow listens to all pull_request workflow_run c
   assert.doesNotMatch(workflow, /github\.event\.workflow_run\.head_branch/);
 });
 
+register("codex PR readiness workflow targets only draft Codex PRs", () => {
+  const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /const TARGET_LABEL = "codex";/);
+  assert.match(workflow, /const BRANCH_PREFIX = "codex\/";/);
+  assert.match(
+    workflow,
+    /if \(!pr \|\| pr\.state !== "open" \|\| pr\.draft !== true\) return false;/
+  );
+  assert.match(workflow, /labels\.includes\(TARGET_LABEL\)/);
+  assert.match(workflow, /headRef\.startsWith\(BRANCH_PREFIX\)/);
+  assert.match(workflow, /CODEX_ACTORS\.some\(\(actor\) => author === normalize\(actor\)\)/);
+  assert.match(workflow, /Skipping PR #\$\{prNumber\}: not a targeted draft Codex PR\./);
+  assert.doesNotMatch(workflow, /return \[context\.payload\.pull_request\.number\];/);
+
+  const filteredEventReturns =
+    workflow.match(/return isAutomationTargetPr\(pr\) \? \[pr\.number\] : \[\];/g) || [];
+  assert.equal(filteredEventReturns.length >= 3, true);
+});
+
 register("codex PR readiness watchdog ignores non-actionable Codex status comments", () => {
   const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
   const workflow = fs.readFileSync(workflowPath, "utf8");


### PR DESCRIPTION
## Summary
- restrict the inline Codex readiness workflow to open draft Codex-target PRs only
- skip evaluation defensively when a PR reaches the workflow but is not a targeted draft Codex PR
- add a regression test that locks the workflow targeting rules

## Validation
- npm run build:ts
- node .tsbuild/scripts/run-gameplay-tests.cjs
- npm run format:check
- npm run lint (0 errors, existing warnings only)
- npm run test:react
- git diff --check

Context: PR #172 is a ready non-Codex-target Sentinel PR, so readiness comments and review events must not keep feeding it back into the Codex automation loop.