### PR TITLE
[codex] Align lobby icon colors with game phases

### DIFF
--- a/frontend/react-shell/src/__tests__/lobby-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/lobby-route.integration.test.tsx
@@ -216,7 +216,8 @@ describe("LobbyRoute War Table theme behavior", () => {
     expect(openShellGameMock).toHaveBeenCalledWith("joinable-game");
   });
 
-  it("uses one War Table game icon color class for each game phase", async () => {
+  it("uses one War Table game icon color and glyph for each game state", async () => {
+    readCurrentPlayerIdMock.mockReturnValue("player-1");
     listGamesMock.mockResolvedValue(
       createLobbyGames([
         createGameSummary({
@@ -227,7 +228,14 @@ describe("LobbyRoute War Table theme behavior", () => {
         createGameSummary({
           id: "active-game",
           name: "Active Game",
-          phase: "active"
+          phase: "active",
+          currentPlayerId: "player-2"
+        }),
+        createGameSummary({
+          id: "my-turn-game",
+          name: "My Turn Game",
+          phase: "active",
+          currentPlayerId: "player-1"
         }),
         createGameSummary({
           id: "finished-game",
@@ -246,13 +254,21 @@ describe("LobbyRoute War Table theme behavior", () => {
     const activeToken = screen
       .getByTestId("react-shell-lobby-row-active-game")
       .querySelector(".war-table-game-token");
+    const myTurnToken = screen
+      .getByTestId("react-shell-lobby-row-my-turn-game")
+      .querySelector(".war-table-game-token");
     const finishedToken = screen
       .getByTestId("react-shell-lobby-row-finished-game")
       .querySelector(".war-table-game-token");
 
     expect(waitingToken).toHaveClass("is-lobby");
     expect(activeToken).toHaveClass("is-active");
+    expect(myTurnToken).toHaveClass("is-active");
     expect(finishedToken).toHaveClass("is-finished");
+    expect(waitingToken).toHaveAttribute("data-war-table-icon", "users");
+    expect(activeToken).toHaveAttribute("data-war-table-icon", "medal");
+    expect(myTurnToken).toHaveAttribute("data-war-table-icon", "objective");
+    expect(finishedToken).toHaveAttribute("data-war-table-icon", "crosshair");
   });
 
   it("keeps the War Table My Turn tab scoped to the current turn owner", async () => {

--- a/frontend/react-shell/src/__tests__/lobby-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/lobby-route.integration.test.tsx
@@ -216,6 +216,45 @@ describe("LobbyRoute War Table theme behavior", () => {
     expect(openShellGameMock).toHaveBeenCalledWith("joinable-game");
   });
 
+  it("uses one War Table game icon color class for each game phase", async () => {
+    listGamesMock.mockResolvedValue(
+      createLobbyGames([
+        createGameSummary({
+          id: "waiting-game",
+          name: "Waiting Game",
+          phase: "lobby"
+        }),
+        createGameSummary({
+          id: "active-game",
+          name: "Active Game",
+          phase: "active"
+        }),
+        createGameSummary({
+          id: "finished-game",
+          name: "Finished Game",
+          phase: "finished"
+        })
+      ])
+    );
+    getGameOptionsMock.mockResolvedValue(createGameOptionsResponse());
+
+    renderLobbyRoute("war-table");
+
+    const waitingToken = (
+      await screen.findByTestId("react-shell-lobby-row-waiting-game")
+    ).querySelector(".war-table-game-token");
+    const activeToken = screen
+      .getByTestId("react-shell-lobby-row-active-game")
+      .querySelector(".war-table-game-token");
+    const finishedToken = screen
+      .getByTestId("react-shell-lobby-row-finished-game")
+      .querySelector(".war-table-game-token");
+
+    expect(waitingToken).toHaveClass("is-lobby");
+    expect(activeToken).toHaveClass("is-active");
+    expect(finishedToken).toHaveClass("is-finished");
+  });
+
   it("keeps the War Table My Turn tab scoped to the current turn owner", async () => {
     let playerSessionListener: () => void = () => undefined;
     subscribeCurrentPlayerIdChangesMock.mockImplementation((listener) => {

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -161,8 +161,8 @@ function warTableStatusClass(game: GameSummary): string {
   return "is-lobby";
 }
 
-function warTableGameIconClass(index: number): string {
-  return ["is-blue", "is-green", "is-gold", "is-red", "is-purple"][index % 5] || "is-blue";
+function warTableGameIconClass(game: GameSummary): string {
+  return warTableStatusClass(game);
 }
 
 function formatWarTableActivity(value: string | null | undefined): string {
@@ -711,7 +711,7 @@ export function LobbyRoute() {
               {listStateMessage}
             </div>
             <div id="game-session-list" className="session-list" data-testid="game-session-list">
-              {renderedGames.map((game, index) =>
+              {renderedGames.map((game) =>
                 isWarTableTheme ? (
                   <div
                     key={game.id}
@@ -734,7 +734,7 @@ export function LobbyRoute() {
                   >
                     <span className="session-primary" data-cell-label={t("lobby.table.game")}>
                       <span
-                        className={`war-table-game-token ${warTableGameIconClass(index)}`}
+                        className={`war-table-game-token ${warTableGameIconClass(game)}`}
                         aria-hidden="true"
                       >
                         <WarTableIcon name="soldier" />

--- a/frontend/react-shell/src/lobby-route.tsx
+++ b/frontend/react-shell/src/lobby-route.tsx
@@ -24,7 +24,7 @@ import { buildNewGamePath } from "@react-shell/public-auth-paths";
 import { lobbyGamesQueryKey } from "@react-shell/react-query";
 import { currentShellTheme } from "@react-shell/theme";
 import { themeCopy } from "@react-shell/theme-copy";
-import { WarTableIcon } from "@react-shell/war-table-icons";
+import { WarTableIcon, type WarTableIconName } from "@react-shell/war-table-icons";
 
 const VISIBLE_GAMES_BATCH_SIZE = 15;
 
@@ -165,6 +165,25 @@ function warTableGameIconClass(game: GameSummary): string {
   return warTableStatusClass(game);
 }
 
+function isWarTableCurrentPlayerTurn(game: GameSummary): boolean {
+  const currentPlayerId = game.phase === "active" ? game.currentPlayerId || null : null;
+  const storedPlayerId = readCurrentPlayerId(game.id);
+
+  return Boolean(currentPlayerId && storedPlayerId === currentPlayerId);
+}
+
+function warTableGameIconName(game: GameSummary): WarTableIconName {
+  if (game.phase === "finished") {
+    return "crosshair";
+  }
+
+  if (game.phase === "active") {
+    return isWarTableCurrentPlayerTurn(game) ? "objective" : "medal";
+  }
+
+  return "users";
+}
+
 function formatWarTableActivity(value: string | null | undefined): string {
   if (!value) {
     return t("common.notAvailable");
@@ -246,10 +265,7 @@ function matchesWarTableFilter(game: GameSummary, filter: WarTableLobbyFilter): 
   }
 
   if (filter === "my-turn") {
-    const currentPlayerId = game.phase === "active" ? game.currentPlayerId || null : null;
-    const storedPlayerId = readCurrentPlayerId(game.id);
-
-    return Boolean(currentPlayerId && storedPlayerId === currentPlayerId);
+    return isWarTableCurrentPlayerTurn(game);
   }
 
   return game.phase === filter;
@@ -480,9 +496,7 @@ export function LobbyRoute() {
     activeGame?.name || selectedGame?.name || t("warTable.lobby.defaultCampaignName");
   const campaignProgress = warTableCampaignProgress(activeGame || selectedGame);
   const isWarTableMyTurn =
-    activeGame?.phase === "active" && activeGame.currentPlayerId
-      ? readCurrentPlayerId(activeGame.id) === activeGame.currentPlayerId
-      : false;
+    activeGame?.phase === "active" ? isWarTableCurrentPlayerTurn(activeGame) : false;
   const loadMoreMessage = !games.length
     ? ""
     : canLoadMoreGames
@@ -735,9 +749,10 @@ export function LobbyRoute() {
                     <span className="session-primary" data-cell-label={t("lobby.table.game")}>
                       <span
                         className={`war-table-game-token ${warTableGameIconClass(game)}`}
+                        data-war-table-icon={warTableGameIconName(game)}
                         aria-hidden="true"
                       >
-                        <WarTableIcon name="soldier" />
+                        <WarTableIcon name={warTableGameIconName(game)} />
                       </span>
                       <span className="session-name" data-open-game-id={game.id}>
                         {game.name}

--- a/frontend/react-shell/src/theme-tokens.css
+++ b/frontend/react-shell/src/theme-tokens.css
@@ -4673,7 +4673,15 @@ html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-toke
   background: linear-gradient(180deg, #227ed7, #114a8e);
 }
 
+html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-token.is-lobby {
+  background: linear-gradient(180deg, #227ed7, #114a8e);
+}
+
 html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-token.is-green {
+  background: linear-gradient(180deg, #72d67b, #267747);
+}
+
+html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-token.is-active {
   background: linear-gradient(180deg, #72d67b, #267747);
 }
 
@@ -4682,6 +4690,10 @@ html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-toke
 }
 
 html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-token.is-red {
+  background: linear-gradient(180deg, #df584b, #8a241e);
+}
+
+html[data-theme="war-table"] body[data-app-section="lobby"] .war-table-game-token.is-finished {
   background: linear-gradient(180deg, #df584b, #8a241e);
 }
 


### PR DESCRIPTION
## Summary

- Map War Table lobby game-row icon color classes from the game phase instead of the row index.
- Map War Table lobby game-row glyphs to the state legend: Lobby, Active, My Turn, and Finished.
- Add semantic token styles so lobby, active, and finished phases resolve to stable blue, green, and red icon backgrounds.
- Cover the War Table lobby behavior with an integration test that prevents phase icon colors or glyphs from drifting from state.

## Validation

- 
px vitest run --config frontend/react-shell/vitest.config.ts frontend/react-shell/src/__tests__/lobby-route.integration.test.tsx
- 
pm run typecheck:react-shell
- 
pm run build:ts
- 
pm run test:react
- 
ode .tsbuild/scripts/run-tests.cjs
- 
ode .tsbuild/scripts/run-gameplay-tests.cjs
- 
pm run lint (passes with existing warnings)

## Notes

- No save-game, API, module manifest, or datastore compatibility impact.