### PR TITLE
[codex] Use workflow token for ready-for-review

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -119,10 +119,9 @@ jobs:
       - name: Evaluate PR readiness and trigger Codex when needed
         uses: actions/github-script@v7
         with:
-          # Optional: if you later add a fine-grained PAT secret named CODEX_TRIGGER_TOKEN,
-          # comments will be posted as that connected user instead of github-actions[bot].
-          # Without it, the workflow still runs with the normal GITHUB_TOKEN.
-          github-token: ${{ secrets.CODEX_TRIGGER_TOKEN || github.token }}
+          # Use the workflow GITHUB_TOKEN here so the readiness mutation can
+          # mark draft PRs ready for review without PAT permission mismatches.
+          github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
 


### PR DESCRIPTION
## Summary
- use the workflow github.token for the readiness watchdog script
- avoid PAT permission mismatches when calling markPullRequestReadyForReview
- keep the existing readiness evaluation logic unchanged

## Validation
- reproduced the current failure on PR #181: Resource not accessible by personal access token
- this change is limited to the workflow authentication path used by the watchdog
