### PR TITLE
[codex] Disable Codex PR readiness workflow

### DIFF
--- a/.github/workflows/codex-pr-readiness.yml
+++ b/.github/workflows/codex-pr-readiness.yml
@@ -60,16 +60,8 @@ concurrency:
 
 jobs:
   codex-pr-readiness:
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request') ||
-      github.event_name == 'pull_request_target' ||
-      github.event_name == 'pull_request_review' ||
-      github.event_name == 'pull_request_review_comment' ||
-      (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request)
+    # Disabled on purpose until the readiness automation is reworked.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 75
 

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -229,15 +229,12 @@ register("codex PR readiness targets only draft Codex PRs", () => {
   assert.equal(skipped.targeted, false);
 });
 
-register("codex PR readiness workflow listens to all pull_request workflow_run completions", () => {
+register("codex PR readiness workflow is disabled while keeping the file in place", () => {
   const workflowPath = path.join(process.cwd(), ".github", "workflows", "codex-pr-readiness.yml");
   const workflow = fs.readFileSync(workflowPath, "utf8");
 
-  assert.match(
-    workflow,
-    /github\.event_name == 'workflow_run' &&\s+github\.event\.workflow_run\.event == 'pull_request'\) \|\|/
-  );
-  assert.doesNotMatch(workflow, /github\.event\.workflow_run\.head_branch/);
+  assert.match(workflow, /Disabled on purpose until the readiness automation is reworked\./);
+  assert.match(workflow, /codex-pr-readiness:\s*\n\s*# Disabled on purpose until the readiness automation is reworked\.\s*\n\s*if: false/);
 });
 
 register("codex PR readiness workflow targets only draft Codex PRs", () => {

--- a/tests/gameplay/regression/codex-pr-readiness.test.cts
+++ b/tests/gameplay/regression/codex-pr-readiness.test.cts
@@ -234,7 +234,10 @@ register("codex PR readiness workflow is disabled while keeping the file in plac
   const workflow = fs.readFileSync(workflowPath, "utf8");
 
   assert.match(workflow, /Disabled on purpose until the readiness automation is reworked\./);
-  assert.match(workflow, /codex-pr-readiness:\s*\n\s*# Disabled on purpose until the readiness automation is reworked\.\s*\n\s*if: false/);
+  assert.match(
+    workflow,
+    /codex-pr-readiness:\s*\n\s*# Disabled on purpose until the readiness automation is reworked\.\s*\n\s*if: false/
+  );
 });
 
 register("codex PR readiness workflow targets only draft Codex PRs", () => {


### PR DESCRIPTION
## Summary
- disable the codex-pr-readiness job in .github/workflows/codex-pr-readiness.yml
- keep the workflow file in place for later rework instead of deleting it
- close the canary investigation PR as requested

## Notes
- no local runtime tests were needed because this is a workflow toggle only
- PR #181 has been closed per request
