### PR TITLE
[codex] Fix landing map preview aspect ratio

### DIFF
--- a/frontend/src/generated/static-text-assets.mts
+++ b/frontend/src/generated/static-text-assets.mts
@@ -1414,6 +1414,7 @@ body[data-landing-menu-open="true"] .ld-menu-toggle-icon::after {
 
 .ld-map-frame {
   position: relative;
+  aspect-ratio: 16 / 9;
   border-radius: var(--radius);
   overflow: hidden;
   border: 2px solid var(--border-hi);
@@ -1434,7 +1435,7 @@ body[data-landing-menu-open="true"] .ld-menu-toggle-icon::after {
 
 .ld-map-frame img {
   width: 100%;
-  aspect-ratio: 16 / 9;
+  height: 100%;
   object-fit: cover;
   filter: contrast(1.08) saturate(0.85);
   display: block;


### PR DESCRIPTION
## Summary
- Move the landing map preview aspect ratio constraint from the image element to the frame.
- Make preview images fill the fixed-ratio frame so the tall Middle-earth image is cropped instead of stretching the card vertically.

## Root cause
The Middle-earth image has a very tall intrinsic ratio. The frame height was still being driven by the replaced image sizing, so the card could become much taller than the intended 16:9 preview.

## Validation
- `npm run build:frontend`
- `npm run build:react-shell`
- Browser check on generated landing at desktop and mobile sizes
- Playwright DOM measurement confirmed both map frames render at ratio `1.778` on desktop and mobile
- `npm run test:all`