### PR TITLE
Fix homepage Middle-earth map proportions

### DIFF
--- a/frontend/react-shell/src/landing-route.tsx
+++ b/frontend/react-shell/src/landing-route.tsx
@@ -198,7 +198,7 @@ export function LandingRoute() {
               </div>
 
               <div className="ld-map-card">
-                <div className="ld-map-frame">
+                <div className="ld-map-frame ld-map-frame--tall">
                   <img
                     src="/assets/maps/middle-earth.jpg"
                     alt="Mappa Terra di Mezzo"

--- a/frontend/src/generated/static-text-assets.mts
+++ b/frontend/src/generated/static-text-assets.mts
@@ -192,7 +192,7 @@ export const staticHtmlAssets = {
           </div>
 
           <div class="ld-map-card">
-            <div class="ld-map-frame">
+            <div class="ld-map-frame ld-map-frame--tall">
               <img
                 src="/assets/maps/middle-earth.jpg"
                 alt="Screenshot del gioco - Mappa Terra di Mezzo con 3 giocatori al turno 7"
@@ -1438,6 +1438,11 @@ body[data-landing-menu-open="true"] .ld-menu-toggle-icon::after {
   object-fit: cover;
   filter: contrast(1.08) saturate(0.85);
   display: block;
+}
+
+.ld-map-frame--tall img {
+  aspect-ratio: 4 / 5;
+  object-position: center top;
 }
 
 .ld-map-frame::after {


### PR DESCRIPTION
## Summary
- reduce the Middle-earth homepage map card to a dedicated tall ratio
- keep the classic map card unchanged

## Validation
- npm run build:frontend
- npm run format:check -- frontend/src/generated/static-text-assets.mts