### PR TITLE
Fix themed select option colors

### DIFF
--- a/frontend/react-shell/src/__tests__/theme.test.ts
+++ b/frontend/react-shell/src/__tests__/theme.test.ts
@@ -115,6 +115,19 @@ describe("theme runtime bridge", () => {
     expect(slotRuleBodies.join("\n")).not.toMatch(/\bdisplay\s*:\s*none\b/i);
   });
 
+  it("keeps native select menu options readable on themed backgrounds", () => {
+    const css = readFileSync(themeTokensPath, "utf8");
+    const optionRuleBody = ruleBodyForSelector(css, "select option");
+    const checkedOptionRuleBody = ruleBodyForSelector(css, "select option:checked");
+
+    expect(optionRuleBody).not.toBeNull();
+    expect(optionRuleBody).toMatch(/background-color\s*:\s*var\(--bg-soft\)/i);
+    expect(optionRuleBody).toMatch(/color\s*:\s*var\(--field-text\)/i);
+    expect(checkedOptionRuleBody).not.toBeNull();
+    expect(checkedOptionRuleBody).toMatch(/background-color\s*:\s*var\(--accent-2\)/i);
+    expect(checkedOptionRuleBody).toMatch(/color\s*:\s*var\(--text-inverse\)/i);
+  });
+
   it("keeps War Table custom-background map territories colored by owner", () => {
     const css = readFileSync(themeTokensPath, "utf8");
     const territoryRuleBody = ruleBodyForSelector(

--- a/frontend/react-shell/src/theme-tokens.css
+++ b/frontend/react-shell/src/theme-tokens.css
@@ -1016,6 +1016,16 @@ select {
   color: var(--field-text);
 }
 
+select option {
+  background-color: var(--bg-soft);
+  color: var(--field-text);
+}
+
+select option:checked {
+  background-color: var(--accent-2);
+  color: var(--text-inverse);
+}
+
 input::placeholder {
   color: var(--field-placeholder);
 }


### PR DESCRIPTION
## Summary
- Style native select options with theme colors so dropdown menus stay readable on dark themed surfaces.
- Add a theme CSS regression test for native select option colors.

## Validation
- npm run test:react -- theme.test.ts
- npm run typecheck:react-shell
- npm run build:react-shell