### PR TITLE
Create first version compatibility registry

### DIFF
--- a/tests/gameplay/shared/version-registry.test.cts
+++ b/tests/gameplay/shared/version-registry.test.cts
@@ -1,4 +1,9 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { createGameSessionStore } = require("../../../backend/game-session-store.cjs");
+const { createGameState } = require("../../../shared/models.cjs");
 const {
   buildVersionSnapshot,
   isModuleApiCompatible,
@@ -19,6 +24,14 @@ const {
 } = require("../../../shared/version-manifest.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function cleanupSqliteFiles(dbFile: string) {
+  [dbFile, dbFile + "-shm", dbFile + "-wal"].forEach((target) => {
+    if (fs.existsSync(target)) {
+      fs.unlinkSync(target);
+    }
+  });
+}
 
 register("version manifest exports the central compatibility fields", () => {
   assert.deepEqual(versionManifest, {
@@ -62,4 +75,66 @@ register("save-game and module compatibility checks use the registry baseline", 
   assert.equal(isModuleApiCompatible("0.0.0"), false);
   assert.equal(isModuleApiCompatible("1.0.1"), false);
   assert.equal(isModuleApiCompatible("invalid"), false);
+});
+
+register("new game states include version metadata from the registry", () => {
+  const state = createGameState();
+
+  assert.deepEqual(state.versionMetadata, {
+    schemaVersion: saveGameSchemaVersion,
+    engineVersion,
+    createdWithAppVersion: appVersion
+  });
+  assert.equal(isSaveGameSchemaCompatible(state.versionMetadata.schemaVersion), true);
+});
+
+register("legacy saved game states without version metadata remain compatible", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-version-registry-"));
+  const dataFile = path.join(tempDir, "games.json");
+  const dbFile = path.join(tempDir, "netrisk.sqlite");
+  const legacyState = createGameState({
+    log: ["Legacy saved game"]
+  });
+  delete (legacyState as Record<string, unknown>).versionMetadata;
+
+  fs.writeFileSync(
+    dataFile,
+    JSON.stringify(
+      {
+        games: [
+          {
+            id: "legacy-version-game",
+            name: "Legacy Version Game",
+            version: 4,
+            creatorUserId: null,
+            state: legacyState,
+            createdAt: "2026-04-01T10:00:00.000Z",
+            updatedAt: "2026-04-01T10:05:00.000Z"
+          }
+        ],
+        activeGameId: "legacy-version-game"
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const store = createGameSessionStore({
+    dataFile,
+    dbFile
+  });
+
+  try {
+    const opened = store.openGame("legacy-version-game");
+
+    assert.equal(opened.game.version, 4);
+    assert.equal(opened.state.log.includes("Legacy saved game"), true);
+    assert.equal(typeof opened.state.versionMetadata, "undefined");
+    assert.equal(isSaveGameSchemaCompatible(opened.state.versionMetadata?.schemaVersion), true);
+  } finally {
+    store.datastore.close();
+    cleanupSqliteFiles(dbFile);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- Confirms the central Version and Compatibility Registry surface already present in `shared/version-manifest.cts` and `shared/compatibility.cts` remains the single source for app, engine, API, datastore, save-game, and module API versions.
- Adds focused gameplay coverage for new game-state version metadata built from the registry.
- Adds focused legacy coverage proving saved games without version metadata remain loadable and compatible as the current baseline.

## Compatibility helpers
- `buildVersionSnapshot()` continues to return the validated registry snapshot used by API clients.
- `isSaveGameSchemaCompatible()` accepts the current baseline and missing legacy metadata, while rejecting invalid old/future values.
- `isModuleApiCompatible()` remains dependency-free and intentionally simple for this first registry foundation.

## API and frontend
- `/api/version` is already wired to return the validated registry payload with `compatible: true`.
- `getVersionInfo()` is already wired through the existing frontend API response-validation pattern.

## Validation
- `npm run typecheck` passed.
- `npm run typecheck:react-shell` passed.
- `npm run test` passed: 156 tests.
- `npm run test:react` passed: 23 files, 121 tests.
- `npm run build:ts` passed.

Note: Vite reported existing runtime asset-resolution warnings for `/assets/maps/world-classic.png` and `/assets/maps/middle-earth.jpg`; the build still completed successfully.

## Follow-ups
- Add richer module API compatibility checks when module manifests need non-exact compatibility policy.
- Introduce explicit save-game migrations only when a future schema change requires one.