### PR TITLE
🛡️ Sentinel: Sanitize /api/health endpoint to prevent information disclosure

### DIFF
--- a/backend/server.cts
+++ b/backend/server.cts
@@ -730,7 +730,6 @@ function createApp(options: CreateAppOptions = {}) {
     const storage = await datastore.healthSummary();
     return {
       ok: storage.ok,
-      storage,
       hasActiveGame: Boolean(activeGameId)
     };
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,9 +170,6 @@ Success responses return:
 ```json
 {
   "ok": true,
-  "storage": {},
-  "activeGameId": "optional-id",
-  "activeGameVersion": 1,
   "hasActiveGame": true
 }
 ```

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -964,17 +964,12 @@ register("http response helpers normalizzano payload localizzati e codici extra"
 
 register("health route usa 503 quando lo snapshot segnala errore", async () => {
   const res = makeMockResponse();
-  const handled = await handleHealthRoute(
-    res,
-    async () => ({ ok: false, storage: { storage: "sqlite" } }),
-    sendJson
-  );
+  const handled = await handleHealthRoute(res, async () => ({ ok: false }), sendJson);
 
   assert.equal(handled, true);
   assert.equal(res.statusCode, 503);
   assert.deepEqual(JSON.parse(res.body), {
-    ok: false,
-    storage: { storage: "sqlite" }
+    ok: false
   });
 });
 
@@ -6599,17 +6594,13 @@ register("GET /api/state risponde con lo stato pubblico", async () => {
   });
 });
 
-register("GET /api/health espone lo stato del datastore sqlite", async () => {
+register("GET /api/health espone lo stato sintetico del server", async () => {
   await withServer(async (baseUrl, context) => {
     const response = await fetch(`${baseUrl}/api/health`);
     assert.equal(response.status, 200);
     const payload: any = await readJson(response);
     assert.equal(payload.ok, true);
-    assert.equal(payload.storage.storage, "sqlite");
-    assert.equal(payload.storage.journalMode, "WAL");
-    assert.equal(typeof payload.storage.counts.users, "number");
-    assert.equal(typeof payload.storage.counts.games, "number");
-    assert.equal(typeof payload.storage.counts.sessions, "number");
+    assert.equal(typeof payload.storage, "undefined");
     assert.equal(payload.hasActiveGame, true);
   });
 });
@@ -6757,7 +6748,8 @@ register(
 
         const healthResponse = await callApp(app, "GET", "/api/health");
         assert.equal(healthResponse.statusCode, 200);
-        assert.equal(healthResponse.payload.storage.storage, "supabase");
+        assert.equal(healthResponse.payload.ok, true);
+        assert.equal(typeof healthResponse.payload.storage, "undefined");
 
         assert.equal(mock.tables.users.length, 1);
         assert.equal(mock.tables.sessions.length, 1);


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Sanitize /api/health endpoint

I have identified and fixed an Information Disclosure issue in the `/api/health` endpoint. Previously, this endpoint returned detailed infrastructure information, including the storage driver being used (SQLite/Supabase), SQLite journal mode, and precise counts of system entities (users, games, sessions).

While helpful for debugging, exposing these internal implementation details and operational metrics publicly increases the reconnaissance surface for potential attackers.

**Changes:**
1.  **Backend:** Modified the `healthSnapshot` function in `backend/server.cts` to return only the essential `ok` status and `hasActiveGame` flag, stripping out the detailed `storage` object.
2.  **Testing:** Updated the test suite in `scripts/run-tests.cts` to match the new sanitized response format. All 153 tests pass correctly.
3.  **Documentation:** Updated `docs/api.md` to ensure the API documentation reflects the actual sanitized response shape.

This enhancement follows the principle of Least Privilege and Information Hiding, ensuring that external monitoring tools get the health status they need without leaking sensitive system internals.

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Disclosure
🎯 **Impact:** Leakage of internal database types, configurations, and sensitive operational statistics.
🔧 **Fix:** Sanitized the health check response to exclude internal metadata.
✅ **Verification:** Verified by running the full test suite (`npm test`), with all 153 tests passing.

---
*PR created automatically by Jules for task [12128242696404714280](https://jules.google.com/task/12128242696404714280) started by @andreame-code*