### PR TITLE
[codex] Update project documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 NetRisk separa in modo netto presentazione, orchestrazione e regole. Il browser non decide mai le regole della partita: il backend valida ogni azione e il motore di gioco contiene la logica pura.
 
-## Stato attuale (aprile 2026)
+## Stato attuale (maggio 2026)
 
 L'applicazione include già:
 
@@ -25,6 +25,7 @@ L'applicazione include già:
 - sincronizzazione stato/eventi e controlli di autorizzazione lato route
 - gestione conflitti di versione in azioni concorrenti
 - runtime moduli con `core.base` come baseline provider, catalogo admin `resolvedCatalog`, enable/disable, content pack, preset e defaults server-side
+- Content Studio admin per moduli autoriali `victory-objectives`, con draft validation, publish/enable/disable e merge nel catalogo runtime
 - persistenza dei metadata modulari di setup, cosi moduli attivi, preset/profili, `scenarioSetup`, `gameplayEffects` e timeout turno sopravvivono ai round trip create/open/save
 
 Mappe correnti: `classic-mini`, `middle-earth`, `world-classic`.
@@ -54,10 +55,13 @@ Output build della shell React, servito dal backend statico come bundle condivis
 Server HTTP, autenticazione, autorizzazione, datastore, sessioni di gioco e route API.
 
 `/backend/engine`  
-Motore di gioco puro: setup, turn flow, rinforzi, attacchi, combattimento, conquista, carte, fortifica, vittoria, AI.
+Motore di gioco puro: setup, turn flow, rinforzi, attacchi, combattimento, conquista, carte, fortifica, timeout turno, vittoria, obiettivi autoriali, AI.
 
 `/backend/routes`  
-Handler route specializzati (auth/account, setup partita, azioni turno/attacco/carte, lettura stato/eventi, overview e management).
+Handler route specializzati (auth/account, setup partita, azioni turno/attacco/carte, lettura stato/eventi, admin, Content Studio, overview e management).
+
+`/backend/scheduler` e `/backend/services`
+Job e servizi applicativi server-side per enforcement timeout turno, recupero turni AI bloccati e retention delle partite concluse.
 
 `/shared`  
 Tipi, modelli dominio, contratti API, mappe e regole condivise tra frontend e backend.
@@ -89,7 +93,10 @@ Suite Playwright per flussi end-to-end UI + API.
 - `conquest-resolution.cts`: gestione conquista e movimento obbligatorio
 - `fortify-movement.cts`: validazione/esecuzione fortifica
 - `victory-detection.cts`: eliminazione player e determinazione vincitore
+- `victory-objectives.cts`: valutazione di obiettivi vittoria autoriali persistiti nello stato partita
+- `turn-timeout.cts`: risoluzione timeout turno configurabili
 - `ai-player.cts`: strategia turno automatica bot
+- `ai-turn-resume.cts`: ripresa sicura di turni AI pendenti
 - `banzai-attack.cts`: variante/utility specifica per attacchi ripetuti
 
 ## Moduli shared rilevanti
@@ -108,6 +115,7 @@ Suite Playwright per flussi end-to-end UI + API.
 - `victory-rule-sets.cts`: registry condizioni di vittoria
 - `site-themes.cts`: registry temi supportati
 - `player-piece-sets.cts`: registry palette/set pedine giocatore
+- `turn-timeouts.cts`: registry timeout turno selezionabili
 - `content-packs.cts`: manifest compositi che raggruppano moduli compatibili
 - `content-catalog.cts`: riepilogo built-in dei contenuti registrati, utile come sorgente shared ma non come snapshot canonico runtime/admin
 - `core-base-catalog.cts`: baseline catalog condiviso del modulo `core.base` per setup e admin surfaces
@@ -189,6 +197,7 @@ Categorie future da trattare con lo stesso modello:
   - Supabase (quando configurato via env)
 - La logica datastore è incapsulata dietro `backend/datastore.cts`.
 - Event stream partita via endpoint dedicato e broadcast server-side.
+- Scheduler applicativo: `/api/cron/scheduled-jobs` esegue timeout turno, recovery AI e retention delle partite concluse dietro `CRON_SECRET`.
 - Correlazione runtime: le risposte `/api/*` espongono `X-Request-Id`; gli errori backend inattesi vengono loggati con `requestId`, route e `release` per facilitare la diagnosi dei problemi emersi dalla shell React.
 - Routing statico: `backend/server.cts` risolve le route React canoniche pulite e gli alias `/react/*`, tratta i documenti deprecati `/legacy/*.html` noti come redirect verso le route canoniche e restituisce `404` per gli asset o i path `/legacy/*` senza equivalente supportato.
 - Guardrail repository/deploy: controllo env richieste, fallback senza `.git` per i check repository, `outputDirectory: public` su Vercel, `.vercelignore` per evitare upload di artefatti locali e `check-no-js-sources` per la TS-complete allowlist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Useful local commands:
 ```bash
 npm start
 npm run dev:react-shell
+npm run build:ts
 npm run format:check
 npm run lint
 npm run typecheck
@@ -67,6 +68,8 @@ Run the smallest relevant validation set for your change, then broaden when the 
 - Shared types, routes, or engine logic: `npm run typecheck` and `npm test`
 - Turn rules, setup rules, or combat/reinforcement changes: `npm run test:gameplay`
 - UI, routing, or end-to-end behavior changes: `npm run test:e2e:smoke` or the most relevant Playwright subset
+- Admin Content Studio or authored gameplay content changes: `npm run test:react` plus `npm run test:gameplay`, with the focused admin/content-studio regression tests when possible
+- Scheduler, datastore, or deployment-surface changes: `npm run typecheck`, `npm test`, and the focused gameplay regression that covers the touched service
 
 If you change public API payloads or shared validation, verify the implementation against `shared/runtime-validation.cts` and `shared/api-contracts.cts`.
 
@@ -112,6 +115,20 @@ Default product content belongs in shared registries plus `shared/core-base-cata
 8. Add or extend regression coverage in `tests/gameplay/regression/module-runtime.test.cts`.
 
 Use the existing `modules/demo.command-center` fixture as the baseline shape for manifests and slot declarations.
+
+## Adding authored Content Studio modules
+
+Admin-authored gameplay content should go through Content Studio when the feature can be expressed as constrained data rather than executable code.
+
+The current authored module type is `victory-objectives`.
+
+1. Keep transport schemas in `shared/runtime-validation.cts`.
+2. Keep persistence behind `backend/authored-modules.cts`.
+3. Keep admin route handling in `backend/routes/admin-content-studio.cts`.
+4. Merge published runtime output through `backend/module-runtime.cts`.
+5. Persist resolved runtime data into `gameConfig` when the game is created.
+6. Let `backend/engine` consume the resolved payload directly instead of performing admin lookups during a turn.
+7. Update `docs/content-studio-victory-objectives.md` or add a sibling document for a new authored module type.
 
 ## API and validation guardrails
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Today the project includes:
 - typed frontend API client helpers for auth, profile, lobby, setup, and gameplay flows
 - canonical React + Vite UI served on clean routes `/`, `/login`, `/register`, `/lobby`, `/lobby/new`, `/profile`, `/game`, and `/game/:gameId`, with `/react/*` kept as a supported alias and the old static UI removed
 - admin-only operational console on `/admin` and `/react/admin` with overview, users, games, configuration, maintenance, runtime modules, and audit log sections
+- admin Content Studio for authored `victory-objectives` modules, with draft validation, publish/enable/disable flows, and runtime catalog integration
 - TanStack Query + Zustand conventions in the React shell, with protected login, lobby, new game, profile, and gameplay routes shared by the canonical URLs and their `/react/*` aliases
 - minimal React shell production observability with Sentry, release tagging, and API request-id correlation
 - initial lobby and reopening saved games
@@ -54,8 +55,13 @@ Currently supported maps are `classic-mini`, `middle-earth`, and `world-classic`
 - [Admin console guide](docs/admin-console.md)
 - [Admin console execution plan](docs/admin-console-plan.md)
 - [Admin console handoff](docs/admin-console-handoff.md)
+- [Content Studio victory objectives](docs/content-studio-victory-objectives.md)
 - [React migration matrix](docs/react-migration-matrix.md)
 - [Extending NetRisk](docs/extending-netrisk.md)
+- [Codex PR readiness gate](docs/codex-pr-readiness-gate.md)
+- [E2E test guide](e2e/README.md)
+- [Gameplay test guide](tests/gameplay/README.md)
+- [React shell testing guide](frontend/react-shell/TESTING.md)
 - [Contributing](CONTRIBUTING.md)
 - [Architecture background](ARCHITECTURE.md)
 
@@ -153,7 +159,7 @@ Production deployments on Vercel execute scheduled checks through `vercel.json`:
 
 The endpoint is protected with `Authorization: Bearer ${CRON_SECRET}` and is intended for Vercel Cron invocations.
 Missing `CRON_SECRET` does not block the rest of the application from booting, but it does disable the cron endpoint until the secret is configured.
-The current scheduled jobs enforce configured turn time limits for active games and recover stuck AI turns. They are structured so additional jobs can be added under the same scheduler entrypoint.
+The current scheduled jobs enforce configured turn time limits for active games, recover stuck AI turns, and prune expired finished games according to the configured retention window. They are structured so additional jobs can be added under the same scheduler entrypoint.
 When an AI recovery is intercepted server-side, the backend also emits a structured `ai_turn_recovery` log event so recovery frequency can be monitored from runtime logs.
 
 ## Vercel deployment notes
@@ -245,9 +251,15 @@ npm run typecheck:react-shell
 npm test
 npm run test:gameplay
 npm run test:e2e
+npm run test:e2e:smoke
+npm run test:e2e:split
+npm run test:e2e:parallel
+npm run test:e2e:serial
+npm run test:e2e:headed
 npm run test:e2e:update
 npm run test:all
 npm run test:all:e2e
+npm run test:all:e2e:split
 ```
 
 - `npm test`: standard repository suite
@@ -267,9 +279,14 @@ npm run test:all:e2e
 - `npm run typecheck:react-shell`: type-checks the React shell sources that back both canonical and `/react/*` routes
 - `npm run test:gameplay`: game engine validation
 - `npm run test:e2e`: Playwright tests for user flows
+- `npm run test:e2e:smoke`: fast Playwright smoke coverage
+- `npm run test:e2e:split` / `npm run test:e2e:parallel`: isolated Playwright shard runners
+- `npm run test:e2e:serial`: explicit single-process Playwright runner
+- `npm run test:e2e:headed`: headed Playwright run for local debugging
 - `npm run test:e2e:update`: intentionally updates Playwright visual baselines after an approved UI change
 - `npm run test:all`: repository + gameplay tests
 - `npm run test:all:e2e`: repository + gameplay + e2e tests
+- `npm run test:all:e2e:split`: repository + gameplay tests plus split E2E shards
 
 ## Code quality
 
@@ -301,6 +318,8 @@ The `tests/gameplay` suite currently covers areas such as:
 - card helpers and trade bonus
 - shared runtime validation schemas and deterministic validation errors
 - multi-module regression flows
+- admin console and Content Studio route regressions
+- scheduler regressions for turn timeout, AI turn recovery, and finished-game retention
 - repository guardrails such as the TS-complete allowlist for tracked sources
 
 The `e2e` suite currently covers:
@@ -429,7 +448,10 @@ Main frontend screens currently available:
 - `/register`: canonical React register route
 - `/lobby`: canonical React lobby
 - `/lobby/new`: canonical React new game setup
+- `/admin`: canonical React admin console
+- `/admin/*`: canonical React admin sections
 - `/profile`: canonical React profile
+- `/unauthorized`: canonical React authorization fallback
 - `/game`: canonical React gameplay index/start shell
 - `/game/:gameId`: canonical React gameplay route
 - `/react/`: supported alias for the React landing/bootstrap route
@@ -437,7 +459,10 @@ Main frontend screens currently available:
 - `/react/register`: supported alias for the React register route
 - `/react/lobby`: supported alias for the React lobby route
 - `/react/lobby/new`: supported alias for the React new game route
+- `/react/admin`: supported alias for the admin console
+- `/react/admin/*`: supported alias for admin sections
 - `/react/profile`: supported alias for the React profile route
+- `/react/unauthorized`: supported alias for the authorization fallback
 - `/react/game`: supported alias for the React gameplay index/start shell
 - `/react/game/:gameId`: supported alias for the React gameplay route
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,9 +46,9 @@ Please report issues such as:
 
 - authentication or authorization bypass
 - privilege escalation between players, lobbies, or game sessions
-- unauthorized access across deprecated `/legacy` document redirects, direct game routes, or the parallel `/react/` shell
+- unauthorized access across deprecated `/legacy` document redirects, direct game routes, canonical React routes, admin/Content Studio routes, or the supported `/react/` alias shell
 - exposure of secrets, session data, backups, or private user information
-- deployment or environment misconfiguration that unintentionally exposes protected API or cron surfaces
+- deployment or environment misconfiguration that unintentionally exposes protected API, admin, Content Studio, module-management, or cron surfaces
 - server-side injection, remote code execution, or arbitrary file access
 - vulnerabilities that let a client bypass backend validation or corrupt authoritative game state
 

--- a/TEST_GAPS.md
+++ b/TEST_GAPS.md
@@ -40,6 +40,8 @@
 - Gameplay E2E: granular rendering reinforcement flow stabilized against async control population
 - React shell routes: bootstrap, auth redirects, lobby/profile/new game, and gameplay route rendering
 - TS-complete allowlist regression: React shell sources are allowed and tracked stray `.js` sources are rejected
+- Admin Content Studio route and runtime integration regressions
+- Scheduler services: turn timeout, AI turn recovery, and finished-game retention
 
 ## Missing
 

--- a/docs/admin-console-handoff.md
+++ b/docs/admin-console-handoff.md
@@ -1,5 +1,7 @@
 # Admin Console Handoff
 
+This handoff is a historical snapshot for the first admin-console PR. For the current admin surface, see `docs/admin-console.md` and `docs/content-studio-victory-objectives.md`.
+
 ## What Was Implemented
 
 - a protected admin React route at `/admin` with sidebar navigation and section-based admin shell
@@ -8,6 +10,7 @@
 - persistent audit logging for core admin mutations
 - guarded admin actions for user role changes, lobby close, game termination, game config repair, and stale lobby cleanup
 - maintenance and diagnostics flows for broken references, stale lobbies, and snapshot/config inspection
+- later follow-up work added Content Studio for authored `victory-objectives` modules and a System Health admin section
 
 ## Routes And Pages Added
 
@@ -27,6 +30,7 @@
 - `GET /api/admin/maintenance`
 - `POST /api/admin/maintenance`
 - `GET /api/admin/audit`
+- follow-up Content Studio APIs are documented in `docs/content-studio-victory-objectives.md`
 
 ## Database Model And Config Changes
 
@@ -68,7 +72,7 @@
 3. richer admin UX for destructive confirmations and bulk operations
 4. pagination, sorting, and larger-scale operational filters
 
-## PR Status
+## Historical PR Status
 
 - branch: `codex/admin-console`
 - selected implementation commits in this PR:

--- a/docs/admin-console-plan.md
+++ b/docs/admin-console-plan.md
@@ -1,5 +1,7 @@
 # Admin Console Execution Plan
 
+This is a historical execution plan for the first admin-console delivery slice. The shipped console has since grown to include Content Studio and system-health surfaces; use `docs/admin-console.md` for the current operator guide.
+
 ## Discovery Summary
 
 - Auth uses cookie-backed sessions via `netrisk_session` and persists `user.role` in the datastore.
@@ -31,5 +33,6 @@
 
 - delivery slices 1 through 6 are now implemented on `codex/admin-console`
 - the shipped console includes `Overview`, `Users`, `Games`, `Configurations`, `Runtime / Modules`, `Maintenance`, and `Audit Log`
+- later documentation reflects the current console including `Content Studio` and `System Health`
 - the latest hardening pass added regression coverage for anonymous/non-admin protection on admin mutations, destructive confirmation failures with audit logging, and admin-default preservation when `ruleSetId` is explicit but `pieceSetId` is omitted
 - the remaining work is now operational hardening rather than missing first-slice functionality: durable audit retention, richer bulk UX, and deeper runtime repair/remap tooling

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -1,6 +1,6 @@
 # Admin Console
 
-The first usable NetRisk administrator area now lives at `/admin`, with `/react/admin` kept as the supported alias while the React shell transition continues.
+The NetRisk administrator area lives at `/admin`, with `/react/admin` kept as the supported alias for the same React shell.
 
 ## Access model
 
@@ -16,7 +16,9 @@ The first usable NetRisk administrator area now lives at `/admin`, with `/react/
 - `Games`: searchable list of games/lobbies, issue summary, player/config inspection, raw state view, close/terminate/repair actions
 - `Configurations`: global admin defaults, enabled modules, profiles, runtime defaults, and maintenance thresholds
 - `Runtime / Modules`: module catalog management through the existing module admin tooling
+- `Content Studio`: constrained authoring for gameplay modules; currently supports `victory-objectives`
 - `Maintenance`: validation report and guarded cleanup/repair actions
+- `System Health`: diagnostics view for module references, game snapshots, stale lobbies, and maintenance findings
 - `Audit Log`: persistent log of admin mutations with actor, action, target, and result
 
 ## Local development admin bootstrap
@@ -42,11 +44,13 @@ Notes:
 
 - admin defaults are stored in `app_state` under `adminConsoleConfig`
 - audit entries are stored in `app_state` under `adminAuditLog`
+- authored Content Studio modules are stored in `app_state` under `authoredGameplayModules`
 - game repair actions update stored snapshots only through server-side normalization helpers
 
 ## Safety notes
 
 - module disable now refuses when the module is still referenced by admin defaults
+- Content Studio modules are schema-validated server-side before publish/enable and never execute arbitrary uploaded code
 - game repair preserves runtime-resolved IDs while synchronizing stale top-level snapshot fields
 - cleanup and destructive actions are audit logged on both success and failure paths where applicable
 
@@ -54,6 +58,7 @@ Notes:
 
 - `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx` verifies admin route gating, non-admin navigation hiding, and overview-shell loading in the React shell
 - `tests/gameplay/regression/admin-console-routes.test.cts` verifies admin API protection for anonymous and non-admin callers, role mutation, destructive confirmation enforcement, failure audit logging, maintenance actions, and admin-default runtime preservation
+- `tests/gameplay/regression/admin-content-studio-routes.test.cts` verifies authored module route protection, validation, publish/enable/disable behavior, and runtime integration
 - `tests/gameplay/regression/vercel-routing-config.test.cts` verifies `/admin` and `/react/admin` continue to route correctly through the deployed rewrite layer
 
 Notable backend regressions covered today:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,10 +4,10 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Layout
 
-NetRisk uses a single-context domain docs layout.
+NetRisk uses a single-context domain docs layout when domain context files are present.
 
-- `CONTEXT.md` at the repo root contains NetRisk domain and project language.
-- `docs/adr/` contains architecture decision records.
+- `CONTEXT.md` at the repo root contains NetRisk domain and project language when created.
+- `docs/adr/` contains architecture decision records when created.
 - `CONTEXT-MAP.md` is not used because this repo is not a monorepo.
 
 ## Before exploring, read these
@@ -15,11 +15,11 @@ NetRisk uses a single-context domain docs layout.
 - **`CONTEXT.md`** at the repo root.
 - **`docs/adr/`** -- read ADRs that touch the area you're about to work in.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. This repository currently allows those files to be created lazily when terms or decisions actually get resolved.
 
 ## File structure
 
-Single-context repo:
+Single-context repo, once the optional domain docs have been created:
 
 ```
 /

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub Issues in `andreame-code/netrisk`. Use the `gh` CLI for all operations.
+Issues and PRDs for this repo live as GitHub Issues in `andreame-code/netrisk`. Use the `gh` CLI for direct issue operations unless a task-specific GitHub connector workflow is explicitly in use.
 
 ## Conventions
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -12,4 +12,4 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+The right-hand column reflects the current default GitHub Issue label vocabulary for this repo.

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,8 @@
 
 This companion guide covers public endpoints that are intentionally snapshot-driven, stream-based, or not yet modeled as first-class OpenAPI schemas.
 
+The OpenAPI artifact currently covers the stable schema-backed auth/login/logout/session, profile/theme, games, module catalog, module mutation, game options, and cron endpoints. This file keeps the broader operational notes close to the snapshot and admin surfaces that are easier to understand in prose.
+
 ## Transport rules
 
 - Session auth uses the `netrisk_session` cookie.
@@ -159,7 +161,7 @@ Success responses return:
 }
 ```
 
-- This route is public, but it is not yet backed by a shared runtime response schema, so it is documented here instead of in `docs/openapi.json`.
+- This route is public and uses shared runtime validation, but it is not yet represented in `docs/openapi.json`.
 
 ### `GET /api/health`
 
@@ -178,5 +180,10 @@ Success responses return:
 - The route answers with `200` when `ok` is true and `503` otherwise.
 
 ## Internal endpoints excluded from public docs
+
+Admin and operator-only JSON endpoints are protected by the `admin:manage` capability and are intentionally documented in their feature guides instead of the public OpenAPI artifact:
+
+- `/api/admin/*`: overview, users, games, config, maintenance, audit
+- `/api/admin/content-studio/*`: authored gameplay module options, CRUD-like draft operations, validate, publish, enable, disable
 
 `/api/test/reset` and `/api/test/next-attack-rolls` exist only for E2E support when `E2E=true`. They are intentionally excluded from the public API reference.

--- a/docs/codex-pr-readiness-gate.md
+++ b/docs/codex-pr-readiness-gate.md
@@ -14,7 +14,7 @@ It does not post noisy comments on unrelated pull requests.
 
 ## Workflow
 
-The automation lives in [`.github/workflows/codex-pr-readiness.yml`](/D:/Andre/Documents/Playground/.github/workflows/codex-pr-readiness.yml) and runs on:
+The automation lives in [`.github/workflows/codex-pr-readiness.yml`](../.github/workflows/codex-pr-readiness.yml) and runs on:
 
 - Codex-relevant draft PR events
 - Codex-relevant review activity
@@ -23,7 +23,7 @@ The automation lives in [`.github/workflows/codex-pr-readiness.yml`](/D:/Andre/D
 - a recurring schedule every 30 minutes
 - manual dispatch
 
-The heavy logic is centralized in [`scripts/evaluate-codex-pr-readiness.cts`](/D:/Andre/Documents/Playground/scripts/evaluate-codex-pr-readiness.cts).
+The heavy logic is centralized in [`scripts/evaluate-codex-pr-readiness.cts`](../scripts/evaluate-codex-pr-readiness.cts).
 
 ## Hard blockers
 
@@ -79,7 +79,7 @@ It updates that comment in place and avoids duplicate status comments. If the bo
 
 ## Allowlists and tuning
 
-Behavior is tuned in [`.github/codex-pr-readiness.json`](/D:/Andre/Documents/Playground/.github/codex-pr-readiness.json), including:
+Behavior is tuned in [`.github/codex-pr-readiness.json`](../.github/codex-pr-readiness.json), including:
 
 - target label and branch prefix
 - Codex actor list

--- a/docs/content-studio-victory-objectives.md
+++ b/docs/content-studio-victory-objectives.md
@@ -30,6 +30,8 @@ The admin UI supports:
 - disabling or re-enabling a published module
 - inspecting the generated runtime JSON
 
+The section is available from the admin console at `/admin/content-studio` and `/react/admin/content-studio`.
+
 Published or disabled modules are read-only in this phase. If later revisioning is needed, the
 next step should introduce explicit draft-from-published versioning rather than in-place mutation.
 
@@ -124,6 +126,7 @@ Current endpoints:
 - `POST /api/admin/content-studio/modules/:id/disable`
 
 These routes reuse the existing admin authorization and audit flow through `backend/admin-console.cts`.
+They are intentionally excluded from the public OpenAPI artifact because they are operator-only workflows, but they still use shared runtime validation schemas.
 
 ## UI structure
 
@@ -143,6 +146,11 @@ The authoring screen owns:
 - live validation
 - player-facing preview
 - generated runtime JSON
+
+Regression coverage lives in:
+
+- `tests/gameplay/regression/admin-content-studio-routes.test.cts`
+- `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx`
 
 ## Extension path for future module types
 

--- a/docs/extending-netrisk.md
+++ b/docs/extending-netrisk.md
@@ -13,12 +13,14 @@ core.base baseline + enabled runtime modules -> backend/module-runtime.cts -> re
 
 Both endpoints now include an additive `resolvedCatalog` field. New consumers should treat `resolvedCatalog` as the canonical source of truth. The flat top-level arrays (`maps`, `ruleSets`, `themes`, and so on) remain available as backward-compatible mirrors derived from that catalog.
 
-NetRisk still supports two authoring paths:
+NetRisk supports three authoring paths:
 
 - shared baseline content under `shared` when the feature becomes part of the default product
 - optional runtime modules under `modules` when the feature should stay discoverable, enable/disable-friendly, and packageable for admins
+- constrained admin-authored content through Content Studio when the feature can be represented as validated data
 
 Choose the shared baseline path when the feature should ship with `core.base`. Choose a runtime module when the feature should remain optional or be rolled out incrementally.
+Choose Content Studio when admins should author validated gameplay content without editing files or executing arbitrary module code.
 
 ## Path 1: built-in maps and rule registries
 
@@ -168,6 +170,13 @@ Use runtime modules when:
 - you need presets, profiles, or UI slot packaging
 - you want to ship content without rewriting the base registries
 
+Use Content Studio when:
+
+- the authored content fits a supported schema such as `victory-objectives`
+- admins need draft/validate/publish/enable/disable flows
+- generated runtime data can be persisted into `gameConfig`
+- the engine can consume that resolved payload directly
+
 ## Guardrails
 
 - Keep game rules in `backend/engine`, not in React components.
@@ -176,3 +185,4 @@ Use runtime modules when:
 - Prefer `resolvedCatalog` in new consumers and keep flat option fields only for compatibility bridges.
 - Prefer additive modules and registries over broad refactors.
 - Back every new map, rule, or module path with focused tests.
+- Keep Content Studio authoring schema-driven and server-validated; do not turn it into an arbitrary code upload path.

--- a/docs/gameplay-flows.md
+++ b/docs/gameplay-flows.md
@@ -30,6 +30,7 @@ Notes:
 - The game remains in `lobby` until a valid start request succeeds.
 - `POST /api/games/open` does not mutate the rules flow; it rehydrates a saved snapshot, preserves modular setup metadata already stored in `gameConfig`, and can resume pending AI work before replying.
 - Player surrender feeds the same victory detection path used by normal turn resolution.
+- Authored victory objectives, when selected, are resolved at game creation and persisted into `gameConfig` so victory checks do not depend on admin lookups during a turn.
 
 ## Turn lifecycle
 
@@ -70,6 +71,7 @@ Notes:
 - A conquest can force a post-combat movement before more attacks are allowed.
 - `endTurn` from attack moves the game into `fortify` before advancing to the next player.
 - Optional gameplay effects can require a minimum number of attacks or force a fortify when one is legally available.
+- Configured turn timeouts are enforced by scheduled backend jobs and use the same backend-authoritative transition model as explicit player actions.
 
 ## Mutation transport and version conflicts
 

--- a/docs/react-migration-matrix.md
+++ b/docs/react-migration-matrix.md
@@ -14,7 +14,9 @@ The React cutover is complete. NetRisk now serves a single React shell on the ca
 | `/register` and `/react/register` | registration and authenticated redirect handling |
 | `/lobby` and `/react/lobby` | lobby list, selection, join/open flows |
 | `/lobby/new` and `/react/lobby/new` | game creation with presets, profiles, and validation |
+| `/admin/*` and `/react/admin/*` | admin console, Content Studio, modules, maintenance, audit, and system-health sections |
 | `/profile` and `/react/profile` | player profile, theme preference, admin module controls |
+| `/unauthorized` and `/react/unauthorized` | predictable fallback for protected routes |
 | `/game`, `/game/:gameId`, `/react/game`, `/react/game/:gameId` | gameplay shell, SSE sync, actions, and recovery flows |
 
 ## Deprecated URLs

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -39,6 +39,7 @@ Each run also uses a temporary SQLite database dedicated to that E2E instance, a
 - gameplay flows for reinforcement, attack/conquest, fortify handoff, surrender, relogin binding, and version conflict
 - React gameplay flows on canonical `/game/:gameId` and supported `/react/game/:gameId` links, including join/start, forced trade, and version-conflict recovery
 - authorization flows for protected games, direct game routes, and spectator access
+- map viewport controls and territory selection flows
 - profile states: loading, error, empty, invalid payload fallback, participating games, and theme preference
 - React shell bootstrap, protected redirects, and route-level rendering on canonical routes plus `/react/*`
 - new game setup happy path plus validation fallback when setup options become invalid

--- a/frontend/react-shell/TESTING.md
+++ b/frontend/react-shell/TESTING.md
@@ -5,3 +5,5 @@
 - Metti i test di integrazione route/provider in `src/__tests__/*.integration.test.tsx`.
 - Se serve attesa controllata, usa `test/deferred.ts` invece di timeout arbitrari.
 - Usa `test/render-react-shell.tsx` per rendere la shell con router, auth provider e `QueryClient` isolato per test.
+- Per route protette, admin e Content Studio, verifica sia gating/redirect sia rendering della sezione reale.
+- Per chiamate remote, preferisci mock dei client tipizzati invece di simulare `fetch` dentro il componente.

--- a/tests/gameplay/README.md
+++ b/tests/gameplay/README.md
@@ -20,10 +20,11 @@ The command builds the current TypeScript sources first and then runs the gamepl
 - `fortify`: fortification movement
 - `victory`: elimination and victory
 - `shared`: shared runtime validation and cross-layer contract helpers
-- `regression`: representative multi-module flows, route regressions, and repository guardrails such as the TS source allowlist
+- `regression`: representative multi-module flows, admin/Content Studio routes, scheduler services, route regressions, and repository guardrails such as the TS source allowlist
 
 ## Notes for contributors
 
 - Gameplay tests are registered explicitly by the harness, so adding a new test file also requires wiring it into `scripts/run-gameplay-tests.cts`.
 - This suite is the right place for engine rules, module-runtime regressions, and deterministic repository checks that do not need a browser.
+- Admin APIs, authored content, scheduler services, and datastore-sensitive route behavior belong here when they can be verified without Playwright.
 - Browser-independent frontend/backend contract tests for the typed HTTP client live in `scripts/run-tests.cts`, not in this gameplay harness.

--- a/ts-sot-phase0-baseline.md
+++ b/ts-sot-phase0-baseline.md
@@ -1,6 +1,7 @@
 # Baseline Fase 0 - Source of Truth in TypeScript
 
 Nota: questo file descrive un checkpoint storico della fase 0 sul branch `codex/ts-sot-phase0`. Non rappresenta il gate corrente del repository; per lo stato attuale fare riferimento a `README.md`, `ARCHITECTURE.md` e ai check della PR attiva.
+Il gate corrente include anche `npm run check:ts-sources`, che rifiuta nuove sorgenti non TypeScript fuori allowlist.
 
 Data: 2026-04-12
 


### PR DESCRIPTION
## Summary

- Refresh project documentation around the current admin console, Content Studio, route contract, scheduler, and test coverage.
- Add missing documentation links for Content Studio, readiness gate, E2E, gameplay, and React shell testing.
- Replace stale historical wording and absolute local links with current, repo-relative references.

## Validation

- `npm run format:check`
- `git diff --check`

## Notes

Documentation-only change. No application source files or dependencies were changed.