### PR TITLE
🛡️ Sentinel: [HIGH] Secure AI Join Endpoint and Harden Health API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Legacy plaintext passwords were being compared using standard string equality (`!==`), which is susceptible to timing attacks.
 **Learning:** Even when migrating to secure hashes like scrypt, the legacy fallback path must remain timing-safe. Node.js's `crypto.timingSafeEqual` requires buffers of equal length. For variable-length secrets, a robust pattern is to check for length equality first and perform a dummy comparison on mismatch to maintain constant-time execution paths without using potentially insecure hashes on password data.
 **Prevention:** Always use timing-safe comparison for any secret-derived data, and normalize lengths via hashing before comparison when the inputs can have different lengths.
+
+## 2025-05-20 - Unauthenticated AI Join Endpoint
+**Vulnerability:** The `/api/ai/join` endpoint was completely unauthenticated and unauthorized, allowing anyone to fill game lobbies with AI bots.
+**Learning:** Security controls must be applied consistently across all endpoints that mutate game state, regardless of whether they represent "human" or "system" actions. Partial authentication (securing `/api/join` but not `/api/ai/join`) creates easy bypasses for disruptive behavior.
+**Prevention:** Audit all endpoints in a feature set (e.g., game setup) to ensure they share the same security posture. Use centralized authorization policies (like `game:start`) to enforce consistent permissions.

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -61,11 +61,15 @@ const {
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
 
 async function handleAiJoinRoute(
+  req: unknown,
   res: unknown,
   body: Record<string, any>,
   url: URL,
+  requireAuth: RequireAuth,
   loadGameContext: LoadGameContext,
   getTargetGameId: GetTargetGameId,
+  getGame: GetGame,
+  authorize: Authorize,
   addPlayer: AddPlayer,
   persistGameContext: PersistGameContext,
   broadcastGame: BroadcastGame,
@@ -73,7 +77,28 @@ async function handleAiJoinRoute(
   sendJson: SendJson,
   sendLocalizedError: SendLocalizedError
 ): Promise<void> {
-  const gameContext = await loadGameContext(getTargetGameId(body, url));
+  const authContext = await requireAuth(req, res, body);
+  if (!authContext) {
+    return;
+  }
+
+  const gameId = getTargetGameId(body, url);
+  try {
+    const activeGame = await getGame(gameId);
+    authorize("game:start", { user: authContext.user, game: activeGame.game });
+  } catch (error: any) {
+    const statusCode = error.statusCode || 403;
+    sendLocalizedError(
+      res,
+      statusCode,
+      error,
+      "Aggiunta AI non autorizzata.",
+      "server.game.aiJoinUnauthorized"
+    );
+    return;
+  }
+
+  const gameContext = await loadGameContext(gameId);
   const result = addPlayer(gameContext.state, body.name, { isAi: true });
   if (!result.ok) {
     sendLocalizedError(

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -730,8 +730,6 @@ function createApp(options: CreateAppOptions = {}) {
     return {
       ok: storage.ok,
       storage,
-      activeGameId,
-      activeGameVersion,
       hasActiveGame: Boolean(activeGameId)
     };
   }
@@ -1535,11 +1533,15 @@ function createApp(options: CreateAppOptions = {}) {
     if (req.method === "POST" && url.pathname === "/api/ai/join") {
       const body = await parseBody(req);
       await handleAiJoinRoute(
+        req,
         res,
         body,
         url,
+        requireAuth,
         loadGameContext,
         getTargetGameId,
+        gameSessions.getGame,
+        authorize,
         addPlayer,
         persistGameContext,
         broadcastGame,

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -5112,7 +5112,7 @@ register("API state e mutazioni restano isolate tra partite diverse tramite game
 
     const aiJoinA = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(ownerA.sessionToken),
       body: JSON.stringify({ name: "CPU A", gameId: payloadA.game.id })
     });
     assert.equal(aiJoinA.status, 201);
@@ -5907,7 +5907,7 @@ register(
 
       const joinAi = await fetch(baseUrl + "/api/ai/join", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders(ownerSession.sessionToken),
         body: JSON.stringify({ name: "CPU Rebind" })
       });
       assert.equal(joinAi.status, 201);
@@ -6152,7 +6152,7 @@ register("API ai join + endTurn esegue automaticamente il turno AI", async () =>
 
     const joinAi = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(humanSession.sessionToken),
       body: JSON.stringify({ name: "CPU Basic" })
     });
     assert.equal(joinAi.status, 201);
@@ -6247,7 +6247,7 @@ register("API games open riprende automaticamente una partita salvata sul turno 
 
     const joinAi = await fetch(baseUrl + "/api/ai/join", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: authHeaders(ownerSession.sessionToken),
       body: JSON.stringify({ name: "CPU Resume" })
     });
     assert.equal(joinAi.status, 201);


### PR DESCRIPTION
🚨 Severity: HIGH/MEDIUM
💡 Vulnerability: The `/api/ai/join` endpoint was completely unauthenticated and unauthorized, allowing any user to inject AI bots into lobbies. Additionally, the `/api/health` endpoint exposed internal state (`activeGameId`, `activeGameVersion`).
🎯 Impact: Unauthorized lobby manipulation and information disclosure of internal system state.
🔧 Fix:
- Added `requireAuth` and `game:start` policy authorization to `handleAiJoinRoute` in `backend/routes/game-setup.cts`.
- Updated `backend/server.cts` to pass required security dependencies to the AI join route.
- Sanitized `healthSnapshot` in `backend/server.cts` to remove internal state fields.
- Updated `scripts/run-tests.cts` to include authentication for AI join integration tests.
✅ Verification: Ran `npm test` - all 153 tests passed. Confirmed AI join now requires authentication and host/admin authorization. Verified information disclosure is removed from health response.

---
*PR created automatically by Jules for task [8042719672185756175](https://jules.google.com/task/8042719672185756175) started by @andreame-code*