### PR TITLE
[codex] improve admin route branch coverage

### DIFF
--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -48,6 +48,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/module-runtime.test.cjs",
   "../tests/gameplay/regression/admin-console-routes.test.cjs",
   "../tests/gameplay/regression/admin-content-studio-routes.test.cjs",
+  "../tests/gameplay/regression/admin-route-validation.test.cjs",
   "../tests/gameplay/regression/auth-store.test.cjs",
   "../tests/gameplay/regression/authorization-rules.test.cjs",
   "../tests/gameplay/regression/authored-modules.test.cjs",

--- a/tests/gameplay/regression/admin-route-validation.test.cts
+++ b/tests/gameplay/regression/admin-route-validation.test.cts
@@ -1,0 +1,535 @@
+const assert = require("node:assert/strict");
+const {
+  handleAdminAuditRoute,
+  handleAdminConfigRoute,
+  handleAdminConfigUpdateRoute,
+  handleAdminGameActionRoute,
+  handleAdminGameDetailRoute,
+  handleAdminGamesRoute,
+  handleAdminMaintenanceActionRoute,
+  handleAdminMaintenanceRoute,
+  handleAdminOverviewRoute,
+  handleAdminUserRoleRoute,
+  handleAdminUsersRoute
+} = require("../../../backend/routes/admin.cjs");
+const {
+  handleAdminContentStudioCreateRoute,
+  handleAdminContentStudioDisableRoute,
+  handleAdminContentStudioEnableRoute,
+  handleAdminContentStudioModuleDetailRoute,
+  handleAdminContentStudioModulesRoute,
+  handleAdminContentStudioOptionsRoute,
+  handleAdminContentStudioPublishRoute,
+  handleAdminContentStudioUpdateRoute,
+  handleAdminContentStudioValidateRoute
+} = require("../../../backend/routes/admin-content-studio.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type LocalizedErrorCall = any[];
+
+function createAuthContext() {
+  return {
+    user: {
+      id: "admin-1",
+      username: "marshal",
+      role: "admin"
+    }
+  };
+}
+
+function requireLocalizedErrorCall(call: LocalizedErrorCall | null): LocalizedErrorCall {
+  if (!call) {
+    throw new Error("Expected a localized error call.");
+  }
+  return call;
+}
+
+function createValidDraft(id: string = "victory.route-validation") {
+  return {
+    id,
+    name: "Route Validation Objective",
+    description: "Objective used to exercise admin content studio route guards.",
+    version: "1.0.0",
+    moduleType: "victory-objectives",
+    content: {
+      mapId: "world-classic",
+      objectives: [
+        {
+          id: "hold-na",
+          title: "Hold North America",
+          description: "Control North America.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["north_america"]
+        }
+      ]
+    }
+  };
+}
+
+register("admin routes return early when auth is missing", async () => {
+  let sendJsonCalls = 0;
+  let sendLocalizedErrorCalls = 0;
+  let adminConsoleCalls = 0;
+  let authorizeCalls = 0;
+
+  const requireAuth = async () => null;
+  const authorize = () => {
+    authorizeCalls += 1;
+  };
+  const sendJson = () => {
+    sendJsonCalls += 1;
+  };
+  const sendLocalizedError = () => {
+    sendLocalizedErrorCalls += 1;
+  };
+  const adminConsole = new Proxy(
+    {},
+    {
+      get() {
+        return async () => {
+          adminConsoleCalls += 1;
+          throw new Error("adminConsole should not run without auth.");
+        };
+      }
+    }
+  );
+
+  await handleAdminOverviewRoute(
+    {},
+    {},
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminUsersRoute(
+    {},
+    {},
+    new URL("http://127.0.0.1/api/admin/users?q=ops&role=user"),
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminUserRoleRoute(
+    {},
+    {},
+    { userId: "user-1", role: "admin" },
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminGamesRoute(
+    {},
+    {},
+    new URL("http://127.0.0.1/api/admin/games?q=ops&status=lobby"),
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminGameDetailRoute(
+    {},
+    {},
+    "game-1",
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminGameActionRoute(
+    {},
+    {},
+    { gameId: "game-1", action: "terminate-game", confirmation: "game-1" },
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminConfigRoute(
+    {},
+    {},
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminConfigUpdateRoute(
+    {},
+    {},
+    { defaults: {}, maintenance: { staleLobbyDays: 7, auditLogLimit: 50 } },
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminMaintenanceRoute(
+    {},
+    {},
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminMaintenanceActionRoute(
+    {},
+    {},
+    { action: "validate-all" },
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminAuditRoute(
+    {},
+    {},
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(sendJsonCalls, 0);
+  assert.equal(sendLocalizedErrorCalls, 0);
+  assert.equal(adminConsoleCalls, 0);
+  assert.equal(authorizeCalls, 0);
+});
+
+register("admin content studio routes return early when auth is missing", async () => {
+  let sendJsonCalls = 0;
+  let sendLocalizedErrorCalls = 0;
+  let adminConsoleCalls = 0;
+  let authorizeCalls = 0;
+
+  const requireAuth = async () => null;
+  const authorize = () => {
+    authorizeCalls += 1;
+  };
+  const sendJson = () => {
+    sendJsonCalls += 1;
+  };
+  const sendLocalizedError = () => {
+    sendLocalizedErrorCalls += 1;
+  };
+  const adminConsole = new Proxy(
+    {},
+    {
+      get() {
+        return async () => {
+          adminConsoleCalls += 1;
+          throw new Error("content studio service should not run without auth.");
+        };
+      }
+    }
+  );
+
+  await handleAdminContentStudioOptionsRoute(
+    {},
+    {},
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioModulesRoute(
+    {},
+    {},
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioModuleDetailRoute(
+    {},
+    {},
+    "victory.route-validation",
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioValidateRoute(
+    {},
+    {},
+    createValidDraft(),
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioCreateRoute(
+    {},
+    {},
+    createValidDraft(),
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioUpdateRoute(
+    {},
+    {},
+    "victory.route-validation",
+    createValidDraft(),
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioPublishRoute(
+    {},
+    {},
+    "victory.route-validation",
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioEnableRoute(
+    {},
+    {},
+    "victory.route-validation",
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+  await handleAdminContentStudioDisableRoute(
+    {},
+    {},
+    "victory.route-validation",
+    requireAuth,
+    authorize,
+    adminConsole,
+    sendJson,
+    sendLocalizedError
+  );
+
+  assert.equal(sendJsonCalls, 0);
+  assert.equal(sendLocalizedErrorCalls, 0);
+  assert.equal(adminConsoleCalls, 0);
+  assert.equal(authorizeCalls, 0);
+});
+
+register("handleAdminUserRoleRoute rejects invalid inbound payloads", async () => {
+  let localizedErrorCall: LocalizedErrorCall | null = null;
+  let updateUserRoleCalls = 0;
+
+  await handleAdminUserRoleRoute(
+    {},
+    {},
+    { userId: 99, role: "owner" },
+    async () => createAuthContext(),
+    () => undefined,
+    {
+      async updateUserRole() {
+        updateUserRoleCalls += 1;
+        throw new Error("updateUserRole should not run for invalid payloads.");
+      }
+    },
+    () => {
+      throw new Error("sendJson should not run for invalid admin role payloads.");
+    },
+    (...args: LocalizedErrorCall) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+  assert.equal(updateUserRoleCalls, 0);
+  assert.equal(localizedError[1], 400);
+  assert.equal(localizedError[6], "REQUEST_VALIDATION_FAILED");
+  assert.deepEqual(
+    localizedError[7].validationErrors.map((entry: { path: string }) => entry.path),
+    ["userId", "role"]
+  );
+});
+
+register("handleAdminContentStudioValidateRoute rejects invalid drafts before service calls", async () => {
+  let localizedErrorCall: LocalizedErrorCall | null = null;
+  let validateCalls = 0;
+
+  await handleAdminContentStudioValidateRoute(
+    {},
+    {},
+    { id: "", content: { mapId: 7, objectives: "invalid" } },
+    async () => createAuthContext(),
+    () => undefined,
+    {
+      async validateAuthoredModuleDraft() {
+        validateCalls += 1;
+        throw new Error("validateAuthoredModuleDraft should not run for invalid payloads.");
+      }
+    },
+    () => {
+      throw new Error("sendJson should not run for invalid content studio payloads.");
+    },
+    (...args: LocalizedErrorCall) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+  const validationPaths = localizedError[7].validationErrors.map(
+    (entry: { path: string }) => entry.path
+  );
+  assert.equal(validateCalls, 0);
+  assert.equal(localizedError[1], 400);
+  assert.equal(localizedError[6], "REQUEST_VALIDATION_FAILED");
+  assert.equal(validationPaths.includes("id"), true);
+  assert.equal(validationPaths.includes("content.mapId"), true);
+  assert.equal(validationPaths.includes("content.objectives"), true);
+});
+
+register("handleAdminGameActionRoute maps failures and swallows failure audit errors", async () => {
+  let localizedErrorCall: LocalizedErrorCall | null = null;
+  let performGameActionCalls = 0;
+  let recordAuditCalls = 0;
+
+  await handleAdminGameActionRoute(
+    {},
+    {},
+    {
+      gameId: "game-9",
+      action: "terminate-game",
+      confirmation: "game-9"
+    },
+    async () => createAuthContext(),
+    () => undefined,
+    {
+      async performGameAction() {
+        performGameActionCalls += 1;
+        const error = new Error("stale lobby") as Error & { statusCode?: number };
+        error.statusCode = 409;
+        throw error;
+      },
+      async recordAudit() {
+        recordAuditCalls += 1;
+        throw new Error("audit offline");
+      }
+    },
+    () => {
+      throw new Error("sendJson should not run after a failed admin game action.");
+    },
+    (...args: LocalizedErrorCall) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  assert.equal(performGameActionCalls, 1);
+  assert.equal(recordAuditCalls, 1);
+  const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+  assert.equal(localizedError[1], 409);
+  assert.equal(localizedError[3], "Operazione admin sulla partita non riuscita.");
+  assert.equal(localizedError[4], "server.admin.gameActionFailed");
+});
+
+register(
+  "handleAdminContentStudioCreateRoute preserves validation details from failed saves",
+  async () => {
+    let localizedErrorCall: LocalizedErrorCall | null = null;
+    let recordAuditCalls = 0;
+
+    const validation = {
+      errors: [
+        {
+          path: "content.objectives[0].territoryCount",
+          code: "territory-count-out-of-range"
+        }
+      ]
+    };
+
+    await handleAdminContentStudioCreateRoute(
+      {},
+      {},
+      createValidDraft("victory.invalid-territory-count"),
+      async () => createAuthContext(),
+      () => undefined,
+      {
+        async saveAuthoredModuleDraft() {
+          const error = new Error("invalid draft") as Error & {
+            statusCode?: number;
+            validation?: unknown;
+          };
+          error.statusCode = 422;
+          error.validation = validation;
+          throw error;
+        },
+        async recordAudit() {
+          recordAuditCalls += 1;
+        }
+      },
+      () => {
+        throw new Error("sendJson should not run when saving the draft fails.");
+      },
+      (...args: LocalizedErrorCall) => {
+        localizedErrorCall = args;
+      }
+    );
+
+    assert.equal(recordAuditCalls, 1);
+    const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+    assert.equal(localizedError[1], 422);
+    assert.equal(localizedError[3], "Unable to save the module draft.");
+    assert.equal(localizedError[4], "server.admin.contentStudio.saveFailed");
+    assert.deepEqual(localizedError[7], { validation });
+  }
+);
+
+register("handleAdminContentStudioPublishRoute keeps the primary error when audit persistence fails", async () => {
+  let localizedErrorCall: LocalizedErrorCall | null = null;
+  let recordAuditCalls = 0;
+
+  await handleAdminContentStudioPublishRoute(
+    {},
+    {},
+    "victory.publish-failure",
+    async () => createAuthContext(),
+    () => undefined,
+    {
+      async publishAuthoredModule() {
+        const error = new Error("module unavailable") as Error & { statusCode?: number };
+        error.statusCode = 503;
+        throw error;
+      },
+      async recordAudit() {
+        recordAuditCalls += 1;
+        throw new Error("audit unavailable");
+      }
+    },
+    () => {
+      throw new Error("sendJson should not run when publishing fails.");
+    },
+    (...args: LocalizedErrorCall) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  assert.equal(recordAuditCalls, 1);
+  const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+  assert.equal(localizedError[1], 503);
+  assert.equal(localizedError[3], "Unable to publish the module.");
+  assert.equal(localizedError[4], "server.admin.contentStudio.publishFailed");
+});

--- a/tests/gameplay/regression/admin-route-validation.test.cts
+++ b/tests/gameplay/regression/admin-route-validation.test.cts
@@ -367,41 +367,44 @@ register("handleAdminUserRoleRoute rejects invalid inbound payloads", async () =
   );
 });
 
-register("handleAdminContentStudioValidateRoute rejects invalid drafts before service calls", async () => {
-  let localizedErrorCall: LocalizedErrorCall | null = null;
-  let validateCalls = 0;
+register(
+  "handleAdminContentStudioValidateRoute rejects invalid drafts before service calls",
+  async () => {
+    let localizedErrorCall: LocalizedErrorCall | null = null;
+    let validateCalls = 0;
 
-  await handleAdminContentStudioValidateRoute(
-    {},
-    {},
-    { id: "", content: { mapId: 7, objectives: "invalid" } },
-    async () => createAuthContext(),
-    () => undefined,
-    {
-      async validateAuthoredModuleDraft() {
-        validateCalls += 1;
-        throw new Error("validateAuthoredModuleDraft should not run for invalid payloads.");
+    await handleAdminContentStudioValidateRoute(
+      {},
+      {},
+      { id: "", content: { mapId: 7, objectives: "invalid" } },
+      async () => createAuthContext(),
+      () => undefined,
+      {
+        async validateAuthoredModuleDraft() {
+          validateCalls += 1;
+          throw new Error("validateAuthoredModuleDraft should not run for invalid payloads.");
+        }
+      },
+      () => {
+        throw new Error("sendJson should not run for invalid content studio payloads.");
+      },
+      (...args: LocalizedErrorCall) => {
+        localizedErrorCall = args;
       }
-    },
-    () => {
-      throw new Error("sendJson should not run for invalid content studio payloads.");
-    },
-    (...args: LocalizedErrorCall) => {
-      localizedErrorCall = args;
-    }
-  );
+    );
 
-  const localizedError = requireLocalizedErrorCall(localizedErrorCall);
-  const validationPaths = localizedError[7].validationErrors.map(
-    (entry: { path: string }) => entry.path
-  );
-  assert.equal(validateCalls, 0);
-  assert.equal(localizedError[1], 400);
-  assert.equal(localizedError[6], "REQUEST_VALIDATION_FAILED");
-  assert.equal(validationPaths.includes("id"), true);
-  assert.equal(validationPaths.includes("content.mapId"), true);
-  assert.equal(validationPaths.includes("content.objectives"), true);
-});
+    const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+    const validationPaths = localizedError[7].validationErrors.map(
+      (entry: { path: string }) => entry.path
+    );
+    assert.equal(validateCalls, 0);
+    assert.equal(localizedError[1], 400);
+    assert.equal(localizedError[6], "REQUEST_VALIDATION_FAILED");
+    assert.equal(validationPaths.includes("id"), true);
+    assert.equal(validationPaths.includes("content.mapId"), true);
+    assert.equal(validationPaths.includes("content.objectives"), true);
+  }
+);
 
 register("handleAdminGameActionRoute maps failures and swallows failure audit errors", async () => {
   let localizedErrorCall: LocalizedErrorCall | null = null;
@@ -498,38 +501,41 @@ register(
   }
 );
 
-register("handleAdminContentStudioPublishRoute keeps the primary error when audit persistence fails", async () => {
-  let localizedErrorCall: LocalizedErrorCall | null = null;
-  let recordAuditCalls = 0;
+register(
+  "handleAdminContentStudioPublishRoute keeps the primary error when audit persistence fails",
+  async () => {
+    let localizedErrorCall: LocalizedErrorCall | null = null;
+    let recordAuditCalls = 0;
 
-  await handleAdminContentStudioPublishRoute(
-    {},
-    {},
-    "victory.publish-failure",
-    async () => createAuthContext(),
-    () => undefined,
-    {
-      async publishAuthoredModule() {
-        const error = new Error("module unavailable") as Error & { statusCode?: number };
-        error.statusCode = 503;
-        throw error;
+    await handleAdminContentStudioPublishRoute(
+      {},
+      {},
+      "victory.publish-failure",
+      async () => createAuthContext(),
+      () => undefined,
+      {
+        async publishAuthoredModule() {
+          const error = new Error("module unavailable") as Error & { statusCode?: number };
+          error.statusCode = 503;
+          throw error;
+        },
+        async recordAudit() {
+          recordAuditCalls += 1;
+          throw new Error("audit unavailable");
+        }
       },
-      async recordAudit() {
-        recordAuditCalls += 1;
-        throw new Error("audit unavailable");
+      () => {
+        throw new Error("sendJson should not run when publishing fails.");
+      },
+      (...args: LocalizedErrorCall) => {
+        localizedErrorCall = args;
       }
-    },
-    () => {
-      throw new Error("sendJson should not run when publishing fails.");
-    },
-    (...args: LocalizedErrorCall) => {
-      localizedErrorCall = args;
-    }
-  );
+    );
 
-  assert.equal(recordAuditCalls, 1);
-  const localizedError = requireLocalizedErrorCall(localizedErrorCall);
-  assert.equal(localizedError[1], 503);
-  assert.equal(localizedError[3], "Unable to publish the module.");
-  assert.equal(localizedError[4], "server.admin.contentStudio.publishFailed");
-});
+    assert.equal(recordAuditCalls, 1);
+    const localizedError = requireLocalizedErrorCall(localizedErrorCall);
+    assert.equal(localizedError[1], 503);
+    assert.equal(localizedError[3], "Unable to publish the module.");
+    assert.equal(localizedError[4], "server.admin.contentStudio.publishFailed");
+  }
+);


### PR DESCRIPTION
## Obiettivo
Aumentare la coverage in modo utile, con priorita alla branch coverage, sulle route admin e content studio senza cambiare il comportamento applicativo.

## Aree toccate
- `backend/routes/admin.cts`
- `backend/routes/admin-content-studio.cts`
- `tests/gameplay/regression/admin-route-validation.test.cts`
- `scripts/run-gameplay-tests.cts`

## Coverage
Prima:
- Statements: 89.26%
- Branches: 76.86%
- Functions: 78.57%
- Lines: 89.26%

Dopo:
- Statements: 89.42%
- Branches: 77.22%
- Functions: 78.55%
- Lines: 89.42%

Miglioramenti mirati:
- `admin.cjs` branch coverage: 62.16% -> 77.92%
- `admin-content-studio.cjs` branch coverage: 65.00% -> 82.08%

## Test aggiunti
- early return quando l'auth manca
- short-circuit su payload admin non validi
- short-circuit su draft content studio non validi
- gestione degli errori con failure audit secondaria
- preservazione dei dettagli `validation` nei salvataggi falliti
- mapping degli errori 409, 422 e 503

## Fix minimi
- Nessun fix applicativo: solo test e registrazione del nuovo file nel runner gameplay.

## Validazione locale
- `npm run test:all`
- `npm run coverage && npm run coverage:check`
- `npm run typecheck`
- `npm run typecheck:react-shell`
- `npm run lint`
- `npm run test:e2e:smoke`

## Rischi residui
- Nessun rischio funzionale emerso localmente; il cambiamento tocca solo la suite di test.
