### PR TITLE
Add loading page animation

### DIFF
--- a/frontend/react-shell/src/__tests__/shell-routing.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/shell-routing.integration.test.tsx
@@ -137,6 +137,17 @@ describe("React shell routing and session integration", () => {
     expect(window.location.pathname).toBe("/");
   });
 
+  it("shows the loading animation while the shell bootstrap is pending", async () => {
+    const sessionRequest = createDeferred<AuthSessionResponse>();
+
+    getSessionMock.mockReturnValue(sessionRequest.promise);
+
+    renderReactShell("/react/");
+
+    expect(await screen.findByTestId("react-shell-loading")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-animation")).toBeInTheDocument();
+  });
+
   it("shows the profile loading state while the session request is pending", async () => {
     const sessionRequest = createDeferred<AuthSessionResponse>();
 

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -28,6 +28,7 @@ import { t, translateGameLogEntries, translateServerMessage } from "@frontend-i1
 
 import { useAuth } from "@react-shell/auth";
 import { GameplayMapViewport } from "@react-shell/gameplay-map-viewport";
+import { LoadingAnimation } from "@react-shell/loading-animation";
 import { readCurrentPlayerId, storeCurrentPlayerId } from "@react-shell/player-session";
 import { buildRegisterPath, useShellNamespace } from "@react-shell/public-auth-paths";
 import { gameplayStateQueryKey } from "@react-shell/react-query";
@@ -800,7 +801,8 @@ export function GameRoute() {
 
   if (gameplayQuery.isLoading && !snapshot) {
     return (
-      <section className="status-panel" data-testid="react-shell-game-loading">
+      <section className="status-panel status-panel-loading" data-testid="react-shell-game-loading">
+        <LoadingAnimation />
         <p className="status-label">Game</p>
         <h2>{t("game.runtime.loadingState")}</h2>
         <p className="status-copy">{t("game.errors.loadActiveGame")}</p>

--- a/frontend/react-shell/src/loading-animation.tsx
+++ b/frontend/react-shell/src/loading-animation.tsx
@@ -1,0 +1,12 @@
+export function LoadingAnimation() {
+  return (
+    <div className="loading-animation" data-testid="loading-animation" aria-hidden="true">
+      <span className="loading-animation-orbit" />
+      <span className="loading-animation-path" />
+      <span className="loading-animation-node loading-animation-node-a" />
+      <span className="loading-animation-node loading-animation-node-b" />
+      <span className="loading-animation-node loading-animation-node-c" />
+      <span className="loading-animation-node loading-animation-node-d" />
+    </div>
+  );
+}

--- a/frontend/react-shell/src/register-route.tsx
+++ b/frontend/react-shell/src/register-route.tsx
@@ -7,6 +7,7 @@ import { validateRegistrationInput } from "@frontend-core/register-validation.mt
 import { t } from "@frontend-i18n";
 
 import { useAuth } from "@react-shell/auth";
+import { LoadingAnimation } from "@react-shell/loading-animation";
 import {
   buildLoginHref,
   buildProfilePath,
@@ -37,7 +38,8 @@ export function RegisterRoute() {
 
   if (state.status === "loading") {
     return (
-      <section className="status-panel" data-testid="react-shell-loading">
+      <section className="status-panel status-panel-loading" data-testid="react-shell-loading">
+        <LoadingAnimation />
         <p className="status-label">Loading</p>
         <h2>Preparing the registration route</h2>
         <p className="status-copy">

--- a/frontend/react-shell/src/routes.tsx
+++ b/frontend/react-shell/src/routes.tsx
@@ -12,6 +12,7 @@ import {
 import { AppShellLayout } from "@react-shell/app-shell-layout";
 import { useAuth, AuthProvider } from "@react-shell/auth";
 import { LandingRoute } from "@react-shell/landing-route";
+import { LoadingAnimation } from "@react-shell/loading-animation";
 import {
   buildBootstrapPath,
   buildLobbyPath,
@@ -44,7 +45,8 @@ const GameRoute = lazy(async () => ({
 
 function LoadingPanel({ title, copy }: { title: string; copy: string }) {
   return (
-    <section className="status-panel" data-testid="react-shell-loading">
+    <section className="status-panel status-panel-loading" data-testid="react-shell-loading">
+      <LoadingAnimation />
       <p className="status-label">Loading</p>
       <h2>{title}</h2>
       <p className="status-copy">{copy}</p>

--- a/frontend/react-shell/src/styles.css
+++ b/frontend/react-shell/src/styles.css
@@ -167,8 +167,138 @@ html[data-theme="ember"] {
   padding: 1.5rem;
 }
 
+.status-panel-loading {
+  position: relative;
+  overflow: hidden;
+}
+
+.loading-animation {
+  position: relative;
+  width: 84px;
+  height: 84px;
+  margin: 0 0 1rem;
+  border: 1px solid var(--shell-border);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, var(--shell-status-surface) 0 24%, transparent 25%),
+    radial-gradient(
+      circle at center,
+      transparent 0 52%,
+      var(--shell-status-surface) 53% 59%,
+      transparent 60%
+    );
+  box-shadow:
+    inset 0 0 22px var(--overlay),
+    0 12px 30px rgba(0, 0, 0, 0.22);
+}
+
+.loading-animation-orbit,
+.loading-animation-path,
+.loading-animation-node {
+  position: absolute;
+  display: block;
+}
+
+.loading-animation-orbit {
+  inset: 12px;
+  border: 1px dashed var(--shell-border-hi);
+  border-radius: 50%;
+  animation: loading-orbit-spin 2600ms linear infinite;
+}
+
+.loading-animation-path {
+  inset: 8px;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0 62%,
+    var(--gold-dim) 72%,
+    var(--gold-hi) 78%,
+    transparent 88%
+  );
+  -webkit-mask: radial-gradient(circle, transparent 0 62%, #000 63% 68%, transparent 69%);
+  mask: radial-gradient(circle, transparent 0 62%, #000 63% 68%, transparent 69%);
+  animation: loading-path-sweep 1800ms cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+.loading-animation-node {
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--shell-border-hi);
+  border-radius: 50%;
+  background: var(--shell-node-bg);
+  box-shadow: 0 0 16px var(--gold-dim);
+  animation: loading-node-pulse 1800ms cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.loading-animation-node-a {
+  top: 8px;
+  left: 36px;
+}
+
+.loading-animation-node-b {
+  top: 36px;
+  right: 8px;
+  animation-delay: 180ms;
+}
+
+.loading-animation-node-c {
+  bottom: 8px;
+  left: 36px;
+  animation-delay: 360ms;
+}
+
+.loading-animation-node-d {
+  top: 36px;
+  left: 8px;
+  animation-delay: 540ms;
+}
+
+@keyframes loading-orbit-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes loading-path-sweep {
+  0% {
+    transform: rotate(0deg);
+    opacity: 0.55;
+  }
+
+  48% {
+    opacity: 1;
+  }
+
+  100% {
+    transform: rotate(360deg);
+    opacity: 0.55;
+  }
+}
+
+@keyframes loading-node-pulse {
+  0%,
+  100% {
+    transform: scale(0.88);
+    opacity: 0.72;
+  }
+
+  45% {
+    transform: scale(1.16);
+    opacity: 1;
+  }
+}
+
 .status-panel-error {
   border-color: var(--shell-danger-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-animation-orbit,
+  .loading-animation-path,
+  .loading-animation-node {
+    animation: none;
+  }
 }
 
 .grid-shell {


### PR DESCRIPTION
## Summary
- Add a reusable React shell loading animation component
- Wire it into shared route, registration, and gameplay loading states
- Add reduced-motion-safe CSS and coverage for shell bootstrap loading

## Validation
- npm run test:react -- --run frontend/react-shell/src/__tests__/shell-routing.integration.test.tsx
- npm run typecheck:react-shell
- npx prettier --check frontend/react-shell/src/loading-animation.tsx frontend/react-shell/src/routes.tsx frontend/react-shell/src/register-route.tsx frontend/react-shell/src/gameplay-route.tsx frontend/react-shell/src/styles.css frontend/react-shell/src/__tests__/shell-routing.integration.test.tsx
- npm run lint
- npm run build:ts
- npm run test:react
- Playwright visual check with /api/auth/session held pending