### PR TITLE
[codex] Configure Matt Pocock skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,19 @@ NetRisk should be built incrementally in this order:
 - Do not mix transport, persistence, and game rules in one file.
 - Do not replace working code just because another design seems cleaner.
 - Respect backward compatibility with the current project unless explicitly told otherwise.
+
+## Agent skills
+
+These skill settings only configure how Matt Pocock's skills find issue-tracker, triage-label, and domain-doc information. They do not override the NetRisk agent instructions above. If there is any conflict, the existing NetRisk guardrails, current user request, and repository-specific instructions take precedence.
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `andreame-code/netrisk`, inferred from the configured `origin` remote. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default GitHub Issue label vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain docs layout with root `CONTEXT.md` and ADRs in `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,43 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+NetRisk uses a single-context domain docs layout.
+
+- `CONTEXT.md` at the repo root contains NetRisk domain and project language.
+- `docs/adr/` contains architecture decision records.
+- `CONTEXT-MAP.md` is not used because this repo is not a monorepo.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** -- read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+|-- CONTEXT.md
+|-- docs/adr/
+|   |-- 0001-record-map-model.md
+|   `-- 0002-record-turn-engine-boundaries.md
+`-- frontend/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal -- either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) -- but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub Issues in `andreame-code/netrisk`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` -- `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `andreame-code/netrisk`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary
- append Matt Pocock skill configuration to AGENTS.md without changing existing NetRisk instructions
- add docs/agents configuration for GitHub Issues, triage labels, and single-context domain docs

## Validation
- git diff --check --cached

## Notes
- No source, tests, package files, CONTEXT.md, ADRs, or .gitignore changes are included.
- Existing local frontend modifications remain unstaged and are not part of this PR.