### PR TITLE
[codex] deepen architecture modules

### DIFF
--- a/backend/module-runtime-contributions.cts
+++ b/backend/module-runtime-contributions.cts
@@ -1,0 +1,135 @@
+import type {
+  NetRiskContentContribution,
+  NetRiskInstalledModule
+} from "../shared/netrisk-modules.cjs";
+
+const CONTENT_CONTRIBUTION_KEYS = [
+  "mapIds",
+  "siteThemeIds",
+  "pieceSkinIds",
+  "playerPieceSetIds",
+  "contentPackIds",
+  "diceRuleSetIds",
+  "cardRuleSetIds",
+  "victoryRuleSetIds",
+  "fortifyRuleSetIds",
+  "reinforcementRuleSetIds"
+] as const;
+
+type RuntimeMapEntry = { map: { id: string } };
+type RuntimeContentPackEntry = { contentPack: { id: string } };
+type RuntimePlayerPieceSetEntry = { pieceSet: { id: string } };
+type RuntimeDiceRuleSetEntry = { diceRuleSet: { id: string } };
+type RuntimeSiteThemeEntry = { theme: { id: string } };
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function emptyContentContribution(): NetRiskContentContribution {
+  return {
+    mapIds: [],
+    siteThemeIds: [],
+    pieceSkinIds: [],
+    playerPieceSetIds: [],
+    contentPackIds: [],
+    diceRuleSetIds: [],
+    cardRuleSetIds: [],
+    victoryRuleSetIds: [],
+    fortifyRuleSetIds: [],
+    reinforcementRuleSetIds: []
+  };
+}
+
+function aggregateContentContribution(
+  modules: NetRiskInstalledModule[],
+  runtimeMapEntries: RuntimeMapEntry[] = [],
+  runtimeContentPackEntries: RuntimeContentPackEntry[] = [],
+  runtimePlayerPieceSetEntries: RuntimePlayerPieceSetEntry[] = [],
+  runtimeDiceRuleSetEntries: RuntimeDiceRuleSetEntry[] = [],
+  runtimeSiteThemeEntries: RuntimeSiteThemeEntry[] = []
+): NetRiskContentContribution {
+  const contribution = emptyContentContribution();
+
+  modules.forEach((moduleEntry) => {
+    const content = moduleEntry.clientManifest?.content;
+    if (!content) {
+      return;
+    }
+
+    CONTENT_CONTRIBUTION_KEYS.forEach((key) => {
+      const currentValues = contribution[key] || [];
+      const nextValues = Array.isArray(content[key]) ? content[key] : [];
+      contribution[key] = unique([...currentValues, ...nextValues]);
+    });
+  });
+
+  if (runtimeMapEntries.length) {
+    contribution.mapIds = unique([
+      ...(contribution.mapIds || []),
+      ...runtimeMapEntries.map((entry) => entry.map.id)
+    ]);
+  }
+
+  if (runtimeContentPackEntries.length) {
+    contribution.contentPackIds = unique([
+      ...(contribution.contentPackIds || []),
+      ...runtimeContentPackEntries.map((entry) => entry.contentPack.id)
+    ]);
+  }
+
+  if (runtimePlayerPieceSetEntries.length) {
+    contribution.playerPieceSetIds = unique([
+      ...(contribution.playerPieceSetIds || []),
+      ...runtimePlayerPieceSetEntries.map((entry) => entry.pieceSet.id)
+    ]);
+  }
+
+  if (runtimeDiceRuleSetEntries.length) {
+    contribution.diceRuleSetIds = unique([
+      ...(contribution.diceRuleSetIds || []),
+      ...runtimeDiceRuleSetEntries.map((entry) => entry.diceRuleSet.id)
+    ]);
+  }
+
+  if (runtimeSiteThemeEntries.length) {
+    contribution.siteThemeIds = unique([
+      ...(contribution.siteThemeIds || []),
+      ...runtimeSiteThemeEntries.map((entry) => entry.theme.id)
+    ]);
+  }
+
+  return contribution;
+}
+
+function moduleEntriesForSelection(
+  modules: NetRiskInstalledModule[],
+  moduleIds: string[]
+): NetRiskInstalledModule[] {
+  const requestedIds = new Set(["core.base", ...moduleIds]);
+  return modules.filter((moduleEntry) => requestedIds.has(moduleEntry.id));
+}
+
+function ensureAllowedContentId(
+  kind: string,
+  requestedId: string | null | undefined,
+  availableIds: string[] | null | undefined
+): void {
+  if (!isNonEmptyString(requestedId) || !Array.isArray(availableIds) || !availableIds.length) {
+    return;
+  }
+
+  if (!availableIds.includes(requestedId)) {
+    throw new Error(`Selected ${kind} "${requestedId}" is not exposed by the active modules.`);
+  }
+}
+
+module.exports = {
+  aggregateContentContribution,
+  ensureAllowedContentId,
+  moduleEntriesForSelection
+};

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -1,5 +1,10 @@
 const fs = require("fs");
 const path = require("path");
+const {
+  aggregateContentContribution,
+  ensureAllowedContentId,
+  moduleEntriesForSelection
+} = require("./module-runtime-contributions.cjs");
 const { listCardRuleSets } = require("../shared/cards.cjs");
 const {
   findCoreBaseSupportedMap,
@@ -133,18 +138,6 @@ type AuthoredPublishedVictoryRuleSet = {
 };
 
 const MODULE_CATALOG_STATE_KEY = "moduleCatalogState";
-const CONTENT_CONTRIBUTION_KEYS = [
-  "mapIds",
-  "siteThemeIds",
-  "pieceSkinIds",
-  "playerPieceSetIds",
-  "contentPackIds",
-  "diceRuleSetIds",
-  "cardRuleSetIds",
-  "victoryRuleSetIds",
-  "fortifyRuleSetIds",
-  "reinforcementRuleSetIds"
-] as const;
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -182,21 +175,6 @@ function toGamePresetArray(
     activeModuleIds: Array.isArray(preset.activeModuleIds) ? [...preset.activeModuleIds] : [],
     defaults: preset.defaults ? { ...preset.defaults } : null
   }));
-}
-
-function emptyContentContribution(): NetRiskContentContribution {
-  return {
-    mapIds: [],
-    siteThemeIds: [],
-    pieceSkinIds: [],
-    playerPieceSetIds: [],
-    contentPackIds: [],
-    diceRuleSetIds: [],
-    cardRuleSetIds: [],
-    victoryRuleSetIds: [],
-    fortifyRuleSetIds: [],
-    reinforcementRuleSetIds: []
-  };
 }
 
 function cloneMapSummary(summary: MapSummary): MapSummary {
@@ -342,96 +320,6 @@ function cloneSupportedMap(map: SupportedMap): SupportedMap {
         }
       : map.mapDefinition
   };
-}
-
-function aggregateContentContribution(
-  modules: NetRiskInstalledModule[],
-  runtimeMapEntries: RuntimeModuleMapEntry[] = [],
-  runtimeContentPackEntries: RuntimeModuleContentPackEntry[] = [],
-  runtimePlayerPieceSetEntries: RuntimeModulePlayerPieceSetEntry[] = [],
-  runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[] = [],
-  runtimeSiteThemeEntries: RuntimeModuleSiteThemeEntry[] = []
-): NetRiskContentContribution {
-  const contribution = emptyContentContribution();
-
-  modules.forEach((moduleEntry) => {
-    const content = moduleEntry.clientManifest?.content;
-    if (!content) {
-      return;
-    }
-
-    CONTENT_CONTRIBUTION_KEYS.forEach((key) => {
-      const currentValues = contribution[key] || [];
-      const nextValues = Array.isArray(content[key]) ? content[key] : [];
-      contribution[key] = Array.from(new Set([...currentValues, ...nextValues]));
-    });
-  });
-
-  if (runtimeMapEntries.length) {
-    contribution.mapIds = Array.from(
-      new Set([...(contribution.mapIds || []), ...runtimeMapEntries.map((entry) => entry.map.id)])
-    );
-  }
-
-  if (runtimeContentPackEntries.length) {
-    contribution.contentPackIds = Array.from(
-      new Set([
-        ...(contribution.contentPackIds || []),
-        ...runtimeContentPackEntries.map((entry) => entry.contentPack.id)
-      ])
-    );
-  }
-
-  if (runtimePlayerPieceSetEntries.length) {
-    contribution.playerPieceSetIds = Array.from(
-      new Set([
-        ...(contribution.playerPieceSetIds || []),
-        ...runtimePlayerPieceSetEntries.map((entry) => entry.pieceSet.id)
-      ])
-    );
-  }
-
-  if (runtimeDiceRuleSetEntries.length) {
-    contribution.diceRuleSetIds = Array.from(
-      new Set([
-        ...(contribution.diceRuleSetIds || []),
-        ...runtimeDiceRuleSetEntries.map((entry) => entry.diceRuleSet.id)
-      ])
-    );
-  }
-
-  if (runtimeSiteThemeEntries.length) {
-    contribution.siteThemeIds = Array.from(
-      new Set([
-        ...(contribution.siteThemeIds || []),
-        ...runtimeSiteThemeEntries.map((entry) => entry.theme.id)
-      ])
-    );
-  }
-
-  return contribution;
-}
-
-function moduleEntriesForSelection(
-  modules: NetRiskInstalledModule[],
-  moduleIds: string[]
-): NetRiskInstalledModule[] {
-  const requestedIds = new Set([CORE_MODULE_ID, ...moduleIds]);
-  return modules.filter((moduleEntry) => requestedIds.has(moduleEntry.id));
-}
-
-function ensureAllowedContentId(
-  kind: string,
-  requestedId: string | null | undefined,
-  availableIds: string[] | null | undefined
-): void {
-  if (!isNonEmptyString(requestedId) || !Array.isArray(availableIds) || !availableIds.length) {
-    return;
-  }
-
-  if (!availableIds.includes(requestedId)) {
-    throw new Error(`Selected ${kind} "${requestedId}" is not exposed by the active modules.`);
-  }
 }
 
 function cloneInstalledModule(moduleEntry: NetRiskInstalledModule): NetRiskInstalledModule {
@@ -2476,7 +2364,7 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       const requestedIds = Array.isArray(input.activeModuleIds)
         ? Array.from(new Set(input.activeModuleIds.filter((value) => isNonEmptyString(value))))
         : [];
-      const selectedModuleEntries = moduleEntriesForSelection(
+      const selectedModuleEntries: NetRiskInstalledModule[] = moduleEntriesForSelection(
         optionsSnapshot.gameModules,
         requestedIds
       );

--- a/backend/routes/game-actions-attack.cts
+++ b/backend/routes/game-actions-attack.cts
@@ -1,3 +1,5 @@
+const { persistBroadcastAndSendMutation } = require("./game-mutation.cjs");
+
 type SendJson = (
   res: unknown,
   statusCode: number,
@@ -135,25 +137,20 @@ async function handleAttackGameActionRoute(
     return true;
   }
 
-  try {
-    await persistGameContext(gameContext, expectedVersion);
-  } catch (error) {
-    if (handleVersionConflict(error)) {
-      return true;
+  await persistBroadcastAndSendMutation({
+    res,
+    gameContext,
+    expectedVersion,
+    user,
+    persistGameContext,
+    broadcastGame,
+    snapshotForUser,
+    handleVersionConflict,
+    sendJson,
+    sendLocalizedError,
+    payload: {
+      rounds: Array.isArray(result.rounds) ? result.rounds : undefined
     }
-    throw error;
-  }
-  broadcastGame(gameContext);
-  sendJson(res, 200, {
-    ok: true,
-    state: snapshotForUser(
-      gameContext.state,
-      gameContext.gameId,
-      gameContext.version,
-      gameContext.gameName,
-      user
-    ),
-    rounds: Array.isArray(result.rounds) ? result.rounds : undefined
   });
   return true;
 }

--- a/backend/routes/game-actions-basic.cts
+++ b/backend/routes/game-actions-basic.cts
@@ -1,3 +1,5 @@
+const { persistBroadcastAndSendMutation } = require("./game-mutation.cjs");
+
 type SendJson = (
   res: unknown,
   statusCode: number,
@@ -72,24 +74,17 @@ async function handleBasicGameActionRoute(
       return true;
     }
 
-    try {
-      await persistGameContext(gameContext, expectedVersion);
-    } catch (error) {
-      if (handleVersionConflict(error)) {
-        return true;
-      }
-      throw error;
-    }
-    broadcastGame(gameContext);
-    sendJson(res, 200, {
-      ok: true,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        user
-      )
+    await persistBroadcastAndSendMutation({
+      res,
+      gameContext,
+      expectedVersion,
+      user,
+      persistGameContext,
+      broadcastGame,
+      snapshotForUser,
+      handleVersionConflict,
+      sendJson,
+      sendLocalizedError
     });
     return true;
   }
@@ -101,24 +96,17 @@ async function handleBasicGameActionRoute(
       return true;
     }
 
-    try {
-      await persistGameContext(gameContext, expectedVersion);
-    } catch (error) {
-      if (handleVersionConflict(error)) {
-        return true;
-      }
-      throw error;
-    }
-    broadcastGame(gameContext);
-    sendJson(res, 200, {
-      ok: true,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        user
-      )
+    await persistBroadcastAndSendMutation({
+      res,
+      gameContext,
+      expectedVersion,
+      user,
+      persistGameContext,
+      broadcastGame,
+      snapshotForUser,
+      handleVersionConflict,
+      sendJson,
+      sendLocalizedError
     });
     return true;
   }
@@ -142,24 +130,17 @@ async function handleBasicGameActionRoute(
       return true;
     }
 
-    try {
-      await persistGameContext(gameContext, expectedVersion);
-    } catch (error) {
-      if (handleVersionConflict(error)) {
-        return true;
-      }
-      throw error;
-    }
-    broadcastGame(gameContext);
-    sendJson(res, 200, {
-      ok: true,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        user
-      )
+    await persistBroadcastAndSendMutation({
+      res,
+      gameContext,
+      expectedVersion,
+      user,
+      persistGameContext,
+      broadcastGame,
+      snapshotForUser,
+      handleVersionConflict,
+      sendJson,
+      sendLocalizedError
     });
     return true;
   }

--- a/backend/routes/game-actions-turn.cts
+++ b/backend/routes/game-actions-turn.cts
@@ -1,3 +1,5 @@
+const { persistBroadcastAndSendMutation } = require("./game-mutation.cjs");
+
 type SendJson = (
   res: unknown,
   statusCode: number,
@@ -51,24 +53,17 @@ async function handleTurnGameActionRoute(
       return true;
     }
 
-    try {
-      await persistWithAiTurns(gameContext, expectedVersion);
-    } catch (error) {
-      if (handleVersionConflict(error)) {
-        return true;
-      }
-      throw error;
-    }
-    broadcastGame(gameContext);
-    sendJson(res, 200, {
-      ok: true,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        user
-      )
+    await persistBroadcastAndSendMutation({
+      res,
+      gameContext,
+      expectedVersion,
+      user,
+      persistGameContext: persistWithAiTurns,
+      broadcastGame,
+      snapshotForUser,
+      handleVersionConflict,
+      sendJson,
+      sendLocalizedError
     });
     return true;
   }
@@ -80,24 +75,17 @@ async function handleTurnGameActionRoute(
       return true;
     }
 
-    try {
-      await persistWithAiTurns(gameContext, expectedVersion);
-    } catch (error) {
-      if (handleVersionConflict(error)) {
-        return true;
-      }
-      throw error;
-    }
-    broadcastGame(gameContext);
-    sendJson(res, 200, {
-      ok: true,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        user
-      )
+    await persistBroadcastAndSendMutation({
+      res,
+      gameContext,
+      expectedVersion,
+      user,
+      persistGameContext: persistWithAiTurns,
+      broadcastGame,
+      snapshotForUser,
+      handleVersionConflict,
+      sendJson,
+      sendLocalizedError
     });
     return true;
   }

--- a/backend/routes/game-actions.cts
+++ b/backend/routes/game-actions.cts
@@ -1,11 +1,11 @@
 const { handleAttackGameActionRoute } = require("./game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("./game-actions-basic.cjs");
+const { sendVersionConflict } = require("./game-mutation.cjs");
 const { handleTurnGameActionRoute } = require("./game-actions-turn.cjs");
 const {
   gameActionEnvelopeSchema,
   gameActionRequestSchema,
-  gameMutationResponseSchema,
-  gameVersionConflictResponseSchema
+  gameMutationResponseSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
 const {
@@ -166,52 +166,32 @@ async function handleGameActionRoute({
       return false;
     }
 
-    sendValidatedJson(
-      nodeResponse,
-      409,
-      {
-        ...localizedPayload(error, error.message, error.messageKey || "server.versionConflict"),
-        code: error.code,
-        currentVersion: error.currentVersion,
-        state: snapshotForUser(
-          error.currentState,
-          gameContext.gameId,
-          error.currentVersion,
-          error.game?.name || gameContext.gameName,
-          currentUser
-        )
-      },
-      gameVersionConflictResponseSchema,
-      sendJson as SendJson,
-      sendLocalizedError as SendLocalizedError
-    );
+    sendVersionConflict({
+      res: nodeResponse,
+      error,
+      gameContext,
+      currentUser,
+      snapshotForUser,
+      sendJson,
+      sendLocalizedError,
+      localizedPayload
+    });
     return true;
   }
 
   if (expectedVersion != null && expectedVersion !== gameContext.version) {
-    sendValidatedJson(
-      nodeResponse,
-      409,
-      {
-        ...localizedPayload(
-          null,
-          "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
-          "server.versionConflict"
-        ),
-        code: "VERSION_CONFLICT",
-        currentVersion: gameContext.version,
-        state: snapshotForUser(
-          gameContext.state,
-          gameContext.gameId,
-          gameContext.version,
-          gameContext.gameName,
-          currentUser
-        )
-      },
-      gameVersionConflictResponseSchema,
-      sendJson as SendJson,
-      sendLocalizedError as SendLocalizedError
-    );
+    sendVersionConflict({
+      res: nodeResponse,
+      gameContext,
+      currentUser,
+      snapshotForUser,
+      sendJson,
+      sendLocalizedError,
+      localizedPayload,
+      fallbackMessage:
+        "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+      fallbackMessageKey: "server.versionConflict"
+    });
     return;
   }
 

--- a/backend/routes/game-cards.cts
+++ b/backend/routes/game-cards.cts
@@ -1,9 +1,6 @@
-const {
-  gameMutationResponseSchema,
-  gameVersionConflictResponseSchema,
-  tradeCardsRequestSchema
-} = require("../../shared/runtime-validation.cjs");
-const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { tradeCardsRequestSchema } = require("../../shared/runtime-validation.cjs");
+const { parseRequestOrSendError } = require("../route-validation.cjs");
+const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
 
 type SendJson = (
   res: unknown,
@@ -109,28 +106,17 @@ async function handleCardsTradeRoute(
 
   const requestedVersion = parsedBody.expectedVersion ?? null;
   if (requestedVersion != null && requestedVersion !== gameContext.version) {
-    sendValidatedJson(
-      nodeResponse,
-      409,
-      {
-        error:
-          "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
-        messageKey: "server.versionConflict",
-        messageParams: {},
-        code: "VERSION_CONFLICT",
-        currentVersion: gameContext.version,
-        state: snapshotForUser(
-          gameContext.state,
-          gameContext.gameId,
-          gameContext.version,
-          gameContext.gameName,
-          authContext.user
-        )
-      },
-      gameVersionConflictResponseSchema,
-      sendJson as SendJson,
-      sendLocalizedError as SendLocalizedError
-    );
+    sendVersionConflict({
+      res: nodeResponse,
+      gameContext,
+      currentUser: authContext.user,
+      snapshotForUser,
+      sendJson,
+      sendLocalizedError,
+      fallbackMessage:
+        "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+      fallbackMessageKey: "server.versionConflict"
+    });
     return;
   }
 
@@ -140,57 +126,21 @@ async function handleCardsTradeRoute(
     return;
   }
 
-  try {
-    await persistGameContext(gameContext, requestedVersion);
-  } catch (error: any) {
-    if (error && error.code === "VERSION_CONFLICT") {
-      sendValidatedJson(
-        nodeResponse,
-        409,
-        {
-          error: error.message,
-          messageKey: error.messageKey || "server.versionConflict",
-          messageParams: {},
-          code: error.code,
-          currentVersion: error.currentVersion,
-          state: snapshotForUser(
-            error.currentState,
-            gameContext.gameId,
-            error.currentVersion,
-            error.game?.name || gameContext.gameName,
-            authContext.user
-          )
-        },
-        gameVersionConflictResponseSchema,
-        sendJson as SendJson,
-        sendLocalizedError as SendLocalizedError
-      );
-      return;
-    }
-
-    throw error;
-  }
-
-  broadcastGame(gameContext);
-  sendValidatedJson(
-    nodeResponse,
-    200,
-    {
-      ok: true,
+  await persistBroadcastAndSendMutation({
+    res: nodeResponse,
+    gameContext,
+    expectedVersion: requestedVersion,
+    user: authContext.user,
+    persistGameContext,
+    broadcastGame,
+    snapshotForUser,
+    sendJson,
+    sendLocalizedError,
+    payload: {
       bonus: result.bonus,
-      validation: result.validation,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        authContext.user
-      )
-    },
-    gameMutationResponseSchema,
-    sendJson as SendJson,
-    sendLocalizedError as SendLocalizedError
-  );
+      validation: result.validation
+    }
+  });
 }
 
 module.exports = {

--- a/backend/routes/game-mutation.cts
+++ b/backend/routes/game-mutation.cts
@@ -1,0 +1,165 @@
+const {
+  gameMutationResponseSchema,
+  gameVersionConflictResponseSchema
+} = require("../../shared/runtime-validation.cjs");
+const { sendValidatedJson } = require("../route-validation.cjs");
+
+type SendJson = (
+  res: unknown,
+  statusCode: number,
+  payload: unknown,
+  headers?: Record<string, string>
+) => void;
+type SendLocalizedError = (
+  res: unknown,
+  statusCode: number,
+  error: any,
+  message?: string,
+  messageKey?: string,
+  messageParams?: Record<string, unknown>,
+  code?: string,
+  extraPayload?: Record<string, unknown>
+) => void;
+type PersistGameContext = (gameContext: any, expectedVersion?: number | null) => Promise<any>;
+type BroadcastGame = (gameContext: any) => void;
+type SnapshotForUser = (
+  state: any,
+  gameId: string | null,
+  version: number | null,
+  gameName: string | null,
+  user: unknown
+) => unknown;
+type LocalizedPayload = (
+  error: any,
+  fallbackMessage: string,
+  fallbackMessageKey?: string
+) => Record<string, unknown>;
+type HandleVersionConflict = (error: unknown) => boolean;
+
+type VersionConflictOptions = {
+  res: unknown;
+  error?: any;
+  gameContext: any;
+  currentUser: unknown;
+  snapshotForUser: SnapshotForUser;
+  sendJson: SendJson;
+  sendLocalizedError: SendLocalizedError;
+  localizedPayload?: LocalizedPayload;
+  fallbackMessage?: string;
+  fallbackMessageKey?: string;
+};
+
+type MutationOptions = {
+  res: unknown;
+  gameContext: any;
+  expectedVersion: number | null;
+  user: unknown;
+  persistGameContext: PersistGameContext;
+  broadcastGame: BroadcastGame;
+  snapshotForUser: SnapshotForUser;
+  sendJson: SendJson;
+  sendLocalizedError: SendLocalizedError;
+  localizedPayload?: LocalizedPayload;
+  handleVersionConflict?: HandleVersionConflict;
+  payload?: Record<string, unknown>;
+};
+
+function conflictPayload(options: VersionConflictOptions): Record<string, unknown> {
+  const error = options.error || null;
+  const currentVersion =
+    error && typeof error.currentVersion === "number"
+      ? error.currentVersion
+      : options.gameContext.version;
+  const currentState =
+    error && "currentState" in error ? error.currentState : options.gameContext.state;
+  const gameName =
+    error?.game?.name || options.gameContext.gameName || options.gameContext.game?.name || null;
+  const fallbackMessage =
+    options.fallbackMessage ||
+    error?.message ||
+    "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.";
+  const fallbackMessageKey =
+    options.fallbackMessageKey || error?.messageKey || "server.versionConflict";
+  const localized = options.localizedPayload
+    ? options.localizedPayload(error, fallbackMessage, fallbackMessageKey)
+    : {
+        error: fallbackMessage,
+        messageKey: fallbackMessageKey,
+        messageParams: {}
+      };
+
+  return {
+    ...localized,
+    code: "VERSION_CONFLICT",
+    currentVersion,
+    state: options.snapshotForUser(
+      currentState,
+      options.gameContext.gameId,
+      currentVersion,
+      gameName,
+      options.currentUser
+    )
+  };
+}
+
+function sendVersionConflict(options: VersionConflictOptions): void {
+  sendValidatedJson(
+    options.res as import("node:http").ServerResponse,
+    409,
+    conflictPayload(options),
+    gameVersionConflictResponseSchema,
+    options.sendJson as SendJson,
+    options.sendLocalizedError as SendLocalizedError
+  );
+}
+
+async function persistBroadcastAndSendMutation(options: MutationOptions): Promise<void> {
+  try {
+    await options.persistGameContext(options.gameContext, options.expectedVersion);
+  } catch (error: any) {
+    if (options.handleVersionConflict?.(error)) {
+      return;
+    }
+
+    if (error && error.code === "VERSION_CONFLICT") {
+      sendVersionConflict({
+        res: options.res,
+        error,
+        gameContext: options.gameContext,
+        currentUser: options.user,
+        snapshotForUser: options.snapshotForUser,
+        sendJson: options.sendJson,
+        sendLocalizedError: options.sendLocalizedError,
+        localizedPayload: options.localizedPayload
+      });
+      return;
+    }
+
+    throw error;
+  }
+
+  options.broadcastGame(options.gameContext);
+  sendValidatedJson(
+    options.res as import("node:http").ServerResponse,
+    200,
+    {
+      ok: true,
+      ...(options.payload || {}),
+      state: options.snapshotForUser(
+        options.gameContext.state,
+        options.gameContext.gameId,
+        options.gameContext.version,
+        options.gameContext.gameName,
+        options.user
+      )
+    },
+    gameMutationResponseSchema,
+    options.sendJson as SendJson,
+    options.sendLocalizedError as SendLocalizedError
+  );
+}
+
+module.exports = {
+  persistBroadcastAndSendMutation,
+  sendVersionConflict
+};

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -55,10 +55,10 @@ type StartGame = (state: any) => any;
 const {
   gameIdRequestSchema,
   gameMutationResponseSchema,
-  gameVersionConflictResponseSchema,
   startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
 
 async function handleAiJoinRoute(
   res: unknown,
@@ -261,28 +261,17 @@ async function handleStartRoute(
   }
 
   if (expectedVersion != null && expectedVersion !== gameContext.version) {
-    sendValidatedJson(
-      nodeResponse,
-      409,
-      {
-        error:
-          "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
-        messageKey: "server.versionConflict",
-        messageParams: {},
-        code: "VERSION_CONFLICT",
-        currentVersion: gameContext.version,
-        state: snapshotForUser(
-          gameContext.state,
-          gameContext.gameId,
-          gameContext.version,
-          gameContext.gameName,
-          authContext.user
-        )
-      },
-      gameVersionConflictResponseSchema,
-      sendJson as SendJson,
-      sendLocalizedError as SendLocalizedError
-    );
+    sendVersionConflict({
+      res: nodeResponse,
+      gameContext,
+      currentUser: authContext.user,
+      snapshotForUser,
+      sendJson,
+      sendLocalizedError,
+      fallbackMessage:
+        "La partita e stata aggiornata da un'altra richiesta. Ricarica lo stato piu recente.",
+      fallbackMessageKey: "server.versionConflict"
+    });
     return;
   }
 
@@ -294,55 +283,20 @@ async function handleStartRoute(
 
   gameContext.state = structuredClone(gameContext.state);
   startGame(gameContext.state);
-  try {
-    await persistWithAiTurns(gameContext, expectedVersion);
-  } catch (error: any) {
-    if (error && error.code === "VERSION_CONFLICT") {
-      sendValidatedJson(
-        nodeResponse,
-        409,
-        {
-          error: error.message,
-          messageKey: error.messageKey || "server.versionConflict",
-          messageParams: {},
-          code: error.code,
-          currentVersion: error.currentVersion,
-          state: snapshotForUser(
-            error.currentState,
-            gameContext.gameId,
-            error.currentVersion,
-            error.game?.name || gameContext.gameName,
-            authContext.user
-          )
-        },
-        gameVersionConflictResponseSchema,
-        sendJson as SendJson,
-        sendLocalizedError as SendLocalizedError
-      );
-      return;
+  await persistBroadcastAndSendMutation({
+    res: nodeResponse,
+    gameContext,
+    expectedVersion,
+    user: authContext.user,
+    persistGameContext: persistWithAiTurns,
+    broadcastGame,
+    snapshotForUser,
+    sendJson,
+    sendLocalizedError,
+    payload: {
+      playerId: parsedBody.playerId
     }
-
-    throw error;
-  }
-  broadcastGame(gameContext);
-  sendValidatedJson(
-    nodeResponse,
-    200,
-    {
-      ok: true,
-      playerId: parsedBody.playerId,
-      state: snapshotForUser(
-        gameContext.state,
-        gameContext.gameId,
-        gameContext.version,
-        gameContext.gameName,
-        authContext.user
-      )
-    },
-    gameMutationResponseSchema,
-    sendJson as SendJson,
-    sendLocalizedError as SendLocalizedError
-  );
+  });
 }
 
 module.exports = {

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -7,6 +7,7 @@ const { loadLocalEnv } = require("./load-local-env.cjs");
 const { createDatastore } = require("./datastore.cjs");
 const { createAuthoredModulesService } = require("./authored-modules.cjs");
 const { createModuleRuntime } = require("./module-runtime.cjs");
+const { createSetupCatalogResolver } = require("./setup-catalog-resolver.cjs");
 const { createAuthStore } = require("./auth.cjs");
 const { authorize } = require("./authorization.cjs");
 const { createGameSessionStore } = require("./game-session-store.cjs");
@@ -1314,7 +1315,7 @@ function createApp(options: CreateAppOptions = {}) {
     if (req.method === "POST" && url.pathname === "/api/games") {
       const body = await parseBody(req);
       const moduleOptions = await moduleRuntime.getModuleOptions();
-      const resolvedCatalog = moduleOptions.resolvedCatalog || moduleOptions;
+      const setupCatalogResolver = createSetupCatalogResolver(moduleRuntime, moduleOptions);
       const adminDefaults = await getSafeAdminDefaults();
       await handleCreateGameRoute(
         req,
@@ -1325,52 +1326,7 @@ function createApp(options: CreateAppOptions = {}) {
         (body: Record<string, unknown>) =>
           createConfiguredInitialState(body, {
             defaultConfigInput: deepClone(adminDefaults || {}),
-            resolveRuleSet: (ruleSetId: string) =>
-              resolvedCatalog.ruleSets.find((entry: { id: string }) => entry.id === ruleSetId) ||
-              null,
-            resolveContentPack: (contentPackId: string) =>
-              moduleRuntime.findContentPack(contentPackId),
-            resolveDiceRuleSet: (diceRuleSetId: string) =>
-              moduleRuntime.findDiceRuleSet(diceRuleSetId),
-            resolvePlayerPieceSet: (pieceSetId: string) =>
-              moduleRuntime.findPlayerPieceSet(pieceSetId),
-            resolveSupportedMap: (mapId: string) => moduleRuntime.findSupportedMap(mapId),
-            resolveVictoryRuleSet: (victoryRuleSetId: string) =>
-              resolvedCatalog.victoryRuleSets.find(
-                (entry: { id: string }) => entry.id === victoryRuleSetId
-              ) || null,
-            resolveVictoryRuleRuntime: (victoryRuleSetId: string) =>
-              moduleRuntime.findVictoryRuleSetRuntime(victoryRuleSetId),
-            resolveTheme: (themeId: string) =>
-              resolvedCatalog.themes.find((entry: { id: string }) => entry.id === themeId) || null,
-            resolveDefaultTheme: () => resolvedCatalog.themes[0] || null,
-            resolvePieceSkin: (pieceSkinId: string) =>
-              resolvedCatalog.pieceSkins.find(
-                (entry: { id: string }) => entry.id === pieceSkinId
-              ) || null,
-            resolveGamePreset: (input: {
-              gamePresetId?: string | null;
-              activeModuleIds?: string[];
-            }) => moduleRuntime.resolveGamePreset(input),
-            resolveGameModuleConfigDefaults: (input: {
-              activeModuleIds?: string[];
-              contentProfileId?: string | null;
-              gameplayProfileId?: string | null;
-              uiProfileId?: string | null;
-            }) => moduleRuntime.resolveGameConfigDefaults(input),
-            resolveGameModuleSelection: (input: {
-              activeModuleIds?: string[];
-              contentProfileId?: string | null;
-              gameplayProfileId?: string | null;
-              uiProfileId?: string | null;
-              contentPackId?: string | null;
-              pieceSetId?: string | null;
-              mapId?: string | null;
-              diceRuleSetId?: string | null;
-              victoryRuleSetId?: string | null;
-              themeId?: string | null;
-              pieceSkinId?: string | null;
-            }) => moduleRuntime.resolveGameSelection(input)
+            ...setupCatalogResolver
           }),
         addPlayer,
         async (state: any, options: Record<string, any>) => {

--- a/backend/setup-catalog-resolver.cts
+++ b/backend/setup-catalog-resolver.cts
@@ -1,0 +1,55 @@
+type CatalogEntry = { id: string };
+type ResolvedCatalog = {
+  ruleSets?: CatalogEntry[];
+  victoryRuleSets?: CatalogEntry[];
+  themes?: CatalogEntry[];
+  pieceSkins?: CatalogEntry[];
+};
+
+type ModuleRuntime = {
+  findContentPack: (contentPackId: string) => unknown;
+  findDiceRuleSet: (diceRuleSetId: string) => unknown;
+  findPlayerPieceSet: (pieceSetId: string) => unknown;
+  findSupportedMap: (mapId: string) => unknown;
+  findVictoryRuleSetRuntime: (victoryRuleSetId: string) => unknown;
+  resolveGamePreset: (input: unknown) => unknown;
+  resolveGameConfigDefaults: (input: unknown) => unknown;
+  resolveGameSelection: (input: unknown) => unknown;
+};
+
+function listFromCatalog(catalog: ResolvedCatalog, key: keyof ResolvedCatalog): CatalogEntry[] {
+  const entries = catalog[key];
+  return Array.isArray(entries) ? entries : [];
+}
+
+function findCatalogEntry(catalog: ResolvedCatalog, key: keyof ResolvedCatalog, id: string) {
+  return listFromCatalog(catalog, key).find((entry) => entry.id === id) || null;
+}
+
+function createSetupCatalogResolver(moduleRuntime: ModuleRuntime, moduleOptions: any) {
+  const resolvedCatalog = moduleOptions?.resolvedCatalog || moduleOptions || {};
+
+  return {
+    resolveRuleSet: (ruleSetId: string) => findCatalogEntry(resolvedCatalog, "ruleSets", ruleSetId),
+    resolveContentPack: (contentPackId: string) => moduleRuntime.findContentPack(contentPackId),
+    resolveDiceRuleSet: (diceRuleSetId: string) => moduleRuntime.findDiceRuleSet(diceRuleSetId),
+    resolvePlayerPieceSet: (pieceSetId: string) => moduleRuntime.findPlayerPieceSet(pieceSetId),
+    resolveSupportedMap: (mapId: string) => moduleRuntime.findSupportedMap(mapId),
+    resolveVictoryRuleSet: (victoryRuleSetId: string) =>
+      findCatalogEntry(resolvedCatalog, "victoryRuleSets", victoryRuleSetId),
+    resolveVictoryRuleRuntime: (victoryRuleSetId: string) =>
+      moduleRuntime.findVictoryRuleSetRuntime(victoryRuleSetId),
+    resolveTheme: (themeId: string) => findCatalogEntry(resolvedCatalog, "themes", themeId),
+    resolveDefaultTheme: () => listFromCatalog(resolvedCatalog, "themes")[0] || null,
+    resolvePieceSkin: (pieceSkinId: string) =>
+      findCatalogEntry(resolvedCatalog, "pieceSkins", pieceSkinId),
+    resolveGamePreset: (input: unknown) => moduleRuntime.resolveGamePreset(input),
+    resolveGameModuleConfigDefaults: (input: unknown) =>
+      moduleRuntime.resolveGameConfigDefaults(input),
+    resolveGameModuleSelection: (input: unknown) => moduleRuntime.resolveGameSelection(input)
+  };
+}
+
+module.exports = {
+  createSetupCatalogResolver
+};

--- a/frontend/react-shell/src/admin-route-sections.ts
+++ b/frontend/react-shell/src/admin-route-sections.ts
@@ -1,0 +1,131 @@
+export type AdminSection =
+  | "audit"
+  | "config"
+  | "content-studio"
+  | "games"
+  | "maintenance"
+  | "modules"
+  | "overview"
+  | "system-health"
+  | "users";
+
+export type AdminIconName =
+  | "activity"
+  | "audit"
+  | "bell"
+  | "close"
+  | "config"
+  | "content"
+  | "danger"
+  | "game"
+  | "health"
+  | "home"
+  | "maintenance"
+  | "menu"
+  | "modules"
+  | "plus"
+  | "refresh"
+  | "search"
+  | "shield"
+  | "users";
+
+export type AdminNavItem = {
+  id: AdminSection;
+  group: "Monitor" | "Operate";
+  icon: AdminIconName;
+  label: string;
+  path: string;
+  description: string;
+};
+
+export function resolveAdminSection(pathname: string): AdminSection {
+  if (pathname.endsWith("/users")) {
+    return "users";
+  }
+
+  if (pathname.endsWith("/games")) {
+    return "games";
+  }
+
+  if (pathname.endsWith("/config")) {
+    return "config";
+  }
+
+  if (pathname.endsWith("/content-studio")) {
+    return "content-studio";
+  }
+
+  if (pathname.endsWith("/modules")) {
+    return "modules";
+  }
+
+  if (pathname.endsWith("/maintenance")) {
+    return "maintenance";
+  }
+
+  if (pathname.endsWith("/system-health")) {
+    return "system-health";
+  }
+
+  if (pathname.endsWith("/audit")) {
+    return "audit";
+  }
+
+  return "overview";
+}
+
+export function statusTone(
+  health: string | null | undefined
+): "danger" | "muted" | "success" | "warning" {
+  if (health === "error") {
+    return "danger";
+  }
+
+  if (health === "warning") {
+    return "warning";
+  }
+
+  if (health === "ok") {
+    return "success";
+  }
+
+  return "muted";
+}
+
+export function formatAdminPhase(phase: string | null | undefined): string {
+  if (!phase) {
+    return "Unknown";
+  }
+
+  return phase
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function severityRank(value: string | null | undefined): number {
+  if (value === "error") {
+    return 0;
+  }
+
+  if (value === "warning") {
+    return 1;
+  }
+
+  if (value === "info") {
+    return 2;
+  }
+
+  if (value === "ok") {
+    return 3;
+  }
+
+  return 4;
+}
+
+export function sortBySeverity<T extends { severity: string | null | undefined }>(items: T[]): T[] {
+  return [...items].sort(
+    (left, right) => severityRank(left.severity) - severityRank(right.severity)
+  );
+}

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -28,6 +28,14 @@ import { formatDate } from "@frontend-i18n";
 
 import { useAuth } from "@react-shell/auth";
 import { AdminContentStudioSection } from "@react-shell/admin-content-studio";
+import {
+  formatAdminPhase,
+  resolveAdminSection,
+  sortBySeverity,
+  statusTone,
+  type AdminIconName,
+  type AdminNavItem
+} from "@react-shell/admin-route-sections";
 import { filterConfigurableGameModules } from "@react-shell/game-setup-options";
 import { ProfileAdminModules } from "@react-shell/profile-admin-modules";
 import {
@@ -44,46 +52,6 @@ import {
   adminOverviewQueryKey,
   adminUsersQueryKey
 } from "@react-shell/react-query";
-
-type AdminSection =
-  | "audit"
-  | "config"
-  | "content-studio"
-  | "games"
-  | "maintenance"
-  | "modules"
-  | "overview"
-  | "system-health"
-  | "users";
-
-type AdminNavItem = {
-  id: AdminSection;
-  group: "Monitor" | "Operate";
-  icon: AdminIconName;
-  label: string;
-  path: string;
-  description: string;
-};
-
-type AdminIconName =
-  | "activity"
-  | "audit"
-  | "bell"
-  | "close"
-  | "config"
-  | "content"
-  | "danger"
-  | "game"
-  | "health"
-  | "home"
-  | "maintenance"
-  | "menu"
-  | "modules"
-  | "plus"
-  | "refresh"
-  | "search"
-  | "shield"
-  | "users";
 
 type AdminFrameContext = {
   basePath: string;
@@ -142,42 +110,6 @@ function requestMessages(scope: string) {
   };
 }
 
-function resolveAdminSection(pathname: string): AdminSection {
-  if (pathname.endsWith("/users")) {
-    return "users";
-  }
-
-  if (pathname.endsWith("/games")) {
-    return "games";
-  }
-
-  if (pathname.endsWith("/config")) {
-    return "config";
-  }
-
-  if (pathname.endsWith("/content-studio")) {
-    return "content-studio";
-  }
-
-  if (pathname.endsWith("/modules")) {
-    return "modules";
-  }
-
-  if (pathname.endsWith("/maintenance")) {
-    return "maintenance";
-  }
-
-  if (pathname.endsWith("/system-health")) {
-    return "system-health";
-  }
-
-  if (pathname.endsWith("/audit")) {
-    return "audit";
-  }
-
-  return "overview";
-}
-
 function formatTimestamp(value: string | null | undefined): string {
   if (!value) {
     return "n/a";
@@ -194,34 +126,6 @@ function formatTimestamp(value: string | null | undefined): string {
     hour: "2-digit",
     minute: "2-digit"
   });
-}
-
-function statusTone(health: string | null | undefined): "danger" | "muted" | "success" | "warning" {
-  if (health === "error") {
-    return "danger";
-  }
-
-  if (health === "warning") {
-    return "warning";
-  }
-
-  if (health === "ok") {
-    return "success";
-  }
-
-  return "muted";
-}
-
-function formatAdminPhase(phase: string | null | undefined): string {
-  if (!phase) {
-    return "Unknown";
-  }
-
-  return phase
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
-    .join(" ");
 }
 
 function filterProfilesForSelectedModules(
@@ -313,32 +217,6 @@ function resolveEnvironmentLabel(): string {
   }
 
   return "Production";
-}
-
-function severityRank(value: string | null | undefined): number {
-  if (value === "error") {
-    return 0;
-  }
-
-  if (value === "warning") {
-    return 1;
-  }
-
-  if (value === "info") {
-    return 2;
-  }
-
-  if (value === "ok") {
-    return 3;
-  }
-
-  return 4;
-}
-
-function sortBySeverity<T extends { severity: string | null | undefined }>(items: T[]): T[] {
-  return [...items].sort(
-    (left, right) => severityRank(left.severity) - severityRank(right.severity)
-  );
 }
 
 function countConfigDifferences(

--- a/frontend/react-shell/src/gameplay-commands.ts
+++ b/frontend/react-shell/src/gameplay-commands.ts
@@ -1,0 +1,109 @@
+import { useMutation } from "@tanstack/react-query";
+
+import type { GameMutationResponse } from "@frontend-generated/shared-runtime-validation.mts";
+import { joinGame, sendGameAction, startGame, tradeCards } from "@frontend-core/api/client.mts";
+import type { GameActionRequest, TradeCardsRequest } from "@frontend-core/api/client.mts";
+
+type ApplyMutationPayload = (
+  payload: GameMutationResponse,
+  options?: { feedback?: string }
+) => void;
+
+type GameplayCommandsOptions = {
+  gameId: string | null;
+  playerId: string | null;
+  currentVersion: number | null;
+  requestFailedMessage: string;
+  invalidPlayerMessage: string;
+  tradeSuccessFeedback: (bonus: number) => string;
+  applyMutationPayload: ApplyMutationPayload;
+  handleMutationError: (error: unknown) => void;
+};
+
+function withExpectedVersion<TRequest extends Record<string, unknown>>(
+  request: TRequest,
+  currentVersion: number | null
+): TRequest & { expectedVersion?: number } {
+  return {
+    ...request,
+    ...(currentVersion ? { expectedVersion: currentVersion } : {})
+  };
+}
+
+export function useGameplayCommands({
+  gameId,
+  playerId,
+  currentVersion,
+  requestFailedMessage,
+  invalidPlayerMessage,
+  tradeSuccessFeedback,
+  applyMutationPayload,
+  handleMutationError
+}: GameplayCommandsOptions) {
+  const clientMessages = {
+    errorMessage: requestFailedMessage,
+    fallbackMessage: requestFailedMessage
+  };
+
+  const joinMutation = useMutation({
+    mutationFn: () => joinGame(gameId || "", clientMessages),
+    onSuccess: (payload) => applyMutationPayload(payload),
+    onError: handleMutationError
+  });
+
+  const startMutation = useMutation({
+    mutationFn: () => {
+      if (!gameId || !playerId) {
+        throw new Error(invalidPlayerMessage);
+      }
+
+      return startGame(
+        withExpectedVersion(
+          {
+            gameId,
+            playerId
+          },
+          currentVersion
+        ),
+        clientMessages
+      );
+    },
+    onSuccess: (payload) => applyMutationPayload(payload),
+    onError: handleMutationError
+  });
+
+  const actionMutation = useMutation({
+    mutationFn: (request: GameActionRequest) => sendGameAction(request, clientMessages),
+    onSuccess: (payload) => applyMutationPayload(payload),
+    onError: handleMutationError
+  });
+
+  const tradeMutation = useMutation({
+    mutationFn: (request: TradeCardsRequest) => tradeCards(request, clientMessages),
+    onSuccess: (payload) =>
+      applyMutationPayload(payload, {
+        feedback: typeof payload.bonus === "number" ? tradeSuccessFeedback(payload.bonus) : ""
+      }),
+    onError: handleMutationError
+  });
+
+  return {
+    join: () => joinMutation.mutateAsync(),
+    start: () => startMutation.mutateAsync(),
+    submitAction: (request: Omit<GameActionRequest, "expectedVersion">) =>
+      actionMutation
+        .mutateAsync(withExpectedVersion(request, currentVersion) as GameActionRequest)
+        .then(() => undefined),
+    trade: (request: Omit<TradeCardsRequest, "expectedVersion">) =>
+      tradeMutation.mutateAsync(withExpectedVersion(request, currentVersion) as TradeCardsRequest),
+    isJoining: joinMutation.isPending,
+    isStarting: startMutation.isPending,
+    isActionPending: actionMutation.isPending,
+    isTrading: tradeMutation.isPending,
+    isAnyPending:
+      joinMutation.isPending ||
+      startMutation.isPending ||
+      actionMutation.isPending ||
+      tradeMutation.isPending
+  };
+}

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useEffectEvent, useState, type CSSProperties } from "react";
 import { Link, Navigate, useParams } from "react-router-dom";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type {
   GameMutationResponse,
@@ -16,17 +16,13 @@ import type { ApiClientError } from "@frontend-core/api/http.mts";
 import {
   extractGameVersionConflict,
   getGameState,
-  joinGame,
-  sendGameAction,
-  startGame,
-  subscribeToGameEvents,
-  tradeCards
+  subscribeToGameEvents
 } from "@frontend-core/api/client.mts";
-import type { GameActionRequest, TradeCardsRequest } from "@frontend-core/api/client.mts";
 import { messageFromError } from "@frontend-core/errors.mts";
 import { t, translateGameLogEntries, translateServerMessage } from "@frontend-i18n";
 
 import { useAuth } from "@react-shell/auth";
+import { useGameplayCommands } from "@react-shell/gameplay-commands";
 import { GameplayMapViewport } from "@react-shell/gameplay-map-viewport";
 import { LoadingAnimation } from "@react-shell/loading-animation";
 import { readCurrentPlayerId, storeCurrentPlayerId } from "@react-shell/player-session";
@@ -488,59 +484,15 @@ export function GameRoute() {
     setStreamStatus("live");
   });
 
-  const joinMutation = useMutation({
-    mutationFn: () =>
-      joinGame(resolvedGameId || "", {
-        errorMessage: t("errors.requestFailed"),
-        fallbackMessage: t("errors.requestFailed")
-      }),
-    onSuccess: (payload) => applyMutationPayload(payload),
-    onError: handleMutationError
-  });
-
-  const startMutation = useMutation({
-    mutationFn: () => {
-      if (!resolvedGameId || !myPlayerId) {
-        throw new Error(t("game.invalidPlayer"));
-      }
-
-      return startGame(
-        {
-          gameId: resolvedGameId,
-          playerId: myPlayerId,
-          ...(currentVersion ? { expectedVersion: currentVersion } : {})
-        },
-        {
-          errorMessage: t("errors.requestFailed"),
-          fallbackMessage: t("errors.requestFailed")
-        }
-      );
-    },
-    onSuccess: (payload) => applyMutationPayload(payload),
-    onError: handleMutationError
-  });
-
-  const actionClientMessages = {
-    errorMessage: t("errors.requestFailed"),
-    fallbackMessage: t("errors.requestFailed")
-  };
-
-  const actionMutation = useMutation({
-    mutationFn: (request: GameActionRequest) => sendGameAction(request, actionClientMessages),
-    onSuccess: (payload) => applyMutationPayload(payload),
-    onError: handleMutationError
-  });
-
-  const tradeMutation = useMutation({
-    mutationFn: (request: TradeCardsRequest) => tradeCards(request, actionClientMessages),
-    onSuccess: (payload) =>
-      applyMutationPayload(payload, {
-        feedback:
-          typeof payload.bonus === "number"
-            ? t("game.runtime.tradeSuccess", { bonus: payload.bonus })
-            : ""
-      }),
-    onError: handleMutationError
+  const gameplayCommands = useGameplayCommands({
+    gameId: resolvedGameId,
+    playerId: myPlayerId,
+    currentVersion: currentVersion ?? null,
+    requestFailedMessage: t("errors.requestFailed"),
+    invalidPlayerMessage: t("game.invalidPlayer"),
+    tradeSuccessFeedback: (bonus) => t("game.runtime.tradeSuccess", { bonus }),
+    applyMutationPayload,
+    handleMutationError
   });
 
   useEffect(() => {
@@ -572,20 +524,16 @@ export function GameRoute() {
     return <Navigate to={lobbyHref} replace />;
   }
 
-  function submitGameAction(request: Parameters<typeof sendGameAction>[0]): Promise<void> {
-    return actionMutation.mutateAsync(request).then(() => undefined);
-  }
-
   async function handleJoinLobby(): Promise<void> {
     if (!resolvedGameId) {
       return;
     }
 
-    await joinMutation.mutateAsync();
+    await gameplayCommands.join();
   }
 
   async function handleStartGame(): Promise<void> {
-    await startMutation.mutateAsync();
+    await gameplayCommands.start();
   }
 
   async function handleReinforce(): Promise<void> {
@@ -598,13 +546,12 @@ export function GameRoute() {
       1,
       Math.max(1, Number(snapshot?.reinforcementPool || 1))
     );
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "reinforce",
       territoryId: reinforceTerritoryId,
-      amount,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      amount
     });
   }
 
@@ -613,13 +560,12 @@ export function GameRoute() {
       return;
     }
 
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "reinforce",
       territoryId: reinforceTerritoryId,
-      amount: Math.max(1, Number(snapshot?.reinforcementPool || 1)),
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      amount: Math.max(1, Number(snapshot?.reinforcementPool || 1))
     });
   }
 
@@ -628,14 +574,13 @@ export function GameRoute() {
       return;
     }
 
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type,
       fromId: attackFromId,
       toId: attackToId,
-      attackDice: Number(attackDiceCount),
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      attackDice: Number(attackDiceCount)
     });
   }
 
@@ -649,12 +594,11 @@ export function GameRoute() {
       pendingConquestMin,
       pendingConquestMax
     );
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "moveAfterConquest",
-      armies,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      armies
     });
   }
 
@@ -663,12 +607,11 @@ export function GameRoute() {
       return;
     }
 
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "moveAfterConquest",
-      armies: pendingConquestMax,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      armies: pendingConquestMax
     });
   }
 
@@ -678,14 +621,13 @@ export function GameRoute() {
     }
 
     const armies = clamp(parsePositiveInteger(fortifyArmies, 1), 1, maxFortifyArmies);
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
       type: "fortify",
       fromId: fortifyFromId,
       toId: fortifyToId,
-      armies,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      armies
     });
   }
 
@@ -694,11 +636,10 @@ export function GameRoute() {
       return;
     }
 
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
-      type: "endTurn",
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      type: "endTurn"
     });
   }
 
@@ -707,11 +648,10 @@ export function GameRoute() {
       return;
     }
 
-    await tradeMutation.mutateAsync({
+    await gameplayCommands.trade({
       gameId: resolvedGameId,
       playerId: myPlayerId,
-      cardIds: selectedTradeCardIds,
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      cardIds: selectedTradeCardIds
     });
   }
 
@@ -751,11 +691,10 @@ export function GameRoute() {
       return;
     }
 
-    await submitGameAction({
+    await gameplayCommands.submitAction({
       gameId: resolvedGameId,
       playerId: myPlayerId,
-      type: "surrender",
-      ...(currentVersion ? { expectedVersion: currentVersion } : {})
+      type: "surrender"
     });
   }
 
@@ -862,12 +801,8 @@ export function GameRoute() {
     return null;
   }
 
-  const canTradeCards = selectedTradeCardIds.length === 3 && !tradeMutation.isPending;
-  const actionPending =
-    joinMutation.isPending ||
-    startMutation.isPending ||
-    actionMutation.isPending ||
-    tradeMutation.isPending;
+  const canTradeCards = selectedTradeCardIds.length === 3 && !gameplayCommands.isTrading;
+  const actionPending = gameplayCommands.isAnyPending;
 
   return (
     <section data-testid="react-shell-game-page">
@@ -1102,7 +1037,7 @@ export function GameRoute() {
                 onClick={() => void handleJoinLobby()}
                 disabled={!showJoinLobby || actionPending}
               >
-                {joinMutation.isPending ? "Joining..." : t("game.join")}
+                {gameplayCommands.isJoining ? "Joining..." : t("game.join")}
               </button>
               <button
                 id="start-button"
@@ -1111,7 +1046,7 @@ export function GameRoute() {
                 onClick={() => void handleStartGame()}
                 disabled={!showStartGame || actionPending || snapshot.players.length < 2}
               >
-                {startMutation.isPending ? "Starting..." : t("game.start")}
+                {gameplayCommands.isStarting ? "Starting..." : t("game.start")}
               </button>
             </div>
           </div>
@@ -1149,7 +1084,7 @@ export function GameRoute() {
                     onClick={() => void handleReinforce()}
                     disabled={!reinforceTerritoryId || actionPending}
                   >
-                    {actionMutation.isPending ? "Applying..." : t("game.actions.add")}
+                    {gameplayCommands.isActionPending ? "Applying..." : t("game.actions.add")}
                   </button>
                   <button
                     id="reinforce-all-button"
@@ -1217,7 +1152,9 @@ export function GameRoute() {
                     onClick={() => void handleAttack("attack")}
                     disabled={!attackFromId || !attackToId || !attackDiceCount || actionPending}
                   >
-                    {actionMutation.isPending ? "Attacking..." : t("game.actions.launchAttack")}
+                    {gameplayCommands.isActionPending
+                      ? "Attacking..."
+                      : t("game.actions.launchAttack")}
                   </button>
                   <button
                     id="attack-banzai-button"
@@ -1225,7 +1162,7 @@ export function GameRoute() {
                     onClick={() => void handleAttack("attackBanzai")}
                     disabled={!attackFromId || !attackToId || !attackDiceCount || actionPending}
                   >
-                    {actionMutation.isPending
+                    {gameplayCommands.isActionPending
                       ? t("game.runtime.banzaiLoading")
                       : t("game.actions.banzai")}
                   </button>
@@ -1254,7 +1191,7 @@ export function GameRoute() {
                     onClick={() => void handleMoveAfterConquest()}
                     disabled={actionPending}
                   >
-                    {actionMutation.isPending ? "Moving..." : t("game.actions.moveArmies")}
+                    {gameplayCommands.isActionPending ? "Moving..." : t("game.actions.moveArmies")}
                   </button>
                   <button
                     id="conquest-all-button"
@@ -1324,7 +1261,9 @@ export function GameRoute() {
                     Boolean(snapshot.fortifyUsed)
                   }
                 >
-                  {actionMutation.isPending ? "Fortifying..." : t("game.actions.moveArmies")}
+                  {gameplayCommands.isActionPending
+                    ? "Fortifying..."
+                    : t("game.actions.moveArmies")}
                 </button>
               </div>
             </div>
@@ -1387,7 +1326,7 @@ export function GameRoute() {
                 onClick={() => void handleTradeCards()}
                 disabled={!canTradeCards}
               >
-                {tradeMutation.isPending ? "Trading..." : t("game.cards.tradeSet")}
+                {gameplayCommands.isTrading ? "Trading..." : t("game.cards.tradeSet")}
               </button>
             </div>
 
@@ -1398,7 +1337,7 @@ export function GameRoute() {
               onClick={() => void handleEndTurn()}
               disabled={actionPending || Boolean(snapshot.pendingConquest)}
             >
-              {actionMutation.isPending ? "Updating..." : endTurnLabel}
+              {gameplayCommands.isActionPending ? "Updating..." : endTurnLabel}
             </button>
           </div>
 


### PR DESCRIPTION
## What changed

- Added a gameplay mutation helper for shared persist/conflict/broadcast/validated-response flow.
- Extracted module-runtime contribution aggregation into a focused helper module.
- Added a setup catalog resolver so game creation no longer hand-assembles catalog lookup callbacks inline.
- Moved gameplay route mutation plumbing into a dedicated React hook.
- Split admin route section/navigation helpers into a small module.

## Why

These changes deepen existing modules without changing public gameplay rules or route contracts. Callers now cross smaller seams for mutation transactions, setup catalog lookup, runtime contribution aggregation, and React command dispatch.

## Validation

- `npm run test:all`
- `npm run lint` (passes with existing warnings)
- `npm run format:check`
