### PR TITLE
Centralize resolvedCatalog view helpers (backend)

### DIFF
--- a/backend/catalog-view.cts
+++ b/backend/catalog-view.cts
@@ -1,0 +1,46 @@
+type CatalogCarrier = {
+  resolvedCatalog?: unknown;
+};
+
+function resolvedCatalogFromCarrier<T extends Record<string, unknown>>(
+  carrier: CatalogCarrier | null | undefined
+): T {
+  const resolved = carrier && typeof carrier === "object" ? (carrier as any).resolvedCatalog : null;
+  if (resolved && typeof resolved === "object") {
+    return resolved as T;
+  }
+
+  if (carrier && typeof carrier === "object") {
+    return carrier as unknown as T;
+  }
+
+  return {} as T;
+}
+
+function listEntries<T>(entries: T[] | null | undefined): T[] {
+  return Array.isArray(entries) ? entries : [];
+}
+
+function listFromCatalog<T extends Record<string, unknown>, K extends keyof T>(
+  catalog: T,
+  key: K
+): Array<any> {
+  const entries = catalog[key];
+  return Array.isArray(entries) ? (entries as any[]) : [];
+}
+
+function findCatalogEntry<T extends Record<string, unknown>, K extends keyof T>(
+  catalog: T,
+  key: K,
+  id: string
+) {
+  return listFromCatalog(catalog, key).find((entry) => entry && entry.id === id) || null;
+}
+
+module.exports = {
+  resolvedCatalogFromCarrier,
+  listEntries,
+  listFromCatalog,
+  findCatalogEntry
+};
+

--- a/backend/catalog-view.cts
+++ b/backend/catalog-view.cts
@@ -43,4 +43,3 @@ module.exports = {
   listFromCatalog,
   findCatalogEntry
 };
-

--- a/backend/routes/game-overview.cts
+++ b/backend/routes/game-overview.cts
@@ -70,7 +70,9 @@ async function handleGameOptionsRoute(
   getExtraGameOptions?: GetExtraGameOptions,
   sendLocalizedError?: SendLocalizedError
 ): Promise<void> {
-  const resolvedCatalog = resolvedCatalogFromCarrier(await getResolvedCatalog()) as GameOptionsResolvedCatalog;
+  const resolvedCatalog = resolvedCatalogFromCarrier(
+    await getResolvedCatalog()
+  ) as GameOptionsResolvedCatalog;
   const payload = {
     ruleSets: listEntries(resolvedCatalog.ruleSets),
     maps: listEntries(resolvedCatalog.maps),

--- a/backend/routes/game-overview.cts
+++ b/backend/routes/game-overview.cts
@@ -38,6 +38,7 @@ const {
   gameListResponseSchema,
   gameOptionsResponseSchema
 } = require("../../shared/runtime-validation.cjs");
+const { listEntries, resolvedCatalogFromCarrier } = require("../catalog-view.cjs");
 const { sendValidatedJson } = require("../route-validation.cjs");
 
 async function handleGamesListRoute(
@@ -69,7 +70,7 @@ async function handleGameOptionsRoute(
   getExtraGameOptions?: GetExtraGameOptions,
   sendLocalizedError?: SendLocalizedError
 ): Promise<void> {
-  const resolvedCatalog = (await getResolvedCatalog()) || {};
+  const resolvedCatalog = resolvedCatalogFromCarrier(await getResolvedCatalog()) as GameOptionsResolvedCatalog;
   const payload = {
     ruleSets: listEntries(resolvedCatalog.ruleSets),
     maps: listEntries(resolvedCatalog.maps),
@@ -105,10 +106,6 @@ async function handleGameOptionsRoute(
     sendJson as SendJson,
     sendLocalizedError
   );
-}
-
-function listEntries<T>(entries: T[] | null | undefined): T[] {
-  return Array.isArray(entries) ? entries : [];
 }
 
 module.exports = {

--- a/backend/setup-catalog-resolver.cts
+++ b/backend/setup-catalog-resolver.cts
@@ -17,17 +17,10 @@ type ModuleRuntime = {
   resolveGameSelection: (input: unknown) => unknown;
 };
 
-function listFromCatalog(catalog: ResolvedCatalog, key: keyof ResolvedCatalog): CatalogEntry[] {
-  const entries = catalog[key];
-  return Array.isArray(entries) ? entries : [];
-}
-
-function findCatalogEntry(catalog: ResolvedCatalog, key: keyof ResolvedCatalog, id: string) {
-  return listFromCatalog(catalog, key).find((entry) => entry.id === id) || null;
-}
+const { findCatalogEntry, listFromCatalog, resolvedCatalogFromCarrier } = require("./catalog-view.cjs");
 
 function createSetupCatalogResolver(moduleRuntime: ModuleRuntime, moduleOptions: any) {
-  const resolvedCatalog = moduleOptions?.resolvedCatalog || moduleOptions || {};
+  const resolvedCatalog = resolvedCatalogFromCarrier(moduleOptions) as ResolvedCatalog;
 
   return {
     resolveRuleSet: (ruleSetId: string) => findCatalogEntry(resolvedCatalog, "ruleSets", ruleSetId),

--- a/backend/setup-catalog-resolver.cts
+++ b/backend/setup-catalog-resolver.cts
@@ -17,7 +17,11 @@ type ModuleRuntime = {
   resolveGameSelection: (input: unknown) => unknown;
 };
 
-const { findCatalogEntry, listFromCatalog, resolvedCatalogFromCarrier } = require("./catalog-view.cjs");
+const {
+  findCatalogEntry,
+  listFromCatalog,
+  resolvedCatalogFromCarrier
+} = require("./catalog-view.cjs");
 
 function createSetupCatalogResolver(moduleRuntime: ModuleRuntime, moduleOptions: any) {
   const resolvedCatalog = resolvedCatalogFromCarrier(moduleOptions) as ResolvedCatalog;


### PR DESCRIPTION
Adds a small catalog-view helper module to concentrate the resolvedCatalog vs legacy carrier fallback logic, and reuses it in setup catalog resolution and game options overview.

- Validated with: npm run typecheck, npm test