### PR TITLE
Enforce release version reports

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -3,6 +3,8 @@ name: Release Gate
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches: ["main"]
   push:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,36 @@
+name: Release Gate
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build release gate
+        run: npm run build:ts
+
+      - name: Enforce version and changelog report
+        run: node .tsbuild/scripts/check-release-gate.cjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
+
+## 0.1.001 - 2026-05-05
+
+- Added the release gate that requires every merge to bump the central app version.
+- Documented NetRisk's long patch version format and release report expectations.
+- Added CI coverage for changelog/report presence before changes reach `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,8 @@ The current authored module type is `victory-objectives`.
 A good PR for NetRisk is narrow, tested, and explicit about touched boundaries.
 
 - Summarize what changed and why.
+- Bump `appVersion` in `shared/version-manifest.cts` using the long patch format, for example `0.1.001`.
+- Add a matching `CHANGELOG.md` entry with a short report of the change.
 - List any public API or docs updates.
 - Mention the validation commands you ran.
 - Call out follow-up work separately instead of folding it into the same change.

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -1,0 +1,28 @@
+# Versioning Policy
+
+NetRisk application releases use the central `appVersion` in `shared/version-manifest.cts`.
+
+## Format
+
+Application versions use a long patch segment:
+
+```text
+MAJOR.MINOR.PATCH
+0.1.001
+```
+
+The patch segment must contain at least three digits. Routine changes should usually increment the patch segment by one. Larger feature sets may increment the minor version and reset the patch segment to `000`. Breaking changes may increment the major version and reset minor and patch to `0.000`.
+
+`package.json` keeps standard npm metadata. Do not use it as the NetRisk application release source of truth because npm SemVer does not allow padded numeric identifiers such as `0.1.001`.
+
+## Merge Requirements
+
+Every PR that targets `main` must include:
+
+- an increased `appVersion` in `shared/version-manifest.cts`
+- a matching `CHANGELOG.md` section
+- at least one bullet under that changelog section describing the user-visible or operational change
+
+If a change affects save games, API responses, datastore shape, module manifests, or module compatibility, update the corresponding central compatibility fields in `shared/version-manifest.cts` and call the compatibility impact out in the changelog entry.
+
+The release gate runs in CI and fails when the version does not move forward or the changelog report is missing.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:theme-tokens": "node .tsbuild/scripts/check-theme-tokenization.cjs",
     "vercel:link:ci": "node .tsbuild/scripts/write-vercel-project-link.cjs",
     "vercel:env:check": "node .tsbuild/scripts/check-vercel-env-parity.cjs",
+    "release:check": "npm run build:ts && node .tsbuild/scripts/check-release-gate.cjs",
     "supabase:check": "npm run build:ts && node .tsbuild/scripts/check-supabase-connection.cjs",
     "coverage:collect": "c8 --clean --reporter=none node .tsbuild/scripts/run-tests.cjs && c8 --clean=false --reporter=none node .tsbuild/scripts/run-gameplay-tests.cjs",
     "coverage:report": "c8 report --reporter=text-summary --reporter=json-summary --reporter=lcov",

--- a/scripts/check-release-gate.cts
+++ b/scripts/check-release-gate.cts
@@ -9,6 +9,10 @@ type LongVersion = {
   patch: number;
 };
 
+type PushEventPayload = {
+  before?: unknown;
+};
+
 const versionManifestPath = "shared/version-manifest.cts";
 const changelogPath = "CHANGELOG.md";
 const longVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(\d{3,})$/;
@@ -34,6 +38,28 @@ function fileAtRef(ref: string, path: string): string | null {
   }
 }
 
+function readPushEventBeforeRef(): string | null {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(readFileSync(eventPath, "utf8")) as PushEventPayload;
+    if (
+      typeof payload.before === "string" &&
+      /^[0-9a-f]{40}$/i.test(payload.before) &&
+      !/^0+$/.test(payload.before)
+    ) {
+      return payload.before;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 function resolveBaseRef(): string | null {
   if (process.env.NETRISK_RELEASE_BASE_REF) {
     return process.env.NETRISK_RELEASE_BASE_REF;
@@ -44,6 +70,11 @@ function resolveBaseRef(): string | null {
   }
 
   if (process.env.GITHUB_EVENT_NAME === "push") {
+    const beforeRef = readPushEventBeforeRef();
+    if (beforeRef) {
+      return beforeRef;
+    }
+
     try {
       return runGit(["rev-parse", "HEAD^1"]);
     } catch {

--- a/scripts/check-release-gate.cts
+++ b/scripts/check-release-gate.cts
@@ -65,7 +65,9 @@ function extractAppVersion(source: string): string | null {
 }
 
 function parseVersion(version: string, requireLongPatch: boolean): LongVersion | null {
-  const match = version.match(requireLongPatch ? longVersionPattern : legacyVersionPattern);
+  const match = requireLongPatch
+    ? version.match(longVersionPattern)
+    : version.match(longVersionPattern) || version.match(legacyVersionPattern);
   if (!match) {
     return null;
   }

--- a/scripts/check-release-gate.cts
+++ b/scripts/check-release-gate.cts
@@ -1,0 +1,169 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type LongVersion = {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+const versionManifestPath = "shared/version-manifest.cts";
+const changelogPath = "CHANGELOG.md";
+const longVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(\d{3,})$/;
+const legacyVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function runGit(args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function currentFile(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+function fileAtRef(ref: string, path: string): string | null {
+  try {
+    return runGit(["show", `${ref}:${path}`]);
+  } catch {
+    return null;
+  }
+}
+
+function resolveBaseRef(): string | null {
+  if (process.env.NETRISK_RELEASE_BASE_REF) {
+    return process.env.NETRISK_RELEASE_BASE_REF;
+  }
+
+  if (process.env.GITHUB_EVENT_NAME === "pull_request" && process.env.GITHUB_BASE_REF) {
+    return `origin/${process.env.GITHUB_BASE_REF}`;
+  }
+
+  if (process.env.GITHUB_EVENT_NAME === "push") {
+    try {
+      return runGit(["rev-parse", "HEAD^1"]);
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    runGit(["rev-parse", "--verify", "origin/main"]);
+    return "origin/main";
+  } catch {
+    return null;
+  }
+}
+
+function extractAppVersion(source: string): string | null {
+  const match = source.match(/export\s+const\s+appVersion\s*=\s*"([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+function parseVersion(version: string, requireLongPatch: boolean): LongVersion | null {
+  const match = version.match(requireLongPatch ? longVersionPattern : legacyVersionPattern);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    raw: version,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3])
+  };
+}
+
+function compareVersions(left: LongVersion, right: LongVersion): number {
+  const leftParts = [left.major, left.minor, left.patch];
+  const rightParts = [right.major, right.minor, right.patch];
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+function hasChangelogReport(changelog: string, version: string): boolean {
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const headingPattern = new RegExp(
+    `^##\\s+(?:\\[${escapedVersion}\\]|${escapedVersion})(?:\\s+-\\s+\\d{4}-\\d{2}-\\d{2})?\\s*$`,
+    "m"
+  );
+  const headingMatch = headingPattern.exec(changelog);
+  if (!headingMatch) {
+    return false;
+  }
+
+  const sectionStart = headingMatch.index + headingMatch[0].length;
+  const nextHeading = changelog.slice(sectionStart).search(/^##\s+/m);
+  const section =
+    nextHeading >= 0
+      ? changelog.slice(sectionStart, sectionStart + nextHeading)
+      : changelog.slice(sectionStart);
+
+  return /^\s*-\s+\S+/m.test(section);
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function main(): void {
+  if (!existsSync(join(process.cwd(), versionManifestPath))) {
+    fail(`Missing ${versionManifestPath}.`);
+  }
+
+  const currentVersionText = currentFile(versionManifestPath);
+  const currentVersionValue = extractAppVersion(currentVersionText);
+  if (!currentVersionValue) {
+    fail(`${versionManifestPath} must export appVersion.`);
+  }
+
+  const currentVersion = parseVersion(currentVersionValue, true);
+  if (!currentVersion) {
+    fail(
+      `${versionManifestPath} appVersion must use MAJOR.MINOR.PATCH with a padded patch, for example 0.1.001.`
+    );
+  }
+
+  const baseRef = resolveBaseRef();
+  const baseVersionText = baseRef ? fileAtRef(baseRef, versionManifestPath) : null;
+  const baseVersionValue = baseVersionText ? extractAppVersion(baseVersionText) : null;
+  if (baseVersionValue) {
+    const baseVersion = parseVersion(baseVersionValue, false);
+    if (!baseVersion) {
+      fail(`Base appVersion "${baseVersionValue}" is not comparable.`);
+    }
+
+    if (compareVersions(currentVersion, baseVersion) <= 0) {
+      fail(
+        `${versionManifestPath} appVersion must increase for every merge to main. Base: ${baseVersion.raw}; current: ${currentVersion.raw}.`
+      );
+    }
+  }
+
+  if (!existsSync(join(process.cwd(), changelogPath))) {
+    fail(`Missing ${changelogPath}. Add a release report for ${currentVersion.raw}.`);
+  }
+
+  const changelog = currentFile(changelogPath);
+  if (!hasChangelogReport(changelog, currentVersion.raw)) {
+    fail(
+      `${changelogPath} must include a section with at least one bullet for ${currentVersion.raw}.`
+    );
+  }
+
+  console.log(`Release gate passed for ${currentVersion.raw}.`);
+}
+
+main();

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -981,7 +981,7 @@ register("health route usa 503 quando lo snapshot segnala errore", async () => {
 
 register("version registry espone manifest e compatibilita baseline", () => {
   const expectedManifest = {
-    appVersion: "0.1.0",
+    appVersion: "0.1.001",
     engineVersion: "1.0.0",
     apiVersion: "1.0.0",
     datastoreSchemaVersion: 1,
@@ -996,6 +996,7 @@ register("version registry espone manifest e compatibilita baseline", () => {
     ...expectedManifest,
     compatible: true
   });
+  assert.match(versionManifest.appVersion, /^\d+\.\d+\.\d{3,}$/);
   assert.equal(versionInfoResponseSchema.safeParse(buildVersionSnapshot()).success, true);
   assert.equal(versionManifest.unversionedSaveGameSchemaVersion, 1);
   assert.equal(isSaveGameSchemaCompatible(versionManifest.saveGameSchemaVersion), true);

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.0";
+export const appVersion = "0.1.001";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- introduce NetRisk app version `0.1.001` using the long patch format in the central version manifest
- add a changelog/report requirement and documentation for release version jumps
- add a Release Gate workflow that blocks merges without a forward appVersion bump and matching changelog entry

## Validation
- npm run build:ts
- node .tsbuild/scripts/check-release-gate.cjs
- npm run release:check
- npm run format:check
- npm run lint (passes with existing warnings)
- npm test
- npm run test:gameplay

## Compatibility
- No save-game, datastore, API, or module compatibility version changes required.
- `package.json` remains npm-compatible; the NetRisk app release source of truth is `shared/version-manifest.cts`.