### PR TITLE
[codex] Harden password auth attempt throttling

### DIFF
--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -20,6 +20,7 @@ type AuthThrottleDecision = {
 };
 
 type AuthAttemptThrottleOptions = {
+  cleanupIntervalMs?: number;
   maxAttempts?: number;
   maxIpAttempts?: number;
   windowMs?: number;
@@ -28,11 +29,16 @@ type AuthAttemptThrottleOptions = {
   now?: () => number;
 };
 
+type RequestIpOptions = {
+  trustProxyHeaders?: boolean;
+};
+
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_MAX_IP_ATTEMPTS = 30;
 const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
 const DEFAULT_LOCKOUT_MS = 60 * 1000;
 const DEFAULT_MAX_LOCKOUT_MS = 15 * 60 * 1000;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 1000;
 
 function normalizeUsername(username: unknown): string {
   return String(username || "")
@@ -50,7 +56,19 @@ function firstHeaderValue(value: HeaderValue): string {
   return Array.isArray(value) ? String(value[0] || "") : String(value || "");
 }
 
-function resolveRequestIp(req: unknown): string {
+function trustsForwardedHeaders(options: RequestIpOptions = {}): boolean {
+  if (typeof options.trustProxyHeaders === "boolean") {
+    return options.trustProxyHeaders;
+  }
+
+  return (
+    process.env.NETRISK_TRUST_PROXY_HEADERS === "true" ||
+    process.env.VERCEL === "1" ||
+    Boolean(process.env.VERCEL_ENV)
+  );
+}
+
+function resolveRequestIp(req: unknown, options: RequestIpOptions = {}): string {
   const request = req as {
     headers?: Record<string, HeaderValue>;
     socket?: {
@@ -58,21 +76,25 @@ function resolveRequestIp(req: unknown): string {
     };
   };
   const headers = request?.headers || {};
+  const socketIp = String(request?.socket?.remoteAddress || "").trim();
+  if (!trustsForwardedHeaders(options)) {
+    return normalizeIp(socketIp || "unknown");
+  }
+
   const forwardedFor = firstHeaderValue(headers["x-forwarded-for"]).split(",")[0].trim();
   const realIp = firstHeaderValue(headers["x-real-ip"]).trim();
-  const socketIp = String(request?.socket?.remoteAddress || "").trim();
-
   return normalizeIp(forwardedFor || realIp || socketIp || "unknown");
 }
 
 function createAuthThrottleKey(
   scope: AuthThrottleScope,
   req: unknown,
-  username: unknown
+  username: unknown,
+  options: RequestIpOptions = {}
 ): AuthThrottleKey {
   return {
     scope,
-    ip: resolveRequestIp(req),
+    ip: resolveRequestIp(req, options),
     username: normalizeUsername(username)
   };
 }
@@ -84,7 +106,9 @@ function createAuthAttemptThrottle(options: AuthAttemptThrottleOptions = {}) {
   const windowMs = options.windowMs || DEFAULT_WINDOW_MS;
   const lockoutMs = options.lockoutMs || DEFAULT_LOCKOUT_MS;
   const maxLockoutMs = options.maxLockoutMs || DEFAULT_MAX_LOCKOUT_MS;
+  const cleanupIntervalMs = options.cleanupIntervalMs || DEFAULT_CLEANUP_INTERVAL_MS;
   const now = options.now || Date.now;
+  let lastCleanupAt = 0;
 
   function bucketIds(key: AuthThrottleKey): Array<{ id: string; limit: number }> {
     return [
@@ -117,8 +141,22 @@ function createAuthAttemptThrottle(options: AuthAttemptThrottleOptions = {}) {
     return bucket;
   }
 
+  function cleanupExpiredBuckets(timestamp: number): void {
+    if (timestamp - lastCleanupAt < cleanupIntervalMs) {
+      return;
+    }
+
+    lastCleanupAt = timestamp;
+    for (const [id, bucket] of buckets.entries()) {
+      if (timestamp - bucket.firstAttemptAt > windowMs && bucket.lockedUntil <= timestamp) {
+        buckets.delete(id);
+      }
+    }
+  }
+
   function check(key: AuthThrottleKey): AuthThrottleDecision {
     const timestamp = now();
+    cleanupExpiredBuckets(timestamp);
     const retryAfterMs = bucketIds(key).reduce((maxRetryAfterMs, entry) => {
       const bucket = currentBucket(entry.id, timestamp);
       if (!bucket || bucket.lockedUntil <= timestamp) {
@@ -136,6 +174,7 @@ function createAuthAttemptThrottle(options: AuthAttemptThrottleOptions = {}) {
 
   function recordFailure(key: AuthThrottleKey): AuthThrottleDecision {
     const timestamp = now();
+    cleanupExpiredBuckets(timestamp);
     for (const entry of bucketIds(key)) {
       const bucket =
         currentBucket(entry.id, timestamp) ||

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,0 +1,176 @@
+type HeaderValue = string | string[] | undefined;
+
+type AuthThrottleScope = "account" | "login";
+
+type AuthThrottleBucket = {
+  attempts: number;
+  firstAttemptAt: number;
+  lockedUntil: number;
+};
+
+type AuthThrottleKey = {
+  scope: AuthThrottleScope;
+  ip: string;
+  username: string;
+};
+
+type AuthThrottleDecision = {
+  allowed: boolean;
+  retryAfterSeconds: number;
+};
+
+type AuthAttemptThrottleOptions = {
+  maxAttempts?: number;
+  maxIpAttempts?: number;
+  windowMs?: number;
+  lockoutMs?: number;
+  maxLockoutMs?: number;
+  now?: () => number;
+};
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_MAX_IP_ATTEMPTS = 30;
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_LOCKOUT_MS = 60 * 1000;
+const DEFAULT_MAX_LOCKOUT_MS = 15 * 60 * 1000;
+
+function normalizeUsername(username: unknown): string {
+  return String(username || "")
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeIp(ip: unknown): string {
+  return String(ip || "")
+    .trim()
+    .toLowerCase();
+}
+
+function firstHeaderValue(value: HeaderValue): string {
+  return Array.isArray(value) ? String(value[0] || "") : String(value || "");
+}
+
+function resolveRequestIp(req: unknown): string {
+  const request = req as {
+    headers?: Record<string, HeaderValue>;
+    socket?: {
+      remoteAddress?: string;
+    };
+  };
+  const headers = request?.headers || {};
+  const forwardedFor = firstHeaderValue(headers["x-forwarded-for"]).split(",")[0].trim();
+  const realIp = firstHeaderValue(headers["x-real-ip"]).trim();
+  const socketIp = String(request?.socket?.remoteAddress || "").trim();
+
+  return normalizeIp(forwardedFor || realIp || socketIp || "unknown");
+}
+
+function createAuthThrottleKey(
+  scope: AuthThrottleScope,
+  req: unknown,
+  username: unknown
+): AuthThrottleKey {
+  return {
+    scope,
+    ip: resolveRequestIp(req),
+    username: normalizeUsername(username)
+  };
+}
+
+function createAuthAttemptThrottle(options: AuthAttemptThrottleOptions = {}) {
+  const buckets = new Map<string, AuthThrottleBucket>();
+  const maxAttempts = options.maxAttempts || DEFAULT_MAX_ATTEMPTS;
+  const maxIpAttempts = options.maxIpAttempts || DEFAULT_MAX_IP_ATTEMPTS;
+  const windowMs = options.windowMs || DEFAULT_WINDOW_MS;
+  const lockoutMs = options.lockoutMs || DEFAULT_LOCKOUT_MS;
+  const maxLockoutMs = options.maxLockoutMs || DEFAULT_MAX_LOCKOUT_MS;
+  const now = options.now || Date.now;
+
+  function bucketIds(key: AuthThrottleKey): Array<{ id: string; limit: number }> {
+    return [
+      {
+        id: primaryBucketId(key),
+        limit: maxAttempts
+      },
+      {
+        id: `${key.scope}:ip:${key.ip}`,
+        limit: maxIpAttempts
+      }
+    ];
+  }
+
+  function primaryBucketId(key: AuthThrottleKey): string {
+    return `${key.scope}:ip:${key.ip}:user:${key.username || "unknown"}`;
+  }
+
+  function currentBucket(id: string, timestamp: number): AuthThrottleBucket | null {
+    const bucket = buckets.get(id);
+    if (!bucket) {
+      return null;
+    }
+
+    if (timestamp - bucket.firstAttemptAt > windowMs && bucket.lockedUntil <= timestamp) {
+      buckets.delete(id);
+      return null;
+    }
+
+    return bucket;
+  }
+
+  function check(key: AuthThrottleKey): AuthThrottleDecision {
+    const timestamp = now();
+    const retryAfterMs = bucketIds(key).reduce((maxRetryAfterMs, entry) => {
+      const bucket = currentBucket(entry.id, timestamp);
+      if (!bucket || bucket.lockedUntil <= timestamp) {
+        return maxRetryAfterMs;
+      }
+
+      return Math.max(maxRetryAfterMs, bucket.lockedUntil - timestamp);
+    }, 0);
+
+    return {
+      allowed: retryAfterMs <= 0,
+      retryAfterSeconds: Math.ceil(retryAfterMs / 1000)
+    };
+  }
+
+  function recordFailure(key: AuthThrottleKey): AuthThrottleDecision {
+    const timestamp = now();
+    for (const entry of bucketIds(key)) {
+      const bucket =
+        currentBucket(entry.id, timestamp) ||
+        ({
+          attempts: 0,
+          firstAttemptAt: timestamp,
+          lockedUntil: 0
+        } satisfies AuthThrottleBucket);
+
+      bucket.attempts += 1;
+      if (bucket.attempts >= entry.limit) {
+        const overflowAttempts = bucket.attempts - entry.limit;
+        const duration = Math.min(lockoutMs * 2 ** overflowAttempts, maxLockoutMs);
+        bucket.lockedUntil = Math.max(bucket.lockedUntil, timestamp + duration);
+      }
+
+      buckets.set(entry.id, bucket);
+    }
+
+    return check(key);
+  }
+
+  function recordSuccess(key: AuthThrottleKey): void {
+    buckets.delete(primaryBucketId(key));
+  }
+
+  return {
+    check,
+    recordFailure,
+    recordSuccess
+  };
+}
+
+module.exports = {
+  createAuthAttemptThrottle,
+  createAuthThrottleKey,
+  resolveRequestIp
+};

--- a/backend/routes/account.cts
+++ b/backend/routes/account.cts
@@ -39,6 +39,11 @@ interface AccountRouteDeps {
       theme: string
     ): Promise<{ preferences?: { theme?: string | null } } | null>;
   };
+  authAttemptThrottle?: {
+    check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+    recordFailure(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+    recordSuccess(key: Record<string, unknown>): void;
+  };
   playerProfiles: {
     getPlayerProfile(username: string): Promise<Record<string, unknown>> | Record<string, unknown>;
   };
@@ -62,6 +67,8 @@ interface AccountRouteDeps {
   supportedSiteThemes: SupportedSiteThemesSource;
   resolveStoredTheme: (theme: string) => string;
 }
+
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
 
 async function resolveRouteSupportedSiteThemes(deps: AccountRouteDeps): Promise<Set<string>> {
   return typeof deps.supportedSiteThemes === "function"
@@ -189,6 +196,27 @@ export async function handleAccountSettingsRoute(
     return true;
   }
 
+  const throttleKey = createAuthThrottleKey("account", deps.req, authContext.user.username);
+  const throttleDecision = deps.authAttemptThrottle?.check(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    deps.sendLocalizedError(
+      deps.res,
+      429,
+      {
+        error: "Troppi tentativi di verifica password. Riprova piu tardi.",
+        errorKey: "auth.throttle.tooManyAttempts",
+        errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        code: "AUTH_RATE_LIMITED"
+      },
+      "Troppi tentativi di verifica password. Riprova piu tardi.",
+      "auth.throttle.tooManyAttempts",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+      "AUTH_RATE_LIMITED",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+    );
+    return true;
+  }
+
   const result = await deps.auth.updateUserAccountSettings({
     userId: authContext.user.id,
     currentPassword: parsedBody.currentPassword,
@@ -198,6 +226,9 @@ export async function handleAccountSettingsRoute(
   });
 
   if (!result.ok || !result.user) {
+    if (result.errorKey === "auth.account.currentPasswordInvalid") {
+      deps.authAttemptThrottle?.recordFailure(throttleKey);
+    }
     deps.sendLocalizedError(
       deps.res,
       result.errorKey === "auth.account.currentPasswordInvalid" ? 401 : 400,
@@ -209,6 +240,7 @@ export async function handleAccountSettingsRoute(
     return true;
   }
 
+  deps.authAttemptThrottle?.recordSuccess(throttleKey);
   const payload: AccountSettingsUpdateResponseContract = {
     ok: true,
     user: result.user as AccountSettingsUpdateResponseContract["user"]

--- a/backend/routes/password-auth.cts
+++ b/backend/routes/password-auth.cts
@@ -28,12 +28,40 @@ type AuthStore = {
 type ExtractSessionToken = (req: unknown, body?: Record<string, unknown>) => string | null;
 type BuildSessionCookie = (req: unknown, sessionToken: string) => string;
 type ClearSessionCookie = (req: unknown) => string;
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordFailure(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordSuccess(key: Record<string, unknown>): void;
+};
 const {
   loginRequestSchema,
   loginResponseSchema,
   registerRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+
+function sendTooManyAuthAttempts(
+  res: unknown,
+  sendLocalizedError: SendLocalizedError,
+  retryAfterSeconds: number
+): void {
+  sendLocalizedError(
+    res,
+    429,
+    {
+      error: "Troppi tentativi di accesso. Riprova piu tardi.",
+      errorKey: "auth.throttle.tooManyAttempts",
+      errorParams: { retryAfterSeconds },
+      code: "AUTH_RATE_LIMITED"
+    },
+    "Troppi tentativi di accesso. Riprova piu tardi.",
+    "auth.throttle.tooManyAttempts",
+    { retryAfterSeconds },
+    "AUTH_RATE_LIMITED",
+    { retryAfterSeconds }
+  );
+}
 
 async function handleRegisterRoute(
   req: unknown,
@@ -91,7 +119,8 @@ async function handleLoginRoute(
   auth: AuthStore,
   sendJson: SendJson,
   sendLocalizedError: SendLocalizedError,
-  buildSessionCookie: BuildSessionCookie
+  buildSessionCookie: BuildSessionCookie,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const parsedBody = parseRequestOrSendError(
     res as import("node:http").ServerResponse,
@@ -103,8 +132,16 @@ async function handleLoginRoute(
     return;
   }
 
+  const throttleKey = createAuthThrottleKey("login", req, parsedBody.username);
+  const throttleDecision = authAttemptThrottle?.check(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    sendTooManyAuthAttempts(res, sendLocalizedError, throttleDecision.retryAfterSeconds);
+    return;
+  }
+
   const result = await auth.loginWithPassword(parsedBody.username, parsedBody.password);
   if (!result.ok) {
+    authAttemptThrottle?.recordFailure(throttleKey);
     sendLocalizedError(
       res,
       401,
@@ -116,6 +153,7 @@ async function handleLoginRoute(
     return;
   }
 
+  authAttemptThrottle?.recordSuccess(throttleKey);
   sendValidatedJson(
     res as import("node:http").ServerResponse,
     200,

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -10,6 +10,7 @@ const { createModuleRuntime } = require("./module-runtime.cjs");
 const { createSetupCatalogResolver } = require("./setup-catalog-resolver.cjs");
 const { createSetupService } = require("./setup-service.cjs");
 const { createAuthStore } = require("./auth.cjs");
+const { createAuthAttemptThrottle } = require("./auth-attempt-throttle.cjs");
 const { authorize } = require("./authorization.cjs");
 const { createGameSessionStore } = require("./game-session-store.cjs");
 const { createPlayerProfileStore } = require("./player-profile-store.cjs");
@@ -317,6 +318,7 @@ function createApp(options: CreateAppOptions = {}) {
   }
 
   const state = createInitialState();
+  const authAttemptThrottle = createAuthAttemptThrottle();
   let activeGameId: string | null = null;
   let activeGameVersion: number | null = null;
   let activeGameName: string | null = null;
@@ -1466,6 +1468,7 @@ function createApp(options: CreateAppOptions = {}) {
           res,
           requireAuth,
           auth,
+          authAttemptThrottle,
           playerProfiles,
           sendJson,
           sendLocalizedError,
@@ -1509,7 +1512,8 @@ function createApp(options: CreateAppOptions = {}) {
         auth,
         sendJson,
         sendLocalizedError,
-        buildSessionCookie
+        buildSessionCookie,
+        authAttemptThrottle
       );
       return;
     }

--- a/frontend/src/locales/de.mts
+++ b/frontend/src/locales/de.mts
@@ -28,6 +28,7 @@ export const de = Object.freeze({
   "auth.sessionExpired": "Sitzung abgelaufen.",
   "auth.userProfile": "Benutzerprofil",
   "auth.login.invalidCredentials": "Ungueltige Zugangsdaten.",
+  "auth.throttle.tooManyAttempts": "Zu viele Versuche. Bitte versuche es spaeter erneut.",
   "auth.register.requiredFields": "Benutzername und Passwort eingeben.",
   "auth.register.invalidUsername":
     "Gueltiger Benutzername: 3-32 Zeichen, Buchstaben, Zahlen, Unterstrich und Bindestrich.",

--- a/frontend/src/locales/en.mts
+++ b/frontend/src/locales/en.mts
@@ -28,6 +28,7 @@ export const en = Object.freeze({
   "auth.sessionExpired": "Session expired.",
   "auth.userProfile": "User profile",
   "auth.login.invalidCredentials": "Invalid credentials.",
+  "auth.throttle.tooManyAttempts": "Too many attempts. Try again later.",
   "auth.register.requiredFields": "Enter username and password.",
   "auth.register.invalidUsername":
     "Valid username: 3-32 characters, letters, numbers, underscore, and hyphen.",

--- a/frontend/src/locales/es.mts
+++ b/frontend/src/locales/es.mts
@@ -28,6 +28,7 @@ export const es = Object.freeze({
   "auth.sessionExpired": "Sesion caducada.",
   "auth.userProfile": "Perfil de usuario",
   "auth.login.invalidCredentials": "Credenciales no validas.",
+  "auth.throttle.tooManyAttempts": "Demasiados intentos. Vuelve a intentarlo mas tarde.",
   "auth.register.requiredFields": "Introduce usuario y contrasena.",
   "auth.register.invalidUsername":
     "Usuario valido: 3-32 caracteres, letras, numeros, guion bajo y guion.",

--- a/frontend/src/locales/it.mts
+++ b/frontend/src/locales/it.mts
@@ -28,6 +28,7 @@ export const it = Object.freeze({
   "auth.sessionExpired": "Sessione scaduta.",
   "auth.userProfile": "Profilo utente",
   "auth.login.invalidCredentials": "Credenziali non valide.",
+  "auth.throttle.tooManyAttempts": "Troppi tentativi. Riprova piu tardi.",
   "auth.register.requiredFields": "Inserisci utente e password.",
   "auth.register.invalidUsername":
     "Username valido: 3-32 caratteri, lettere, numeri, underscore e trattino.",

--- a/tests/gameplay/regression/account-validation-routes.test.cts
+++ b/tests/gameplay/regression/account-validation-routes.test.cts
@@ -137,6 +137,24 @@ register("auth attempt throttle keeps IP lockout state after a user success", ()
   assert.equal(decision.retryAfterSeconds, 60);
 });
 
+register("auth attempt throttle ignores spoofed forwarded IPs unless trusted", () => {
+  const req = {
+    headers: {
+      "x-forwarded-for": "203.0.113.22, 198.51.100.1",
+      "x-real-ip": "203.0.113.23"
+    },
+    socket: {
+      remoteAddress: "198.51.100.44"
+    }
+  };
+
+  assert.equal(createAuthThrottleKey("login", req, "alice").ip, "198.51.100.44");
+  assert.equal(
+    createAuthThrottleKey("login", req, "alice", { trustProxyHeaders: true }).ip,
+    "203.0.113.22"
+  );
+});
+
 register("account routes return early when auth is missing", async () => {
   let sendJsonCalls = 0;
   let sendLocalizedErrorCalls = 0;

--- a/tests/gameplay/regression/account-validation-routes.test.cts
+++ b/tests/gameplay/regression/account-validation-routes.test.cts
@@ -9,6 +9,10 @@ const {
   handleLoginRoute,
   handleRegisterRoute
 } = require("../../../backend/routes/password-auth.cjs");
+const {
+  createAuthAttemptThrottle,
+  createAuthThrottleKey
+} = require("../../../backend/auth-attempt-throttle.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
@@ -26,6 +30,7 @@ type LocalizedErrorCall = [
   string,
   { validationErrors: ValidationIssue[] }
 ];
+type AnyLocalizedErrorCall = [unknown, number, unknown, ...unknown[]];
 
 function requireLocalizedErrorCall(call: LocalizedErrorCall | null): LocalizedErrorCall {
   if (!call) {
@@ -107,6 +112,30 @@ function createAccountDeps(overrides = {}) {
     ...overrides
   };
 }
+
+register("auth attempt throttle keeps IP lockout state after a user success", () => {
+  const throttle = createAuthAttemptThrottle({
+    maxAttempts: 10,
+    maxIpAttempts: 2,
+    lockoutMs: 60_000,
+    now: () => 1_000
+  });
+  const req = {
+    headers: {
+      "x-forwarded-for": "203.0.113.11"
+    }
+  };
+
+  const aliceKey = createAuthThrottleKey("login", req, "alice");
+  throttle.recordFailure(aliceKey);
+  throttle.recordSuccess(aliceKey);
+  throttle.recordFailure(createAuthThrottleKey("login", req, "bob"));
+
+  const decision = throttle.check(createAuthThrottleKey("login", req, "carol"));
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.retryAfterSeconds, 60);
+});
 
 register("account routes return early when auth is missing", async () => {
   let sendJsonCalls = 0;
@@ -200,6 +229,55 @@ register(
   }
 );
 
+register("handleLoginRoute rate limits repeated password failures before auth work", async () => {
+  const statuses: number[] = [];
+  const throttle = createAuthAttemptThrottle({
+    maxAttempts: 2,
+    maxIpAttempts: 20,
+    lockoutMs: 60_000,
+    now: () => 1_000
+  });
+  let loginCalls = 0;
+
+  async function attemptLogin() {
+    await handleLoginRoute(
+      {
+        headers: {
+          "x-forwarded-for": "203.0.113.7"
+        }
+      },
+      {},
+      { username: "Commander", password: "wrongpass" },
+      {
+        async loginWithPassword() {
+          loginCalls += 1;
+          return {
+            ok: false,
+            error: "Credenziali non valide.",
+            errorKey: "auth.login.invalidCredentials",
+            errorParams: {}
+          };
+        }
+      },
+      () => {
+        throw new Error("sendJson should not be called for failed login attempts.");
+      },
+      (...args: AnyLocalizedErrorCall) => {
+        statuses.push(args[1]);
+      },
+      (_req: unknown, _sessionToken: string) => "session-cookie",
+      throttle
+    );
+  }
+
+  await attemptLogin();
+  await attemptLogin();
+  await attemptLogin();
+
+  assert.deepEqual(statuses, [401, 401, 429]);
+  assert.equal(loginCalls, 2);
+});
+
 register(
   "handleAccountSettingsRoute rejects invalid inbound account payloads with mapped validation errors",
   async () => {
@@ -223,6 +301,57 @@ register(
     );
   }
 );
+
+register("handleAccountSettingsRoute rate limits repeated current password failures", async () => {
+  const statuses: number[] = [];
+  const throttle = createAuthAttemptThrottle({
+    maxAttempts: 2,
+    maxIpAttempts: 20,
+    lockoutMs: 60_000,
+    now: () => 1_000
+  });
+  const baseDeps = createAccountDeps();
+  let accountUpdateCalls = 0;
+
+  async function attemptAccountUpdate() {
+    await handleAccountSettingsRoute(
+      createAccountDeps({
+        req: {
+          headers: {
+            "x-forwarded-for": "203.0.113.9"
+          }
+        },
+        authAttemptThrottle: throttle,
+        auth: {
+          ...baseDeps.auth,
+          async updateUserAccountSettings() {
+            accountUpdateCalls += 1;
+            return {
+              ok: false,
+              error: "Password attuale non valida.",
+              errorKey: "auth.account.currentPasswordInvalid",
+              errorParams: {}
+            };
+          }
+        },
+        sendLocalizedError(...args: AnyLocalizedErrorCall) {
+          statuses.push(args[1]);
+        }
+      }),
+      {
+        currentPassword: "wrongpass",
+        email: "new@example.com"
+      }
+    );
+  }
+
+  await attemptAccountUpdate();
+  await attemptAccountUpdate();
+  await attemptAccountUpdate();
+
+  assert.deepEqual(statuses, [401, 401, 429]);
+  assert.equal(accountUpdateCalls, 2);
+});
 
 register(
   "handleThemePreferenceRoute rejects invalid inbound theme payloads with mapped validation errors",


### PR DESCRIPTION
## What changed
- Add an in-memory auth attempt throttle keyed by scope, client IP, and normalized username.
- Apply the throttle to password login before expensive password verification, and to account settings password verification after repeated current-password failures.
- Return localized 429 `AUTH_RATE_LIMITED` responses with retry timing.
- Add regression coverage for login throttling, account password throttling, and preserving IP-level lockout state after a successful user login.

## Why
GHSA-wxvx-xmhc-hqhp reports missing rate limiting and lockout on password authentication flows. The previous login path allowed repeated password attempts to reach synchronous password hashing work.

## Validation
- `npm run test:all`
- `npm run typecheck`
- `npm run format:check`
- `npm run test:gameplay`
- `npm run lint` (passes with existing warnings)

## Compatibility
No save-game, module manifest, API version, or datastore schema changes.