### PR TITLE
[codex] Fix session cookie regression test coverage

### DIFF
--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -50,6 +50,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/canonical-game-route-redirect.test.cjs",
   "../tests/gameplay/regression/codex-pr-readiness.test.cjs",
   "../tests/gameplay/regression/finished-game-retention.test.cjs",
+  "../tests/gameplay/regression/session-cookie-persistence.test.cjs",
   "../tests/gameplay/regression/startup-init-error.test.cjs",
   "../tests/gameplay/regression/tooling-and-supabase-regressions.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",

--- a/tests/gameplay/regression/session-cookie-persistence.test.cts
+++ b/tests/gameplay/regression/session-cookie-persistence.test.cts
@@ -95,8 +95,7 @@ register(
 
       const registerResponse = await callApp(app, "POST", "/api/auth/register", {
         username,
-        password,
-        email: `${username}@example.com`
+        password
       });
 
       assert.equal(registerResponse.statusCode, 201);


### PR DESCRIPTION
## What changed

- Wires `session-cookie-persistence.test.cjs` into the fixed gameplay regression test manifest.
- Removes the optional email field from that regression setup so registration does not depend on `AUTH_ENCRYPTION_KEY`.

## Why

Daily bug scan found that commit `57ad7ff` added a new cookie persistence regression file, but `scripts/run-gameplay-tests.cts` uses an explicit module list and did not include it. Once included, the test setup would also fail on unrelated email encryption validation instead of isolating session cookie persistence.

## Validation

- `npm run build:ts`
- `npm run test:gameplay` (331 tests passed, including `login response persists the session cookie for the server-side session lifetime`)
