### PR TITLE
Deduplicate module capability constants

### DIFF
--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -1,7 +1,7 @@
 // Generated from shared/runtime-validation.cts. Do not edit manually.
 import { z } from "zod";
 
-const NETRISK_MODULE_CAPABILITY_KIND_VALUES = [
+export const NETRISK_MODULE_CAPABILITY_KIND_VALUES = [
   "card-rule-set",
   "content-pack",
   "dice-rule-set",
@@ -14,7 +14,7 @@ const NETRISK_MODULE_CAPABILITY_KIND_VALUES = [
   "ui-slot",
   "victory-rule-set"
 ] as const;
-const NETRISK_UI_SLOT_ID_VALUES = [
+export const NETRISK_UI_SLOT_ID_VALUES = [
   "admin-modules-page",
   "game.sidebar",
   "lobby.page",

--- a/shared/netrisk-modules.cts
+++ b/shared/netrisk-modules.cts
@@ -4,7 +4,10 @@ import {
   moduleApiVersion,
   saveGameSchemaVersion
 } from "./version-manifest.cjs";
-import { NETRISK_MODULE_CAPABILITY_KIND_VALUES, NETRISK_UI_SLOT_ID_VALUES } from "./runtime-validation.cjs";
+import {
+  NETRISK_MODULE_CAPABILITY_KIND_VALUES,
+  NETRISK_UI_SLOT_ID_VALUES
+} from "./runtime-validation.cjs";
 
 export const NETRISK_ENGINE_VERSION = engineVersion;
 export const NETRISK_MODULE_MANIFEST_SCHEMA_VERSION = 1;

--- a/shared/netrisk-modules.cts
+++ b/shared/netrisk-modules.cts
@@ -4,32 +4,15 @@ import {
   moduleApiVersion,
   saveGameSchemaVersion
 } from "./version-manifest.cjs";
+import { NETRISK_MODULE_CAPABILITY_KIND_VALUES, NETRISK_UI_SLOT_ID_VALUES } from "./runtime-validation.cjs";
 
 export const NETRISK_ENGINE_VERSION = engineVersion;
 export const NETRISK_MODULE_MANIFEST_SCHEMA_VERSION = 1;
 export const NETRISK_MODULE_SCHEMA_VERSION = 1;
 export const CORE_MODULE_ID = "core.base";
 export const CORE_MODULE_VERSION = "1.0.0";
-export const NETRISK_MODULE_CAPABILITY_KINDS = [
-  "card-rule-set",
-  "content-pack",
-  "dice-rule-set",
-  "fortify-rule-set",
-  "gameplay-hook",
-  "map",
-  "player-piece-set",
-  "reinforcement-rule-set",
-  "site-theme",
-  "ui-slot",
-  "victory-rule-set"
-] as const;
-export const NETRISK_UI_SLOT_IDS = [
-  "admin-modules-page",
-  "game.sidebar",
-  "lobby.page",
-  "new-game.sidebar",
-  "top-nav-bar"
-] as const;
+export const NETRISK_MODULE_CAPABILITY_KINDS = NETRISK_MODULE_CAPABILITY_KIND_VALUES;
+export const NETRISK_UI_SLOT_IDS = NETRISK_UI_SLOT_ID_VALUES;
 
 import type { ContentPackSummary } from "./content-packs.cjs";
 import type { DiceRuleSet, DiceRuleSetSummary } from "./dice.cjs";

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const NETRISK_MODULE_CAPABILITY_KIND_VALUES = [
+export const NETRISK_MODULE_CAPABILITY_KIND_VALUES = [
   "card-rule-set",
   "content-pack",
   "dice-rule-set",
@@ -13,7 +13,7 @@ const NETRISK_MODULE_CAPABILITY_KIND_VALUES = [
   "ui-slot",
   "victory-rule-set"
 ] as const;
-const NETRISK_UI_SLOT_ID_VALUES = [
+export const NETRISK_UI_SLOT_ID_VALUES = [
   "admin-modules-page",
   "game.sidebar",
   "lobby.page",


### PR DESCRIPTION
### Cosa cambia
- `shared/runtime-validation.cts`: esporta `NETRISK_MODULE_CAPABILITY_KIND_VALUES` e `NETRISK_UI_SLOT_ID_VALUES` come unica source of truth (schema + costanti).
- `shared/netrisk-modules.cts`: riusa le costanti esportate invece di duplicare le string-list.
- `frontend/src/generated/shared-runtime-validation.mts`: rigenerato tramite sync (non editare a mano).

### Perche'
Riduce drift tra runtime validation e modelli modulo: piu' locality, meno duplicazione.

### Test
- `npm test`
