### PR TITLE
[codex] Ignore Codex execution summaries in PR readiness watchdog

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -315,7 +315,11 @@ jobs:
                 hasResolvedWorkSignal ||
                 body.includes("no code changes are needed") ||
                 body.includes("created commit") ||
-                body.includes("opened a follow-up pr");
+                body.includes("opened a follow-up pr") ||
+                body.includes("created a follow-up pr") ||
+                body.includes("created a dedicated follow-up branch") ||
+                body.includes("created and switched to a dedicated follow-up branch") ||
+                body.includes("view task");
 
               return (
                 body.includes("### summary") &&


### PR DESCRIPTION
## Summary
- treat Codex execution summary comments as non-blocking readiness signals when they clearly represent task output
- recognize follow-up branch/PR summary wording used by Codex automation
- keep true blocking review markers unchanged

## Validation
- targeted Node check against the exact PR #179 summary comment pattern
- verified clean review comments still do not classify as execution summaries
