### PR TITLE
🛡️ Sentinel: Harden error masking for 500 Internal Server Errors

### DIFF
--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -158,7 +158,7 @@ export function sendLocalizedError(
     ? localizedPayload(null, fallbackMessage, fallbackKey, fallbackParams)
     : rawPayload;
 
-  const sanitizedCode = isInternalError ? (code || null) : rawCode;
+  const sanitizedCode = isInternalError ? code || null : rawCode;
 
   sendJson(res, statusCode, {
     ...sanitizedPayload,

--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -145,12 +145,24 @@ export function sendLocalizedError(
   code: string | null = null,
   extra: Record<string, unknown> = {}
 ): void {
-  const payload = localizedPayload(input, fallbackMessage, fallbackKey, fallbackParams);
-  const resolvedCode = code || input?.code || null;
-  logUnexpectedServerError(res, statusCode, payload, resolvedCode, input);
+  const isInternalError = statusCode >= 500;
+
+  // We always compute the "raw" payload and code for server-side logging first.
+  const rawPayload = localizedPayload(input, fallbackMessage, fallbackKey, fallbackParams);
+  const rawCode = code || input?.code || null;
+  logUnexpectedServerError(res, statusCode, rawPayload, rawCode, input);
+
+  // For internal errors, we MUST NOT leak the raw input details to the client.
+  // We compute a sanitized version of the payload and code for the response.
+  const sanitizedPayload = isInternalError
+    ? localizedPayload(null, fallbackMessage, fallbackKey, fallbackParams)
+    : rawPayload;
+
+  const sanitizedCode = isInternalError ? (code || null) : rawCode;
+
   sendJson(res, statusCode, {
-    ...payload,
-    code: resolvedCode,
-    ...extra
+    ...sanitizedPayload,
+    code: sanitizedCode,
+    ...(isInternalError ? {} : extra)
   });
 }

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -61,7 +61,8 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/game-read-routes.test.cjs",
   "../tests/gameplay/regression/game-overview-route.test.cjs",
   "../tests/gameplay/regression/modules-routes.test.cjs",
-  "../tests/gameplay/regression/event-broadcast.test.cjs"
+  "../tests/gameplay/regression/event-broadcast.test.cjs",
+  "../tests/gameplay/verify_error_masking.test.cjs"
 ];
 
 gameplayTestModules.forEach((relativePath) => {

--- a/tests/gameplay/verify_error_masking.test.cts
+++ b/tests/gameplay/verify_error_masking.test.cts
@@ -1,0 +1,49 @@
+const { sendLocalizedError } = require("../../backend/http-response.cjs");
+const assert = require("node:assert/strict");
+
+(global as any).register("sendLocalizedError masks internal error details for the client", async () => {
+  class MockResponse {
+    statusCode: number = 0;
+    headers: Record<string, string> = {};
+    data: string = "";
+    headersSent: boolean = false;
+    writableEnded: boolean = false;
+
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+    }
+
+    end(payload: string) {
+      this.data = payload;
+      this.writableEnded = true;
+    }
+
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    }
+  }
+
+  // Test Case 1: 400 Client Error - Details should be visible
+  const res400 = new MockResponse();
+  const input400 = { message: "Detailed client error", code: "CLIENT_CODE" };
+  sendLocalizedError(res400 as any, 400, input400, "Fallback", "fallback.key", {}, null, { extra: "info" });
+
+  const payload400 = JSON.parse(res400.data);
+  assert.strictEqual(res400.statusCode, 400);
+  assert.strictEqual(payload400.error, "Detailed client error");
+  assert.strictEqual(payload400.code, "CLIENT_CODE");
+  assert.strictEqual(payload400.extra, "info");
+
+  // Test Case 2: 500 Internal Error - Details should be MASKED
+  const res500 = new MockResponse();
+  const input500 = { message: "Sensitive internal detail", code: "INTERNAL_CODE" };
+  sendLocalizedError(res500 as any, 500, input500, "Generic internal error", "server.internalError", {}, null, { extra: "leaked" });
+
+  const payload500 = JSON.parse(res500.data);
+  assert.strictEqual(res500.statusCode, 500);
+  assert.strictEqual(payload500.error, "Generic internal error");
+  assert.strictEqual(payload500.messageKey, "server.internalError");
+  assert.strictEqual(payload500.code, null);
+  assert.strictEqual(payload500.extra, undefined);
+});

--- a/tests/gameplay/verify_error_masking.test.cts
+++ b/tests/gameplay/verify_error_masking.test.cts
@@ -1,49 +1,63 @@
 const { sendLocalizedError } = require("../../backend/http-response.cjs");
 const assert = require("node:assert/strict");
 
-(global as any).register("sendLocalizedError masks internal error details for the client", async () => {
-  class MockResponse {
-    statusCode: number = 0;
-    headers: Record<string, string> = {};
-    data: string = "";
-    headersSent: boolean = false;
-    writableEnded: boolean = false;
+(global as any).register(
+  "sendLocalizedError masks internal error details for the client",
+  async () => {
+    class MockResponse {
+      statusCode: number = 0;
+      headers: Record<string, string> = {};
+      data: string = "";
+      headersSent: boolean = false;
+      writableEnded: boolean = false;
 
-    writeHead(status: number, headers: Record<string, string>) {
-      this.statusCode = status;
-      this.headers = headers;
+      writeHead(status: number, headers: Record<string, string>) {
+        this.statusCode = status;
+        this.headers = headers;
+      }
+
+      end(payload: string) {
+        this.data = payload;
+        this.writableEnded = true;
+      }
+
+      setHeader(name: string, value: string) {
+        this.headers[name] = value;
+      }
     }
 
-    end(payload: string) {
-      this.data = payload;
-      this.writableEnded = true;
-    }
+    // Test Case 1: 400 Client Error - Details should be visible
+    const res400 = new MockResponse();
+    const input400 = { message: "Detailed client error", code: "CLIENT_CODE" };
+    sendLocalizedError(res400 as any, 400, input400, "Fallback", "fallback.key", {}, null, {
+      extra: "info"
+    });
 
-    setHeader(name: string, value: string) {
-      this.headers[name] = value;
-    }
+    const payload400 = JSON.parse(res400.data);
+    assert.strictEqual(res400.statusCode, 400);
+    assert.strictEqual(payload400.error, "Detailed client error");
+    assert.strictEqual(payload400.code, "CLIENT_CODE");
+    assert.strictEqual(payload400.extra, "info");
+
+    // Test Case 2: 500 Internal Error - Details should be MASKED
+    const res500 = new MockResponse();
+    const input500 = { message: "Sensitive internal detail", code: "INTERNAL_CODE" };
+    sendLocalizedError(
+      res500 as any,
+      500,
+      input500,
+      "Generic internal error",
+      "server.internalError",
+      {},
+      null,
+      { extra: "leaked" }
+    );
+
+    const payload500 = JSON.parse(res500.data);
+    assert.strictEqual(res500.statusCode, 500);
+    assert.strictEqual(payload500.error, "Generic internal error");
+    assert.strictEqual(payload500.messageKey, "server.internalError");
+    assert.strictEqual(payload500.code, null);
+    assert.strictEqual(payload500.extra, undefined);
   }
-
-  // Test Case 1: 400 Client Error - Details should be visible
-  const res400 = new MockResponse();
-  const input400 = { message: "Detailed client error", code: "CLIENT_CODE" };
-  sendLocalizedError(res400 as any, 400, input400, "Fallback", "fallback.key", {}, null, { extra: "info" });
-
-  const payload400 = JSON.parse(res400.data);
-  assert.strictEqual(res400.statusCode, 400);
-  assert.strictEqual(payload400.error, "Detailed client error");
-  assert.strictEqual(payload400.code, "CLIENT_CODE");
-  assert.strictEqual(payload400.extra, "info");
-
-  // Test Case 2: 500 Internal Error - Details should be MASKED
-  const res500 = new MockResponse();
-  const input500 = { message: "Sensitive internal detail", code: "INTERNAL_CODE" };
-  sendLocalizedError(res500 as any, 500, input500, "Generic internal error", "server.internalError", {}, null, { extra: "leaked" });
-
-  const payload500 = JSON.parse(res500.data);
-  assert.strictEqual(res500.statusCode, 500);
-  assert.strictEqual(payload500.error, "Generic internal error");
-  assert.strictEqual(payload500.messageKey, "server.internalError");
-  assert.strictEqual(payload500.code, null);
-  assert.strictEqual(payload500.extra, undefined);
-});
+);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Leakage on Internal Server Errors (500+)
🎯 Impact: Technical details like stack traces, database structure, or internal IDs could be exposed to users in the JSON response body when a server-side error occurs.
🔧 Fix: Modified `sendLocalizedError` to compute a sanitized response for any status code >= 500. It now forces the use of fallback messages/keys and strips 'extra' metadata from the public response while keeping them in server logs.
✅ Verification: Added `tests/gameplay/verify_error_masking.test.cts` and verified with `npm test`. All 153 tests passed.

---
*PR created automatically by Jules for task [3648897578428978346](https://jules.google.com/task/3648897578428978346) started by @andreame-code*