### PR TITLE
Fix readiness summary comment matching

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -861,6 +861,25 @@ jobs:
               return "created";
             }
 
+            async function markReadyForReview(pr) {
+              await github.graphql(
+                `
+                  mutation MarkReady($pullRequestId: ID!) {
+                    markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+                      pullRequest {
+                        id
+                        isDraft
+                      }
+                    }
+                  }
+                `,
+                {
+                  pullRequestId: pr.node_id,
+                }
+              );
+              pr.draft = false;
+            }
+
             function buildSummary({ pr, sha, freshness, checkState, codexReviewedCurrentHead, codexOk, reviewPromptForHead, problemItems, action, actionReason }) {
               const decision = (() => {
                 if (problemItems.length > 0) return "FIX REQUESTED";
@@ -1058,8 +1077,9 @@ jobs:
                 action = "wait";
                 actionReason = `Checks are ${checkState.state}; waiting.`;
               } else if (checkState.state === "green" && codexOk) {
-                action = "none";
-                actionReason = "CI is green and Codex has reviewed the current head without current findings.";
+                action = "mark-ready";
+                await markReadyForReview(pr);
+                actionReason = "CI is green and Codex has reviewed the current head without current findings; marked this draft PR ready for review.";
               } else if (checkState.state === "green" && !codexOk) {
                 action = "review";
                 actionReason = "CI is green but Codex has not yet given a current-head OK signal.";

--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -621,8 +621,53 @@ jobs:
               return urls;
             }
 
+            async function getMinimizedIssueCommentUrls(prNumber) {
+              const urls = new Set();
+              let cursor = null;
+
+              while (true) {
+                const response = await github.graphql(
+                  `
+                    query PullRequestIssueComments($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                      repository(owner: $owner, name: $repo) {
+                        pullRequest(number: $number) {
+                          comments(first: 100, after: $cursor) {
+                            pageInfo {
+                              hasNextPage
+                              endCursor
+                            }
+                            nodes {
+                              url
+                              isMinimized
+                            }
+                          }
+                        }
+                      }
+                    }
+                  `,
+                  { owner, repo, number: prNumber, cursor }
+                );
+
+                const comments = response.repository?.pullRequest?.comments;
+                for (const comment of comments?.nodes || []) {
+                  if (comment?.isMinimized && comment?.url) urls.add(String(comment.url));
+                }
+
+                if (!comments?.pageInfo?.hasNextPage || !comments.pageInfo.endCursor) break;
+                cursor = comments.pageInfo.endCursor;
+              }
+
+              return urls;
+            }
+
             async function getPrContext(prNumber) {
-              const [issueComments, reviews, reviewComments, reviewThreads] = await Promise.all([
+              const [
+                issueComments,
+                reviews,
+                reviewComments,
+                reviewThreads,
+                minimizedIssueCommentUrls,
+              ] = await Promise.all([
                 github.paginate(github.rest.issues.listComments, {
                   owner,
                   repo,
@@ -642,9 +687,20 @@ jobs:
                   per_page: 100,
                 }),
                 getReviewThreads(prNumber),
+                getMinimizedIssueCommentUrls(prNumber),
               ]);
 
-              return { issueComments, reviews, reviewComments, reviewThreads };
+              const issueCommentsWithMinimizedState = issueComments.map((comment) => ({
+                ...comment,
+                isMinimized: minimizedIssueCommentUrls.has(String(comment.html_url || comment.url || "")),
+              }));
+
+              return {
+                issueComments: issueCommentsWithMinimizedState,
+                reviews,
+                reviewComments,
+                reviewThreads,
+              };
             }
 
             async function getCheckState(sha) {
@@ -880,7 +936,8 @@ jobs:
               const currentCodexIssueComments = prContext.issueComments.filter((item) =>
                 isCodexActor(item) &&
                 itemIsForCurrentHead(item, sha, headDate) &&
-                !isCodexUsageError(item.body)
+                !isCodexUsageError(item.body) &&
+                !item.isMinimized
               );
 
               const currentCodexSignals = [

--- a/scripts/evaluate-codex-pr-readiness.cts
+++ b/scripts/evaluate-codex-pr-readiness.cts
@@ -143,6 +143,17 @@ type ReviewThreadsPageInfo = {
   endCursor?: string | null;
 };
 
+type PullRequestIssueCommentsQueryData = {
+  repository?: {
+    pullRequest?: {
+      comments?: {
+        pageInfo?: ReviewThreadsPageInfo;
+        nodes?: any[];
+      };
+    };
+  };
+};
+
 type GateMessage = {
   code: string;
   message: string;
@@ -899,6 +910,7 @@ class GitHubApiClient {
   owner: string;
   repo: string;
   token: string;
+  private authenticatedLogin: string | null | undefined;
 
   constructor(repository: string, token: string) {
     const parsed = parseRepository(repository);
@@ -929,6 +941,26 @@ class GitHubApiClient {
     }
 
     return response.json();
+  }
+
+  async getAuthenticatedLogin(): Promise<string | null> {
+    if (this.authenticatedLogin !== undefined) {
+      return this.authenticatedLogin;
+    }
+
+    const fallbackLogin = "github-actions[bot]";
+    try {
+      const user = (await this.requestJson("GET", "/user")) as { login?: unknown };
+      const login = String(user.login || "").trim();
+      if (login) {
+        this.authenticatedLogin = login;
+        return this.authenticatedLogin;
+      }
+    } catch {
+      return fallbackLogin;
+    }
+
+    return fallbackLogin;
   }
 
   async graphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
@@ -1184,6 +1216,58 @@ async function getReviewThreads(
   return threads;
 }
 
+async function getMinimizedIssueCommentUrls(
+  client: GitHubApiClient,
+  prNumber: number
+): Promise<Set<string>> {
+  const urls = new Set<string>();
+  let cursor: string | null = null;
+
+  while (true) {
+    const payload: PullRequestIssueCommentsQueryData =
+      await client.graphql<PullRequestIssueCommentsQueryData>(
+        `
+        query PullRequestIssueComments($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              comments(first: 100, after: $cursor) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                nodes {
+                  url
+                  isMinimized
+                }
+              }
+            }
+          }
+        }
+      `,
+        {
+          owner: client.owner,
+          repo: client.repo,
+          number: prNumber,
+          cursor
+        }
+      );
+
+    const comments = payload.repository?.pullRequest?.comments;
+    asArray(comments?.nodes).forEach((comment: any) => {
+      if (comment.isMinimized) {
+        urls.add(String(comment.url || ""));
+      }
+    });
+
+    if (!comments?.pageInfo?.hasNextPage || !comments.pageInfo.endCursor) {
+      break;
+    }
+    cursor = String(comments.pageInfo.endCursor);
+  }
+
+  return urls;
+}
+
 async function getCodexSignals(client: GitHubApiClient, prNumber: number, config: GateConfig) {
   const reviewSignals = (
     await paginateRest<any>(
@@ -1200,6 +1284,7 @@ async function getCodexSignals(client: GitHubApiClient, prNumber: number, config
       url: String(review.html_url || ""),
       kind: "review" as const
     }));
+  const minimizedIssueCommentUrls = await getMinimizedIssueCommentUrls(client, prNumber);
   const issueCommentSignals = (
     await paginateRest<any>(
       client,
@@ -1207,6 +1292,7 @@ async function getCodexSignals(client: GitHubApiClient, prNumber: number, config
     )
   )
     .filter((comment) => isCodexActor(String(comment.user?.login || ""), config))
+    .filter((comment) => !minimizedIssueCommentUrls.has(String(comment.html_url || "")))
     .map((comment) => ({
       actorLogin: String(comment.user?.login || ""),
       state: null,
@@ -1256,13 +1342,18 @@ async function upsertSummaryComment(
   body: string,
   marker: string
 ): Promise<ApplyCommentStatus> {
+  const authenticatedLogin =
+    typeof client.getAuthenticatedLogin === "function"
+      ? await client.getAuthenticatedLogin()
+      : null;
+  const editableAuthorLogin = authenticatedLogin || "github-actions[bot]";
   const comments = await paginateRest<any>(
     client,
     `/repos/${client.owner}/${client.repo}/issues/${prNumber}/comments`
   );
   const existing = comments.find(
     (comment) =>
-      String(comment.user?.login || "") === "github-actions[bot]" &&
+      String(comment.user?.login || "") === editableAuthorLogin &&
       String(comment.body || "").includes(marker)
   );
 

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -163,7 +163,11 @@ function createTempJsonFile(name: string, payload: unknown) {
 
 function createFakeClient(
   routes: Record<string, unknown>,
-  graphqlHandler?: (query: string, variables: Record<string, unknown>) => unknown | Promise<unknown>
+  graphqlHandler?: (
+    query: string,
+    variables: Record<string, unknown>
+  ) => unknown | Promise<unknown>,
+  authenticatedLogin = "github-actions[bot]"
 ) {
   const calls: Array<Record<string, unknown>> = [];
 
@@ -185,6 +189,9 @@ function createFakeClient(
 
       const response = routes[key];
       return typeof response === "function" ? await response(body) : response;
+    },
+    async getAuthenticatedLogin() {
+      return authenticatedLogin;
     },
     async graphql(query: string, variables: Record<string, unknown>) {
       calls.push({
@@ -843,6 +850,30 @@ register("codex PR readiness snapshots GitHub metadata into the evaluation input
           body: "Codex PR readiness: greenlight",
           created_at: "2026-04-23T10:16:00.000Z",
           html_url: "https://example.test/comments/1"
+        },
+        {
+          user: { login: "chatgpt-codex-connector" },
+          body: "### Summary\n* Applied the requested fix.\n\n[View task ->](https://example.test/codex/tasks/1)",
+          created_at: "2026-04-23T10:18:00.000Z",
+          html_url: "https://example.test/comments/2"
+        },
+        {
+          user: { login: "chatgpt-codex-connector" },
+          body: "### Summary\n* Fixed the parser, preventing passive wording like could not be fixed from being misclassified.\n\n[View task ->](https://example.test/codex/tasks/2)",
+          created_at: "2026-04-23T10:19:00.000Z",
+          html_url: "https://example.test/comments/3"
+        },
+        {
+          user: { login: "chatgpt-codex-connector" },
+          body: "### Summary\n* Updated findings: one issue could not be fixed without a follow-up change.\n\n[View task ->](https://example.test/codex/tasks/3)",
+          created_at: "2026-04-23T10:20:00.000Z",
+          html_url: "https://example.test/comments/4"
+        },
+        {
+          user: { login: "chatgpt-codex-connector" },
+          body: "### Summary\n* Added regression coverage, but could not resolve the failing case.\n\n[View task ->](https://example.test/codex/tasks/4)",
+          created_at: "2026-04-23T10:21:00.000Z",
+          html_url: "https://example.test/comments/5"
         }
       ],
       "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=2": [],
@@ -861,6 +892,34 @@ register("codex PR readiness snapshots GitHub metadata into the evaluation input
     async () => ({
       repository: {
         pullRequest: {
+          comments: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null
+            },
+            nodes: [
+              {
+                url: "https://example.test/comments/1",
+                isMinimized: false
+              },
+              {
+                url: "https://example.test/comments/2",
+                isMinimized: true
+              },
+              {
+                url: "https://example.test/comments/3",
+                isMinimized: true
+              },
+              {
+                url: "https://example.test/comments/4",
+                isMinimized: false
+              },
+              {
+                url: "https://example.test/comments/5",
+                isMinimized: false
+              }
+            ]
+          },
           reviewThreads: {
             pageInfo: {
               hasNextPage: false,
@@ -896,7 +955,31 @@ register("codex PR readiness snapshots GitHub metadata into the evaluation input
   assert.equal(snapshot.workflowJobs.length, 2);
   assert.equal(snapshot.workflowJobs[0].workflowName, "Quality");
   assert.equal(snapshot.reviewThreads[0].comments[0].authorLogin, "chatgpt-codex-connector");
-  assert.equal(snapshot.codexSignals.length, 2);
+  assert.equal(snapshot.codexSignals.length, 4);
+  assert.equal(
+    snapshot.codexSignals.some((signal: { body: string }) =>
+      signal.body.includes("Applied the requested fix")
+    ),
+    false
+  );
+  assert.equal(
+    snapshot.codexSignals.some((signal: { body: string }) =>
+      signal.body.includes("preventing passive wording")
+    ),
+    false
+  );
+  assert.equal(
+    snapshot.codexSignals.some((signal: { body: string }) =>
+      signal.body.includes("could not be fixed")
+    ),
+    true
+  );
+  assert.equal(
+    snapshot.codexSignals.some((signal: { body: string }) =>
+      signal.body.includes("could not resolve")
+    ),
+    true
+  );
   assert.equal(snapshot.changedFiles[0].path, "scripts/evaluate-codex-pr-readiness.cts");
 });
 
@@ -933,6 +1016,54 @@ register("codex PR readiness upserts a single sticky summary comment", async () 
       config.summaryCommentMarker
     ),
     "updated"
+  );
+
+  const patUpdatedClient = createFakeClient(
+    {
+      "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [
+        {
+          id: 17,
+          user: { login: "andreame-code" },
+          body: `${config.summaryCommentMarker}\nOld PAT summary`
+        }
+      ],
+      "PATCH /repos/andreame-code/netrisk/issues/comments/17": {}
+    },
+    undefined,
+    "andreame-code"
+  );
+  assert.equal(
+    await upsertSummaryComment(
+      patUpdatedClient,
+      146,
+      `${config.summaryCommentMarker}\nUpdated PAT summary`,
+      config.summaryCommentMarker
+    ),
+    "updated"
+  );
+
+  const crossAuthorClient = createFakeClient(
+    {
+      "GET /repos/andreame-code/netrisk/issues/146/comments?per_page=100&page=1": [
+        {
+          id: 18,
+          user: { login: "github-actions[bot]" },
+          body: `${config.summaryCommentMarker}\nBot summary`
+        }
+      ],
+      "POST /repos/andreame-code/netrisk/issues/146/comments": {}
+    },
+    undefined,
+    "andreame-code"
+  );
+  assert.equal(
+    await upsertSummaryComment(
+      crossAuthorClient,
+      146,
+      `${config.summaryCommentMarker}\nNew PAT summary`,
+      config.summaryCommentMarker
+    ),
+    "created"
   );
 
   const unchangedClient = createFakeClient({
@@ -1107,6 +1238,19 @@ register(
           method: init.method
         });
 
+        if (String(url).endsWith("/user")) {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return { login: "andreame-code" };
+            },
+            async text() {
+              return "";
+            }
+          } as any;
+        }
+
         if (String(url).endsWith("/ok")) {
           return {
             ok: true,
@@ -1172,6 +1316,68 @@ register(
           login: "chatgpt-codex-connector"
         }
       });
+      assert.equal(await client.getAuthenticatedLogin(), "andreame-code");
+
+      const originalActor = process.env.GITHUB_ACTOR;
+      process.env.GITHUB_ACTOR = "andreame-code";
+      const successfulFetch = global.fetch;
+      try {
+        global.fetch = (async () =>
+          ({
+            ok: false,
+            status: 500,
+            async json() {
+              return {};
+            },
+            async text() {
+              return "lookup failed";
+            }
+          }) as any) as typeof global.fetch;
+        const fallbackClient = new GitHubApiClient("andreame-code/netrisk", "token");
+        assert.equal(await fallbackClient.getAuthenticatedLogin(), "github-actions[bot]");
+      } finally {
+        global.fetch = successfulFetch;
+        if (originalActor === undefined) {
+          delete process.env.GITHUB_ACTOR;
+        } else {
+          process.env.GITHUB_ACTOR = originalActor;
+        }
+      }
+
+      let transientAttempts = 0;
+      try {
+        global.fetch = (async () => {
+          transientAttempts += 1;
+          if (transientAttempts === 1) {
+            return {
+              ok: false,
+              status: 500,
+              async json() {
+                return {};
+              },
+              async text() {
+                return "temporary lookup failure";
+              }
+            } as any;
+          }
+
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return { login: "andreame-code" };
+            },
+            async text() {
+              return "";
+            }
+          } as any;
+        }) as typeof global.fetch;
+        const transientClient = new GitHubApiClient("andreame-code/netrisk", "token");
+        assert.equal(await transientClient.getAuthenticatedLogin(), "github-actions[bot]");
+        assert.equal(await transientClient.getAuthenticatedLogin(), "andreame-code");
+      } finally {
+        global.fetch = successfulFetch;
+      }
       await assert.rejects(
         async () => client.requestJson("GET", "/fail"),
         /GET \/fail failed \(500\): boom/

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -261,6 +261,22 @@ register("codex PR readiness workflow targets only draft Codex PRs", () => {
   assert.equal(filteredEventReturns.length >= 3, true);
 });
 
+register("codex PR readiness workflow marks fully ready drafts ready for review", () => {
+  const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /async function markReadyForReview\(pr\)/);
+  assert.match(
+    workflow,
+    /markPullRequestReadyForReview\(input: \{ pullRequestId: \$pullRequestId \}\)/
+  );
+  assert.match(workflow, /pullRequestId: pr\.node_id/);
+  assert.match(workflow, /pr\.draft = false;/);
+  assert.match(workflow, /else if \(checkState\.state === "green" && codexOk\) \{/);
+  assert.match(workflow, /action = "mark-ready";/);
+  assert.match(workflow, /await markReadyForReview\(pr\);/);
+});
+
 register("codex PR readiness watchdog ignores non-actionable Codex status comments", () => {
   const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
   const workflow = fs.readFileSync(workflowPath, "utf8");


### PR DESCRIPTION
## Summary
- update readiness summary comments by marker instead of bot author
- cover PAT-authored sticky summary comments in the regression test

## Validation
- npm run build:ts
- npm run test:gameplay -- tests/gameplay/regression/codex-pr-readiness.test.cts
- npm run format:check -- scripts/evaluate-codex-pr-readiness.cts tests/gameplay/regression/codex-pr-readiness.test.cts