### PR TITLE
[codex] Restrict module static asset serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.003 - 2026-05-06
+
+- Restricted module static file serving to declared public asset directories so module manifests and server entrypoints are not exposed.
+
 ## 0.1.002 - 2026-05-06
 
 - Implemented rate limiting on the registration endpoint to prevent automated account creation and username enumeration.

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1668,7 +1668,6 @@ function createApp(options: CreateAppOptions = {}) {
 
   function serveStatic(res: Response, url: URL) {
     const isModuleAssetRequest = url.pathname.indexOf("/modules/") === 0;
-    const staticRoot = isModuleAssetRequest ? runtimeModulesDir : runtimePublicDir;
     const isReactShellDocumentRoute =
       !isModuleAssetRequest &&
       (url.pathname === "/" ||
@@ -1686,11 +1685,18 @@ function createApp(options: CreateAppOptions = {}) {
         url.pathname === "/react/" ||
         (url.pathname.indexOf("/react/") === 0 && path.extname(url.pathname) === "") ||
         /^\/game\/[^/]+$/.test(url.pathname));
-    const relativePath = isModuleAssetRequest
-      ? url.pathname.replace(/^\/modules\//, "")
-      : isReactShellDocumentRoute
-        ? "/react/index.html"
-        : url.pathname;
+    let staticRoot = runtimePublicDir;
+    let relativePath = isReactShellDocumentRoute ? "/react/index.html" : url.pathname;
+    if (isModuleAssetRequest) {
+      const moduleAssetPath = resolveModuleAssetPath(url);
+      if (!moduleAssetPath) {
+        sendLocalizedError(res, 404, null, "File non trovato.", "server.static.fileNotFound");
+        return;
+      }
+
+      staticRoot = moduleAssetPath.staticRoot;
+      relativePath = moduleAssetPath.relativePath;
+    }
     const resolvedStaticRoot = path.resolve(staticRoot);
     const filePath = path.resolve(path.join(staticRoot, relativePath));
     if (filePath !== resolvedStaticRoot && !filePath.startsWith(resolvedStaticRoot + path.sep)) {
@@ -1726,6 +1732,60 @@ function createApp(options: CreateAppOptions = {}) {
       });
       res.end(data);
     });
+  }
+
+  function resolveModuleAssetPath(url: URL): { staticRoot: string; relativePath: string } | null {
+    const relativeModulePath = url.pathname.replace(/^\/modules\//, "");
+    const separatorIndex = relativeModulePath.indexOf("/");
+    if (separatorIndex <= 0) {
+      return null;
+    }
+
+    const moduleId = relativeModulePath.slice(0, separatorIndex);
+    const requestedAssetPath = relativeModulePath.slice(separatorIndex + 1);
+    if (!moduleId || !requestedAssetPath) {
+      return null;
+    }
+
+    const resolvedModulesRoot = path.resolve(runtimeModulesDir);
+    const moduleRoot = path.resolve(path.join(runtimeModulesDir, moduleId));
+    if (
+      moduleRoot !== resolvedModulesRoot &&
+      !moduleRoot.startsWith(resolvedModulesRoot + path.sep)
+    ) {
+      return null;
+    }
+
+    const manifestPath = path.join(moduleRoot, "module.json");
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+
+    const assetsDir =
+      typeof manifest.assetsDir === "string" && manifest.assetsDir.trim()
+        ? manifest.assetsDir.trim()
+        : null;
+    if (!assetsDir || path.isAbsolute(assetsDir)) {
+      return null;
+    }
+
+    const assetsRoot = path.resolve(path.join(moduleRoot, assetsDir));
+    if (assetsRoot !== moduleRoot && !assetsRoot.startsWith(moduleRoot + path.sep)) {
+      return null;
+    }
+
+    const requestedFile = path.resolve(path.join(moduleRoot, requestedAssetPath));
+    if (requestedFile !== assetsRoot && !requestedFile.startsWith(assetsRoot + path.sep)) {
+      return null;
+    }
+
+    return {
+      staticRoot: assetsRoot,
+      relativePath: path.relative(assetsRoot, requestedFile)
+    };
   }
 
   function addSecurityHeaders(res: Response) {

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -975,7 +975,7 @@ register("health route usa 503 quando lo snapshot segnala errore", async () => {
 
 register("version registry espone manifest e compatibilita baseline", () => {
   const expectedManifest = {
-    appVersion: "0.1.002",
+    appVersion: "0.1.003",
     engineVersion: "1.0.0",
     apiVersion: "1.0.0",
     datastoreSchemaVersion: 1,

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.002";
+export const appVersion = "0.1.003";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/module-runtime.test.cts
+++ b/tests/gameplay/regression/module-runtime.test.cts
@@ -804,6 +804,7 @@ register("module runtime serve gli asset modulo dal projectRoot runtime", async 
           displayName: "Runtime Assets",
           engineVersion: "1.0.0",
           kind: "ui",
+          assetsDir: "assets",
           capabilities: []
         },
         serverEntryPath: "assets/runtime-only.css",

--- a/tests/gameplay/regression/retired-runtime-assets.test.cts
+++ b/tests/gameplay/regression/retired-runtime-assets.test.cts
@@ -87,3 +87,30 @@ register(
     });
   }
 );
+
+register("GET /modules serves declared public module assets", async () => {
+  await withApp(async (app: any) => {
+    const response = await callRequest(
+      app,
+      "/modules/demo.command-center/assets/command-center.css"
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["Content-Type"], "text/css; charset=utf-8");
+  });
+});
+
+register("GET /modules does not serve module manifests or server entrypoints", async () => {
+  await withApp(async (app: any) => {
+    const cases = [
+      "/modules/demo.command-center/module.json",
+      "/modules/demo.command-center/server-module.cts"
+    ];
+
+    for (const requestPath of cases) {
+      const response = await callRequest(app, requestPath);
+
+      assert.equal(response.statusCode, 404, requestPath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Ports the GHSA-336c module static serving fix onto the real `main` branch line.
- Restricts `/modules/...` static responses to files under a module's declared `assetsDir`.
- Adds regression coverage that public module assets still load while `module.json` and server entrypoints are not exposed.
- Bumps `appVersion` to `0.1.003` with a matching changelog entry for the release gate.

## Validation

- `npm ci`
- `npm run build:ts`
- `npm run test:gameplay`
- `node .tsbuild/scripts/check-release-gate.cjs`
- `npm run coverage`

## Notes

Local `npm run coverage` passed 157 base tests and 387 gameplay tests. It emitted the existing SQLite experimental warning and an expected audit-store failure log from a regression test that verifies that path.