### PR TITLE
Fix Vercel build regression from Supabase probe

### DIFF
--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -340,10 +340,7 @@ register("landing CSS limita i reset document-wide alla route marketing", () => 
 register("vercel build command compila TypeScript prima della sync degli asset", () => {
   const config = readProjectJson("vercel.json");
   assert.equal(typeof config.buildCommand, "string");
-  assert.equal(
-    config.buildCommand,
-    "npm run build:ts && node .tsbuild/scripts/check-supabase-connection.cjs"
-  );
+  assert.equal(config.buildCommand, "npm run build:ts");
 });
 
 register(

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "buildCommand": "npm run build:ts && node .tsbuild/scripts/check-supabase-connection.cjs",
+  "buildCommand": "npm run build:ts",
   "outputDirectory": "public",
   "functions": {
     "api/index.ts": {


### PR DESCRIPTION
## Summary
- restore the Vercel build command to 
pm run build:ts
- keep the Supabase connectivity probe as an explicit script instead of a deploy-time hard dependency
- update the regression test that asserts the Vercel build command

## Evidence
- commit 6a50d3b changed ercel.json to run .tsbuild/scripts/check-supabase-connection.cjs on every Vercel build
- reproducing that exact post-build step locally failed with Missing Supabase connection env: SUPABASE_URL
- quality.yml only runs 
pm run build:ts, so this regression would bypass CI and fail later at deploy time

## Validation
- 
pm ci
- 
pm run build:ts
- 
ode .tsbuild/scripts/run-tests.cjs
- reproduced previous failure with 
pm run build:ts; node .tsbuild/scripts/check-supabase-connection.cjs after clearing Supabase env vars
