### PR TITLE
Set War Table as default theme

### DIFF
--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -360,17 +360,30 @@ async function maybeResolve<T>(value: Promise<T> | T): Promise<T> {
   return value;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> | null {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
+    : null;
+}
+
 function createAdminConsole(options: AdminConsoleOptions) {
-  async function ensureRuntimeCatalogReady(): Promise<void> {
+  async function ensureRuntimeCatalogReady(): Promise<Record<string, unknown> | null> {
     if (typeof options.moduleRuntime.getModuleOptions !== "function") {
-      return;
+      return null;
     }
 
-    await maybeResolve(options.moduleRuntime.getModuleOptions());
+    return asRecord(await maybeResolve(options.moduleRuntime.getModuleOptions()));
   }
 
   async function resolveAdminDefaults(input: Record<string, unknown> = {}) {
-    await ensureRuntimeCatalogReady();
+    const moduleOptions = await ensureRuntimeCatalogReady();
+    const resolvedCatalog =
+      asRecord(moduleOptions?.resolvedCatalog) || asRecord(moduleOptions) || null;
+    const resolvedThemes = asRecordArray(resolvedCatalog?.themes);
     const configured = await maybeResolve(
       options.createConfiguredInitialState(input, {
         resolveContentPack: (contentPackId: string) =>
@@ -385,9 +398,15 @@ function createAdminConsole(options: AdminConsoleOptions) {
             ? options.moduleRuntime.findVictoryRuleSet(victoryRuleSetId)
             : findVictoryRuleSet(victoryRuleSetId),
         resolveTheme: (themeId: string) =>
-          typeof options.moduleRuntime.findSiteTheme === "function"
-            ? options.moduleRuntime.findSiteTheme(themeId)
-            : findVisualTheme(themeId),
+          resolvedThemes
+            ? resolvedThemes.find((entry) => entry.id === themeId) || null
+            : typeof options.moduleRuntime.findSiteTheme === "function"
+              ? options.moduleRuntime.findSiteTheme(themeId)
+              : findVisualTheme(themeId),
+        resolveDefaultTheme: () =>
+          resolvedThemes
+            ? resolvedThemes.find((entry) => typeof entry.id === "string") || null
+            : null,
         resolveGamePreset: (presetInput: Record<string, unknown>) =>
           options.moduleRuntime.resolveGamePreset(presetInput),
         resolveGameModuleConfigDefaults: (selectionInput: Record<string, unknown>) =>

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -676,7 +676,7 @@ function defaultCoreClientManifest(): NetRiskModuleClientManifest {
           mapId: "classic-mini",
           diceRuleSetId: "standard",
           victoryRuleSetId: "conquest",
-          themeId: "command",
+          themeId: "war-table",
           pieceSkinId: "classic-color"
         }
       }

--- a/backend/new-game-config.cts
+++ b/backend/new-game-config.cts
@@ -281,6 +281,7 @@ export function validateNewGameConfig(
     resolveSupportedMap?: (mapId: string) => SupportedMap | null;
     resolveVictoryRuleSet?: (victoryRuleSetId: string) => VictoryRuleSet | null;
     resolveTheme?: (themeId: string) => VisualTheme | null;
+    resolveDefaultTheme?: () => VisualTheme | null;
     resolvePieceSkin?: (pieceSkinId: string) => PieceSkin | null;
   } = {}
 ): ValidatedNewGameConfig {
@@ -420,17 +421,24 @@ export function validateNewGameConfig(
     );
   }
 
-  const requestedThemeId = String(
-    input.themeId ||
-      (canPreferFallbackPresentationDefaults ? fallbackConfigInput.themeId : null) ||
-      selectedContentPack.defaultSiteThemeId ||
-      selectedRuleSet.defaults.themeId ||
-      fallbackConfigInput.themeId ||
-      DEFAULT_THEME_ID
-  );
   const resolveTheme =
     typeof options.resolveTheme === "function" ? options.resolveTheme : findVisualTheme;
-  const selectedTheme = resolveTheme(requestedThemeId);
+  const explicitThemeId =
+    typeof input.themeId === "string" && input.themeId !== "" ? input.themeId : null;
+  const themeCandidateIds = explicitThemeId
+    ? [explicitThemeId]
+    : [
+        canPreferFallbackPresentationDefaults ? fallbackConfigInput.themeId : null,
+        selectedContentPack.defaultSiteThemeId,
+        selectedRuleSet.defaults.themeId,
+        fallbackConfigInput.themeId,
+        DEFAULT_THEME_ID
+      ].filter((themeId): themeId is string => typeof themeId === "string" && themeId !== "");
+  const selectedTheme =
+    themeCandidateIds.map((themeId) => resolveTheme(themeId)).find(Boolean) ||
+    (!explicitThemeId && typeof options.resolveDefaultTheme === "function"
+      ? options.resolveDefaultTheme()
+      : null);
   if (!selectedTheme) {
     throw createLocalizedError("Il tema selezionato non e supportato.", "newGame.invalidTheme");
   }
@@ -539,6 +547,7 @@ export function createConfiguredInitialState(
     resolveVictoryRuleSet?: (victoryRuleSetId: string) => VictoryRuleSet | null;
     resolveVictoryRuleRuntime?: (victoryRuleSetId: string) => AuthoredVictoryModuleRuntime | null;
     resolveTheme?: (themeId: string) => VisualTheme | null;
+    resolveDefaultTheme?: () => VisualTheme | null;
     resolvePieceSkin?: (pieceSkinId: string) => PieceSkin | null;
     resolveGamePreset?: (input: {
       gamePresetId?: string | null;
@@ -728,6 +737,7 @@ export function createConfiguredInitialState(
         resolveSupportedMap: options.resolveSupportedMap,
         resolveVictoryRuleSet: options.resolveVictoryRuleSet,
         resolveTheme: options.resolveTheme,
+        resolveDefaultTheme: options.resolveDefaultTheme,
         resolvePieceSkin: options.resolvePieceSkin
       });
       const resolvedModuleSelection =

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1341,6 +1341,7 @@ function createApp(options: CreateAppOptions = {}) {
               moduleRuntime.findVictoryRuleSetRuntime(victoryRuleSetId),
             resolveTheme: (themeId: string) =>
               resolvedCatalog.themes.find((entry: { id: string }) => entry.id === themeId) || null,
+            resolveDefaultTheme: () => resolvedCatalog.themes[0] || null,
             resolvePieceSkin: (pieceSkinId: string) =>
               resolvedCatalog.pieceSkins.find(
                 (entry: { id: string }) => entry.id === pieceSkinId

--- a/e2e/smoke/react-shell-lobby.spec.ts
+++ b/e2e/smoke/react-shell-lobby.spec.ts
@@ -27,6 +27,10 @@ async function loadGameState(page, sessionToken, gameId) {
   return stateResponse.json();
 }
 
+function joinSelectedBattleButton(page) {
+  return page.getByRole("button", { name: /Join Battle|Unisciti alla battaglia/i });
+}
+
 test("react lobby keeps guest access inline with the shared auth copy", async ({ page }) => {
   await resetGame(page);
 
@@ -167,8 +171,8 @@ test("react lobby can join an available game and navigate to the React gameplay 
   await targetRow.click();
 
   await expect(page.getByTestId("react-shell-lobby-details")).toContainText(gameName);
-  await expect(page.getByTestId("react-shell-lobby-join-selected")).toBeVisible();
-  await page.getByTestId("react-shell-lobby-join-selected").click();
+  await expect(joinSelectedBattleButton(page)).toBeVisible();
+  await joinSelectedBattleButton(page).click();
 
   await expect
     .poll(() => page.url(), { timeout: 15000 })
@@ -224,7 +228,7 @@ test("react lobby shows controlled feedback when join fails", async ({ page }) =
   });
   await expect(targetRow).toBeVisible();
   await targetRow.click();
-  await page.getByTestId("react-shell-lobby-join-selected").click();
+  await joinSelectedBattleButton(page).click();
 
   await expect(page).toHaveURL(/\/react\/lobby$/);
   await expect(page.getByTestId("react-shell-lobby-action-error")).toBeVisible();

--- a/e2e/smoke/react-shell.spec.ts
+++ b/e2e/smoke/react-shell.spec.ts
@@ -90,7 +90,7 @@ test("react profile shows query loading before resolving into the empty-history 
 
   await expect(page.locator("#profile-name")).toContainText(username);
   await expect(page.getByTestId("react-shell-profile-empty")).toBeVisible();
-  await expect(page.getByTestId("react-shell-profile-theme-select")).toHaveValue("command");
+  await expect(page.getByTestId("react-shell-profile-theme-select")).toHaveValue("war-table");
 });
 
 test("react profile shows the empty-history state for a new authenticated user", async ({ page }) => {
@@ -118,7 +118,7 @@ test("react profile theme mutation keeps shell theme coherent across navigation"
   await page.goto("/react/profile");
 
   const themeSelect = page.getByTestId("react-shell-profile-theme-select");
-  await expect(themeSelect).toHaveValue("command");
+  await expect(themeSelect).toHaveValue("war-table");
 
   await themeSelect.selectOption("midnight");
 
@@ -223,12 +223,12 @@ test("react profile restores the previous theme when the mutation fails", async 
   await page.goto("/react/profile");
 
   const themeSelect = page.getByTestId("react-shell-profile-theme-select");
-  await expect(themeSelect).toHaveValue("command");
+  await expect(themeSelect).toHaveValue("war-table");
 
   await themeSelect.selectOption("ember");
 
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "command");
-  await expect(themeSelect).toHaveValue("command");
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "war-table");
+  await expect(themeSelect).toHaveValue("war-table");
   await expect(page.getByTestId("react-shell-profile-theme-status")).toContainText(
     /Save failed|Salvataggio non riuscito|Theme update failed|Richiesta fallita/
   );

--- a/frontend/react-shell/src/__tests__/app-shell-layout.test.ts
+++ b/frontend/react-shell/src/__tests__/app-shell-layout.test.ts
@@ -116,10 +116,10 @@ describe("resolveCurrentGameId", () => {
     renderLayout();
 
     await waitFor(() => {
-      expect(document.documentElement.dataset.theme).toBe("command");
+      expect(document.documentElement.dataset.theme).toBe("war-table");
     });
-    expect(document.body.dataset.theme).toBe("command");
-    expect(window.localStorage.getItem("netrisk.theme")).toBe("command");
+    expect(document.body.dataset.theme).toBe("war-table");
+    expect(window.localStorage.getItem("netrisk.theme")).toBe("war-table");
   });
 
   it("preserves a saved module theme until runtime theme ids are available", async () => {

--- a/frontend/react-shell/src/__tests__/theme.test.ts
+++ b/frontend/react-shell/src/__tests__/theme.test.ts
@@ -96,10 +96,10 @@ describe("theme runtime bridge", () => {
 
     const availableThemes = setAvailableShellThemes(["ember", "aurora"]);
 
-    expect(availableThemes).toEqual(["command", "ember", "aurora"]);
-    expect(currentShellTheme()).toBe("command");
-    expect(listShellThemes()).toEqual([{ id: "command" }, { id: "ember" }, { id: "aurora" }]);
-    expect(window.netriskTheme?.getThemes()).toEqual(["command", "ember", "aurora"]);
+    expect(availableThemes).toEqual(["war-table", "ember", "aurora"]);
+    expect(currentShellTheme()).toBe("war-table");
+    expect(listShellThemes()).toEqual([{ id: "war-table" }, { id: "ember" }, { id: "aurora" }]);
+    expect(window.netriskTheme?.getThemes()).toEqual(["war-table", "ember", "aurora"]);
   });
 
   it("uses War Table copy overrides without changing other theme copy", () => {

--- a/frontend/src/core/contracts.mts
+++ b/frontend/src/core/contracts.mts
@@ -10,7 +10,7 @@ export const registeredThemes = Object.freeze<readonly ThemeDefinition[]>([
   Object.freeze({ id: "war-table", labelKey: "profile.preferences.theme.warTable" })
 ]);
 
-export const DEFAULT_THEME = "command";
+export const DEFAULT_THEME = "war-table";
 export const SUPPORTED_THEMES = registeredThemes.map((theme) => theme.id);
 
 export type ThemeName = string;

--- a/modules/core.base/client-manifest.json
+++ b/modules/core.base/client-manifest.json
@@ -45,7 +45,7 @@
         "mapId": "classic-mini",
         "diceRuleSetId": "standard",
         "victoryRuleSetId": "conquest",
-        "themeId": "command",
+        "themeId": "war-table",
         "pieceSkinId": "classic-color"
       }
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -4443,7 +4443,7 @@ register("publicState espone modelli condivisi e stato corrente", () => {
   assert.equal(snapshot.gameConfig?.mapId, "classic-mini");
   assert.equal(snapshot.gameConfig?.diceRuleSetId, "standard");
   assert.equal(snapshot.gameConfig?.victoryRuleSetId, "conquest");
-  assert.equal(snapshot.gameConfig?.themeId, "command");
+  assert.equal(snapshot.gameConfig?.themeId, "war-table");
   assert.equal(snapshot.gameConfig?.pieceSkinId, "classic-color");
 });
 

--- a/shared/content/site-themes/index.cts
+++ b/shared/content/site-themes/index.cts
@@ -5,7 +5,7 @@ import { midnightSiteTheme } from "./midnight.cjs";
 import { warTableSiteTheme } from "./war-table.cjs";
 import type { SiteTheme, SiteThemeSummary } from "./types.cjs";
 
-export const DEFAULT_SITE_THEME_ID = "command";
+export const DEFAULT_SITE_THEME_ID = "war-table";
 
 const siteThemeRegistry = createModuleRegistry<SiteTheme>([
   commandSiteTheme,

--- a/shared/extensions.cts
+++ b/shared/extensions.cts
@@ -18,7 +18,7 @@ export const EXTENSION_SCHEMA_VERSION = 1;
 export const DEFAULT_EXTENSION_PACK_ID = "classic";
 export const DEFAULT_VICTORY_RULE_SET_ID = "conquest";
 export const MAJORITY_CONTROL_VICTORY_RULE_SET_ID = "majority-control";
-export const DEFAULT_THEME_ID = "command";
+export const DEFAULT_THEME_ID = "war-table";
 export const DEFAULT_PIECE_SKIN_ID = "classic-color";
 
 export interface MapDefinition {
@@ -133,7 +133,7 @@ const visualThemes = Object.freeze<Record<string, Readonly<VisualTheme>>>({
   command: Object.freeze({
     id: "command",
     name: "Command",
-    description: "Operational default theme with high-contrast military styling."
+    description: "Operational command theme with high-contrast military styling."
   }),
   midnight: Object.freeze({
     id: "midnight",
@@ -148,7 +148,8 @@ const visualThemes = Object.freeze<Record<string, Readonly<VisualTheme>>>({
   "war-table": Object.freeze({
     id: "war-table",
     name: "War Table",
-    description: "Dark tactical table interface with brass accents and dense command panels."
+    description:
+      "Default dark tactical table interface with brass accents and dense command panels."
   })
 });
 

--- a/tests/gameplay/regression/module-runtime.test.cts
+++ b/tests/gameplay/regression/module-runtime.test.cts
@@ -954,6 +954,7 @@ register(
         assert.equal(createGameResponse.statusCode, 201);
         assert.equal(createGameResponse.payload.state.gameConfig.ruleSetId, "classic-defense-3");
         assert.equal(createGameResponse.payload.state.gameConfig.diceRuleSetId, "standard");
+        assert.equal(createGameResponse.payload.state.gameConfig.themeId, "command");
 
         const invalidCreateResponse = await callApp(
           app,

--- a/tests/gameplay/regression/module-runtime.test.cts
+++ b/tests/gameplay/regression/module-runtime.test.cts
@@ -938,6 +938,22 @@ register(
           ["classic", "classic-defense-3"]
         );
 
+        const adminConfigResponse = await callApp(
+          app,
+          "PUT",
+          "/api/admin/config",
+          {
+            defaults: {
+              mapId: "classic-mini",
+              ruleSetId: "classic-defense-3",
+              diceRuleSetId: "standard"
+            }
+          },
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(adminConfigResponse.statusCode, 200);
+        assert.equal(adminConfigResponse.payload.config.defaults.themeId, "command");
+
         const createGameResponse = await callApp(
           app,
           "POST",

--- a/tests/gameplay/setup/new-game-config.test.cts
+++ b/tests/gameplay/setup/new-game-config.test.cts
@@ -103,7 +103,7 @@ register("validateNewGameConfig derives modular defaults from the selected exten
   assert.equal(config.ruleSetId, "classic-defense-3");
   assert.equal(config.diceRuleSetId, "defense-3");
   assert.equal(config.victoryRuleSetId, "conquest");
-  assert.equal(config.themeId, "command");
+  assert.equal(config.themeId, "war-table");
   assert.equal(config.pieceSkinId, "classic-color");
   assert.equal(config.extensionSchemaVersion, 1);
 });
@@ -135,7 +135,7 @@ register(
     assert.equal(config.mapId, "classic-mini");
     assert.equal(config.diceRuleSetId, "defense-3");
     assert.equal(config.victoryRuleSetId, "conquest");
-    assert.equal(config.themeId, "command");
+    assert.equal(config.themeId, "war-table");
     assert.equal(config.pieceSkinId, "classic-color");
   }
 );

--- a/tests/gameplay/setup/new-game-config.test.cts
+++ b/tests/gameplay/setup/new-game-config.test.cts
@@ -16,6 +16,14 @@ const {
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
+function testTheme(themeId: string) {
+  return {
+    id: themeId,
+    name: `Test ${themeId}`,
+    description: "Theme resolved by a test catalog"
+  };
+}
+
 register("new game rule set lookups expose only the minimal built-in adapter shape", () => {
   const listedRuleSet = listNewGameRuleSets().find(
     (ruleSet: { id: string }) => ruleSet.id === "classic-defense-3"
@@ -184,6 +192,48 @@ register("validateNewGameConfig supports injected victory, theme, and piece skin
   assert.equal(config.themeId, "runtime-theme");
   assert.equal(config.pieceSkinId, "runtime-skin");
 });
+
+register(
+  "validateNewGameConfig falls back to the default resolved theme for implicit selections",
+  () => {
+    const config = validateNewGameConfig(
+      {
+        totalPlayers: 2,
+        players: [{ type: "human" }, { type: "ai" }]
+      },
+      {
+        random: () => 0,
+        resolveTheme: (themeId: string) => (themeId === "command" ? testTheme("command") : null),
+        resolveDefaultTheme: () => testTheme("command")
+      }
+    );
+
+    assert.equal(config.themeId, "command");
+  }
+);
+
+register(
+  "validateNewGameConfig rejects explicit unsupported themes before default fallback",
+  () => {
+    assert.throws(
+      () =>
+        validateNewGameConfig(
+          {
+            themeId: "war-table",
+            totalPlayers: 2,
+            players: [{ type: "human" }, { type: "ai" }]
+          },
+          {
+            random: () => 0,
+            resolveTheme: (themeId: string) =>
+              themeId === "command" ? testTheme("command") : null,
+            resolveDefaultTheme: () => testTheme("command")
+          }
+        ),
+      (error: { messageKey?: string }) => error.messageKey === "newGame.invalidTheme"
+    );
+  }
+);
 
 register(
   "createConfiguredInitialState forwards runtime preset victory, theme and piece skin defaults",


### PR DESCRIPTION
## Summary
- Make War Table the default shell/site/game theme across shared defaults, core manifest, and tests.
- Keep explicit theme validation strict while letting implicit defaults fall back to the active catalog theme when modules expose a restricted theme set.
- Propagate that restricted-catalog theme fallback into admin defaults and cover it with regression tests.
- Add direct gameplay setup regressions for implicit theme fallback and explicit unsupported-theme rejection.
- Update smoke E2E expectations for War Table as the default lobby/profile theme.

## Validation
- npm run test:gameplay
- npm run test:all
- npm run test:e2e:smoke
- npm run format:check
- npm run lint (passes with existing warnings)