### PR TITLE
🛡️ Sentinel: Fix information disclosure in health endpoint

### DIFF
--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -488,8 +488,6 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
       return {
         ok: true,
         storage: "supabase",
-        url: supabaseUrl,
-        schema,
         counts: {
           users: await countRows("users", "id"),
           games: await countRows("games", "id"),

--- a/backend/datastore.cts
+++ b/backend/datastore.cts
@@ -413,7 +413,6 @@ function createDatastore(options: DatastoreOptions = {}) {
       return {
         ok: Boolean(probe && probe.ok === 1),
         storage: "sqlite",
-        dbFile,
         journalMode: "WAL",
         counts: {
           users: Number(statements.countUsers.get().count) || 0,

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -6604,7 +6604,6 @@ register("GET /api/health espone lo stato del datastore sqlite", async () => {
     assert.equal(payload.ok, true);
     assert.equal(payload.storage.storage, "sqlite");
     assert.equal(payload.storage.journalMode, "WAL");
-    assert.equal(payload.storage.dbFile, context.tempDbFile);
     assert.equal(typeof payload.storage.counts.users, "number");
     assert.equal(typeof payload.storage.counts.games, "number");
     assert.equal(typeof payload.storage.counts.sessions, "number");
@@ -6713,8 +6712,6 @@ register("datastore supabase espone healthSummary async quando configurato via e
     assert.equal(datastore.driver, "supabase");
     assert.equal(health.ok, true);
     assert.equal(health.storage, "supabase");
-    assert.equal(health.url, "https://example.supabase.co");
-    assert.equal(health.schema, "public");
     assert.deepEqual(health.counts, { users: 0, games: 0, sessions: 0 });
 
     datastore.close();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/health` endpoint was exposing sensitive internal infrastructure details, including absolute filesystem paths to the SQLite database and the Supabase connection URL and schema.
🎯 Impact: This information could be used by an attacker for reconnaissance, enabling them to better understand the server's internal structure and potentially target external services directly.
🔧 Fix: Sanitized the `healthSummary` output in both `backend/datastore.cts` and `backend/datastore-supabase.cts` to exclude `dbFile`, `url`, and `schema`. Updated test expectations in `scripts/run-tests.cts`.
✅ Verification: Ran `npm test` and verified that all 153 tests pass, including the updated health check tests.

---
*PR created automatically by Jules for task [4949325404138287404](https://jules.google.com/task/4949325404138287404) started by @andreame-code*