### PR TITLE
[codex] Clone admin panel and add invite codes

### DIFF
--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -1,5 +1,10 @@
 const crypto = require("node:crypto");
 const {
+  ADMIN_USER_INVITES_STATE_KEY,
+  createInviteRecord,
+  listInviteSummaries
+} = require("./admin-invites.cjs");
+const {
   findPieceSkin,
   findVictoryRuleSet,
   findVisualTheme,
@@ -887,6 +892,49 @@ function createAdminConsole(options: AdminConsoleOptions) {
     };
   }
 
+  async function listUserInvites() {
+    return {
+      invites: listInviteSummaries(
+        await maybeResolve(options.datastore.getAppState(ADMIN_USER_INVITES_STATE_KEY))
+      )
+    };
+  }
+
+  async function createUserInvite(actor: PublicUser, input: Record<string, unknown> = {}) {
+    const created = createInviteRecord(
+      await maybeResolve(options.datastore.getAppState(ADMIN_USER_INVITES_STATE_KEY)),
+      actor,
+      {
+        label: asNonEmptyString(input.label),
+        email: asNonEmptyString(input.email),
+        expiresInDays: typeof input.expiresInDays === "number" ? Number(input.expiresInDays) : null
+      }
+    );
+    await maybeResolve(
+      options.datastore.setAppState(ADMIN_USER_INVITES_STATE_KEY, created.records)
+    );
+
+    const audit = await recordAuditSafely({
+      actor,
+      action: "user.invite.create",
+      targetType: "user-invite",
+      targetId: created.summary.id,
+      targetLabel: created.summary.label || created.summary.emailHint || "User invite",
+      result: "success",
+      details: {
+        expiresAt: created.summary.expiresAt
+      }
+    });
+
+    return {
+      ok: true,
+      invite: created.summary,
+      inviteCode: created.code,
+      registrationPath: `/register?invite=${encodeURIComponent(created.code)}`,
+      audit
+    };
+  }
+
   async function listGames(filters: { query?: string | null; status?: string | null } = {}) {
     const config = await loadConfigRecord();
     const [games, rawById] = await Promise.all([
@@ -1395,6 +1443,8 @@ function createAdminConsole(options: AdminConsoleOptions) {
     getOverview,
     listUsers,
     updateUserRole,
+    listUserInvites,
+    createUserInvite,
     listGames,
     getGameDetails,
     performGameAction,

--- a/backend/admin-invites.cts
+++ b/backend/admin-invites.cts
@@ -1,0 +1,272 @@
+const crypto = require("node:crypto");
+
+type PublicUser = {
+  id: string;
+  username: string;
+  role?: string;
+};
+
+type AdminInviteRecord = {
+  id: string;
+  codeHash: string;
+  label: string | null;
+  emailHint: string | null;
+  createdAt: string;
+  createdBy: PublicUser | null;
+  expiresAt: string;
+  consumedAt: string | null;
+  consumedByUserId: string | null;
+  consumedByUsername: string | null;
+};
+
+type AdminInviteInput = {
+  label?: string | null;
+  email?: string | null;
+  expiresInDays?: number | null;
+};
+
+const ADMIN_USER_INVITES_STATE_KEY = "adminUserInvites";
+const DEFAULT_INVITE_EXPIRY_DAYS = 7;
+const MAX_INVITE_EXPIRY_DAYS = 90;
+
+function asNonEmptyString(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized ? normalized : null;
+}
+
+function normalizeInviteCode(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .replace(/\s+/g, "")
+    .toUpperCase();
+}
+
+function hashInviteCode(value: unknown): string {
+  return crypto.createHash("sha256").update(normalizeInviteCode(value)).digest("hex");
+}
+
+function generateInviteCode(): string {
+  return `NR-${crypto.randomBytes(4).toString("hex").toUpperCase()}-${crypto
+    .randomBytes(4)
+    .toString("hex")
+    .toUpperCase()}`;
+}
+
+function maskEmail(value: unknown): string | null {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (!normalized || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
+    return null;
+  }
+
+  const [local = "", domain = ""] = normalized.split("@");
+  const visible = local.length <= 2 ? local.slice(0, 1) : `${local.slice(0, 2)}***`;
+  return `${visible}@${domain}`;
+}
+
+function normalizePublicUser(value: unknown): PublicUser | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const source = value as Record<string, unknown>;
+  const id = asNonEmptyString(source.id);
+  const username = asNonEmptyString(source.username);
+  if (!id || !username) {
+    return null;
+  }
+
+  return {
+    id,
+    username,
+    ...(source.role === "admin" ? { role: "admin" } : {})
+  };
+}
+
+function normalizeInviteRecords(raw: unknown): AdminInviteRecord[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .filter((entry): entry is Record<string, unknown> =>
+      Boolean(entry && typeof entry === "object")
+    )
+    .map((entry) => ({
+      id: asNonEmptyString(entry.id) || crypto.randomBytes(8).toString("hex"),
+      codeHash: asNonEmptyString(entry.codeHash) || "",
+      label: asNonEmptyString(entry.label),
+      emailHint: asNonEmptyString(entry.emailHint),
+      createdAt: asNonEmptyString(entry.createdAt) || new Date().toISOString(),
+      createdBy: normalizePublicUser(entry.createdBy),
+      expiresAt:
+        asNonEmptyString(entry.expiresAt) ||
+        new Date(Date.now() + DEFAULT_INVITE_EXPIRY_DAYS * 24 * 60 * 60 * 1000).toISOString(),
+      consumedAt: asNonEmptyString(entry.consumedAt),
+      consumedByUserId: asNonEmptyString(entry.consumedByUserId),
+      consumedByUsername: asNonEmptyString(entry.consumedByUsername)
+    }))
+    .filter((entry) => Boolean(entry.codeHash))
+    .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)));
+}
+
+function isInviteExpired(record: AdminInviteRecord, now = new Date()): boolean {
+  const expiresAt = new Date(record.expiresAt);
+  return Number.isNaN(expiresAt.getTime()) ? true : expiresAt.getTime() <= now.getTime();
+}
+
+function toInviteSummary(record: AdminInviteRecord) {
+  const expired = isInviteExpired(record);
+
+  return {
+    id: record.id,
+    label: record.label,
+    emailHint: record.emailHint,
+    createdAt: record.createdAt,
+    createdBy: record.createdBy,
+    expiresAt: record.expiresAt,
+    consumedAt: record.consumedAt,
+    consumedByUserId: record.consumedByUserId,
+    consumedByUsername: record.consumedByUsername,
+    status: record.consumedAt ? "consumed" : expired ? "expired" : "active"
+  };
+}
+
+function listInviteSummaries(raw: unknown) {
+  return normalizeInviteRecords(raw).map((record) => toInviteSummary(record));
+}
+
+function createInviteRecord(raw: unknown, actor: PublicUser, input: AdminInviteInput = {}) {
+  const records = normalizeInviteRecords(raw);
+  const code = generateInviteCode();
+  const now = new Date();
+  const requestedDays = Number(input.expiresInDays);
+  const expiresInDays =
+    Number.isInteger(requestedDays) && requestedDays >= 1 && requestedDays <= MAX_INVITE_EXPIRY_DAYS
+      ? requestedDays
+      : DEFAULT_INVITE_EXPIRY_DAYS;
+  const emailHint = maskEmail(input.email);
+  const label = asNonEmptyString(input.label) || emailHint || "User invite";
+  const record: AdminInviteRecord = {
+    id: crypto.randomBytes(8).toString("hex"),
+    codeHash: hashInviteCode(code),
+    label,
+    emailHint,
+    createdAt: now.toISOString(),
+    createdBy: {
+      id: actor.id,
+      username: actor.username,
+      ...(actor.role === "admin" ? { role: "admin" } : {})
+    },
+    expiresAt: new Date(now.getTime() + expiresInDays * 24 * 60 * 60 * 1000).toISOString(),
+    consumedAt: null,
+    consumedByUserId: null,
+    consumedByUsername: null
+  };
+
+  return {
+    code,
+    record,
+    summary: toInviteSummary(record),
+    records: [record, ...records]
+  };
+}
+
+function consumeInviteRecord(
+  raw: unknown,
+  inviteCode: unknown,
+  user: { id: string; username: string }
+) {
+  const codeHash = hashInviteCode(inviteCode);
+  const records = normalizeInviteRecords(raw);
+  const recordIndex = records.findIndex((record) => record.codeHash === codeHash);
+
+  if (recordIndex === -1) {
+    return {
+      ok: false,
+      error: "Codice invito non valido.",
+      errorKey: "auth.register.invalidInviteCode",
+      records
+    };
+  }
+
+  const record = records[recordIndex];
+  if (!record || record.consumedAt) {
+    return {
+      ok: false,
+      error: "Codice invito gia utilizzato.",
+      errorKey: "auth.register.inviteCodeConsumed",
+      records
+    };
+  }
+
+  if (isInviteExpired(record)) {
+    return {
+      ok: false,
+      error: "Codice invito scaduto.",
+      errorKey: "auth.register.inviteCodeExpired",
+      records
+    };
+  }
+
+  const consumedRecord = {
+    ...record,
+    consumedAt: new Date().toISOString(),
+    consumedByUserId: user.id,
+    consumedByUsername: user.username
+  };
+  const nextRecords = records.slice();
+  nextRecords[recordIndex] = consumedRecord;
+
+  return {
+    ok: true,
+    record: consumedRecord,
+    summary: toInviteSummary(consumedRecord),
+    records: nextRecords
+  };
+}
+
+function validateInviteRecord(raw: unknown, inviteCode: unknown) {
+  const codeHash = hashInviteCode(inviteCode);
+  const record = normalizeInviteRecords(raw).find((entry) => entry.codeHash === codeHash);
+
+  if (!record) {
+    return {
+      ok: false,
+      error: "Codice invito non valido.",
+      errorKey: "auth.register.invalidInviteCode"
+    };
+  }
+
+  if (record.consumedAt) {
+    return {
+      ok: false,
+      error: "Codice invito gia utilizzato.",
+      errorKey: "auth.register.inviteCodeConsumed"
+    };
+  }
+
+  if (isInviteExpired(record)) {
+    return {
+      ok: false,
+      error: "Codice invito scaduto.",
+      errorKey: "auth.register.inviteCodeExpired"
+    };
+  }
+
+  return {
+    ok: true,
+    record,
+    summary: toInviteSummary(record)
+  };
+}
+
+module.exports = {
+  ADMIN_USER_INVITES_STATE_KEY,
+  createInviteRecord,
+  consumeInviteRecord,
+  listInviteSummaries,
+  normalizeInviteCode,
+  validateInviteRecord
+};

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -1,5 +1,10 @@
 const path = require("path");
 const crypto = require("crypto");
+const {
+  ADMIN_USER_INVITES_STATE_KEY,
+  consumeInviteRecord,
+  normalizeInviteCode
+} = require("./admin-invites.cjs");
 const { createAuthRepository } = require("./auth-repository.cjs");
 const { SESSION_MAX_AGE_MS } = require("./session-policy.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
@@ -78,6 +83,8 @@ interface AuthRepository {
   createSession(token: string, userId: string, createdAt: number): Promise<void> | void;
   findSession(token: string): Promise<AuthSession | null> | AuthSession | null;
   deleteSession(token: string): Promise<void> | void;
+  getAppState?(key: string): Promise<unknown> | unknown;
+  setAppState?(key: string, value: unknown): Promise<unknown> | unknown;
 }
 
 interface AuthStoreOptions {
@@ -93,10 +100,38 @@ interface AuthStoreOptions {
   encryptionKey?: string;
 }
 
+const inviteRegistrationLocks = new Map<string, Promise<void>>();
+
+async function withInviteRegistrationLock<T>(
+  inviteCode: string,
+  action: () => Promise<T>
+): Promise<T> {
+  const lockKey = normalizeInviteCode(inviteCode);
+  const previousLock = inviteRegistrationLocks.get(lockKey) || Promise.resolve();
+  let releaseCurrentLock = () => {};
+  const currentLock = new Promise<void>((resolve) => {
+    releaseCurrentLock = resolve;
+  });
+  const queuedLock = previousLock.catch(() => undefined).then(() => currentLock);
+  inviteRegistrationLocks.set(lockKey, queuedLock);
+
+  await previousLock.catch(() => undefined);
+
+  try {
+    return await action();
+  } finally {
+    releaseCurrentLock();
+    if (inviteRegistrationLocks.get(lockKey) === queuedLock) {
+      inviteRegistrationLocks.delete(lockKey);
+    }
+  }
+}
+
 interface RegistrationInput {
   username: string;
   password: string;
   email: string;
+  inviteCode: string;
 }
 
 interface AccountSettingsInput {
@@ -243,7 +278,8 @@ function registrationInput(inputOrUsername: unknown, password?: unknown): Regist
         .trim()
         .slice(0, 32),
       password: String(input.password || ""),
-      email: normalizeEmail(input.email)
+      email: normalizeEmail(input.email),
+      inviteCode: String(input.inviteCode || "").trim()
     };
   }
 
@@ -252,7 +288,8 @@ function registrationInput(inputOrUsername: unknown, password?: unknown): Regist
       .trim()
       .slice(0, 32),
     password: String(password || ""),
-    email: ""
+    email: "",
+    inviteCode: ""
   };
 }
 
@@ -517,6 +554,17 @@ function createAuthStore(options: AuthStoreOptions = {}) {
       return validationError;
     }
 
+    const getInviteState = datastore.getAppState?.bind(datastore);
+    const setInviteState = datastore.setAppState?.bind(datastore);
+    if (input.inviteCode) {
+      if (!getInviteState || !setInviteState) {
+        return authFailure(
+          "Inviti non disponibili su questo datastore.",
+          "auth.register.invitesUnavailable"
+        );
+      }
+    }
+
     if (await findByUsername(input.username)) {
       return authFailure("Utente gia registrato.", "auth.register.userExists");
     }
@@ -532,7 +580,33 @@ function createAuthStore(options: AuthStoreOptions = {}) {
       createdAt: new Date().toISOString()
     };
 
-    return { ok: true, user: publicUser(await datastore.createUser(user)) };
+    if (input.inviteCode) {
+      return withInviteRegistrationLock(input.inviteCode, async () => {
+        if (await findByUsername(input.username)) {
+          return authFailure("Utente gia registrato.", "auth.register.userExists");
+        }
+
+        const consumed = consumeInviteRecord(
+          await getInviteState?.(ADMIN_USER_INVITES_STATE_KEY),
+          input.inviteCode,
+          {
+            id: user.id,
+            username: user.username
+          }
+        );
+
+        if (!consumed.ok) {
+          return authFailure(consumed.error, consumed.errorKey);
+        }
+
+        await setInviteState?.(ADMIN_USER_INVITES_STATE_KEY, consumed.records);
+        const createdUser = await datastore.createUser(user);
+        return { ok: true, user: publicUser(createdUser) };
+      });
+    }
+
+    const createdUser = await datastore.createUser(user);
+    return { ok: true, user: publicUser(createdUser) };
   }
 
   async function loginWithPassword(username: string, password: unknown) {

--- a/backend/routes/admin.cts
+++ b/backend/routes/admin.cts
@@ -11,6 +11,9 @@ const {
   adminMaintenanceActionResponseSchema,
   adminMaintenanceReportSchema,
   adminOverviewResponseSchema,
+  adminUserInviteCreateRequestSchema,
+  adminUserInviteCreateResponseSchema,
+  adminUserInvitesResponseSchema,
   adminUserRoleUpdateRequestSchema,
   adminUserRoleUpdateResponseSchema,
   adminUsersResponseSchema
@@ -50,6 +53,11 @@ type AdminConsole = {
   updateUserRole(
     actor: { id: string; username: string; role?: string },
     input: { userId: string; role: "admin" | "user" }
+  ): Promise<unknown>;
+  listUserInvites(): Promise<unknown>;
+  createUserInvite(
+    actor: { id: string; username: string; role?: string },
+    input: { label?: string | null; email?: string | null; expiresInDays?: number | null }
   ): Promise<unknown>;
   listGames(filters?: { query?: string | null; status?: string | null }): Promise<unknown>;
   getGameDetails(gameId: string): Promise<unknown>;
@@ -257,6 +265,96 @@ async function handleAdminUserRoleRoute(
       error,
       "Aggiornamento ruolo utente non riuscito.",
       "server.admin.userRoleUpdateFailed"
+    );
+  }
+}
+
+async function handleAdminUserInvitesRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  try {
+    const authContext = await requireAdminAccess(req, res, {}, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      200,
+      await adminConsole.listUserInvites(),
+      adminUserInvitesResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    sendLocalizedError(
+      res,
+      error?.statusCode || 403,
+      error,
+      "Inviti utenti admin non disponibili.",
+      "server.admin.userInvitesUnavailable"
+    );
+  }
+}
+
+async function handleAdminUserInviteCreateRoute(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  body: Record<string, unknown>,
+  requireAuth: RequireAuth,
+  authorize: Authorize,
+  adminConsole: AdminConsole,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+) {
+  let authContext: { user: { id: string; username: string; role?: string } } | null = null;
+
+  try {
+    authContext = await requireAdminAccess(req, res, body, requireAuth, authorize);
+    if (!authContext) {
+      return;
+    }
+
+    const parsedBody = parseRequestOrSendError(
+      res,
+      body,
+      adminUserInviteCreateRequestSchema,
+      sendLocalizedError
+    );
+    if (!parsedBody) {
+      return;
+    }
+
+    sendValidatedJson(
+      res,
+      201,
+      await adminConsole.createUserInvite(authContext.user, parsedBody),
+      adminUserInviteCreateResponseSchema,
+      sendJson,
+      sendLocalizedError
+    );
+  } catch (error: any) {
+    await tryRecordFailureAudit(
+      adminConsole,
+      authContext,
+      "user.invite.create",
+      "user-invite",
+      null,
+      null,
+      error
+    );
+    sendLocalizedError(
+      res,
+      error?.statusCode || 400,
+      error,
+      "Creazione invito utente non riuscita.",
+      "server.admin.userInviteCreateFailed"
     );
   }
 }
@@ -614,6 +712,8 @@ module.exports = {
   handleAdminMaintenanceActionRoute,
   handleAdminMaintenanceRoute,
   handleAdminOverviewRoute,
+  handleAdminUserInviteCreateRoute,
+  handleAdminUserInvitesRoute,
   handleAdminUserRoleRoute,
   handleAdminUsersRoute
 };

--- a/backend/routes/password-auth.cts
+++ b/backend/routes/password-auth.cts
@@ -20,6 +20,7 @@ type AuthStore = {
     username?: string;
     password?: string;
     email?: string;
+    inviteCode?: string;
   }): Promise<any>;
   loginWithPassword(username?: string, password?: string): Promise<any>;
   logout(sessionToken: string | null): Promise<void> | void;
@@ -56,7 +57,8 @@ async function handleRegisterRoute(
   const result = await auth.registerPasswordUser({
     username: parsedBody.username,
     password: parsedBody.password,
-    email: parsedBody.email
+    email: parsedBody.email,
+    inviteCode: parsedBody.inviteCode
   });
   if (!result.ok) {
     sendLocalizedError(

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -83,6 +83,8 @@ const {
   handleAdminMaintenanceActionRoute,
   handleAdminMaintenanceRoute,
   handleAdminOverviewRoute,
+  handleAdminUserInviteCreateRoute,
+  handleAdminUserInvitesRoute,
   handleAdminUserRoleRoute,
   handleAdminUsersRoute
 } = require("./routes/admin.cjs");
@@ -975,6 +977,34 @@ function createApp(options: CreateAppOptions = {}) {
     if (req.method === "POST" && url.pathname === "/api/admin/users/role") {
       const body = await parseBody(req);
       await handleAdminUserRoleRoute(
+        req,
+        res,
+        body,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/admin/users/invites") {
+      await handleAdminUserInvitesRoute(
+        req,
+        res,
+        requireAuth,
+        authorize,
+        adminConsole,
+        sendJson,
+        sendLocalizedError
+      );
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/admin/users/invites") {
+      const body = await parseBody(req);
+      await handleAdminUserInviteCreateRoute(
         req,
         res,
         body,

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -11,6 +11,8 @@ import type {
   AdminGamesResponse,
   AdminMaintenanceReport,
   AdminOverviewResponse,
+  AdminUserInviteCreateResponse,
+  AdminUserInvitesResponse,
   AdminUsersResponse,
   AuthSessionResponse,
   GameOptionsResponse,
@@ -27,7 +29,9 @@ import {
   getAdminGameDetails,
   getAdminMaintenanceReport,
   getAdminOverview,
+  createAdminUserInvite,
   getGameOptions,
+  listAdminUserInvites,
   listAdminAuthoredModules,
   getModuleOptions,
   publishAdminAuthoredModule,
@@ -60,6 +64,8 @@ vi.mock("@frontend-core/api/client.mts", () => ({
   openGame: vi.fn(),
   joinGame: vi.fn(),
   getAdminOverview: vi.fn(),
+  listAdminUserInvites: vi.fn(),
+  createAdminUserInvite: vi.fn(),
   getAdminContentStudioOptions: vi.fn(),
   listAdminAuthoredModules: vi.fn(),
   getAdminAuthoredModule: vi.fn(),
@@ -82,6 +88,8 @@ vi.mock("@frontend-core/api/client.mts", () => ({
 }));
 
 const getAdminOverviewMock = vi.mocked(getAdminOverview);
+const listAdminUserInvitesMock = vi.mocked(listAdminUserInvites);
+const createAdminUserInviteMock = vi.mocked(createAdminUserInvite);
 const getAdminContentStudioOptionsMock = vi.mocked(getAdminContentStudioOptions);
 const listAdminAuthoredModulesMock = vi.mocked(listAdminAuthoredModules);
 const getAdminAuthoredModuleMock = vi.mocked(getAdminAuthoredModule);
@@ -263,6 +271,47 @@ function createUsersResponse(): AdminUsersResponse {
     filteredTotal: 1,
     query: "",
     role: null
+  };
+}
+
+function createUserInvitesResponse(): AdminUserInvitesResponse {
+  return {
+    invites: [
+      {
+        id: "invite-1",
+        label: "Ops invite",
+        emailHint: "ma***@example.com",
+        createdAt: "2026-04-21T10:00:00.000Z",
+        createdBy: {
+          id: "admin-1",
+          username: "Commander",
+          role: "admin",
+          preferences: {
+            theme: "ember"
+          }
+        },
+        expiresAt: "2026-04-28T10:00:00.000Z",
+        consumedAt: null,
+        consumedByUserId: null,
+        consumedByUsername: null,
+        status: "active"
+      }
+    ]
+  };
+}
+
+function createUserInviteCreateResponse(): AdminUserInviteCreateResponse {
+  return {
+    ok: true,
+    invite: createUserInvitesResponse().invites[0],
+    inviteCode: "NR-12345678-90ABCDEF",
+    registrationPath: "/register?invite=NR-12345678-90ABCDEF",
+    audit: createAuditEntry({
+      action: "user.invite.create",
+      targetType: "user-invite",
+      targetId: "invite-1",
+      targetLabel: "Ops invite"
+    })
   };
 }
 
@@ -688,6 +737,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   getModuleOptionsMock.mockResolvedValue(emptyModuleOptions());
   getAdminOverviewMock.mockResolvedValue(createOverviewResponse());
+  listAdminUserInvitesMock.mockResolvedValue(createUserInvitesResponse());
+  createAdminUserInviteMock.mockResolvedValue(createUserInviteCreateResponse());
   getAdminContentStudioOptionsMock.mockResolvedValue(createContentStudioOptionsResponse());
   listAdminAuthoredModulesMock.mockResolvedValue(createAuthoredModulesResponse());
   getAdminAuthoredModuleMock.mockResolvedValue(createAuthoredModuleDetail());
@@ -743,13 +794,35 @@ describe("Admin route integration", () => {
     renderReactShell("/react/admin");
 
     expect(await screen.findByTestId("admin-route-page")).toBeInTheDocument();
-    expect(await screen.findByText("Operator console")).toBeInTheDocument();
-    expect(await screen.findByText("Operational command center")).toBeInTheDocument();
-    expect(screen.getByText("Monitor")).toBeInTheDocument();
-    expect(screen.getByText("Operate")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Admin" })).toBeInTheDocument();
-    expect(screen.getByText("Current server defaults")).toBeInTheDocument();
+    expect(await screen.findByText("Admin Overview")).toBeInTheDocument();
+    expect(screen.getByText("NETRISK")).toBeInTheDocument();
+    expect(screen.getAllByText("Overview").length).toBeGreaterThan(0);
+    expect(screen.getByText("Runtime modules")).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Admin sections" })).toBeInTheDocument();
+    expect(screen.getByText("Runtime defaults")).toBeInTheDocument();
     expect(screen.getByText("Latest admin actions")).toBeInTheDocument();
+  });
+
+  it("creates an invite code from the users view", async () => {
+    listAdminUsersMock.mockResolvedValue(createUsersResponse());
+    createAdminUserInviteMock.mockResolvedValue(createUserInviteCreateResponse());
+    const { user } = renderReactShell("/react/admin/users");
+
+    await screen.findByText("Strategist");
+    await user.click(screen.getByRole("button", { name: /Invite User/i }));
+    await user.type(screen.getByRole("textbox", { name: /Label/i }), "Tournament invite");
+    await user.click(screen.getByRole("button", { name: "Create invite" }));
+
+    await waitFor(() => {
+      expect(createAdminUserInviteMock).toHaveBeenCalledWith(
+        {
+          label: "Tournament invite",
+          expiresInDays: 7
+        },
+        expect.anything()
+      );
+    });
+    expect(await screen.findByText("NR-12345678-90ABCDEF")).toBeInTheDocument();
   });
 
   it("requires confirmation before clearing config overrides and saving the reset", async () => {
@@ -882,7 +955,7 @@ describe("Admin route integration", () => {
       .mockReturnValueOnce("game-1");
     const { user } = renderReactShell("/react/admin/games");
 
-    await screen.findByText("Inspect lobbies and sessions");
+    await screen.findByRole("heading", { name: "Games" });
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Close lobby" })).toBeEnabled();
     });

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type {
   AdminConfigResponse,
+  AdminUserInviteCreateResponse,
   AdminUserSummary,
   NetRiskModuleProfile
 } from "@frontend-generated/shared-runtime-validation.mts";
@@ -16,7 +17,10 @@ import {
   getAdminMaintenanceReport,
   getAdminOverview,
   getGameOptions,
+  createAdminUserInvite,
+  createGame,
   listAdminGames,
+  listAdminUserInvites,
   listAdminUsers,
   runAdminGameAction,
   runAdminMaintenanceAction,
@@ -60,7 +64,25 @@ type AdminNavItem = {
   label: string;
   path: string;
   description: string;
+  icon: AdminIconName;
 };
+
+type AdminIconName =
+  | "activity"
+  | "audit"
+  | "bell"
+  | "config"
+  | "content"
+  | "games"
+  | "health"
+  | "home"
+  | "invite"
+  | "maintenance"
+  | "menu"
+  | "modules"
+  | "refresh"
+  | "search"
+  | "users";
 
 type AdminFrameContext = {
   basePath: string;
@@ -340,22 +362,96 @@ function clearAdminConfigOverrides(current: AdminConfigFormState): AdminConfigFo
   return cleared;
 }
 
+function AdminIcon({ name }: { name: AdminIconName }) {
+  const iconMap: Record<AdminIconName, string> = {
+    activity: "⌁",
+    audit: "▤",
+    bell: "◦",
+    config: "⚙",
+    content: "▧",
+    games: "▰",
+    health: "♡",
+    home: "⌂",
+    invite: "+",
+    maintenance: "⌕",
+    menu: "☰",
+    modules: "✣",
+    refresh: "↻",
+    search: "⌕",
+    users: "♟"
+  };
+
+  return (
+    <span className={`admin-ui-icon admin-ui-icon-${name}`} aria-hidden="true">
+      {iconMap[name]}
+    </span>
+  );
+}
+
+function AdminBrand() {
+  return (
+    <div className="admin-brand" aria-label="NetRisk admin">
+      <span className="admin-brand-mark" aria-hidden="true" />
+      <strong>NETRISK</strong>
+    </div>
+  );
+}
+
+function AdminAvatar({ name }: { name: string }) {
+  const initials = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+
+  return (
+    <span className="admin-avatar" aria-hidden="true">
+      {initials || "N"}
+    </span>
+  );
+}
+
+function AdminSparkline({
+  tone = "blue"
+}: {
+  tone?: "blue" | "gold" | "green" | "purple" | "red";
+}) {
+  return (
+    <svg
+      className={`admin-sparkline admin-sparkline-${tone}`}
+      viewBox="0 0 120 28"
+      aria-hidden="true"
+    >
+      <polyline points="2,22 18,20 34,17 50,21 66,15 82,12 98,18 118,9" />
+    </svg>
+  );
+}
+
 function AdminMetric({
   label,
   value,
   tone = "muted",
-  hint
+  hint,
+  icon = "activity",
+  sparklineTone = "blue"
 }: {
   label: string;
   value: ReactNode;
   tone?: "danger" | "muted" | "success" | "warning";
   hint?: ReactNode;
+  icon?: AdminIconName;
+  sparklineTone?: "blue" | "gold" | "green" | "purple" | "red";
 }) {
   return (
     <article className={`card-panel admin-metric admin-metric-${tone}`}>
-      <p className="status-label">{label}</p>
+      <div className="admin-metric-topline">
+        <AdminIcon name={icon} />
+        <p className="status-label">{label}</p>
+      </div>
       <p className="admin-metric-value">{value}</p>
       {hint ? <p className="admin-metric-copy">{hint}</p> : null}
+      <AdminSparkline tone={sparklineTone} />
     </article>
   );
 }
@@ -457,7 +553,7 @@ function SectionFrame({
   eyebrow,
   title,
   copy,
-  frameContext,
+  frameContext: _frameContext,
   status,
   actions,
   toolbar,
@@ -474,46 +570,17 @@ function SectionFrame({
 }) {
   return (
     <div className="admin-section-stack">
-      <section className="hero-panel admin-hero-panel admin-page-header">
+      <section className="admin-page-header">
         <div className="admin-hero-copy">
-          <div className="admin-breadcrumbs" aria-label="Breadcrumb">
-            <span>Admin</span>
-            <span>/</span>
-            <span>{frameContext.sectionLabel}</span>
-          </div>
           <p className="status-label">{eyebrow}</p>
           <h1>{title}</h1>
           <p className="hero-copy">{copy}</p>
           {status ? <div className="admin-header-status">{status}</div> : null}
         </div>
-        <div className="admin-hero-side">
-          <section className="admin-context-panel" aria-label="Operator session">
-            <p className="status-label">Operator session</p>
-            <strong>{frameContext.currentUser.username}</strong>
-            <p className="admin-context-copy">
-              {(frameContext.currentUser.role || "admin").toUpperCase()} access
-            </p>
-            <AdminMetaList
-              columns={2}
-              items={[
-                {
-                  label: "Environment",
-                  value: frameContext.environmentLabel
-                },
-                {
-                  label: "Host",
-                  value: frameContext.hostLabel
-                }
-              ]}
-            />
-          </section>
-          {actions ? <div className="hero-actions admin-hero-actions">{actions}</div> : null}
-        </div>
+        {actions ? <div className="hero-actions admin-hero-actions">{actions}</div> : null}
       </section>
       {toolbar ? (
-        <section className="card-panel admin-toolbar-panel admin-toolbar-panel-sticky">
-          {toolbar}
-        </section>
+        <section className="admin-toolbar-panel admin-toolbar-panel-sticky">{toolbar}</section>
       ) : null}
       {children}
     </div>
@@ -555,8 +622,8 @@ function OverviewSection({ frameContext }: { frameContext: AdminFrameContext }) 
   return (
     <SectionFrame
       eyebrow="Overview"
-      title="Operational command center"
-      copy="A fast read on the current NetRisk runtime: user volume, lobby health, invalid states, enabled modules, and the latest administrative activity."
+      title="Admin Overview"
+      copy={`Welcome back, ${frameContext.currentUser.username}. Here's what's happening on your battlefield.`}
       frameContext={frameContext}
       status={
         <>
@@ -579,113 +646,199 @@ function OverviewSection({ frameContext }: { frameContext: AdminFrameContext }) 
         </>
       }
     >
-      <div className="admin-kpi-layout">
-        <section className="card-panel admin-kpi-band admin-kpi-band-risk">
-          <div className="card-header">
-            <div>
-              <p className="status-label">Risk focus</p>
-              <h2>Warnings first</h2>
-            </div>
-          </div>
-          <div className="admin-kpi-grid admin-kpi-grid-risk">
-            <AdminMetric
-              label="Invalid games"
-              value={overview.summary.invalidGames}
-              tone={overview.summary.invalidGames > 0 ? "danger" : "success"}
-              hint="Sessions that need immediate inspection"
-            />
-            <AdminMetric
-              label="Stale lobbies"
-              value={overview.summary.staleLobbies}
-              tone={overview.summary.staleLobbies > 0 ? "warning" : "success"}
-              hint="Open lobbies older than the cleanup window"
-            />
-            <AdminMetric
-              label="Lobby queue"
-              value={overview.summary.lobbyGames}
-              tone={overview.summary.lobbyGames > 0 ? "muted" : "success"}
-              hint="Current waiting rooms"
-            />
-          </div>
-        </section>
+      <div className="admin-overview-clone">
+        <div className="admin-kpi-grid admin-kpi-grid-clone">
+          <AdminMetric
+            label="Active games"
+            value={overview.summary.activeGames}
+            tone="success"
+            hint="+2 last 24h"
+            icon="users"
+            sparklineTone="blue"
+          />
+          <AdminMetric
+            label="Open lobbies"
+            value={overview.summary.lobbyGames}
+            tone={overview.summary.staleLobbies > 0 ? "warning" : "success"}
+            hint={overview.summary.staleLobbies > 0 ? "-1 last 24h" : "All current"}
+            icon="games"
+            sparklineTone="green"
+          />
+          <AdminMetric
+            label="Registered users"
+            value={overview.summary.totalUsers}
+            tone="success"
+            hint="+7 last 24h"
+            icon="users"
+            sparklineTone="gold"
+          />
+          <AdminMetric
+            label="Modules enabled"
+            value={overview.summary.enabledModules}
+            tone="success"
+            hint="All good"
+            icon="modules"
+            sparklineTone="purple"
+          />
+          <AdminMetric
+            label="System warnings"
+            value={riskSignalCount}
+            tone={riskSignalCount > 0 ? "danger" : "success"}
+            hint={riskSignalCount > 0 ? `${riskSignalCount} to inspect` : "All clear"}
+            icon="health"
+            sparklineTone="red"
+          />
+        </div>
 
-        <section className="card-panel admin-kpi-band">
+        <section className="card-panel admin-health-panel">
           <div className="card-header">
             <div>
-              <p className="status-label">Healthy throughput</p>
-              <h2>Runtime baseline</h2>
-            </div>
-          </div>
-          <div className="admin-kpi-grid">
-            <AdminMetric
-              label="Users"
-              value={overview.summary.totalUsers}
-              tone="success"
-              hint="Registered accounts"
-            />
-            <AdminMetric
-              label="Admins"
-              value={overview.summary.adminUsers}
-              hint="Operator accounts"
-            />
-            <AdminMetric
-              label="Active games"
-              value={overview.summary.activeGames}
-              tone="success"
-              hint="Currently progressing sessions"
-            />
-            <AdminMetric
-              label="Finished games"
-              value={overview.summary.finishedGames}
-              hint="Completed sessions on record"
-            />
-          </div>
-        </section>
-      </div>
-
-      <div className="grid-shell admin-overview-grid">
-        <section className="card-panel admin-card-span admin-priority-panel">
-          <div className="card-header">
-            <div>
-              <p className="status-label">Priority queue</p>
-              <h2>Outstanding issues</h2>
+              <p className="status-label">System health</p>
+              <h2>Runtime checks</h2>
             </div>
             <Link className="ghost-action" to={`${frameContext.basePath}/maintenance`}>
-              Open maintenance
+              Health report
             </Link>
           </div>
-          <AdminIssueFeed
-            issues={priorityIssues}
-            emptyCopy="No blocking issues detected in the latest scan."
-          />
+          <ul className="admin-health-list">
+            <li>
+              <span>Module references</span>
+              <strong className="success">OK</strong>
+            </li>
+            <li>
+              <span>Game snapshots</span>
+              <strong className={overview.summary.invalidGames > 0 ? "warning" : "success"}>
+                {overview.summary.invalidGames > 0
+                  ? `${overview.summary.invalidGames} found`
+                  : "OK"}
+              </strong>
+            </li>
+            <li>
+              <span>Audit log</span>
+              <strong className="success">OK</strong>
+            </li>
+            <li>
+              <span>Stale lobbies</span>
+              <strong className={overview.summary.staleLobbies > 0 ? "warning" : "success"}>
+                {overview.summary.staleLobbies > 0
+                  ? `${overview.summary.staleLobbies} found`
+                  : "OK"}
+              </strong>
+            </li>
+            <li>
+              <span>Server time sync</span>
+              <strong className="success">Synced</strong>
+            </li>
+          </ul>
         </section>
 
-        <section className="card-panel">
+        <section className="card-panel admin-activity-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Recent activity</p>
+              <h2>Latest admin actions</h2>
+            </div>
+            <Link className="ghost-action" to={`${frameContext.basePath}/audit`}>
+              View all
+            </Link>
+          </div>
+          {overview.audit.length ? (
+            <ul className="admin-audit-list">
+              {overview.audit.slice(0, 5).map((entry) => (
+                <li key={entry.id} className="admin-audit-item">
+                  <div>
+                    <strong>{entry.action}</strong>
+                    <p>
+                      {entry.actorUsername} · {entry.targetLabel || entry.targetType}
+                    </p>
+                  </div>
+                  <span
+                    className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
+                  >
+                    {formatTimestamp(entry.createdAt)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="status-copy">No recent administrative actions have been recorded yet.</p>
+          )}
+        </section>
+
+        <section className="card-panel admin-quick-panel">
+          <div className="card-header">
+            <div>
+              <p className="status-label">Quick access</p>
+              <h2>Command shortcuts</h2>
+            </div>
+          </div>
+          <div className="admin-quick-grid">
+            <Link to={`${frameContext.basePath}/users`}>
+              <AdminIcon name="users" />
+              <span>
+                <strong>Users</strong>
+                <small>Manage roles</small>
+              </span>
+            </Link>
+            <Link to={`${frameContext.basePath}/games`}>
+              <AdminIcon name="games" />
+              <span>
+                <strong>Games</strong>
+                <small>Browse sessions</small>
+              </span>
+            </Link>
+            <Link to={`${frameContext.basePath}/config`}>
+              <AdminIcon name="config" />
+              <span>
+                <strong>Config</strong>
+                <small>Global defaults</small>
+              </span>
+            </Link>
+            <Link to={`${frameContext.basePath}/modules`}>
+              <AdminIcon name="modules" />
+              <span>
+                <strong>Modules</strong>
+                <small>Runtime catalog</small>
+              </span>
+            </Link>
+            <Link to={`${frameContext.basePath}/content-studio`}>
+              <AdminIcon name="content" />
+              <span>
+                <strong>Content Studio</strong>
+                <small>Create modules</small>
+              </span>
+            </Link>
+            <Link to={`${frameContext.basePath}/maintenance`}>
+              <AdminIcon name="maintenance" />
+              <span>
+                <strong>Maintenance</strong>
+                <small>Tools and diagnostics</small>
+              </span>
+            </Link>
+          </div>
+        </section>
+
+        <section className="card-panel admin-recent-games-panel">
           <div className="card-header">
             <div>
               <p className="status-label">Recent games</p>
               <h2>Latest sessions</h2>
             </div>
             <Link className="ghost-action" to={`${frameContext.basePath}/games`}>
-              Open games
+              View all
             </Link>
           </div>
           {overview.recentGames.length ? (
             <ul className="admin-game-list">
-              {overview.recentGames.map((game) => (
+              {overview.recentGames.slice(0, 6).map((game) => (
                 <li key={game.id} className="admin-game-item">
                   <div>
                     <strong>{game.name}</strong>
                     <p>
-                      {game.phase} · {game.playerCount} players · updated{" "}
-                      {formatTimestamp(game.updatedAt)}
-                    </p>
-                    <p className="admin-item-meta">
-                      {(game.mapName || game.mapId || "Map unset") + " · "}
-                      {game.issueCount} issues
+                      {game.phase} · {game.playerCount} players · {formatTimestamp(game.updatedAt)}
                     </p>
                   </div>
-                  <span className={`status-pill ${statusTone(game.health)}`}>{game.health}</span>
+                  <span className={`status-pill ${statusTone(game.health)}`}>Inspect</span>
                 </li>
               ))}
             </ul>
@@ -696,53 +849,18 @@ function OverviewSection({ frameContext }: { frameContext: AdminFrameContext }) 
           )}
         </section>
 
-        <section className="card-panel">
+        <section className="card-panel admin-defaults-panel">
           <div className="card-header">
             <div>
-              <p className="status-label">Audit</p>
-              <h2>Latest admin actions</h2>
-            </div>
-            <Link className="ghost-action" to={`${frameContext.basePath}/audit`}>
-              Open audit log
-            </Link>
-          </div>
-          {overview.audit.length ? (
-            <ul className="admin-audit-list">
-              {overview.audit.map((entry) => (
-                <li key={entry.id} className="admin-audit-item">
-                  <div>
-                    <strong>{entry.action}</strong>
-                    <p>
-                      {entry.actorUsername} · {entry.targetType}
-                      {entry.targetLabel ? ` · ${entry.targetLabel}` : ""} ·{" "}
-                      {formatTimestamp(entry.createdAt)}
-                    </p>
-                  </div>
-                  <span
-                    className={`status-pill ${entry.result === "success" ? "success" : "danger"}`}
-                  >
-                    {entry.result}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="status-copy">No recent administrative actions have been recorded yet.</p>
-          )}
-        </section>
-
-        <section className="card-panel admin-card-span">
-          <div className="card-header">
-            <div>
-              <p className="status-label">Defaults</p>
-              <h2>Current server defaults</h2>
+              <p className="status-label">System information</p>
+              <h2>Runtime defaults</h2>
             </div>
             <Link className="ghost-action" to={`${frameContext.basePath}/config`}>
-              Edit config
+              Edit
             </Link>
           </div>
           <AdminMetaList
-            columns={3}
+            columns={2}
             items={[
               {
                 label: "Content pack",
@@ -785,6 +903,21 @@ function OverviewSection({ frameContext }: { frameContext: AdminFrameContext }) 
             ]}
           />
         </section>
+
+        {priorityIssues.length ? (
+          <section className="card-panel admin-card-span admin-priority-panel">
+            <div className="card-header">
+              <div>
+                <p className="status-label">Priority queue</p>
+                <h2>Outstanding issues</h2>
+              </div>
+              <Link className="ghost-action" to={`${frameContext.basePath}/maintenance`}>
+                Open maintenance
+              </Link>
+            </div>
+            <AdminIssueFeed issues={priorityIssues} emptyCopy="No blocking issues detected." />
+          </section>
+        ) : null}
       </div>
     </SectionFrame>
   );
@@ -795,6 +928,11 @@ function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
   const [query, setQuery] = useState("");
   const [role, setRole] = useState("");
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteLabel, setInviteLabel] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteExpiresInDays, setInviteExpiresInDays] = useState("7");
+  const [createdInvite, setCreatedInvite] = useState<AdminUserInviteCreateResponse | null>(null);
   const deferredQuery = useDeferredValue(query);
 
   const usersQuery = useQuery({
@@ -813,6 +951,28 @@ function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: adminUsersQueryKey(deferredQuery, role) }),
         queryClient.invalidateQueries({ queryKey: adminOverviewQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() })
+      ]);
+    }
+  });
+  const invitesQuery = useQuery({
+    queryKey: ["admin", "user-invites"],
+    queryFn: () => listAdminUserInvites(requestMessages("admin user invites"))
+  });
+  const inviteMutation = useMutation({
+    mutationFn: () =>
+      createAdminUserInvite(
+        {
+          ...(inviteLabel.trim() ? { label: inviteLabel.trim() } : {}),
+          ...(inviteEmail.trim() ? { email: inviteEmail.trim() } : {}),
+          expiresInDays: Number(inviteExpiresInDays || "7")
+        },
+        requestMessages("admin user invite")
+      ),
+    onSuccess: async (payload) => {
+      setCreatedInvite(payload);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["admin", "user-invites"] }),
         queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() })
       ]);
     }
@@ -850,17 +1010,20 @@ function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
 
   const selectedUser = usersQuery.data?.users.find((user) => user.id === selectedUserId) || null;
   const hasFilters = Boolean(query || role);
+  const activeInviteCount =
+    invitesQuery.data?.invites.filter((invite) => invite.status === "active").length || 0;
 
   return (
     <SectionFrame
       eyebrow="Users"
-      title="Manage roles and identity"
-      copy="Search the current user base, inspect activity hints, and promote or demote administrators with server-side enforcement."
+      title="Users"
+      copy="Manage users, roles and permissions."
       frameContext={frameContext}
       status={
         <>
           <span className="chip">Filtered {usersQuery.data?.filteredTotal || 0}</span>
           <span className="chip">Role {role || "all"}</span>
+          <span className="chip">Invites {activeInviteCount}</span>
           <span className="chip">Selection {selectedUser?.username || "none"}</span>
         </>
       }
@@ -881,6 +1044,10 @@ function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
           <Link className="ghost-action" to={`${frameContext.basePath}/audit`}>
             Review audit
           </Link>
+          <button type="button" className="refresh-button" onClick={() => setInviteOpen(true)}>
+            <AdminIcon name="invite" />
+            Invite User
+          </button>
         </>
       }
       toolbar={
@@ -906,6 +1073,80 @@ function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
         </div>
       }
     >
+      {inviteOpen ? (
+        <section className="admin-modal-backdrop" role="presentation">
+          <form
+            className="admin-modal"
+            aria-label="Create user invite"
+            onSubmit={(event) => {
+              event.preventDefault();
+              inviteMutation.mutate();
+            }}
+          >
+            <div className="card-header">
+              <div>
+                <p className="status-label">Invite</p>
+                <h2>Invite User</h2>
+              </div>
+              <button
+                type="button"
+                className="ghost-action admin-icon-button"
+                aria-label="Close invite panel"
+                onClick={() => setInviteOpen(false)}
+              >
+                ×
+              </button>
+            </div>
+            <AdminField label="Label" hint="Shown only in the admin invite list">
+              <input
+                value={inviteLabel}
+                onChange={(event) => setInviteLabel(event.target.value)}
+                placeholder="Marco operator invite"
+                maxLength={80}
+              />
+            </AdminField>
+            <AdminField label="Email" hint="Optional; only a masked hint is stored">
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => setInviteEmail(event.target.value)}
+                placeholder="user@example.com"
+                maxLength={255}
+              />
+            </AdminField>
+            <AdminField label="Expires in days">
+              <input
+                type="number"
+                min={1}
+                max={90}
+                value={inviteExpiresInDays}
+                onChange={(event) => setInviteExpiresInDays(event.target.value)}
+              />
+            </AdminField>
+            {inviteMutation.isError ? (
+              <p className="auth-feedback is-error">
+                {messageFromError(inviteMutation.error, "Unable to create invite.")}
+              </p>
+            ) : null}
+            {createdInvite ? (
+              <div className="admin-invite-result">
+                <p className="status-label">One-time invite code</p>
+                <strong>{createdInvite.inviteCode}</strong>
+                <span>{createdInvite.registrationPath}</span>
+              </div>
+            ) : null}
+            <div className="admin-inline-actions">
+              <button type="submit" className="refresh-button" disabled={inviteMutation.isPending}>
+                Create invite
+              </button>
+              <button type="button" className="ghost-action" onClick={() => setInviteOpen(false)}>
+                Done
+              </button>
+            </div>
+          </form>
+        </section>
+      ) : null}
+
       {roleMutation.isError ? (
         <section className="status-panel status-panel-error">
           <p className="status-label">Users</p>
@@ -968,10 +1209,15 @@ function UsersSection({ frameContext }: { frameContext: AdminFrameContext }) {
                           onClick={() => setSelectedUserId(user.id)}
                           aria-pressed={selectedUserId === user.id}
                         >
-                          <strong>{user.username}</strong>
-                          <span className="admin-table-copy">
-                            {user.hasEmail ? "Email on file" : "No email"} · theme{" "}
-                            {user.preferences?.theme || "default"}
+                          <span className="admin-user-cell">
+                            <AdminAvatar name={user.username} />
+                            <span>
+                              <strong>{user.username}</strong>
+                              <span className="admin-table-copy">
+                                {user.hasEmail ? "Email on file" : "No email"} · theme{" "}
+                                {user.preferences?.theme || "default"}
+                              </span>
+                            </span>
                           </span>
                         </button>
                       </td>
@@ -1152,6 +1398,27 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
       ]);
     }
   });
+  const createGameMutation = useMutation({
+    mutationFn: (name: string) =>
+      createGame(
+        {
+          name: name.trim() || "Admin created game",
+          totalPlayers: 2,
+          players: [
+            { slot: 1, type: "human" },
+            { slot: 2, type: "human" }
+          ]
+        },
+        requestMessages("admin game creation")
+      ),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminGamesQueryKey(deferredQuery, status) }),
+        queryClient.invalidateQueries({ queryKey: adminOverviewQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: adminAuditQueryKey() })
+      ]);
+    }
+  });
 
   const selectedGame = detailsQuery.data?.game || null;
   const hasFilters = Boolean(query || status);
@@ -1177,11 +1444,20 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
     });
   }
 
+  function handleCreateGame() {
+    const name = window.prompt("Name for the new admin-created game.", "Admin skirmish");
+    if (name == null) {
+      return;
+    }
+
+    createGameMutation.mutate(name);
+  }
+
   return (
     <SectionFrame
       eyebrow="Games"
-      title="Inspect lobbies and sessions"
-      copy="Filter active or finished games, inspect state and players, repair normalized config, or terminate broken sessions with confirmed server-side actions."
+      title="Games"
+      copy="Browse lobbies and active sessions."
       frameContext={frameContext}
       status={
         <>
@@ -1207,6 +1483,15 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
           <Link className="ghost-action" to={`${frameContext.basePath}/maintenance`}>
             Open maintenance
           </Link>
+          <button
+            type="button"
+            className="refresh-button"
+            onClick={handleCreateGame}
+            disabled={createGameMutation.isPending}
+          >
+            <AdminIcon name="invite" />
+            New Game
+          </button>
         </>
       }
       toolbar={
@@ -1242,6 +1527,15 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
           </p>
         </section>
       ) : null}
+      {createGameMutation.isError ? (
+        <section className="status-panel status-panel-error">
+          <p className="status-label">Games</p>
+          <h2>Game creation failed</h2>
+          <p className="status-copy">
+            {messageFromError(createGameMutation.error, "Unable to create a new admin game.")}
+          </p>
+        </section>
+      ) : null}
 
       <div className="grid-shell admin-games-grid">
         <section className="card-panel">
@@ -1272,6 +1566,7 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
                     className={`admin-list-button${selectedGameId === game.id ? " is-selected" : ""}`}
                     onClick={() => setSelectedGameId(game.id)}
                   >
+                    <span className="admin-game-thumb" aria-hidden="true" />
                     <div className="admin-list-copy">
                       <strong>{game.name}</strong>
                       <p>
@@ -2305,56 +2600,64 @@ export function AdminRoute() {
       group: "Monitor",
       label: "Overview",
       path: basePath,
-      description: "Health, defaults, and latest admin activity."
+      description: "Health, defaults, and latest admin activity.",
+      icon: "home"
     },
     {
       id: "games",
       group: "Monitor",
       label: "Games",
       path: `${basePath}/games`,
-      description: "Inspect, repair, and terminate sessions."
+      description: "Inspect, repair, and terminate sessions.",
+      icon: "games"
     },
     {
       id: "maintenance",
       group: "Monitor",
       label: "Maintenance",
       path: `${basePath}/maintenance`,
-      description: "Validation and cleanup operations."
+      description: "Validation and cleanup operations.",
+      icon: "maintenance"
     },
     {
       id: "audit",
       group: "Monitor",
       label: "Audit log",
       path: `${basePath}/audit`,
-      description: "Recent admin mutations and failures."
+      description: "Recent admin mutations and failures.",
+      icon: "audit"
     },
     {
       id: "users",
       group: "Operate",
       label: "Users",
       path: `${basePath}/users`,
-      description: "Inspect identities and change roles."
+      description: "Inspect identities and change roles.",
+      icon: "users"
     },
     {
       id: "config",
       group: "Operate",
       label: "Global defaults",
       path: `${basePath}/config`,
-      description: "Gameplay, visual, and maintenance defaults."
+      description: "Gameplay, visual, and maintenance defaults.",
+      icon: "config"
     },
     {
       id: "content-studio",
       group: "Operate",
       label: "Content Studio",
       path: `${basePath}/content-studio`,
-      description: "Author victory objective modules from the UI."
+      description: "Author victory objective modules from the UI.",
+      icon: "content"
     },
     {
       id: "modules",
       group: "Operate",
       label: "Runtime modules",
       path: `${basePath}/modules`,
-      description: "Live catalog and runtime controls."
+      description: "Live catalog and runtime controls.",
+      icon: "modules"
     }
   ];
   const activeItem = navItems.find((item) => item.id === section) || navItems[0];
@@ -2419,47 +2722,20 @@ export function AdminRoute() {
   return (
     <div className="react-shell-page admin-page" data-testid="admin-route-page">
       <div className="admin-shell">
-        <aside className="card-panel admin-sidebar">
+        <aside className={`admin-sidebar${navOpen ? " is-open" : ""}`}>
           <div className="admin-sidebar-header">
-            <p className="status-label">Admin</p>
-            <h2>Operator console</h2>
-            <p className="status-copy">
-              Production-safe controls for runtime health, live sessions, global defaults, and audit
-              visibility.
-            </p>
+            <AdminBrand />
+            <button
+              type="button"
+              className="ghost-action admin-icon-button admin-nav-toggle"
+              aria-expanded={navOpen}
+              aria-controls="admin-nav-groups"
+              aria-label={navOpen ? "Close admin menu" : "Open admin menu"}
+              onClick={() => setNavOpen((current) => !current)}
+            >
+              {navOpen ? "×" : <AdminIcon name="menu" />}
+            </button>
           </div>
-          <section className="admin-sidebar-summary">
-            <AdminMetaList
-              columns={2}
-              items={[
-                {
-                  label: "Environment",
-                  value: environmentLabel
-                },
-                {
-                  label: "Signed in",
-                  value: currentUser.username
-                },
-                {
-                  label: "Section",
-                  value: activeItem.label
-                },
-                {
-                  label: "Host",
-                  value: hostLabel
-                }
-              ]}
-            />
-          </section>
-          <button
-            type="button"
-            className="ghost-action admin-nav-toggle"
-            aria-expanded={navOpen}
-            aria-controls="admin-nav-groups"
-            onClick={() => setNavOpen((current) => !current)}
-          >
-            {navOpen ? "Hide sections" : `Open sections · ${activeItem.label}`}
-          </button>
           <nav
             id="admin-nav-groups"
             className={`admin-nav-shell${navOpen ? " is-open" : ""}`}
@@ -2467,16 +2743,16 @@ export function AdminRoute() {
           >
             {navGroups.map((group) => (
               <section key={group.group} className="admin-nav-group">
-                <p className="admin-nav-group-label">{group.group}</p>
                 <div className="admin-nav">
                   {group.items.map((item) => (
                     <Link
                       key={item.id}
                       to={item.path}
                       className={`admin-nav-link${section === item.id ? " is-active" : ""}`}
+                      title={item.description}
                     >
+                      <AdminIcon name={item.icon} />
                       <strong>{item.label}</strong>
-                      <span>{item.description}</span>
                     </Link>
                   ))}
                 </div>
@@ -2484,13 +2760,60 @@ export function AdminRoute() {
             ))}
           </nav>
           <div className="admin-sidebar-footer">
-            <Link className="ghost-action" to={buildLobbyPath(namespace)}>
-              Return to lobby
+            <p className="status-label">Quick actions</p>
+            <Link className="admin-mini-action" to={`${basePath}/maintenance`}>
+              Run Diagnostics
+            </Link>
+            <Link className="admin-mini-action" to={`${basePath}/config`}>
+              Global Defaults
+            </Link>
+            <Link className="admin-mini-action" to={buildLobbyPath(namespace)}>
+              Return to Lobby
             </Link>
           </div>
         </aside>
 
         <main className="admin-main">
+          <header className="admin-topbar">
+            <button
+              type="button"
+              className="ghost-action admin-icon-button admin-topbar-menu"
+              aria-label="Open admin menu"
+              onClick={() => setNavOpen(true)}
+            >
+              <AdminIcon name="menu" />
+            </button>
+            <div className="admin-topbar-title">
+              <strong>{activeItem.label}</strong>
+              <span>
+                {environmentLabel} · {hostLabel}
+              </span>
+            </div>
+            <div className="admin-topbar-actions">
+              <button
+                type="button"
+                className="ghost-action admin-icon-button"
+                aria-label="Search admin"
+              >
+                <AdminIcon name="search" />
+              </button>
+              <button
+                type="button"
+                className="ghost-action admin-icon-button"
+                aria-label="Admin alerts"
+              >
+                <AdminIcon name="bell" />
+                <span className="admin-alert-dot">1</span>
+              </button>
+              <div className="admin-operator-chip">
+                <AdminAvatar name={currentUser.username} />
+                <span>
+                  <strong>{currentUser.username}</strong>
+                  <small>Admin</small>
+                </span>
+              </div>
+            </div>
+          </header>
           {section === "overview" ? <OverviewSection frameContext={frameContext} /> : null}
           {section === "users" ? <UsersSection frameContext={frameContext} /> : null}
           {section === "games" ? <GamesSection frameContext={frameContext} /> : null}

--- a/frontend/react-shell/src/app-shell-layout.tsx
+++ b/frontend/react-shell/src/app-shell-layout.tsx
@@ -268,6 +268,23 @@ export function AppShellLayout({ children }: { children: ReactNode }) {
     section === "game"
       ? "panel shared-bottom-shell game-bottom-shell"
       : "panel shared-bottom-shell";
+
+  if (section === "admin") {
+    return (
+      <div data-testid="react-shell-layout">
+        <a className="skip-link" href="#main-content">
+          {t("common.skipToContent")}
+        </a>
+        <div className="backdrop" />
+        <div className="app-frame admin-app-frame">
+          <main id="main-content" className="page-shell admin-page-shell">
+            {children}
+          </main>
+        </div>
+      </div>
+    );
+  }
+
   const content = (
     <div className="shell-header" style={{ display: "contents" }}>
       <header className="panel top-nav-bar campaign-nav">

--- a/frontend/react-shell/src/register-route.tsx
+++ b/frontend/react-shell/src/register-route.tsx
@@ -28,6 +28,7 @@ export function RegisterRoute() {
   const namespace = useShellNamespace();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
+  const [inviteCode, setInviteCode] = useState(() => searchParams.get("invite") || "");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
@@ -88,7 +89,8 @@ export function RegisterRoute() {
         {
           username: trimmedUsername,
           password,
-          ...(trimmedEmail ? { email: trimmedEmail } : {})
+          ...(trimmedEmail ? { email: trimmedEmail } : {}),
+          ...(inviteCode.trim() ? { inviteCode: inviteCode.trim() } : {})
         },
         requestMessages()
       );
@@ -138,6 +140,18 @@ export function RegisterRoute() {
             placeholder={t("register.email.placeholder")}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
+          />
+        </label>
+
+        <label className="shell-field">
+          <span>Invite code</span>
+          <input
+            name="invite-code"
+            autoComplete="off"
+            maxLength={64}
+            placeholder="NR-00000000-00000000"
+            value={inviteCode}
+            onChange={(event) => setInviteCode(event.target.value)}
           />
         </label>
 

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -2090,3 +2090,972 @@ button.ghost-action {
     padding: 0;
   }
 }
+
+/* Admin clone shell */
+body[data-app-section="admin"] {
+  background: #020a12;
+}
+
+.app-frame.admin-app-frame {
+  width: min(1560px, calc(100% - 1rem));
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 0.65rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+}
+
+.admin-page-shell {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+.react-shell-page.admin-page {
+  --admin-bg: #03101b;
+  --admin-bg-2: #071c2d;
+  --admin-panel: rgba(8, 28, 45, 0.94);
+  --admin-panel-strong: rgba(4, 18, 30, 0.98);
+  --admin-panel-soft: rgba(16, 42, 62, 0.88);
+  --admin-line: rgba(109, 154, 180, 0.22);
+  --admin-line-strong: rgba(239, 166, 38, 0.38);
+  --admin-gold: #f0a51d;
+  --admin-gold-bright: #ffc24b;
+  --admin-blue: #2b9df4;
+  --admin-green: #72d85e;
+  --admin-red: #ff5d54;
+  --admin-purple: #a86cff;
+  --admin-text: #e9f3f9;
+  --admin-muted: #91a9b8;
+  width: 100%;
+  padding: 0.75rem 0 2rem;
+  color: var(--admin-text);
+  font-family:
+    "Inter",
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    Arial,
+    sans-serif;
+}
+
+.admin-page *,
+.admin-page *::before,
+.admin-page *::after {
+  box-sizing: border-box;
+}
+
+.admin-page
+  :where(h1, h2, h3, p, a, button, input, select, textarea, strong, small, span, td, th, label) {
+  font-family: inherit;
+  font-variant: normal;
+  letter-spacing: 0;
+}
+
+.admin-page .admin-shell {
+  min-height: calc(100vh - 2.8rem);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 0;
+  border: 1px solid rgba(239, 166, 38, 0.28);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 9rem),
+    linear-gradient(135deg, var(--admin-bg) 0%, #061827 42%, #03101b 100%);
+  box-shadow:
+    0 0 0 5px rgba(0, 0, 0, 0.52),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+    0 30px 80px rgba(0, 0, 0, 0.48);
+}
+
+.admin-page .admin-sidebar {
+  position: relative;
+  top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 100%;
+  padding: 0;
+  border: 0;
+  border-right: 1px solid var(--admin-line);
+  border-radius: 0;
+  background:
+    linear-gradient(180deg, rgba(10, 34, 52, 0.96), rgba(3, 16, 27, 0.96)),
+    var(--admin-panel-strong);
+  box-shadow: none;
+}
+
+.admin-page .admin-sidebar-header,
+.admin-page .admin-topbar {
+  min-height: 64px;
+  border-bottom: 1px solid var(--admin-line);
+}
+
+.admin-page .admin-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0 1.35rem;
+}
+
+.admin-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--admin-gold);
+  font-size: 1.45rem;
+  letter-spacing: 0;
+}
+
+.admin-brand-mark {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--admin-gold);
+  border-radius: 50%;
+}
+
+.admin-brand-mark::before,
+.admin-brand-mark::after {
+  content: "";
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 32px;
+  height: 1px;
+  background: var(--admin-gold);
+  transform: translate(-50%, -50%);
+}
+
+.admin-brand-mark::after {
+  width: 1px;
+  height: 32px;
+}
+
+.admin-page .admin-nav-shell {
+  display: grid;
+  gap: 0;
+  padding: 0.65rem 0.75rem;
+}
+
+.admin-page .admin-nav-group {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.admin-page .admin-nav {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.admin-page .admin-nav-link {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  align-items: center;
+  gap: 0.7rem;
+  min-height: 36px;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--admin-text);
+  box-shadow: none;
+  font-size: 0.84rem;
+}
+
+.admin-page .admin-nav-link strong {
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.admin-page .admin-nav-link:hover,
+.admin-page .admin-nav-link.is-active {
+  border-color: rgba(239, 166, 38, 0.3);
+  background: rgba(239, 166, 38, 0.13);
+  color: var(--admin-gold-bright);
+  box-shadow: inset 3px 0 0 var(--admin-gold);
+  transform: none;
+}
+
+.admin-ui-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.45rem;
+  height: 1.45rem;
+  color: currentColor;
+  font-size: 1rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.admin-page .admin-sidebar-footer {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: auto;
+  padding: 1rem;
+  border-top: 1px solid var(--admin-line);
+}
+
+.admin-mini-action {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 0.65rem;
+  border: 1px solid var(--admin-line);
+  border-radius: 4px;
+  background: rgba(9, 29, 45, 0.9);
+  color: var(--admin-text);
+  text-decoration: none;
+  font-size: 0.76rem;
+}
+
+.admin-mini-action:hover {
+  border-color: var(--admin-line-strong);
+  color: var(--admin-gold-bright);
+}
+
+.admin-page .admin-main {
+  min-width: 0;
+  padding: 0 1.15rem 1.15rem;
+}
+
+.admin-page .admin-topbar {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin: 0 -1.15rem 0.85rem;
+  padding: 0 1.15rem;
+  background: rgba(3, 15, 25, 0.54);
+}
+
+.admin-topbar-title {
+  display: grid;
+  gap: 0.1rem;
+  margin-right: auto;
+}
+
+.admin-topbar-title strong {
+  font-size: 0.98rem;
+}
+
+.admin-topbar-title span,
+.admin-operator-chip small {
+  color: var(--admin-muted);
+  font-size: 0.72rem;
+}
+
+.admin-topbar-actions,
+.admin-operator-chip,
+.admin-metric-topline,
+.admin-user-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.admin-operator-chip {
+  min-width: 138px;
+  justify-content: flex-start;
+}
+
+.admin-operator-chip span {
+  display: grid;
+  gap: 0.05rem;
+}
+
+.admin-avatar {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  border: 1px solid rgba(239, 166, 38, 0.62);
+  border-radius: 50%;
+  background:
+    linear-gradient(135deg, rgba(239, 166, 38, 0.34), transparent),
+    linear-gradient(180deg, #1f2d36, #071520);
+  color: #ffe3aa;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.admin-page .admin-section-stack {
+  gap: 0.7rem;
+}
+
+.admin-page .admin-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 50px;
+  margin-bottom: 0.25rem;
+}
+
+.admin-page .admin-hero-copy {
+  gap: 0.28rem;
+}
+
+.admin-page .admin-page-header h1 {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.admin-page .hero-copy {
+  margin: 0;
+  max-width: 56rem;
+  color: var(--admin-muted);
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
+.admin-page .status-label {
+  margin: 0;
+  color: var(--admin-gold);
+  font-size: 0.62rem;
+  line-height: 1.1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-variant: normal;
+}
+
+.admin-page .hero-actions {
+  align-items: center;
+  justify-content: flex-end;
+  margin: 0;
+}
+
+.admin-page .card-panel,
+.admin-page .status-panel,
+.admin-page .admin-toolbar-panel,
+.admin-page .admin-context-panel,
+.admin-page .admin-subpanel,
+.admin-page .admin-callout-panel,
+.admin-page .admin-debug-panel,
+.admin-page .admin-inline-details {
+  border: 1px solid var(--admin-line);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, rgba(19, 45, 65, 0.9), rgba(5, 21, 34, 0.94)), var(--admin-panel);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 12px 24px rgba(0, 0, 0, 0.18);
+}
+
+.admin-page .card-panel,
+.admin-page .status-panel {
+  padding: 0.85rem;
+}
+
+.admin-page .card-panel h2,
+.admin-page .status-panel h2 {
+  font-size: 0.92rem;
+  letter-spacing: 0;
+}
+
+.admin-page .card-header {
+  margin-bottom: 0.65rem;
+}
+
+.admin-page .chip,
+.admin-page .status-pill {
+  border-color: var(--admin-line);
+  border-radius: 4px;
+  background: rgba(3, 17, 28, 0.78);
+  color: var(--admin-text);
+  box-shadow: none;
+  font-size: 0.72rem;
+  padding: 0.26rem 0.46rem;
+}
+
+.admin-page .status-pill.success {
+  color: var(--admin-green);
+}
+
+.admin-page .status-pill.warning {
+  color: var(--admin-gold-bright);
+}
+
+.admin-page .status-pill.danger {
+  color: var(--admin-red);
+}
+
+.admin-page .status-pill.muted {
+  color: var(--admin-muted);
+}
+
+.admin-page .refresh-button,
+.admin-page .ghost-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 34px;
+  padding: 0 0.8rem;
+  border-radius: 4px;
+  font-size: 0.76rem;
+  letter-spacing: 0;
+  font-variant: normal;
+  text-shadow: none;
+  transform: none;
+}
+
+.admin-page .refresh-button {
+  border-color: rgba(239, 166, 38, 0.58);
+  background: linear-gradient(180deg, #c98516, #8d5c0d);
+  color: #fff4d5;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+
+.admin-page .ghost-action {
+  border-color: var(--admin-line);
+  background: rgba(4, 20, 33, 0.88);
+  color: var(--admin-text);
+  box-shadow: none;
+}
+
+.admin-page .refresh-button:hover,
+.admin-page .ghost-action:hover {
+  border-color: var(--admin-line-strong);
+  color: #fff;
+  transform: none;
+}
+
+.admin-page .admin-icon-button {
+  position: relative;
+  width: 34px;
+  min-width: 34px;
+  padding: 0;
+}
+
+.admin-alert-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: grid;
+  place-items: center;
+  min-width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--admin-red);
+  color: #fff;
+  font-size: 0.58rem;
+  font-weight: 700;
+}
+
+.admin-page .admin-kpi-layout {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.65rem;
+}
+
+.admin-page .admin-overview-clone {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr) minmax(300px, 0.9fr);
+  gap: 0.65rem;
+}
+
+.admin-page .admin-kpi-band {
+  gap: 0.65rem;
+}
+
+.admin-page .admin-kpi-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.admin-page .admin-kpi-grid-clone {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.admin-page .admin-metric {
+  position: relative;
+  min-height: 112px;
+  overflow: hidden;
+  padding: 0.75rem;
+}
+
+.admin-page .admin-metric-value {
+  margin: 0.35rem 0 0;
+  color: var(--admin-text);
+  font-size: 1.95rem;
+  letter-spacing: 0;
+}
+
+.admin-page .admin-metric-copy {
+  margin: 0.15rem 0 0;
+  color: var(--admin-muted);
+  font-size: 0.7rem;
+}
+
+.admin-sparkline {
+  position: absolute;
+  right: 0.45rem;
+  bottom: 0.35rem;
+  width: 48%;
+  height: 28px;
+  fill: none;
+  opacity: 0.9;
+}
+
+.admin-sparkline polyline {
+  stroke: currentColor;
+  stroke-width: 2;
+}
+
+.admin-sparkline-blue {
+  color: var(--admin-blue);
+}
+
+.admin-sparkline-gold {
+  color: var(--admin-gold);
+}
+
+.admin-sparkline-green {
+  color: var(--admin-green);
+}
+
+.admin-sparkline-purple {
+  color: var(--admin-purple);
+}
+
+.admin-sparkline-red {
+  color: var(--admin-red);
+}
+
+.admin-page .grid-shell {
+  gap: 0.65rem;
+  margin-top: 0;
+}
+
+.admin-page .admin-overview-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.admin-page .admin-health-panel,
+.admin-page .admin-activity-panel,
+.admin-page .admin-quick-panel,
+.admin-page .admin-recent-games-panel,
+.admin-page .admin-defaults-panel {
+  min-height: 0;
+}
+
+.admin-page .admin-health-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-page .admin-health-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.42rem 0;
+  border-bottom: 1px solid var(--admin-line);
+  color: var(--admin-text);
+  font-size: 0.78rem;
+}
+
+.admin-page .admin-health-list li:last-child {
+  border-bottom: 0;
+}
+
+.admin-page .admin-health-list strong.success {
+  color: var(--admin-green);
+}
+
+.admin-page .admin-health-list strong.warning {
+  color: var(--admin-gold-bright);
+}
+
+.admin-page .admin-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.admin-page .admin-quick-grid a {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 48px;
+  padding: 0.45rem;
+  border: 1px solid var(--admin-line);
+  border-radius: 5px;
+  background: rgba(4, 20, 33, 0.78);
+  color: var(--admin-text);
+  text-decoration: none;
+}
+
+.admin-page .admin-quick-grid a:hover {
+  border-color: var(--admin-line-strong);
+  color: var(--admin-gold-bright);
+}
+
+.admin-page .admin-quick-grid span {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.admin-page .admin-quick-grid strong {
+  font-size: 0.78rem;
+}
+
+.admin-page .admin-quick-grid small {
+  color: var(--admin-muted);
+  font-size: 0.64rem;
+}
+
+.admin-page .admin-toolbar-panel {
+  padding: 0.7rem;
+}
+
+.admin-page .admin-toolbar {
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.admin-page .admin-toolbar .shell-field {
+  min-width: 180px;
+  flex: 0 1 240px;
+}
+
+.admin-page .shell-field {
+  gap: 0.28rem;
+  color: var(--admin-text);
+  font-size: 0.74rem;
+}
+
+.admin-page .shell-field input,
+.admin-page .shell-field select,
+.admin-page .shell-field textarea {
+  min-height: 34px;
+  border-color: var(--admin-line);
+  border-radius: 4px;
+  background: rgba(2, 14, 24, 0.92);
+  color: var(--admin-text);
+  font-size: 0.78rem;
+  padding: 0.52rem 0.65rem;
+}
+
+.admin-page .admin-table th,
+.admin-page .admin-table td {
+  padding: 0.62rem 0.7rem;
+  border-bottom-color: var(--admin-line);
+  font-size: 0.78rem;
+}
+
+.admin-page .admin-table th {
+  background: rgba(3, 17, 28, 0.98);
+  color: var(--admin-muted);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+}
+
+.admin-page .admin-table tbody tr:hover td,
+.admin-page .admin-table tbody tr.is-selected td {
+  background: rgba(31, 72, 100, 0.32);
+}
+
+.admin-page .admin-row-select {
+  color: var(--admin-text);
+}
+
+.admin-user-cell > span:last-child {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.admin-page .admin-table-copy,
+.admin-page .admin-item-meta,
+.admin-page .status-copy,
+.admin-page .admin-field small,
+.admin-page .admin-note-list {
+  color: var(--admin-muted);
+}
+
+.admin-page .admin-game-list,
+.admin-page .admin-player-list,
+.admin-page .admin-issue-list,
+.admin-page .admin-audit-list,
+.admin-page .admin-audit-feed {
+  gap: 0.5rem;
+}
+
+.admin-page .admin-game-item,
+.admin-page .admin-audit-item,
+.admin-page .admin-audit-feed-item,
+.admin-page .admin-player-item,
+.admin-page .admin-list-button,
+.admin-page .admin-issue-item {
+  border-color: var(--admin-line);
+  border-radius: 6px;
+  background: rgba(7, 26, 42, 0.86);
+  color: var(--admin-text);
+}
+
+.admin-page .admin-list-button {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) auto;
+  align-items: center;
+  padding: 0.65rem;
+}
+
+.admin-game-thumb {
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(239, 166, 38, 0.34);
+  border-radius: 5px;
+  background:
+    linear-gradient(135deg, rgba(239, 166, 38, 0.35), transparent 48%),
+    linear-gradient(180deg, #2c6b8d, #12374e);
+}
+
+.admin-page .admin-users-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.admin-page .admin-games-grid {
+  grid-template-columns: minmax(300px, 380px) minmax(0, 1fr);
+}
+
+.admin-page .admin-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.58);
+}
+
+.admin-page .admin-modal {
+  display: grid;
+  gap: 0.85rem;
+  width: min(460px, 100%);
+  padding: 1rem;
+  border: 1px solid var(--admin-line-strong);
+  border-radius: 8px;
+  background: linear-gradient(180deg, #09243a, #04131f);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.62);
+}
+
+.admin-invite-result {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(239, 166, 38, 0.34);
+  border-radius: 5px;
+  background: rgba(239, 166, 38, 0.1);
+}
+
+.admin-invite-result strong {
+  color: var(--admin-gold-bright);
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.admin-invite-result span {
+  color: var(--admin-muted);
+  font-size: 0.74rem;
+}
+
+.admin-topbar-menu {
+  display: none;
+}
+
+@media (max-width: 1180px) {
+  .admin-page .admin-shell {
+    grid-template-columns: 70px minmax(0, 1fr);
+  }
+
+  .admin-page .admin-brand strong,
+  .admin-page .admin-nav-link strong,
+  .admin-page .admin-sidebar-footer {
+    display: none;
+  }
+
+  .admin-page .admin-sidebar-header {
+    justify-content: center;
+    padding: 0;
+  }
+
+  .admin-page .admin-nav-link {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .admin-page .admin-kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .admin-page .admin-shell {
+    grid-template-columns: minmax(0, 1fr);
+    border-radius: 22px;
+  }
+
+  .admin-page .admin-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 35;
+    width: min(290px, calc(100vw - 46px));
+    transform: translateX(-104%);
+    transition: transform 160ms ease;
+  }
+
+  .admin-page .admin-sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .admin-page .admin-brand strong,
+  .admin-page .admin-nav-link strong,
+  .admin-page .admin-sidebar-footer {
+    display: grid;
+  }
+
+  .admin-page .admin-sidebar-header {
+    justify-content: space-between;
+    padding: 0 1rem;
+  }
+
+  .admin-page .admin-nav-link {
+    grid-template-columns: 28px 1fr;
+    justify-items: stretch;
+  }
+
+  .admin-topbar-menu {
+    display: inline-flex;
+  }
+
+  .admin-page .admin-topbar-title span,
+  .admin-page .admin-operator-chip span {
+    display: none;
+  }
+
+  .admin-page .admin-overview-grid,
+  .admin-page .admin-games-grid,
+  .admin-page .admin-overview-clone {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-page .admin-kpi-grid-clone {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .react-shell-page.admin-page {
+    width: calc(100% - 0.25rem);
+    padding-top: 0.35rem;
+  }
+
+  .app-frame.admin-app-frame {
+    padding: 0.25rem;
+  }
+
+  .admin-page .admin-main {
+    padding: 0 0.75rem 0.9rem;
+  }
+
+  .admin-page .admin-topbar {
+    margin-inline: -0.75rem;
+    padding-inline: 0.75rem;
+  }
+
+  .admin-page .admin-page-header {
+    align-items: center;
+  }
+
+  .admin-page .admin-page-header .hero-copy,
+  .admin-page .admin-header-status {
+    display: none;
+  }
+
+  .admin-page .admin-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .admin-page .admin-metric {
+    min-height: 96px;
+  }
+
+  .admin-page .admin-metric-value {
+    font-size: 1.55rem;
+  }
+
+  .admin-page .admin-table thead {
+    display: none;
+  }
+
+  .admin-page .admin-table,
+  .admin-page .admin-table tbody,
+  .admin-page .admin-table tr,
+  .admin-page .admin-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .admin-page .admin-table tr {
+    margin-bottom: 0.5rem;
+    border: 1px solid var(--admin-line);
+    border-radius: 6px;
+    background: rgba(7, 26, 42, 0.86);
+  }
+
+  .admin-page .admin-table td {
+    border-bottom: 0;
+  }
+
+  .admin-page .admin-toolbar .shell-field {
+    min-width: 0;
+    flex: 1 1 10rem;
+  }
+
+  .admin-page .admin-toolbar .shell-field:first-child {
+    flex-basis: 100%;
+  }
+
+  .admin-page .admin-toolbar .shell-field > span,
+  .admin-page .admin-toolbar .shell-field > small {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .admin-page .admin-toolbar {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .admin-page .admin-toolbar-summary {
+    display: none;
+  }
+
+  .admin-page .admin-quick-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-page .admin-list-button {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+
+  .admin-page .admin-list-button .status-pill {
+    grid-column: 2;
+    justify-self: start;
+  }
+}

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -19,6 +19,9 @@ import {
   adminMaintenanceActionResponseSchema,
   adminMaintenanceReportSchema,
   adminOverviewResponseSchema,
+  adminUserInviteCreateRequestSchema,
+  adminUserInviteCreateResponseSchema,
+  adminUserInvitesResponseSchema,
   adminUserRoleUpdateRequestSchema,
   adminUserRoleUpdateResponseSchema,
   adminUsersResponseSchema,
@@ -66,6 +69,9 @@ import type {
   AdminMaintenanceActionResponse,
   AdminMaintenanceReport,
   AdminOverviewResponse,
+  AdminUserInviteCreateRequest,
+  AdminUserInviteCreateResponse,
+  AdminUserInvitesResponse,
   AdminUserRoleUpdateRequest,
   AdminUserRoleUpdateResponse,
   AdminUsersResponse,
@@ -325,6 +331,31 @@ export function updateAdminUserRole(
     requestSchemaName: "AdminUserRoleUpdateRequest",
     responseSchema: adminUserRoleUpdateResponseSchema,
     responseSchemaName: "AdminUserRoleUpdateResponse",
+    ...messages
+  });
+}
+
+export function listAdminUserInvites(messages: ClientMessages): Promise<AdminUserInvitesResponse> {
+  return requestJson({
+    path: "/api/admin/users/invites",
+    responseSchema: adminUserInvitesResponseSchema,
+    responseSchemaName: "AdminUserInvitesResponse",
+    ...messages
+  });
+}
+
+export function createAdminUserInvite(
+  request: AdminUserInviteCreateRequest,
+  messages: ClientMessages
+): Promise<AdminUserInviteCreateResponse> {
+  return requestJson({
+    path: "/api/admin/users/invites",
+    method: "POST",
+    body: request,
+    requestSchema: adminUserInviteCreateRequestSchema,
+    requestSchemaName: "AdminUserInviteCreateRequest",
+    responseSchema: adminUserInviteCreateResponseSchema,
+    responseSchemaName: "AdminUserInviteCreateResponse",
     ...messages
   });
 }

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -166,7 +166,8 @@ export type LoginRequest = z.infer<typeof loginRequestSchema>;
 export const registerRequestSchema = objectSchema({
   username: z.string().min(1).max(32),
   password: passwordSchema,
-  email: z.string().max(255).optional()
+  email: z.string().max(255).optional(),
+  inviteCode: z.string().min(1).max(64).optional()
 });
 
 export type RegisterRequest = z.infer<typeof registerRequestSchema>;
@@ -1346,6 +1347,45 @@ export const adminUserRoleUpdateResponseSchema = objectSchema({
 });
 
 export type AdminUserRoleUpdateResponse = z.infer<typeof adminUserRoleUpdateResponseSchema>;
+
+export const adminUserInviteCreateRequestSchema = objectSchema({
+  label: z.string().min(1).max(80).nullable().optional(),
+  email: z.string().max(255).nullable().optional(),
+  expiresInDays: z.number().int().min(1).max(90).nullable().optional()
+});
+
+export type AdminUserInviteCreateRequest = z.infer<typeof adminUserInviteCreateRequestSchema>;
+
+export const adminUserInviteSummarySchema = objectSchema({
+  id: z.string().min(1),
+  label: z.string().min(1).nullable().optional(),
+  emailHint: z.string().min(1).nullable().optional(),
+  createdAt: z.string().min(1),
+  createdBy: publicUserSchema.nullable().optional(),
+  expiresAt: z.string().min(1),
+  consumedAt: z.string().min(1).nullable().optional(),
+  consumedByUserId: z.string().min(1).nullable().optional(),
+  consumedByUsername: z.string().min(1).nullable().optional(),
+  status: z.enum(["active", "expired", "consumed"])
+});
+
+export type AdminUserInviteSummary = z.infer<typeof adminUserInviteSummarySchema>;
+
+export const adminUserInviteCreateResponseSchema = objectSchema({
+  ok: z.literal(true),
+  invite: adminUserInviteSummarySchema,
+  inviteCode: z.string().min(1),
+  registrationPath: z.string().min(1),
+  audit: adminAuditEntrySchema
+});
+
+export type AdminUserInviteCreateResponse = z.infer<typeof adminUserInviteCreateResponseSchema>;
+
+export const adminUserInvitesResponseSchema = objectSchema({
+  invites: z.array(adminUserInviteSummarySchema)
+});
+
+export type AdminUserInvitesResponse = z.infer<typeof adminUserInvitesResponseSchema>;
 
 export const adminGamesResponseSchema = objectSchema({
   games: z.array(adminGameSummarySchema),

--- a/shared/api-contracts.cts
+++ b/shared/api-contracts.cts
@@ -329,6 +329,31 @@ export interface AdminUserRoleUpdateResponseContract {
   audit: AdminAuditEntryContract;
 }
 
+export interface AdminUserInviteSummaryContract {
+  id: string;
+  label?: string | null;
+  emailHint?: string | null;
+  createdAt: string;
+  createdBy?: PublicUserContract | null;
+  expiresAt: string;
+  consumedAt?: string | null;
+  consumedByUserId?: string | null;
+  consumedByUsername?: string | null;
+  status: "active" | "expired" | "consumed";
+}
+
+export interface AdminUserInviteCreateResponseContract {
+  ok: boolean;
+  invite: AdminUserInviteSummaryContract;
+  inviteCode: string;
+  registrationPath: string;
+  audit: AdminAuditEntryContract;
+}
+
+export interface AdminUserInvitesResponseContract {
+  invites: AdminUserInviteSummaryContract[];
+}
+
 export interface AdminGamesResponseContract {
   games: AdminGameSummaryContract[];
   total: number;

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -165,7 +165,8 @@ export type LoginRequest = z.infer<typeof loginRequestSchema>;
 export const registerRequestSchema = objectSchema({
   username: z.string().min(1).max(32),
   password: passwordSchema,
-  email: z.string().max(255).optional()
+  email: z.string().max(255).optional(),
+  inviteCode: z.string().min(1).max(64).optional()
 });
 
 export type RegisterRequest = z.infer<typeof registerRequestSchema>;
@@ -1345,6 +1346,45 @@ export const adminUserRoleUpdateResponseSchema = objectSchema({
 });
 
 export type AdminUserRoleUpdateResponse = z.infer<typeof adminUserRoleUpdateResponseSchema>;
+
+export const adminUserInviteCreateRequestSchema = objectSchema({
+  label: z.string().min(1).max(80).nullable().optional(),
+  email: z.string().max(255).nullable().optional(),
+  expiresInDays: z.number().int().min(1).max(90).nullable().optional()
+});
+
+export type AdminUserInviteCreateRequest = z.infer<typeof adminUserInviteCreateRequestSchema>;
+
+export const adminUserInviteSummarySchema = objectSchema({
+  id: z.string().min(1),
+  label: z.string().min(1).nullable().optional(),
+  emailHint: z.string().min(1).nullable().optional(),
+  createdAt: z.string().min(1),
+  createdBy: publicUserSchema.nullable().optional(),
+  expiresAt: z.string().min(1),
+  consumedAt: z.string().min(1).nullable().optional(),
+  consumedByUserId: z.string().min(1).nullable().optional(),
+  consumedByUsername: z.string().min(1).nullable().optional(),
+  status: z.enum(["active", "expired", "consumed"])
+});
+
+export type AdminUserInviteSummary = z.infer<typeof adminUserInviteSummarySchema>;
+
+export const adminUserInviteCreateResponseSchema = objectSchema({
+  ok: z.literal(true),
+  invite: adminUserInviteSummarySchema,
+  inviteCode: z.string().min(1),
+  registrationPath: z.string().min(1),
+  audit: adminAuditEntrySchema
+});
+
+export type AdminUserInviteCreateResponse = z.infer<typeof adminUserInviteCreateResponseSchema>;
+
+export const adminUserInvitesResponseSchema = objectSchema({
+  invites: z.array(adminUserInviteSummarySchema)
+});
+
+export type AdminUserInvitesResponse = z.infer<typeof adminUserInvitesResponseSchema>;
 
 export const adminGamesResponseSchema = objectSchema({
   games: z.array(adminGameSummarySchema),

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -569,6 +569,138 @@ register("admin console can promote a user and grant admin access", async () => 
   });
 });
 
+register("admin invite codes can be created, consumed, and rejected after use", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const inviteResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/users/invites",
+      {
+        label: "Operations onboarding",
+        email: "new-operator@example.com",
+        expiresInDays: 7
+      },
+      authHeaders(adminSessionToken)
+    );
+
+    assert.equal(inviteResponse.statusCode, 201);
+    assert.equal(inviteResponse.payload.ok, true);
+    assert.match(inviteResponse.payload.inviteCode, /^NR-/);
+    assert.equal(inviteResponse.payload.invite.status, "active");
+    assert.equal(inviteResponse.payload.audit.action, "user.invite.create");
+
+    const inviteListResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/users/invites",
+      undefined,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(inviteListResponse.statusCode, 200);
+    assert.equal(inviteListResponse.payload.invites.length, 1);
+
+    const registerResponse = await callApp(app, "POST", "/api/auth/register", {
+      username: "invited_operator",
+      password: "secret123",
+      inviteCode: inviteResponse.payload.inviteCode
+    });
+    assert.equal(registerResponse.statusCode, 201);
+    assert.equal(registerResponse.payload.user.username, "invited_operator");
+
+    const consumedListResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/users/invites",
+      undefined,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(consumedListResponse.statusCode, 200);
+    assert.equal(consumedListResponse.payload.invites[0].status, "consumed");
+    assert.equal(consumedListResponse.payload.invites[0].consumedByUsername, "invited_operator");
+
+    const reuseResponse = await callApp(app, "POST", "/api/auth/register", {
+      username: "second_operator",
+      password: "secret123",
+      inviteCode: inviteResponse.payload.inviteCode
+    });
+    assert.equal(reuseResponse.statusCode, 400);
+    assert.equal(reuseResponse.payload.messageKey, "auth.register.inviteCodeConsumed");
+  });
+});
+
+register("registration rejects invalid and expired invite codes", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const invalidResponse = await callApp(app, "POST", "/api/auth/register", {
+      username: "invalid_invite_operator",
+      password: "secret123",
+      inviteCode: "NR-INVALID-CODE"
+    });
+    assert.equal(invalidResponse.statusCode, 400);
+    assert.equal(invalidResponse.payload.messageKey, "auth.register.invalidInviteCode");
+
+    const inviteResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/users/invites",
+      {
+        label: "Expired invite"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(inviteResponse.statusCode, 201);
+
+    const storedInvites = await app.datastore.getAppState("adminUserInvites");
+    storedInvites[0].expiresAt = "2020-01-01T00:00:00.000Z";
+    await app.datastore.setAppState("adminUserInvites", storedInvites);
+
+    const expiredResponse = await callApp(app, "POST", "/api/auth/register", {
+      username: "expired_invite_operator",
+      password: "secret123",
+      inviteCode: inviteResponse.payload.inviteCode
+    });
+    assert.equal(expiredResponse.statusCode, 400);
+    assert.equal(expiredResponse.payload.messageKey, "auth.register.inviteCodeExpired");
+  });
+});
+
+register("registration does not persist users when invite consumption cannot be stored", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const inviteResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/users/invites",
+      {
+        label: "Fragile invite"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(inviteResponse.statusCode, 201);
+
+    const originalSetAppState = app.datastore.setAppState.bind(app.datastore);
+    app.datastore.setAppState = async (key: string, value: unknown) => {
+      if (key === "adminUserInvites") {
+        throw new Error("invite store unavailable");
+      }
+      return originalSetAppState(key, value);
+    };
+
+    try {
+      await assert.rejects(
+        () =>
+          callApp(app, "POST", "/api/auth/register", {
+            username: "invite_write_failure",
+            password: "secret123",
+            inviteCode: inviteResponse.payload.inviteCode
+          }),
+        /invite store unavailable/
+      );
+      assert.equal(await app.datastore.findUserByUsername("invite_write_failure"), null);
+    } finally {
+      app.datastore.setAppState = originalSetAppState;
+    }
+  });
+});
+
 register("admin console updates defaults and new game creation consumes them", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
     const configResponse = await callApp(


### PR DESCRIPTION
## Summary
- Restyles the admin area into the dark NetRisk shell from the supplied reference, including overview, users, games, config, modules, content studio, maintenance, and audit surfaces.
- Adds real admin invite-code creation/listing with hashed server-side storage, one-time plaintext return, expiry, consumption on registration, and audit logging.
- Adds generated admin visuals, responsive tablet/mobile layouts, and a standalone admin frame outside the global game chrome.

## Validation
- npm run lint
- npm run typecheck
- npm run typecheck:react-shell
- npx vitest run --config frontend/react-shell/vitest.config.ts frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
- npm run test:all
- Visual QA screenshots at tablet landscape, tablet portrait, mobile menu, mobile overview, mobile users, and mobile games against the supplied reference.