### PR TITLE
[codex] Improve attack branch coverage

### DIFF
--- a/tests/gameplay/combat/banzai-attack.test.cts
+++ b/tests/gameplay/combat/banzai-attack.test.cts
@@ -92,3 +92,108 @@ register("resolveBanzaiAttack normalizes attack dice as armies drop", () => {
   assert.equal(state.territories.bastion.armies, 0);
   assert.equal(state.pendingConquest.toId, "bastion");
 });
+
+register("resolveBanzaiAttack uses the maximum legal dice when no dice count is requested", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "aurora", ownerId: "p1", armies: 3 },
+      { id: "bastion", ownerId: "p2", armies: 2 }
+    ]),
+    turnPhase: TurnPhase.ATTACK,
+    currentTurnIndex: 0
+  });
+  state.mapTerritories = [
+    { id: "aurora", name: "Aurora", neighbors: ["bastion"], continentId: null },
+    { id: "bastion", name: "Bastion", neighbors: ["aurora"], continentId: null }
+  ];
+  const random = createFixedRandom(rollsToRandomValues([6, 6, 1, 1]));
+
+  const result = resolveBanzaiAttack(state, "p1", "aurora", "bastion", random);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.rounds.length, 1);
+  assert.equal(result.rounds[0].attackDiceCount, 2);
+  assert.equal(result.rounds[0].conqueredTerritory, true);
+  assert.equal(state.pendingConquest.toId, "bastion");
+});
+
+register("resolveBanzaiAttack clamps requested dice with persisted runtime dice metadata", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "aurora", ownerId: "p1", armies: 5 },
+      { id: "bastion", ownerId: "p2", armies: 1 }
+    ]),
+    turnPhase: TurnPhase.ATTACK,
+    currentTurnIndex: 0
+  });
+  state.mapTerritories = [
+    { id: "aurora", name: "Aurora", neighbors: ["bastion"], continentId: null },
+    { id: "bastion", name: "Bastion", neighbors: ["aurora"], continentId: null }
+  ];
+  state.diceRuleSetId = "runtime.duel";
+  state.gameConfig = {
+    diceRuleSetName: "Runtime Duel",
+    diceRuleSetAttackerMaxDice: 1,
+    diceRuleSetDefenderMaxDice: 1,
+    diceRuleSetAttackerMustLeaveOneArmyBehind: true,
+    diceRuleSetDefenderWinsTies: true
+  };
+  const random = createFixedRandom(rollsToRandomValues([6, 1]));
+
+  const result = resolveBanzaiAttack(state, "p1", "aurora", "bastion", random, 3);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.rounds.length, 1);
+  assert.equal(result.rounds[0].attackDiceCount, 1);
+  assert.equal(result.rounds[0].defendDiceCount, 1);
+  assert.equal(result.rounds[0].conqueredTerritory, true);
+});
+
+register("resolveBanzaiAttack stops after one round when the attacker cannot continue", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "aurora", ownerId: "p1", armies: 2 },
+      { id: "bastion", ownerId: "p2", armies: 3 }
+    ]),
+    turnPhase: TurnPhase.ATTACK,
+    currentTurnIndex: 0
+  });
+  state.mapTerritories = [
+    { id: "aurora", name: "Aurora", neighbors: ["bastion"], continentId: null },
+    { id: "bastion", name: "Bastion", neighbors: ["aurora"], continentId: null }
+  ];
+  const random = createFixedRandom(rollsToRandomValues([1, 6, 6]));
+
+  const result = resolveBanzaiAttack(state, "p1", "aurora", "bastion", random, 1);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.rounds.length, 1);
+  assert.equal(result.rounds[0].attackerArmiesRemaining, 1);
+  assert.equal(state.pendingConquest, null);
+  assert.equal(state.territories.bastion.ownerId, "p2");
+});
+
+register("resolveBanzaiAttack returns the initial attack failure without synthetic rounds", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "aurora", ownerId: "p1", armies: 1 },
+      { id: "bastion", ownerId: "p2", armies: 1 }
+    ]),
+    turnPhase: TurnPhase.ATTACK,
+    currentTurnIndex: 0
+  });
+  state.mapTerritories = [
+    { id: "aurora", name: "Aurora", neighbors: ["bastion"], continentId: null },
+    { id: "bastion", name: "Bastion", neighbors: ["aurora"], continentId: null }
+  ];
+
+  const result = resolveBanzaiAttack(state, "p1", "aurora", "bastion");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.rounds, undefined);
+  assert.equal(state.pendingConquest, null);
+});

--- a/tests/gameplay/regression/attack-route-guard.test.cts
+++ b/tests/gameplay/regression/attack-route-guard.test.cts
@@ -3,6 +3,75 @@ const { handleAttackGameActionRoute } = require("../../../backend/routes/game-ac
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
+async function callAttackRoute(overrides: Record<string, any> = {}): Promise<any> {
+  const calls: Record<string, any> = {
+    broadcastCount: 0,
+    handledVersionConflict: null,
+    localizedError: null,
+    persisted: false,
+    sentJson: null
+  };
+  const gameContext = overrides.gameContext || {
+    state: {},
+    gameId: "g-1",
+    version: 4,
+    gameName: "Attack Guard"
+  };
+
+  const handled = await handleAttackGameActionRoute(
+    Object.prototype.hasOwnProperty.call(overrides, "type") ? overrides.type : "attack",
+    overrides.res || {},
+    overrides.body || { fromId: "aurora", toId: "bastion", attackDice: 2 },
+    gameContext,
+    overrides.playerId || "p1",
+    Object.prototype.hasOwnProperty.call(overrides, "expectedVersion")
+      ? overrides.expectedVersion
+      : 4,
+    overrides.user || { id: "u1" },
+    overrides.resolveAttack ||
+      (() => ({
+        ok: true
+      })),
+    overrides.resolveBanzaiAttack ||
+      (() => ({
+        ok: true,
+        rounds: [{ round: 1 }]
+      })),
+    overrides.consumeQueuedAttackRandom || (() => null),
+    overrides.persistGameContext ||
+      (async () => {
+        calls.persisted = true;
+        return { version: 5 };
+      }),
+    overrides.broadcastGame ||
+      (() => {
+        calls.broadcastCount += 1;
+      }),
+    overrides.snapshotForUser || (() => ({ ok: true })),
+    overrides.handleVersionConflict ||
+      ((error: unknown) => {
+        calls.handledVersionConflict = error;
+        return false;
+      }),
+    overrides.isValidTerritoryId ||
+      ((territoryId: string) => territoryId === "aurora" || territoryId === "bastion"),
+    overrides.sendJson ||
+      ((_res: unknown, statusCode: number, payload: Record<string, unknown>) => {
+        calls.sentJson = { statusCode, payload };
+      }),
+    overrides.sendLocalizedError ||
+      ((...args: any[]) => {
+        calls.localizedError = args;
+      })
+  );
+
+  return {
+    ...calls,
+    gameContext,
+    handled
+  };
+}
+
 register(
   "handleAttackGameActionRoute maps stale attack dice runtime errors to a localized 400",
   async () => {
@@ -94,3 +163,146 @@ register(
     });
   }
 );
+
+register("handleAttackGameActionRoute ignores unsupported action types", async () => {
+  const result = await callAttackRoute({
+    type: "reinforce",
+    consumeQueuedAttackRandom: () => {
+      throw new Error("Random queue should not be touched for unsupported action types.");
+    },
+    resolveAttack: () => {
+      throw new Error("Attack resolver should not run for unsupported action types.");
+    }
+  });
+
+  assert.equal(result.handled, false);
+  assert.equal(result.localizedError, null);
+  assert.equal(result.sentJson, null);
+  assert.equal(result.persisted, false);
+  assert.equal(result.broadcastCount, 0);
+});
+
+register(
+  "handleAttackGameActionRoute rejects invalid territories before resolving combat",
+  async () => {
+    const result = await callAttackRoute({
+      body: { fromId: "invalid-territory", toId: "bastion", attackDice: 1 },
+      resolveAttack: () => {
+        throw new Error("Attack resolver should not run for invalid route territory ids.");
+      }
+    });
+
+    assert.equal(result.handled, true);
+    assert.ok(result.localizedError);
+    assert.equal(result.localizedError?.[1], 400);
+    assert.equal(result.localizedError?.[3], "Territorio non valido.");
+    assert.equal(result.localizedError?.[4], "game.invalidTerritory");
+    assert.equal(result.persisted, false);
+    assert.equal(result.broadcastCount, 0);
+  }
+);
+
+register(
+  "handleAttackGameActionRoute delegates banzai attacks with queued randomness",
+  async () => {
+    const queuedRandom = () => 0.5;
+    let banzaiArgs: any[] | null = null;
+
+    const result = await callAttackRoute({
+      type: "attackBanzai",
+      body: { fromId: "aurora", toId: "bastion", attackDice: "" },
+      consumeQueuedAttackRandom: () => queuedRandom,
+      resolveAttack: () => {
+        throw new Error("Single attack resolver should not run for banzai attacks.");
+      },
+      resolveBanzaiAttack: (...args: any[]) => {
+        banzaiArgs = args;
+        return {
+          ok: true,
+          rounds: [{ round: 1, conqueredTerritory: true }]
+        };
+      }
+    });
+
+    assert.equal(result.handled, true);
+    assert.ok(banzaiArgs);
+    assert.equal(banzaiArgs?.[1], "p1");
+    assert.equal(banzaiArgs?.[2], "aurora");
+    assert.equal(banzaiArgs?.[3], "bastion");
+    assert.equal(banzaiArgs?.[4], queuedRandom);
+    assert.equal(banzaiArgs?.[5], null);
+    assert.deepEqual(result.sentJson?.payload, {
+      ok: true,
+      state: { ok: true },
+      rounds: [{ round: 1, conqueredTerritory: true }]
+    });
+    assert.equal(result.persisted, true);
+    assert.equal(result.broadcastCount, 1);
+  }
+);
+
+register("handleAttackGameActionRoute maps failed combat results to localized errors", async () => {
+  const result = await callAttackRoute({
+    resolveAttack: () => ({
+      ok: false,
+      message: "Attacco non consentito.",
+      messageKey: "game.attack.blocked",
+      messageParams: { reason: "phase" }
+    })
+  });
+
+  assert.equal(result.handled, true);
+  assert.ok(result.localizedError);
+  assert.equal(result.localizedError?.[1], 400);
+  assert.equal(result.localizedError?.[3], "Attacco non consentito.");
+  assert.equal(result.localizedError?.[4], "game.attack.blocked");
+  assert.deepEqual(result.localizedError?.[5], { reason: "phase" });
+  assert.equal(result.persisted, false);
+  assert.equal(result.sentJson, null);
+});
+
+register("handleAttackGameActionRoute maps defender dice runtime errors", async () => {
+  const result = await callAttackRoute({
+    resolveAttack: () => {
+      throw new Error("Defender dice must be between 1 and 2.");
+    }
+  });
+
+  assert.equal(result.handled, true);
+  assert.ok(result.localizedError);
+  assert.equal(result.localizedError?.[1], 400);
+  assert.equal(result.localizedError?.[3], "Territori non validi.");
+  assert.equal(result.localizedError?.[4], "game.attack.invalidTerritories");
+  assert.equal(result.persisted, false);
+});
+
+register("handleAttackGameActionRoute rethrows unmapped resolver errors", async () => {
+  await assert.rejects(
+    () =>
+      callAttackRoute({
+        resolveAttack: () => {
+          throw new Error("Unexpected resolver failure.");
+        }
+      }),
+    /Unexpected resolver failure/
+  );
+});
+
+register("handleAttackGameActionRoute stops response handling on version conflicts", async () => {
+  const conflictError = new Error("Version conflict.");
+
+  const result = await callAttackRoute({
+    persistGameContext: async () => {
+      throw conflictError;
+    },
+    handleVersionConflict: (error: unknown) => {
+      assert.equal(error, conflictError);
+      return true;
+    }
+  });
+
+  assert.equal(result.handled, true);
+  assert.equal(result.sentJson, null);
+  assert.equal(result.localizedError, null);
+  assert.equal(result.broadcastCount, 0);
+});


### PR DESCRIPTION
## Obiettivo
Aumentare la branch coverage con test utili sui rami di combattimento e gestione errori attack, senza cambiare comportamento applicativo.

## Aree toccate
- `backend/engine/banzai-attack.cts`
- `backend/routes/game-actions-attack.cts`
- `tests/gameplay/combat/banzai-attack.test.cts`
- `tests/gameplay/regression/attack-route-guard.test.cts`

## Cosa cambia
- aggiunge casi banzai su dadi default massimi, clamp da metadata runtime, stop quando l'attaccante non puo continuare e passthrough del failure iniziale
- aggiunge casi route attack su tipo non supportato, territori invalidi, delega `attackBanzai`, risultati combat falliti, mapping errori defender dice, rethrow errori non mappati e version conflict in persistenza
- incrementa il runner gameplay da 290 a 301 test

## Coverage
- Prima: Statements 88.97%, Branches 74.72% (4811/6438), Functions 80.40%, Lines 88.97%
- Dopo: Statements 89.11%, Branches 75.01% (4839/6451), Functions 80.40%, Lines 89.11%
- Miglioramenti mirati: `banzai-attack` branch coverage 42.30% -> 81.25%; `game-actions-attack` 60.00% -> 81.08%

## Fix minimi
Nessun fix applicativo. Solo test di regressione/branch coverage.

## Validazione locale
- `npm run coverage`
- `npm run format:check`
- `npm run test:gameplay`
- `npm run test:all`
- `npm run typecheck`
- `npm run lint`
- `npm run test:e2e:smoke`

## Rischi residui
- `npm run lint` resta verde con 139 warning preesistenti non toccati.