### PR TITLE
Create version compatibility registry

### DIFF
--- a/backend/routes/version.cts
+++ b/backend/routes/version.cts
@@ -1,0 +1,37 @@
+const { buildVersionSnapshot } = require("../../shared/compatibility.cjs");
+const { versionInfoResponseSchema } = require("../../shared/runtime-validation.cjs");
+const { sendValidatedJson } = require("../route-validation.cjs");
+
+type SendJson = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  payload: unknown,
+  headers?: Record<string, string>
+) => void;
+
+type SendLocalizedError = (
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  input: Record<string, unknown> | null,
+  fallbackMessage: string,
+  fallbackKey: string | null,
+  fallbackParams?: Record<string, unknown>,
+  code?: string | null,
+  extra?: Record<string, unknown>
+) => void;
+
+export async function handleVersionRoute(
+  res: import("node:http").ServerResponse,
+  sendJson: SendJson,
+  sendLocalizedError: SendLocalizedError
+): Promise<boolean> {
+  sendValidatedJson(
+    res,
+    200,
+    buildVersionSnapshot(),
+    versionInfoResponseSchema,
+    sendJson,
+    sendLocalizedError
+  );
+  return true;
+}

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -56,6 +56,7 @@ const { handleGamesListRoute, handleGameOptionsRoute } = require("./routes/game-
 const { handleEventsRoute, handleStateRoute } = require("./routes/game-read.cjs");
 const { handleAiJoinRoute, handleJoinRoute, handleStartRoute } = require("./routes/game-setup.cjs");
 const { handleHealthRoute } = require("./routes/health.cjs");
+const { handleVersionRoute } = require("./routes/version.cjs");
 const {
   handleDisableModuleRoute,
   handleEnableModuleRoute,
@@ -763,6 +764,11 @@ function createApp(options: CreateAppOptions = {}) {
 
     if (req.method === "GET" && url.pathname === "/api/health") {
       await handleHealthRoute(res, healthSnapshot, sendJson);
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/version") {
+      await handleVersionRoute(res, sendJson, sendLocalizedError);
       return;
     }
 

--- a/frontend/src/core/api/client.mts
+++ b/frontend/src/core/api/client.mts
@@ -43,7 +43,8 @@ import {
   startGameRequestSchema,
   themePreferenceRequestSchema,
   themePreferenceResponseSchema,
-  tradeCardsRequestSchema
+  tradeCardsRequestSchema,
+  versionInfoResponseSchema
 } from "../../generated/shared-runtime-validation.mjs";
 import type {
   AccountSettingsRequest,
@@ -87,7 +88,8 @@ import type {
   RegisterRequest,
   StartGameRequest,
   TradeCardsRequest,
-  ThemePreferenceResponse
+  ThemePreferenceResponse,
+  VersionInfoResponse
 } from "../../generated/shared-runtime-validation.mjs";
 import type { ApiClientError } from "./http.mjs";
 import { requestJson } from "./http.mjs";
@@ -125,7 +127,7 @@ type GameEventSubscriptionOptions = {
 };
 
 export type { GameActionRequest, GameEventPayload, GameStateResponse, StartGameRequest };
-export type { TradeCardsRequest };
+export type { TradeCardsRequest, VersionInfoResponse };
 
 export function getSession(messages: ClientMessages): Promise<AuthSessionResponse> {
   return requestJson({
@@ -205,6 +207,15 @@ export function getModuleOptions(messages: ClientMessages): Promise<ModuleOption
     path: "/api/modules/options",
     responseSchema: moduleOptionsResponseSchema,
     responseSchemaName: "ModuleOptionsResponse",
+    ...messages
+  });
+}
+
+export function getVersionInfo(messages: ClientMessages): Promise<VersionInfoResponse> {
+  return requestJson({
+    path: "/api/version",
+    responseSchema: versionInfoResponseSchema,
+    responseSchemaName: "VersionInfoResponse",
     ...messages
   });
 }

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -75,6 +75,20 @@ export const transportErrorPayloadSchema = messagePayloadSchema.extend({
 
 export type TransportErrorPayload = z.infer<typeof transportErrorPayloadSchema>;
 
+export const versionInfoResponseSchema = objectSchema({
+  appVersion: z.string().min(1),
+  engineVersion: z.string().min(1),
+  apiVersion: z.string().min(1),
+  datastoreSchemaVersion: z.number().int(),
+  saveGameSchemaVersion: z.number().int(),
+  moduleApiVersion: z.string().min(1),
+  minimumCompatibleSaveGameSchemaVersion: z.number().int(),
+  minimumCompatibleModuleApiVersion: z.string().min(1),
+  compatible: z.literal(true)
+});
+
+export type VersionInfoResponse = z.infer<typeof versionInfoResponseSchema>;
+
 function objectSchema<T extends z.ZodRawShape>(shape: T) {
   return z.object(shape).passthrough();
 }

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -24,6 +24,7 @@ const gameplayTestModules = [
   "../tests/gameplay/shared/continent-loader.test.cjs",
   "../tests/gameplay/shared/extensions.test.cjs",
   "../tests/gameplay/shared/core-base-catalog.test.cjs",
+  "../tests/gameplay/shared/version-registry.test.cjs",
   "../tests/gameplay/shared/runtime-validation.test.cjs",
   "../tests/gameplay/ai/ai-player.test.cjs",
   "../tests/gameplay/setup/game-setup.test.cjs",

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -95,6 +95,14 @@ const classicMiniMap = require("../shared/maps/classic-mini.cjs");
 const middleEarthMap = require("../shared/maps/middle-earth.cjs");
 const worldClassicMap = require("../shared/maps/world-classic.cjs");
 const { listSupportedMaps } = require("../shared/maps/index.cjs");
+const { createGameState } = require("../shared/models.cjs");
+const {
+  buildVersionSnapshot,
+  isModuleApiCompatible,
+  isSaveGameSchemaCompatible
+} = require("../shared/compatibility.cjs");
+const versionManifest = require("../shared/version-manifest.cjs");
+const { versionInfoResponseSchema } = require("../shared/runtime-validation.cjs");
 
 type TestFn = () => void | Promise<void>;
 type TestCase = {
@@ -967,6 +975,46 @@ register("health route usa 503 quando lo snapshot segnala errore", async () => {
   assert.equal(res.statusCode, 503);
   assert.deepEqual(JSON.parse(res.body), {
     ok: false
+  });
+});
+
+register("version registry espone manifest e compatibilita baseline", () => {
+  const expectedManifest = {
+    appVersion: "0.1.0",
+    engineVersion: "1.0.0",
+    apiVersion: "1.0.0",
+    datastoreSchemaVersion: 1,
+    saveGameSchemaVersion: 1,
+    moduleApiVersion: "1.0.0",
+    minimumCompatibleSaveGameSchemaVersion: 1,
+    minimumCompatibleModuleApiVersion: "1.0.0"
+  };
+
+  assert.deepEqual(versionManifest.versionManifest, expectedManifest);
+  assert.deepEqual(buildVersionSnapshot(), {
+    ...expectedManifest,
+    compatible: true
+  });
+  assert.equal(versionInfoResponseSchema.safeParse(buildVersionSnapshot()).success, true);
+  assert.equal(versionManifest.unversionedSaveGameSchemaVersion, 1);
+  assert.equal(isSaveGameSchemaCompatible(versionManifest.saveGameSchemaVersion), true);
+  assert.equal(isSaveGameSchemaCompatible(undefined), true);
+  assert.equal(isSaveGameSchemaCompatible(0), false);
+  assert.equal(isSaveGameSchemaCompatible(versionManifest.saveGameSchemaVersion + 1), false);
+  assert.equal(isSaveGameSchemaCompatible("invalid"), false);
+  assert.equal(isModuleApiCompatible(versionManifest.moduleApiVersion), true);
+  assert.equal(isModuleApiCompatible("0.0.0"), false);
+  assert.equal(isModuleApiCompatible("1.0.1"), false);
+  assert.equal(isModuleApiCompatible("invalid"), false);
+});
+
+register("new game states include version metadata from the registry", () => {
+  const state = createGameState();
+
+  assert.deepEqual(state.versionMetadata, {
+    schemaVersion: versionManifest.saveGameSchemaVersion,
+    engineVersion: versionManifest.engineVersion,
+    createdWithAppVersion: versionManifest.appVersion
   });
 });
 
@@ -2612,6 +2660,15 @@ register("frontend API client valida sessione, profilo e lobby list al boundary"
         };
       }
 
+      if (input === "/api/version") {
+        return {
+          ok: true,
+          async json() {
+            return buildVersionSnapshot();
+          }
+        };
+      }
+
       return {
         ok: true,
         async json() {
@@ -2643,16 +2700,22 @@ register("frontend API client valida sessione, profilo e lobby list al boundary"
         errorMessage: "Lobby non disponibile",
         fallbackMessage: "Lobby non valida"
       });
+      const versionInfo = await client.getVersionInfo({
+        errorMessage: "Versione non disponibile",
+        fallbackMessage: "Versione non valida"
+      });
 
       assert.equal(session.user.username, "Alice");
       assert.equal(profile.profile.gamesPlayed, 3);
       assert.equal(games.games[0].id, "game-1");
+      assert.equal(versionInfo.compatible, true);
+      assert.equal(versionInfo.apiVersion, "1.0.0");
     }
   );
 
   assert.deepEqual(
     calls.map((entry) => entry.input),
-    ["/api/auth/session", "/api/profile", "/api/games"]
+    ["/api/auth/session", "/api/profile", "/api/games", "/api/version"]
   );
   assert.ok(
     calls.every((entry) => entry.init?.credentials === "same-origin"),
@@ -4958,6 +5021,7 @@ register("game session store importa partite legacy da JSON al primo avvio", () 
 
   const legacyState = createInitialState();
   legacyState.log.push("Migrata da json");
+  delete (legacyState as Record<string, unknown>).versionMetadata;
 
   fs.writeFileSync(
     tempGames,
@@ -4989,6 +5053,8 @@ register("game session store importa partite legacy da JSON al primo avvio", () 
     assert.equal(reopened.game.name, "Legacy match");
     assert.equal(reopened.game.version, 3);
     assert.equal(reopened.state.log.includes("Migrata da json"), true);
+    assert.equal(typeof reopened.state.versionMetadata, "undefined");
+    assert.equal(isSaveGameSchemaCompatible(reopened.state.versionMetadata?.schemaVersion), true);
     assert.equal(store.datastore.getActiveGameId(), "legacy-game");
   } finally {
     store.datastore.close();
@@ -6599,6 +6665,18 @@ register("GET /api/health espone lo stato sintetico del server", async () => {
     assert.equal(payload.ok, true);
     assert.equal(typeof payload.storage, "undefined");
     assert.equal(payload.hasActiveGame, true);
+  });
+});
+
+register("GET /api/version espone il registry validato", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/version`);
+    assert.equal(response.status, 200);
+    const payload: any = await readJson(response);
+    const parsed = versionInfoResponseSchema.safeParse(payload);
+
+    assert.equal(parsed.success, true);
+    assert.deepEqual(payload, buildVersionSnapshot());
   });
 });
 

--- a/shared/compatibility.cts
+++ b/shared/compatibility.cts
@@ -1,0 +1,97 @@
+import {
+  apiVersion,
+  appVersion,
+  datastoreSchemaVersion,
+  engineVersion,
+  minimumCompatibleModuleApiVersion,
+  minimumCompatibleSaveGameSchemaVersion,
+  moduleApiVersion,
+  saveGameSchemaVersion,
+  unversionedSaveGameSchemaVersion
+} from "./version-manifest.cjs";
+
+export interface VersionSnapshot {
+  appVersion: string;
+  engineVersion: string;
+  apiVersion: string;
+  datastoreSchemaVersion: number;
+  saveGameSchemaVersion: number;
+  moduleApiVersion: string;
+  minimumCompatibleSaveGameSchemaVersion: number;
+  minimumCompatibleModuleApiVersion: string;
+  compatible: true;
+}
+
+export interface GameStateVersionMetadata {
+  schemaVersion: number;
+  engineVersion: string;
+  createdWithAppVersion: string;
+}
+
+export function buildVersionSnapshot(): VersionSnapshot {
+  return {
+    appVersion,
+    engineVersion,
+    apiVersion,
+    datastoreSchemaVersion,
+    saveGameSchemaVersion,
+    moduleApiVersion,
+    minimumCompatibleSaveGameSchemaVersion,
+    minimumCompatibleModuleApiVersion,
+    compatible: true
+  };
+}
+
+export function buildGameStateVersionMetadata(): GameStateVersionMetadata {
+  return {
+    schemaVersion: saveGameSchemaVersion,
+    engineVersion,
+    createdWithAppVersion: appVersion
+  };
+}
+
+export function isSaveGameSchemaCompatible(version: unknown): boolean {
+  const schemaVersion = version == null ? unversionedSaveGameSchemaVersion : Number(version);
+  return (
+    Number.isInteger(schemaVersion) &&
+    schemaVersion >= minimumCompatibleSaveGameSchemaVersion &&
+    schemaVersion <= saveGameSchemaVersion
+  );
+}
+
+function parseVersionParts(version: string): [number, number, number] | null {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersionParts(left: [number, number, number], right: [number, number, number]) {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = left[index] - right[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+export function isModuleApiCompatible(version: unknown): boolean {
+  if (typeof version !== "string") {
+    return false;
+  }
+
+  const requested = parseVersionParts(version);
+  const minimum = parseVersionParts(minimumCompatibleModuleApiVersion);
+  const current = parseVersionParts(moduleApiVersion);
+  if (!requested || !minimum || !current) {
+    return false;
+  }
+
+  return (
+    compareVersionParts(requested, minimum) >= 0 && compareVersionParts(requested, current) <= 0
+  );
+}

--- a/shared/core-domain.cts
+++ b/shared/core-domain.cts
@@ -1,4 +1,5 @@
 import type { Card } from "./cards.cjs";
+import { buildGameStateVersionMetadata, type GameStateVersionMetadata } from "./compatibility.cjs";
 import type { LogEntry } from "./messages.cjs";
 import type { NetRiskGameplayEffects, NetRiskModuleReference } from "./netrisk-modules.cjs";
 
@@ -73,6 +74,7 @@ export interface GameConfig {
 }
 
 export interface GameState {
+  versionMetadata: GameStateVersionMetadata;
   phase: string;
   turnPhase: TurnPhaseValue;
   turnStartedAt: string | null;
@@ -149,6 +151,10 @@ export function createContinent(input: CreateContinentInput = {}): Continent {
 
 export function createGameState(input: CreateGameStateInput = {}): GameState {
   return {
+    versionMetadata:
+      input.versionMetadata && typeof input.versionMetadata === "object"
+        ? input.versionMetadata
+        : buildGameStateVersionMetadata(),
     phase: input.phase || "lobby",
     turnPhase: input.turnPhase || TurnPhase.LOBBY,
     turnStartedAt: typeof input.turnStartedAt === "string" ? input.turnStartedAt : null,

--- a/shared/models.cts
+++ b/shared/models.cts
@@ -1,4 +1,23 @@
 export {
+  appVersion,
+  engineVersion,
+  apiVersion,
+  datastoreSchemaVersion,
+  saveGameSchemaVersion,
+  moduleApiVersion,
+  minimumCompatibleSaveGameSchemaVersion,
+  minimumCompatibleModuleApiVersion,
+  versionManifest
+} from "./version-manifest.cjs";
+export type { VersionManifest } from "./version-manifest.cjs";
+export {
+  buildGameStateVersionMetadata,
+  buildVersionSnapshot,
+  isModuleApiCompatible,
+  isSaveGameSchemaCompatible
+} from "./compatibility.cjs";
+export type { GameStateVersionMetadata, VersionSnapshot } from "./compatibility.cjs";
+export {
   TurnPhase,
   createContinent,
   createGameState,

--- a/shared/netrisk-modules.cts
+++ b/shared/netrisk-modules.cts
@@ -1,4 +1,6 @@
-export const NETRISK_ENGINE_VERSION = "1.0.0";
+import { engineVersion } from "./version-manifest.cjs";
+
+export const NETRISK_ENGINE_VERSION = engineVersion;
 export const NETRISK_MODULE_MANIFEST_SCHEMA_VERSION = 1;
 export const NETRISK_MODULE_SCHEMA_VERSION = 1;
 export const CORE_MODULE_ID = "core.base";

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -74,6 +74,20 @@ export const transportErrorPayloadSchema = messagePayloadSchema.extend({
 
 export type TransportErrorPayload = z.infer<typeof transportErrorPayloadSchema>;
 
+export const versionInfoResponseSchema = objectSchema({
+  appVersion: z.string().min(1),
+  engineVersion: z.string().min(1),
+  apiVersion: z.string().min(1),
+  datastoreSchemaVersion: z.number().int(),
+  saveGameSchemaVersion: z.number().int(),
+  moduleApiVersion: z.string().min(1),
+  minimumCompatibleSaveGameSchemaVersion: z.number().int(),
+  minimumCompatibleModuleApiVersion: z.string().min(1),
+  compatible: z.literal(true)
+});
+
+export type VersionInfoResponse = z.infer<typeof versionInfoResponseSchema>;
+
 function objectSchema<T extends z.ZodRawShape>(shape: T) {
   return z.object(shape).passthrough();
 }

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,0 +1,22 @@
+export const appVersion = "0.1.0";
+export const engineVersion = "1.0.0";
+export const apiVersion = "1.0.0";
+export const datastoreSchemaVersion = 1;
+export const saveGameSchemaVersion = 1;
+export const moduleApiVersion = "1.0.0";
+export const minimumCompatibleSaveGameSchemaVersion = 1;
+export const minimumCompatibleModuleApiVersion = "1.0.0";
+export const unversionedSaveGameSchemaVersion = 1;
+
+export const versionManifest = Object.freeze({
+  appVersion,
+  engineVersion,
+  apiVersion,
+  datastoreSchemaVersion,
+  saveGameSchemaVersion,
+  moduleApiVersion,
+  minimumCompatibleSaveGameSchemaVersion,
+  minimumCompatibleModuleApiVersion
+});
+
+export type VersionManifest = typeof versionManifest;

--- a/tests/gameplay/shared/version-registry.test.cts
+++ b/tests/gameplay/shared/version-registry.test.cts
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const {
+  buildVersionSnapshot,
+  isModuleApiCompatible,
+  isSaveGameSchemaCompatible
+} = require("../../../shared/compatibility.cjs");
+const {
+  apiVersion,
+  appVersion,
+  datastoreSchemaVersion,
+  engineVersion,
+  minimumCompatibleModuleApiVersion,
+  minimumCompatibleSaveGameSchemaVersion,
+  moduleApiVersion,
+  saveGameSchemaVersion,
+  unversionedSaveGameSchemaVersion,
+  versionManifest
+} = require("../../../shared/version-manifest.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("version manifest exports the central compatibility fields", () => {
+  assert.deepEqual(versionManifest, {
+    appVersion,
+    engineVersion,
+    apiVersion,
+    datastoreSchemaVersion,
+    saveGameSchemaVersion,
+    moduleApiVersion,
+    minimumCompatibleSaveGameSchemaVersion,
+    minimumCompatibleModuleApiVersion
+  });
+});
+
+register("version snapshot exposes the current compatibility surface", () => {
+  assert.deepEqual(buildVersionSnapshot(), {
+    appVersion,
+    engineVersion,
+    apiVersion,
+    datastoreSchemaVersion,
+    saveGameSchemaVersion,
+    moduleApiVersion,
+    minimumCompatibleSaveGameSchemaVersion,
+    minimumCompatibleModuleApiVersion,
+    compatible: true
+  });
+});
+
+register("save-game and module compatibility checks use the registry baseline", () => {
+  assert.equal(isSaveGameSchemaCompatible(saveGameSchemaVersion), true);
+  assert.equal(unversionedSaveGameSchemaVersion, 1);
+  assert.equal(isSaveGameSchemaCompatible(undefined), true);
+  assert.equal(isSaveGameSchemaCompatible(0), false);
+  assert.equal(isSaveGameSchemaCompatible(saveGameSchemaVersion + 1), false);
+  assert.equal(isSaveGameSchemaCompatible("invalid"), false);
+
+  assert.equal(isModuleApiCompatible(moduleApiVersion), true);
+  assert.equal(isModuleApiCompatible("0.0.0"), false);
+  assert.equal(isModuleApiCompatible("1.0.1"), false);
+  assert.equal(isModuleApiCompatible("invalid"), false);
+});


### PR DESCRIPTION
## Summary
- Add `shared/version-manifest.cts` as the central source of truth for app, engine, API, datastore, save-game, and module API compatibility versions.
- Add `shared/compatibility.cts` helpers for version snapshots, save-game schema compatibility, module API compatibility, and new game-state version metadata.
- Add validated `GET /api/version` and a typed frontend `getVersionInfo()` client helper.
- New game states now include version metadata from the registry; existing saved games without metadata are treated as the current baseline and remain loadable.

## Validation
- `npm run typecheck`
- `npm run typecheck:react-shell`
- `npm run test`
- `npm run test:react`
- `npm run build:ts`
- Extra: `npm run test:gameplay`

## Follow-up recommendations
- Add module manifest compatibility checks against module API, engine, and save-game versions when module loading starts enforcing compatibility.
- Add a minimal save-game migration entrypoint only when the first breaking save-game schema change is required.