### PR TITLE
Remove unused lobby button from game rail

### DIFF
--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -262,4 +262,19 @@ describe("GameRoute integration", () => {
 
     expect(closeStreamMock).toHaveBeenCalledTimes(1);
   }, 20_000);
+
+  it("hides the empty action section while the game is still in the lobby", async () => {
+    getGameStateMock.mockResolvedValue(
+      createGameplayState({
+        phase: "lobby",
+        turnPhase: "lobby",
+        reinforcementPool: 0
+      })
+    );
+
+    const { container } = renderReactShell("/react/game/g-1");
+
+    expect(await screen.findByTestId("react-shell-game-page")).toBeInTheDocument();
+    expect(container.querySelector(".actions-section")).toHaveAttribute("hidden");
+  });
 });

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -921,12 +921,6 @@ export function GameRoute() {
             </span>
           </div>
 
-          <div className="rail-section game-navigation-actions">
-            <Link className="ghost-button full-width" to={lobbyHref}>
-              {t("nav.lobby")}
-            </Link>
-          </div>
-
           <div
             className="rail-section game-reinforcement-banner"
             id="reinforcement-banner"

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -391,6 +391,14 @@ export function GameRoute() {
       ? t("game.runtime.combat.defenseBroken")
       : t("game.runtime.combat.resolved");
   const showTradePanel = Boolean(playerHand.length) || mustTradeCards;
+  const showActionsSection = Boolean(
+    showReinforceGroup ||
+    showAttackGroup ||
+    showConquestGroup ||
+    showFortifyGroup ||
+    showTradePanel ||
+    showEndTurn
+  );
   const gameFeedbackMessage = feedbackMessage || actionError;
   const gameFeedbackIsError = !feedbackMessage && Boolean(actionError);
 
@@ -1045,7 +1053,7 @@ export function GameRoute() {
             </div>
           </div>
 
-          <div className="rail-section actions-section">
+          <div className="rail-section actions-section" hidden={!showActionsSection}>
             <div
               className="action-group compact-group"
               id="reinforce-group"


### PR DESCRIPTION
## Summary
- remove the unused Lobby button from the in-game right action rail
- keep existing lobby fallback navigation for error states untouched

## Validation
- npm run typecheck:react-shell
- npm run test:react -- gameplay-route.integration.test.tsx
- npm run lint -- frontend/react-shell/src/gameplay-route.tsx (passes with existing repo warnings)
- npm run test:react
- npm run build:react-shell