### PR TITLE
[codex] Prune expired finished games

### DIFF
--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -630,6 +630,14 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
 
       return normalizeGame(updated[0] || null);
     },
+    async deleteGame(gameId: string) {
+      await ensureInitialized();
+      await deleteRows("games", { id: `eq.${gameId}` });
+      const activeGameId = await datastore.getActiveGameId();
+      if (activeGameId === gameId) {
+        await datastore.setActiveGameId(null);
+      }
+    },
     async getActiveGameId() {
       await ensureInitialized();
       const row = await selectOne<AppStateRow>("app_state", { key: "eq.activeGameId" });

--- a/backend/datastore.cts
+++ b/backend/datastore.cts
@@ -273,6 +273,7 @@ function createDatastore(options: DatastoreOptions = {}) {
     updateGame: db.prepare(
       "UPDATE games SET name = ?, version = ?, creator_user_id = ?, state_json = ?, updated_at = ? WHERE id = ?"
     ) as Statement<unknown>,
+    deleteGame: db.prepare("DELETE FROM games WHERE id = ?") as Statement<unknown>,
     getAppState: db.prepare(
       "SELECT value_json FROM app_state WHERE key = ?"
     ) as Statement<AppStateRow | null>,
@@ -514,6 +515,15 @@ function createDatastore(options: DatastoreOptions = {}) {
         );
       });
       return datastore.findGameById(entry.id);
+    },
+    deleteGame(gameId: string) {
+      transaction(() => {
+        statements.deleteGame.run(gameId);
+        const activeGameId = datastore.getActiveGameId();
+        if (activeGameId === gameId) {
+          statements.setAppState.run("activeGameId", JSON.stringify(null));
+        }
+      });
     },
     getActiveGameId() {
       const row = statements.getAppState.get("activeGameId");

--- a/backend/game-session-store.cts
+++ b/backend/game-session-store.cts
@@ -77,6 +77,7 @@ interface GameSessionStoreOptions {
     findGameById(gameId: string): GameEntry | null | Promise<GameEntry | null>;
     getActiveGameId(): string | null | Promise<string | null>;
     updateGame(entry: GameEntry): GameEntry | Promise<GameEntry>;
+    deleteGame?(gameId: string): void | Promise<void>;
   };
   dbFile?: string;
   dataFile?: string;

--- a/backend/scheduler/finished-game-retention-job.cts
+++ b/backend/scheduler/finished-game-retention-job.cts
@@ -1,0 +1,13 @@
+import { pruneExpiredFinishedGames } from "../services/finished-game-retention.cjs";
+
+export async function runFinishedGameRetentionJob(
+  options: Parameters<typeof pruneExpiredFinishedGames>[0]
+): Promise<{
+  name: "finished-game-retention";
+  result: Awaited<ReturnType<typeof pruneExpiredFinishedGames>>;
+}> {
+  return {
+    name: "finished-game-retention",
+    result: await pruneExpiredFinishedGames(options)
+  };
+}

--- a/backend/scheduler/index.cts
+++ b/backend/scheduler/index.cts
@@ -1,16 +1,25 @@
 import { runAiTurnRecoveryJob } from "./ai-turn-recovery-job.cjs";
+import { runFinishedGameRetentionJob } from "./finished-game-retention-job.cjs";
 import { runTurnTimeoutJob } from "./turn-timeout-job.cjs";
 
 export async function runScheduledJobs(
-  options: Parameters<typeof runTurnTimeoutJob>[0] & Parameters<typeof runAiTurnRecoveryJob>[0]
+  options: Parameters<typeof runTurnTimeoutJob>[0] &
+    Parameters<typeof runAiTurnRecoveryJob>[0] &
+    Parameters<typeof runFinishedGameRetentionJob>[0]
 ): Promise<{
   ok: true;
   jobs: Array<
-    Awaited<ReturnType<typeof runTurnTimeoutJob>> | Awaited<ReturnType<typeof runAiTurnRecoveryJob>>
+    | Awaited<ReturnType<typeof runTurnTimeoutJob>>
+    | Awaited<ReturnType<typeof runAiTurnRecoveryJob>>
+    | Awaited<ReturnType<typeof runFinishedGameRetentionJob>>
   >;
 }> {
   return {
     ok: true,
-    jobs: [await runTurnTimeoutJob(options), await runAiTurnRecoveryJob(options)]
+    jobs: [
+      await runTurnTimeoutJob(options),
+      await runAiTurnRecoveryJob(options),
+      await runFinishedGameRetentionJob(options)
+    ]
   };
 }

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1235,6 +1235,20 @@ function createApp(options: CreateAppOptions = {}) {
         () =>
           runScheduledJobs({
             listGames: () => gameSessions.datastore.listGames(),
+            deleteGame: (gameId: string) => {
+              if (typeof gameSessions.datastore.deleteGame !== "function") {
+                throw new Error("Il datastore non supporta la cancellazione delle partite.");
+              }
+              return gameSessions.datastore.deleteGame(gameId);
+            },
+            afterDelete: ({ gameId }: { gameId: string; gameName: string | null }) => {
+              if (gameId === activeGameId) {
+                activeGameId = null;
+                activeGameVersion = null;
+                activeGameName = null;
+                replaceState(createInitialState());
+              }
+            },
             saveGame: (
               gameId: string,
               nextState: Record<string, unknown>,

--- a/backend/services/finished-game-retention.cts
+++ b/backend/services/finished-game-retention.cts
@@ -1,0 +1,91 @@
+import { resolveTurnTimeoutHours } from "../engine/turn-timeout.cjs";
+
+type GameEntry = {
+  id: string;
+  name?: string;
+  state: Record<string, unknown>;
+  updatedAt?: string | null;
+};
+
+export interface FinishedGameRetentionResult {
+  scannedGames: number;
+  eligibleFinishedGames: number;
+  deletedGames: number;
+  skippedWithoutTimeout: number;
+  deletedGameIds: string[];
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function finishedGameRetentionExpiresAt(entry: GameEntry): Date | null {
+  if (entry?.state?.phase !== "finished") {
+    return null;
+  }
+
+  const timeoutHours = resolveTurnTimeoutHours(
+    entry.state as unknown as Parameters<typeof resolveTurnTimeoutHours>[0]
+  );
+  if (timeoutHours == null) {
+    return null;
+  }
+
+  const finishedAt = parseDate(entry.updatedAt);
+  if (!finishedAt) {
+    return null;
+  }
+
+  return new Date(finishedAt.getTime() + timeoutHours * 2 * 60 * 60 * 1000);
+}
+
+export async function pruneExpiredFinishedGames(options: {
+  listGames: () => Promise<GameEntry[]> | GameEntry[];
+  deleteGame: (gameId: string) => Promise<unknown> | unknown;
+  afterDelete?: (payload: { gameId: string; gameName: string | null }) => Promise<void> | void;
+  now?: Date;
+}): Promise<FinishedGameRetentionResult> {
+  const entries = await options.listGames();
+  const now = options.now || new Date();
+  const result: FinishedGameRetentionResult = {
+    scannedGames: entries.length,
+    eligibleFinishedGames: 0,
+    deletedGames: 0,
+    skippedWithoutTimeout: 0,
+    deletedGameIds: []
+  };
+
+  for (const entry of entries) {
+    if (entry?.state?.phase !== "finished") {
+      continue;
+    }
+
+    result.eligibleFinishedGames += 1;
+    const expiresAt = finishedGameRetentionExpiresAt(entry);
+    if (!expiresAt) {
+      result.skippedWithoutTimeout += 1;
+      continue;
+    }
+
+    if (expiresAt.getTime() >= now.getTime()) {
+      continue;
+    }
+
+    await options.deleteGame(entry.id);
+    if (options.afterDelete) {
+      await options.afterDelete({
+        gameId: entry.id,
+        gameName: typeof entry.name === "string" ? entry.name : null
+      });
+    }
+    result.deletedGames += 1;
+    result.deletedGameIds.push(entry.id);
+  }
+
+  return result;
+}

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -47,6 +47,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/auth-store.test.cjs",
   "../tests/gameplay/regression/authored-modules.test.cjs",
   "../tests/gameplay/regression/codex-pr-readiness.test.cjs",
+  "../tests/gameplay/regression/finished-game-retention.test.cjs",
   "../tests/gameplay/regression/startup-init-error.test.cjs",
   "../tests/gameplay/regression/tooling-and-supabase-regressions.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -4910,6 +4910,7 @@ register(
 register("scheduler entrypoint espone anche il job di recovery AI", async () => {
   const payload = await runScheduledJobs({
     listGames: () => [],
+    deleteGame: () => undefined,
     saveGame: () => ({ version: 1 }),
     forceEndTurn,
     recoverAiTurnState: async () => ({
@@ -4926,7 +4927,7 @@ register("scheduler entrypoint espone anche il job di recovery AI", async () => 
   assert.equal(payload.ok, true);
   assert.deepEqual(
     payload.jobs.map((job: any) => job.name),
-    ["turn-timeout-enforcement", "ai-turn-recovery"]
+    ["turn-timeout-enforcement", "ai-turn-recovery", "finished-game-retention"]
   );
 });
 
@@ -5449,7 +5450,7 @@ register(
         assert.equal(cronPayload.jobs[0].result.forcedTurns, 1);
         assert.deepEqual(
           cronPayload.jobs.map((job: any) => job.name),
-          ["turn-timeout-enforcement", "ai-turn-recovery"]
+          ["turn-timeout-enforcement", "ai-turn-recovery", "finished-game-retention"]
         );
 
         const stateResponse = await fetch(

--- a/tests/gameplay/regression/finished-game-retention.test.cts
+++ b/tests/gameplay/regression/finished-game-retention.test.cts
@@ -1,0 +1,94 @@
+const assert = require("node:assert/strict");
+const {
+  finishedGameRetentionExpiresAt,
+  pruneExpiredFinishedGames
+} = require("../../../backend/services/finished-game-retention.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function gameEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "game-1",
+    name: "Finished game",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    state: {
+      phase: "finished",
+      gameConfig: {
+        turnTimeoutHours: 24
+      }
+    },
+    ...overrides
+  };
+}
+
+register("finished game retention expires after twice the configured turn timeout", () => {
+  const expiresAt = finishedGameRetentionExpiresAt(gameEntry());
+
+  assert.equal(expiresAt?.toISOString(), "2026-04-22T10:00:00.000Z");
+});
+
+register("finished game retention ignores active games and games without a turn timeout", () => {
+  assert.equal(
+    finishedGameRetentionExpiresAt(
+      gameEntry({
+        state: {
+          phase: "active",
+          gameConfig: { turnTimeoutHours: 24 }
+        }
+      })
+    ),
+    null
+  );
+
+  assert.equal(
+    finishedGameRetentionExpiresAt(
+      gameEntry({
+        state: {
+          phase: "finished",
+          gameConfig: { turnTimeoutHours: null }
+        }
+      })
+    ),
+    null
+  );
+});
+
+register("finished game retention deletes only expired finished games", async () => {
+  const deletedGameIds: string[] = [];
+  const result = await pruneExpiredFinishedGames({
+    now: new Date("2026-04-22T10:00:01.000Z"),
+    listGames: () => [
+      gameEntry({ id: "expired-finished" }),
+      gameEntry({
+        id: "fresh-finished",
+        updatedAt: "2026-04-21T10:00:00.000Z"
+      }),
+      gameEntry({
+        id: "active-expired",
+        state: {
+          phase: "active",
+          gameConfig: { turnTimeoutHours: 24 }
+        }
+      }),
+      gameEntry({
+        id: "finished-without-timeout",
+        state: {
+          phase: "finished",
+          gameConfig: {}
+        }
+      })
+    ],
+    deleteGame: (gameId: string) => {
+      deletedGameIds.push(gameId);
+    }
+  });
+
+  assert.deepEqual(deletedGameIds, ["expired-finished"]);
+  assert.deepEqual(result, {
+    scannedGames: 4,
+    eligibleFinishedGames: 3,
+    deletedGames: 1,
+    skippedWithoutTimeout: 1,
+    deletedGameIds: ["expired-finished"]
+  });
+});


### PR DESCRIPTION
## Summary
- add a finished-game retention job to the scheduled cron pipeline
- delete only games in `finished` phase after `2 * turnTimeoutHours` from their last update
- add datastore deletion support for SQLite and Supabase, with active-game cleanup when needed
- cover retention expiry and pruning behavior in gameplay regression tests

## Validation
- `npm run build:ts`
- `node .tsbuild/scripts/run-gameplay-tests.cjs`
- `npm run format:check`
- `npm run lint` (passes with existing warnings)
- `npm run test:react`
- `git diff --check`