### PR TITLE
[codex] Improve route helper coverage

### DIFF
--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -53,7 +53,9 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",
   "../tests/gameplay/regression/vercel-routing-config.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",
+  "../tests/gameplay/regression/game-actions-basic-route.test.cjs",
   "../tests/gameplay/regression/game-read-routes.test.cjs",
+  "../tests/gameplay/regression/modules-routes.test.cjs",
   "../tests/gameplay/regression/event-broadcast.test.cjs"
 ];
 

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -52,9 +52,11 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/tooling-and-supabase-regressions.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",
   "../tests/gameplay/regression/vercel-routing-config.test.cjs",
+  "../tests/gameplay/regression/account-validation-routes.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",
   "../tests/gameplay/regression/game-actions-basic-route.test.cjs",
   "../tests/gameplay/regression/game-read-routes.test.cjs",
+  "../tests/gameplay/regression/game-overview-route.test.cjs",
   "../tests/gameplay/regression/modules-routes.test.cjs",
   "../tests/gameplay/regression/event-broadcast.test.cjs"
 ];

--- a/tests/gameplay/regression/account-validation-routes.test.cts
+++ b/tests/gameplay/regression/account-validation-routes.test.cts
@@ -124,10 +124,7 @@ register("account routes return early when auth is missing", async () => {
   assert.equal(await handleAuthSessionRoute(deps), true);
   assert.equal(await handleProfileRoute(deps), true);
   assert.equal(await handleThemePreferenceRoute(deps, { theme: "command" }), true);
-  assert.equal(
-    await handleAccountSettingsRoute(deps, { currentPassword: "secret123" }),
-    true
-  );
+  assert.equal(await handleAccountSettingsRoute(deps, { currentPassword: "secret123" }), true);
   assert.equal(sendJsonCalls, 0);
   assert.equal(sendLocalizedErrorCalls, 0);
 });

--- a/tests/gameplay/regression/account-validation-routes.test.cts
+++ b/tests/gameplay/regression/account-validation-routes.test.cts
@@ -108,6 +108,30 @@ function createAccountDeps(overrides = {}) {
   };
 }
 
+register("account routes return early when auth is missing", async () => {
+  let sendJsonCalls = 0;
+  let sendLocalizedErrorCalls = 0;
+  const deps = createAccountDeps({
+    requireAuth: async () => null,
+    sendJson() {
+      sendJsonCalls += 1;
+    },
+    sendLocalizedError() {
+      sendLocalizedErrorCalls += 1;
+    }
+  });
+
+  assert.equal(await handleAuthSessionRoute(deps), true);
+  assert.equal(await handleProfileRoute(deps), true);
+  assert.equal(await handleThemePreferenceRoute(deps, { theme: "command" }), true);
+  assert.equal(
+    await handleAccountSettingsRoute(deps, { currentPassword: "secret123" }),
+    true
+  );
+  assert.equal(sendJsonCalls, 0);
+  assert.equal(sendLocalizedErrorCalls, 0);
+});
+
 register(
   "handleRegisterRoute rejects invalid inbound registration payloads with mapped validation errors",
   async () => {
@@ -279,6 +303,29 @@ register("handleProfileRoute traps invalid outbound profile payloads", async () 
   );
 });
 
+register("handleProfileRoute maps profile store failures to a localized 400", async () => {
+  let localizedErrorCall: any[] | null = null;
+
+  const handled = await handleProfileRoute(
+    createAccountDeps({
+      playerProfiles: {
+        async getPlayerProfile() {
+          throw new Error("profile store unavailable");
+        }
+      },
+      sendLocalizedError(...args: any[]) {
+        localizedErrorCall = args;
+      }
+    })
+  );
+
+  assert.equal(handled, true);
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 400);
+  assert.equal(localizedErrorCall?.[3], "Profilo non disponibile.");
+  assert.equal(localizedErrorCall?.[4], "server.profile.unavailable");
+});
+
 register("handleAccountSettingsRoute traps invalid outbound account payloads", async () => {
   let localizedErrorCall: LocalizedErrorCall | null = null;
 
@@ -362,10 +409,99 @@ register(
     assert.equal(call[6], "RESPONSE_VALIDATION_FAILED");
     assert.deepEqual(
       call[7].validationErrors.map((entry: ValidationIssue) => entry.path),
-      ["user.id"]
+      ["user.id", "user.username"]
     );
   }
 );
+
+register("handleThemePreferenceRoute rejects unsupported themes before persistence", async () => {
+  let localizedErrorCall: any[] | null = null;
+  let updateCalls = 0;
+
+  const handled = await handleThemePreferenceRoute(
+    createAccountDeps({
+      auth: {
+        publicUser(user: { id: string; username: string }) {
+          return {
+            id: user.id,
+            username: user.username,
+            role: "user",
+            authMethods: ["password"],
+            hasEmail: false,
+            preferences: { theme: "command" }
+          };
+        },
+        async updateUserThemePreference() {
+          updateCalls += 1;
+          return null;
+        },
+        async updateUserAccountSettings() {
+          throw new Error("Not used in this test.");
+        }
+      },
+      sendLocalizedError(...args: any[]) {
+        localizedErrorCall = args;
+      }
+    }),
+    { theme: "unsupported-theme" }
+  );
+
+  assert.equal(handled, true);
+  assert.equal(updateCalls, 0);
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 400);
+  assert.equal(localizedErrorCall?.[3], "Tema non supportato.");
+  assert.equal(localizedErrorCall?.[4], "server.profile.invalidTheme");
+});
+
+register("handleThemePreferenceRoute falls back to the resolved stored theme", async () => {
+  let sentPayload: Record<string, unknown> | null = null;
+
+  const handled = await handleThemePreferenceRoute(
+    createAccountDeps({
+      auth: {
+        publicUser(user: { id: string; username: string }) {
+          return {
+            id: user.id,
+            username: user.username,
+            role: "user",
+            authMethods: ["password"],
+            hasEmail: false,
+            preferences: { theme: "command" }
+          };
+        },
+        async updateUserThemePreference(userId: string) {
+          return {
+            id: userId,
+            username: "commander"
+          };
+        },
+        async updateUserAccountSettings() {
+          throw new Error("Not used in this test.");
+        }
+      },
+      resolveStoredTheme(theme: string) {
+        return `${theme}-stored`;
+      },
+      sendJson(_res: unknown, _statusCode: number, payload: Record<string, unknown>) {
+        sentPayload = payload;
+      }
+    }),
+    { theme: "midnight" }
+  );
+
+  assert.equal(handled, true);
+  assert.deepEqual(sentPayload, {
+    ok: true,
+    user: {
+      id: "u-1",
+      username: "commander"
+    },
+    preferences: {
+      theme: "midnight-stored"
+    }
+  });
+});
 
 register("handleLoginRoute traps invalid outbound login payloads", async () => {
   let localizedErrorCall: LocalizedErrorCall | null = null;
@@ -436,3 +572,51 @@ register("handleRegisterRoute traps invalid outbound register payloads", async (
     ["user.id"]
   );
 });
+
+register(
+  "handleAccountSettingsRoute maps invalid current password errors to an auth response",
+  async () => {
+    let localizedErrorCall: any[] | null = null;
+
+    const handled = await handleAccountSettingsRoute(
+      createAccountDeps({
+        auth: {
+          publicUser(user: { id: string; username: string }) {
+            return {
+              id: user.id,
+              username: user.username,
+              role: "user",
+              authMethods: ["password"],
+              hasEmail: true,
+              preferences: { theme: "command" }
+            };
+          },
+          async updateUserThemePreference() {
+            throw new Error("Not used in this test.");
+          },
+          async updateUserAccountSettings() {
+            return {
+              ok: false,
+              error: "Password corrente non valida.",
+              errorKey: "auth.account.currentPasswordInvalid"
+            };
+          }
+        },
+        sendLocalizedError(...args: any[]) {
+          localizedErrorCall = args;
+        }
+      }),
+      {
+        currentPassword: "wrong-password",
+        newPassword: "UpdatedSecret!",
+        confirmNewPassword: "UpdatedSecret!"
+      }
+    );
+
+    assert.equal(handled, true);
+    assert.ok(localizedErrorCall);
+    assert.equal(localizedErrorCall?.[1], 401);
+    assert.equal(localizedErrorCall?.[3], "Password corrente non valida.");
+    assert.equal(localizedErrorCall?.[4], "auth.account.currentPasswordInvalid");
+  }
+);

--- a/tests/gameplay/regression/game-actions-basic-route.test.cts
+++ b/tests/gameplay/regression/game-actions-basic-route.test.cts
@@ -1,0 +1,201 @@
+const assert = require("node:assert/strict");
+const { handleBasicGameActionRoute } = require("../../../backend/routes/game-actions-basic.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function createGameContext() {
+  return {
+    state: { phase: "active" },
+    gameId: "game-1",
+    version: 7,
+    gameName: "Route Helper"
+  };
+}
+
+register("handleBasicGameActionRoute returns false for unsupported action types", async () => {
+  const handled = await handleBasicGameActionRoute(
+    "unsupported",
+    {},
+    {},
+    createGameContext(),
+    "player-1",
+    7,
+    { id: "user-1" },
+    () => {
+      throw new Error("applyReinforcement should not run for unsupported actions.");
+    },
+    () => {
+      throw new Error("moveAfterConquest should not run for unsupported actions.");
+    },
+    () => {
+      throw new Error("applyFortify should not run for unsupported actions.");
+    },
+    async () => {
+      throw new Error("persistGameContext should not run for unsupported actions.");
+    },
+    () => {
+      throw new Error("broadcastGame should not run for unsupported actions.");
+    },
+    () => {
+      throw new Error("snapshotForUser should not run for unsupported actions.");
+    },
+    () => false,
+    () => true,
+    () => {
+      throw new Error("sendJson should not run for unsupported actions.");
+    },
+    () => {
+      throw new Error("sendLocalizedError should not run for unsupported actions.");
+    }
+  );
+
+  assert.equal(handled, false);
+});
+
+register(
+  "handleBasicGameActionRoute reinforce stops cleanly on version conflicts",
+  async () => {
+    let broadcastCalls = 0;
+    let sendJsonCalls = 0;
+    let versionConflictCalls = 0;
+
+    const handled = await handleBasicGameActionRoute(
+      "reinforce",
+      {},
+      { territoryId: "aurora", amount: 2 },
+      createGameContext(),
+      "player-1",
+      7,
+      { id: "user-1" },
+      () => ({ ok: true }),
+      () => {
+        throw new Error("moveAfterConquest should not run for reinforce.");
+      },
+      () => {
+        throw new Error("applyFortify should not run for reinforce.");
+      },
+      async () => {
+        throw new Error("stale version");
+      },
+      () => {
+        broadcastCalls += 1;
+      },
+      () => ({ ok: true }),
+      (error: unknown) => {
+        versionConflictCalls += 1;
+        return error instanceof Error && error.message === "stale version";
+      },
+      (territoryId: string) => territoryId === "aurora",
+      () => {
+        sendJsonCalls += 1;
+      },
+      () => {
+        throw new Error("sendLocalizedError should not run for version conflicts.");
+      }
+    );
+
+    assert.equal(handled, true);
+    assert.equal(versionConflictCalls, 1);
+    assert.equal(broadcastCalls, 0);
+    assert.equal(sendJsonCalls, 0);
+  }
+);
+
+register(
+  "handleBasicGameActionRoute returns localized engine errors for move-after-conquest",
+  async () => {
+    let localizedErrorCall: any[] | null = null;
+
+    const handled = await handleBasicGameActionRoute(
+      "moveAfterConquest",
+      {},
+      { armies: 0 },
+      createGameContext(),
+      "player-1",
+      7,
+      { id: "user-1" },
+      () => {
+        throw new Error("applyReinforcement should not run for moveAfterConquest.");
+      },
+      () => ({
+        ok: false,
+        message: "Nessuna conquista in sospeso.",
+        messageKey: "game.conquest.none"
+      }),
+      () => {
+        throw new Error("applyFortify should not run for moveAfterConquest.");
+      },
+      async () => {
+        throw new Error("persistGameContext should not run after a rejected conquest move.");
+      },
+      () => {
+        throw new Error("broadcastGame should not run after a rejected conquest move.");
+      },
+      () => ({ ok: true }),
+      () => false,
+      () => true,
+      () => {
+        throw new Error("sendJson should not run after a rejected conquest move.");
+      },
+      (...args: any[]) => {
+        localizedErrorCall = args;
+      }
+    );
+
+    assert.equal(handled, true);
+    assert.ok(localizedErrorCall);
+    assert.equal(localizedErrorCall?.[1], 400);
+    assert.equal(localizedErrorCall?.[3], "Nessuna conquista in sospeso.");
+    assert.equal(localizedErrorCall?.[4], "game.conquest.none");
+  }
+);
+
+register(
+  "handleBasicGameActionRoute validates fortify territory ids before the engine runs",
+  async () => {
+    let localizedErrorCall: any[] | null = null;
+    let fortifyCalls = 0;
+
+    const handled = await handleBasicGameActionRoute(
+      "fortify",
+      {},
+      { fromId: "aurora", toId: "invalid", armies: 3 },
+      createGameContext(),
+      "player-1",
+      7,
+      { id: "user-1" },
+      () => {
+        throw new Error("applyReinforcement should not run for fortify.");
+      },
+      () => {
+        throw new Error("moveAfterConquest should not run for fortify.");
+      },
+      () => {
+        fortifyCalls += 1;
+        return { ok: true };
+      },
+      async () => {
+        throw new Error("persistGameContext should not run for invalid territory ids.");
+      },
+      () => {
+        throw new Error("broadcastGame should not run for invalid territory ids.");
+      },
+      () => ({ ok: true }),
+      () => false,
+      (territoryId: string) => territoryId === "aurora",
+      () => {
+        throw new Error("sendJson should not run for invalid fortify ids.");
+      },
+      (...args: any[]) => {
+        localizedErrorCall = args;
+      }
+    );
+
+    assert.equal(handled, true);
+    assert.equal(fortifyCalls, 0);
+    assert.ok(localizedErrorCall);
+    assert.equal(localizedErrorCall?.[1], 400);
+    assert.equal(localizedErrorCall?.[3], "Territorio non valido.");
+    assert.equal(localizedErrorCall?.[4], "game.invalidTerritory");
+  }
+);

--- a/tests/gameplay/regression/game-actions-basic-route.test.cts
+++ b/tests/gameplay/regression/game-actions-basic-route.test.cts
@@ -52,54 +52,51 @@ register("handleBasicGameActionRoute returns false for unsupported action types"
   assert.equal(handled, false);
 });
 
-register(
-  "handleBasicGameActionRoute reinforce stops cleanly on version conflicts",
-  async () => {
-    let broadcastCalls = 0;
-    let sendJsonCalls = 0;
-    let versionConflictCalls = 0;
+register("handleBasicGameActionRoute reinforce stops cleanly on version conflicts", async () => {
+  let broadcastCalls = 0;
+  let sendJsonCalls = 0;
+  let versionConflictCalls = 0;
 
-    const handled = await handleBasicGameActionRoute(
-      "reinforce",
-      {},
-      { territoryId: "aurora", amount: 2 },
-      createGameContext(),
-      "player-1",
-      7,
-      { id: "user-1" },
-      () => ({ ok: true }),
-      () => {
-        throw new Error("moveAfterConquest should not run for reinforce.");
-      },
-      () => {
-        throw new Error("applyFortify should not run for reinforce.");
-      },
-      async () => {
-        throw new Error("stale version");
-      },
-      () => {
-        broadcastCalls += 1;
-      },
-      () => ({ ok: true }),
-      (error: unknown) => {
-        versionConflictCalls += 1;
-        return error instanceof Error && error.message === "stale version";
-      },
-      (territoryId: string) => territoryId === "aurora",
-      () => {
-        sendJsonCalls += 1;
-      },
-      () => {
-        throw new Error("sendLocalizedError should not run for version conflicts.");
-      }
-    );
+  const handled = await handleBasicGameActionRoute(
+    "reinforce",
+    {},
+    { territoryId: "aurora", amount: 2 },
+    createGameContext(),
+    "player-1",
+    7,
+    { id: "user-1" },
+    () => ({ ok: true }),
+    () => {
+      throw new Error("moveAfterConquest should not run for reinforce.");
+    },
+    () => {
+      throw new Error("applyFortify should not run for reinforce.");
+    },
+    async () => {
+      throw new Error("stale version");
+    },
+    () => {
+      broadcastCalls += 1;
+    },
+    () => ({ ok: true }),
+    (error: unknown) => {
+      versionConflictCalls += 1;
+      return error instanceof Error && error.message === "stale version";
+    },
+    (territoryId: string) => territoryId === "aurora",
+    () => {
+      sendJsonCalls += 1;
+    },
+    () => {
+      throw new Error("sendLocalizedError should not run for version conflicts.");
+    }
+  );
 
-    assert.equal(handled, true);
-    assert.equal(versionConflictCalls, 1);
-    assert.equal(broadcastCalls, 0);
-    assert.equal(sendJsonCalls, 0);
-  }
-);
+  assert.equal(handled, true);
+  assert.equal(versionConflictCalls, 1);
+  assert.equal(broadcastCalls, 0);
+  assert.equal(sendJsonCalls, 0);
+});
 
 register(
   "handleBasicGameActionRoute returns localized engine errors for move-after-conquest",

--- a/tests/gameplay/regression/game-overview-route.test.cts
+++ b/tests/gameplay/regression/game-overview-route.test.cts
@@ -1,7 +1,32 @@
 const assert = require("node:assert/strict");
-const { handleGameOptionsRoute } = require("../../../backend/routes/game-overview.cjs");
+const {
+  handleGameOptionsRoute,
+  handleGamesListRoute
+} = require("../../../backend/routes/game-overview.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type ValidationIssue = {
+  path: string;
+};
+
+type LocalizedErrorCall = [
+  unknown,
+  number,
+  unknown,
+  string,
+  string,
+  Record<string, unknown> | undefined,
+  string,
+  { validationErrors: ValidationIssue[] }
+];
+
+function requireLocalizedErrorCall(call: LocalizedErrorCall | null): LocalizedErrorCall {
+  if (!call) {
+    throw new Error("Expected a localized validation error call.");
+  }
+  return call;
+}
 
 register("handleGameOptionsRoute derives legacy options from the resolved catalog", async () => {
   const payloads: Array<Record<string, unknown>> = [];
@@ -56,4 +81,114 @@ register("handleGameOptionsRoute derives legacy options from the resolved catalo
     uiProfiles: [{ id: "demo.ui" }],
     uiSlots: [{ slotId: "topnav.before", itemId: "demo.slot", title: "Demo", kind: "panel" }]
   });
+});
+
+register("handleGamesListRoute validates outbound list payloads", async () => {
+  let localizedErrorCall: LocalizedErrorCall | null = null;
+
+  await handleGamesListRoute(
+    {},
+    () => [
+      {
+        id: "game-1",
+        phase: "lobby",
+        playerCount: 2,
+        updatedAt: "2026-04-26T00:00:00.000Z"
+      }
+    ],
+    () => 42 as unknown as string,
+    () => {
+      throw new Error("sendJson should not run when list payload validation fails.");
+    },
+    new URL("http://127.0.0.1/api/games"),
+    (...args: LocalizedErrorCall) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  assert.ok(localizedErrorCall);
+  const call = requireLocalizedErrorCall(localizedErrorCall);
+  assert.equal(call[1], 500);
+  assert.equal(call[6], "RESPONSE_VALIDATION_FAILED");
+  assert.equal(
+    call[7].validationErrors.some(
+      (entry: ValidationIssue) => entry.path === "games.0.name" || entry.path === "activeGameId"
+    ),
+    true
+  );
+});
+
+register("handleGameOptionsRoute normalizes empty catalog sections and merges extra options", async () => {
+  const payloads: Array<Record<string, unknown>> = [];
+
+  await handleGameOptionsRoute(
+    {},
+    () => null,
+    () => [24, 48, 72],
+    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+      payloads.push(payload);
+    },
+    async () => ({
+      customFeatureFlags: ["demo"],
+      activeGameId: "game-2"
+    })
+  );
+
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(payloads[0].modules, []);
+  assert.deepEqual(payloads[0].maps, []);
+  assert.deepEqual(payloads[0].themes, []);
+  assert.deepEqual(payloads[0].turnTimeoutHoursOptions, [24, 48, 72]);
+  assert.deepEqual(payloads[0].playerRange, { min: 2, max: 4 });
+  assert.deepEqual(payloads[0].customFeatureFlags, ["demo"]);
+  assert.equal(payloads[0].activeGameId, "game-2");
+});
+
+register("handleGameOptionsRoute validates outbound payloads when response validation is enabled", async () => {
+  let localizedErrorCall: LocalizedErrorCall | null = null;
+
+  await handleGameOptionsRoute(
+    {},
+    () => ({
+      modules: [],
+      gameModules: [],
+      enabledModules: [],
+      maps: [],
+      ruleSets: [],
+      playerPieceSets: [],
+      diceRuleSets: [],
+      contentPacks: [],
+      victoryRuleSets: [],
+      themes: [],
+      pieceSkins: [],
+      gamePresets: [],
+      uiSlots: [],
+      contentProfiles: [],
+      gameplayProfiles: [],
+      uiProfiles: [],
+      content: {}
+    }),
+    () => [12, 24],
+    () => {
+      throw new Error("sendJson should not run when options payload validation fails.");
+    },
+    () => ({
+      playerRange: {
+        min: "two",
+        max: 4
+      }
+    }),
+    (...args: LocalizedErrorCall) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  assert.ok(localizedErrorCall);
+  const call = requireLocalizedErrorCall(localizedErrorCall);
+  assert.equal(call[1], 500);
+  assert.equal(call[6], "RESPONSE_VALIDATION_FAILED");
+  assert.equal(
+    call[7].validationErrors.some((entry: ValidationIssue) => entry.path === "playerRange.min"),
+    true
+  );
 });

--- a/tests/gameplay/regression/game-overview-route.test.cts
+++ b/tests/gameplay/regression/game-overview-route.test.cts
@@ -118,77 +118,83 @@ register("handleGamesListRoute validates outbound list payloads", async () => {
   );
 });
 
-register("handleGameOptionsRoute normalizes empty catalog sections and merges extra options", async () => {
-  const payloads: Array<Record<string, unknown>> = [];
+register(
+  "handleGameOptionsRoute normalizes empty catalog sections and merges extra options",
+  async () => {
+    const payloads: Array<Record<string, unknown>> = [];
 
-  await handleGameOptionsRoute(
-    {},
-    () => null,
-    () => [24, 48, 72],
-    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
-      payloads.push(payload);
-    },
-    async () => ({
-      customFeatureFlags: ["demo"],
-      activeGameId: "game-2"
-    })
-  );
+    await handleGameOptionsRoute(
+      {},
+      () => null,
+      () => [24, 48, 72],
+      (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+        payloads.push(payload);
+      },
+      async () => ({
+        customFeatureFlags: ["demo"],
+        activeGameId: "game-2"
+      })
+    );
 
-  assert.equal(payloads.length, 1);
-  assert.deepEqual(payloads[0].modules, []);
-  assert.deepEqual(payloads[0].maps, []);
-  assert.deepEqual(payloads[0].themes, []);
-  assert.deepEqual(payloads[0].turnTimeoutHoursOptions, [24, 48, 72]);
-  assert.deepEqual(payloads[0].playerRange, { min: 2, max: 4 });
-  assert.deepEqual(payloads[0].customFeatureFlags, ["demo"]);
-  assert.equal(payloads[0].activeGameId, "game-2");
-});
+    assert.equal(payloads.length, 1);
+    assert.deepEqual(payloads[0].modules, []);
+    assert.deepEqual(payloads[0].maps, []);
+    assert.deepEqual(payloads[0].themes, []);
+    assert.deepEqual(payloads[0].turnTimeoutHoursOptions, [24, 48, 72]);
+    assert.deepEqual(payloads[0].playerRange, { min: 2, max: 4 });
+    assert.deepEqual(payloads[0].customFeatureFlags, ["demo"]);
+    assert.equal(payloads[0].activeGameId, "game-2");
+  }
+);
 
-register("handleGameOptionsRoute validates outbound payloads when response validation is enabled", async () => {
-  let localizedErrorCall: LocalizedErrorCall | null = null;
+register(
+  "handleGameOptionsRoute validates outbound payloads when response validation is enabled",
+  async () => {
+    let localizedErrorCall: LocalizedErrorCall | null = null;
 
-  await handleGameOptionsRoute(
-    {},
-    () => ({
-      modules: [],
-      gameModules: [],
-      enabledModules: [],
-      maps: [],
-      ruleSets: [],
-      playerPieceSets: [],
-      diceRuleSets: [],
-      contentPacks: [],
-      victoryRuleSets: [],
-      themes: [],
-      pieceSkins: [],
-      gamePresets: [],
-      uiSlots: [],
-      contentProfiles: [],
-      gameplayProfiles: [],
-      uiProfiles: [],
-      content: {}
-    }),
-    () => [12, 24],
-    () => {
-      throw new Error("sendJson should not run when options payload validation fails.");
-    },
-    () => ({
-      playerRange: {
-        min: "two",
-        max: 4
+    await handleGameOptionsRoute(
+      {},
+      () => ({
+        modules: [],
+        gameModules: [],
+        enabledModules: [],
+        maps: [],
+        ruleSets: [],
+        playerPieceSets: [],
+        diceRuleSets: [],
+        contentPacks: [],
+        victoryRuleSets: [],
+        themes: [],
+        pieceSkins: [],
+        gamePresets: [],
+        uiSlots: [],
+        contentProfiles: [],
+        gameplayProfiles: [],
+        uiProfiles: [],
+        content: {}
+      }),
+      () => [12, 24],
+      () => {
+        throw new Error("sendJson should not run when options payload validation fails.");
+      },
+      () => ({
+        playerRange: {
+          min: "two",
+          max: 4
+        }
+      }),
+      (...args: LocalizedErrorCall) => {
+        localizedErrorCall = args;
       }
-    }),
-    (...args: LocalizedErrorCall) => {
-      localizedErrorCall = args;
-    }
-  );
+    );
 
-  assert.ok(localizedErrorCall);
-  const call = requireLocalizedErrorCall(localizedErrorCall);
-  assert.equal(call[1], 500);
-  assert.equal(call[6], "RESPONSE_VALIDATION_FAILED");
-  assert.equal(
-    call[7].validationErrors.some((entry: ValidationIssue) => entry.path === "playerRange.min"),
-    true
-  );
-});
+    assert.ok(localizedErrorCall);
+    const call = requireLocalizedErrorCall(localizedErrorCall);
+    assert.equal(call[1], 500);
+    assert.equal(call[6], "RESPONSE_VALIDATION_FAILED");
+    assert.equal(
+      call[7].validationErrors.some((entry: ValidationIssue) => entry.path === "playerRange.min"),
+      true
+    );
+  }
+);

--- a/tests/gameplay/regression/modules-routes.test.cts
+++ b/tests/gameplay/regression/modules-routes.test.cts
@@ -1,0 +1,211 @@
+const assert = require("node:assert/strict");
+const {
+  handleDisableModuleRoute,
+  handleEnableModuleRoute,
+  handleListModulesRoute,
+  handleModuleOptionsRoute,
+  handleRescanModulesRoute
+} = require("../../../backend/routes/modules.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function createAuthContext() {
+  return {
+    user: {
+      id: "admin-1",
+      username: "marshal"
+    }
+  };
+}
+
+register("handleModuleOptionsRoute returns the current module options snapshot", async () => {
+  let sentPayload: unknown = null;
+
+  await handleModuleOptionsRoute(
+    {},
+    async () => ({
+      gameModules: [{ id: "demo.valid" }]
+    }),
+    (_res: unknown, _statusCode: number, payload: unknown) => {
+      sentPayload = payload;
+    }
+  );
+
+  assert.deepEqual(sentPayload, {
+    gameModules: [{ id: "demo.valid" }]
+  });
+});
+
+register("handleListModulesRoute returns early when auth is missing", async () => {
+  let sendJsonCalls = 0;
+  let sendLocalizedErrorCalls = 0;
+
+  await handleListModulesRoute(
+    {},
+    {},
+    async () => null,
+    () => {
+      throw new Error("authorize should not run without auth.");
+    },
+    async () => {
+      throw new Error("listInstalledModules should not run without auth.");
+    },
+    async () => {
+      throw new Error("getEnabledModules should not run without auth.");
+    },
+    () => {
+      sendJsonCalls += 1;
+    },
+    () => {
+      sendLocalizedErrorCalls += 1;
+    },
+    "engine-1"
+  );
+
+  assert.equal(sendJsonCalls, 0);
+  assert.equal(sendLocalizedErrorCalls, 0);
+});
+
+register("handleListModulesRoute maps authorization failures to localized errors", async () => {
+  let localizedErrorCall: any[] | null = null;
+
+  await handleListModulesRoute(
+    {},
+    {},
+    async () => createAuthContext(),
+    () => {
+      const error = new Error("forbidden") as Error & { statusCode?: number };
+      error.statusCode = 418;
+      throw error;
+    },
+    async () => {
+      throw new Error("listInstalledModules should not run after authorize fails.");
+    },
+    async () => {
+      throw new Error("getEnabledModules should not run after authorize fails.");
+    },
+    () => {
+      throw new Error("sendJson should not run after authorize fails.");
+    },
+    (...args: any[]) => {
+      localizedErrorCall = args;
+    },
+    "engine-1"
+  );
+
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 418);
+  assert.equal(localizedErrorCall?.[3], "Accesso catalogo moduli non autorizzato.");
+  assert.equal(localizedErrorCall?.[4], "server.modules.listUnauthorized");
+});
+
+register("handleEnableModuleRoute returns the refreshed module payload", async () => {
+  let sentPayload: Record<string, unknown> | null = null;
+
+  await handleEnableModuleRoute(
+    {},
+    {},
+    "demo.valid",
+    async () => createAuthContext(),
+    () => undefined,
+    async (moduleId: string) => [{ id: moduleId, enabled: true }],
+    async () => [{ id: "demo.valid", version: "1.0.0" }],
+    (_res: unknown, _statusCode: number, payload: Record<string, unknown>) => {
+      sentPayload = payload;
+    },
+    () => {
+      throw new Error("sendLocalizedError should not run for a successful enable.");
+    },
+    "engine-7"
+  );
+
+  assert.deepEqual(sentPayload, {
+    ok: true,
+    modules: [{ id: "demo.valid", enabled: true }],
+    enabledModules: [{ id: "demo.valid", version: "1.0.0" }],
+    engineVersion: "engine-7"
+  });
+});
+
+register("handleRescanModulesRoute defaults unexpected failures to status 400", async () => {
+  let localizedErrorCall: any[] | null = null;
+
+  await handleRescanModulesRoute(
+    {},
+    {},
+    async () => createAuthContext(),
+    () => undefined,
+    async () => {
+      throw new Error("scan failed");
+    },
+    async () => [{ id: "core.base", version: "1.0.0" }],
+    () => {
+      throw new Error("sendJson should not run when rescan fails.");
+    },
+    (...args: any[]) => {
+      localizedErrorCall = args;
+    },
+    "engine-1"
+  );
+
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 400);
+  assert.equal(localizedErrorCall?.[3], "Rescan moduli non riuscito.");
+  assert.equal(localizedErrorCall?.[4], "server.modules.rescanFailed");
+});
+
+register("handleDisableModuleRoute maps active-game conflicts to a 409", async () => {
+  let localizedErrorCall: any[] | null = null;
+
+  await handleDisableModuleRoute(
+    {},
+    {},
+    "demo.valid",
+    async () => createAuthContext(),
+    () => undefined,
+    async () => {
+      throw new Error("module still used by active game");
+    },
+    async () => [{ id: "core.base", version: "1.0.0" }],
+    () => {
+      throw new Error("sendJson should not run when disable fails.");
+    },
+    (...args: any[]) => {
+      localizedErrorCall = args;
+    },
+    "engine-1"
+  );
+
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 409);
+  assert.equal(localizedErrorCall?.[3], "Il modulo e ancora usato da una partita attiva.");
+  assert.equal(localizedErrorCall?.[4], "server.modules.disableInUse");
+});
+
+register("handleDisableModuleRoute maps admin-default conflicts to a 409", async () => {
+  let localizedErrorCall: any[] | null = null;
+
+  await handleDisableModuleRoute(
+    {},
+    {},
+    "demo.valid",
+    async () => createAuthContext(),
+    () => undefined,
+    async () => {
+      throw new Error("module still used by admin defaults");
+    },
+    async () => [{ id: "core.base", version: "1.0.0" }],
+    () => {
+      throw new Error("sendJson should not run when disable fails.");
+    },
+    (...args: any[]) => {
+      localizedErrorCall = args;
+    },
+    "engine-1"
+  );
+
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 409);
+  assert.equal(localizedErrorCall?.[3], "Il modulo e ancora usato dalla configurazione admin.");
+  assert.equal(localizedErrorCall?.[4], "server.modules.disableAdminConfigInUse");
+});


### PR DESCRIPTION
## Obiettivo
Aumentare in modo utile la test coverage con focus sulla branch coverage delle route helper backend, senza cambiare il comportamento applicativo.

## Aree toccate
- `backend/routes/account.cts`
- `backend/routes/game-overview.cts`
- `backend/routes/game-actions-basic.cts`
- `backend/routes/modules.cts`
- `scripts/run-gameplay-tests.cts`

## Cosa cambia
- estende i test di regressione delle route account con rami su auth mancante, store error, tema non supportato, fallback preferenze tema e current password invalida
- estende i test delle route game overview con validazione outbound, catalogo vuoto normalizzato ed extra options
- aggiunge una suite dedicata per `game-actions-basic` su tipo non supportato, version conflict, errore `moveAfterConquest` e validazione territori `fortify`
- aggiunge una suite dedicata per `modules` su auth/authorization, rescan failure, enable success e conflitti di disabilitazione
- registra tutte le suite route-helper interessate nel gameplay runner attivo, incluso il follow-up richiesto dalla review Codex

## Coverage
- Prima: Statements 88.82%, Branches 74.43%, Functions 80.32%, Lines 88.82%
- Dopo: Statements 88.97%, Branches 74.72% (covered branches 4774 -> 4809), Functions 80.40%, Lines 88.97%
- Miglioramenti mirati: `game-actions-basic` branch coverage 54.54% -> 65.38%, `modules` 59.09% -> 65.51%; i test account/game-overview ora sono inclusi anche nel runner `test:gameplay`/coverage

## Fix minimi
Nessun fix applicativo. Solo test utili e mirati; il follow-up finale ha corretto il wiring del runner test.

## Validazione locale
- `npm run build:ts`
- `npm run format:check`
- `npm run test:gameplay`
- `npm run test:all`
- `npm run coverage`
- `npm run typecheck`
- `npm run lint`
- `npm run test:e2e:smoke`

## Rischi residui
- `npm run lint` resta verde con warning preesistenti non toccati in questa PR.