### PR TITLE
Fix game map player colors

### DIFF
--- a/frontend/react-shell/src/__tests__/theme.test.ts
+++ b/frontend/react-shell/src/__tests__/theme.test.ts
@@ -72,9 +72,7 @@ function ruleBodyForSelector(css: string, selector: string): string | null {
   const normalizedSelector = selector.trim().replace(/\s+/g, " ");
 
   for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-    const selectorList = match[1]
-      .split(",")
-      .map((entry) => entry.trim().replace(/\s+/g, " "));
+    const selectorList = match[1].split(",").map((entry) => entry.trim().replace(/\s+/g, " "));
 
     if (selectorList.includes(normalizedSelector)) {
       return match[2];

--- a/frontend/react-shell/src/__tests__/theme.test.ts
+++ b/frontend/react-shell/src/__tests__/theme.test.ts
@@ -68,6 +68,18 @@ function warTableReferenceGapSelectors(css: string): string[] {
   );
 }
 
+function exactRuleBody(css: string, selector: string): string | null {
+  const normalizedSelector = selector.trim().replace(/\s+/g, " ");
+
+  for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (match[1].trim().replace(/\s+/g, " ") === normalizedSelector) {
+      return match[2];
+    }
+  }
+
+  return null;
+}
+
 describe("theme runtime bridge", () => {
   beforeEach(() => {
     document.documentElement.removeAttribute("data-theme");
@@ -99,6 +111,19 @@ describe("theme runtime bridge", () => {
 
     expect(slotRuleBodies.length).toBeGreaterThan(0);
     expect(slotRuleBodies.join("\n")).not.toMatch(/\bdisplay\s*:\s*none\b/i);
+  });
+
+  it("keeps War Table custom-background map territories colored by owner", () => {
+    const css = readFileSync(themeTokensPath, "utf8");
+    const territoryRuleBody = exactRuleBody(
+      css,
+      'html[data-theme="war-table"] .map-board-surface:has(.map-board.has-custom-background) .territory-node'
+    );
+
+    expect(territoryRuleBody).not.toBeNull();
+    expect(territoryRuleBody).toMatch(/background\s*:\s*var\(--owner-color/i);
+    expect(territoryRuleBody).toMatch(/border-radius\s*:\s*999px/i);
+    expect(territoryRuleBody).not.toMatch(/background\s*:\s*transparent/i);
   });
 
   it("keeps War Table visual refinements scoped to reusable shell surfaces", () => {

--- a/frontend/react-shell/src/__tests__/theme.test.ts
+++ b/frontend/react-shell/src/__tests__/theme.test.ts
@@ -68,11 +68,15 @@ function warTableReferenceGapSelectors(css: string): string[] {
   );
 }
 
-function exactRuleBody(css: string, selector: string): string | null {
+function ruleBodyForSelector(css: string, selector: string): string | null {
   const normalizedSelector = selector.trim().replace(/\s+/g, " ");
 
   for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-    if (match[1].trim().replace(/\s+/g, " ") === normalizedSelector) {
+    const selectorList = match[1]
+      .split(",")
+      .map((entry) => entry.trim().replace(/\s+/g, " "));
+
+    if (selectorList.includes(normalizedSelector)) {
       return match[2];
     }
   }
@@ -115,7 +119,7 @@ describe("theme runtime bridge", () => {
 
   it("keeps War Table custom-background map territories colored by owner", () => {
     const css = readFileSync(themeTokensPath, "utf8");
-    const territoryRuleBody = exactRuleBody(
+    const territoryRuleBody = ruleBodyForSelector(
       css,
       'html[data-theme="war-table"] .map-board-surface:has(.map-board.has-custom-background) .territory-node'
     );
@@ -124,6 +128,18 @@ describe("theme runtime bridge", () => {
     expect(territoryRuleBody).toMatch(/background\s*:\s*var\(--owner-color/i);
     expect(territoryRuleBody).toMatch(/border-radius\s*:\s*999px/i);
     expect(territoryRuleBody).not.toMatch(/background\s*:\s*transparent/i);
+
+    for (const stateSelector of [
+      'html[data-theme="war-table"] .map-board-surface:has(.map-board.has-custom-background) .territory-node:hover',
+      'html[data-theme="war-table"] .map-board-surface:has(.map-board.has-custom-background) .territory-node.is-source',
+      'html[data-theme="war-table"] .map-board-surface:has(.map-board.has-custom-background) .territory-node.is-target',
+      'html[data-theme="war-table"] .map-board-surface:has(.map-board.has-custom-background) .territory-node.is-reinforce'
+    ]) {
+      const stateRuleBody = ruleBodyForSelector(css, stateSelector);
+
+      expect(stateRuleBody).not.toBeNull();
+      expect(stateRuleBody).toMatch(/background\s*:\s*var\(--owner-color/i);
+    }
   });
 
   it("keeps War Table visual refinements scoped to reusable shell surfaces", () => {

--- a/frontend/react-shell/src/theme-tokens.css
+++ b/frontend/react-shell/src/theme-tokens.css
@@ -2507,7 +2507,7 @@ html[data-theme="war-table"]
   .map-board-surface:has(.map-board.has-custom-background)
   .territory-node.is-reinforce {
   border: 1px solid rgba(173, 210, 255, 0.92);
-  background: rgba(18, 73, 130, 0.34);
+  background: var(--owner-color, var(--owner-color-default));
   box-shadow:
     0 0 0 2px rgba(91, 161, 255, 0.34),
     0 0 18px rgba(91, 161, 255, 0.58);

--- a/frontend/react-shell/src/theme-tokens.css
+++ b/frontend/react-shell/src/theme-tokens.css
@@ -2482,10 +2482,13 @@ html[data-theme="war-table"]
   height: 28px;
   min-width: 28px;
   min-height: 28px;
-  border: 0;
-  background: transparent;
+  border: 2px solid rgba(243, 247, 248, 0.88);
+  border-radius: 999px;
+  background: var(--owner-color, var(--owner-color-default));
   color: #f3f7f8;
-  box-shadow: none;
+  box-shadow:
+    0 0 0 1px rgba(1, 8, 13, 0.62),
+    0 8px 18px rgba(1, 8, 13, 0.42);
   text-shadow:
     0 1px 3px rgba(0, 0, 0, 0.95),
     0 0 8px rgba(0, 0, 0, 0.95);


### PR DESCRIPTION
## Summary
- Restore owner-colored territory markers on War Table custom-background game maps.
- Keep those markers circular instead of inheriting rectangular button styling.
- Add a CSS regression test for the War Table custom-background territory rule.

## Validation
- npm run test:react -- frontend/react-shell/src/__tests__/theme.test.ts
- npm run typecheck:react-shell
- npm run test:react
- Chromium computed-style check for owner color, circular radius, and zero padding
- npm run build:react-shell
- npm run test:all