### PR TITLE
[codex] Deepen game mutation preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.034 - 2026-06-05
+
+- Consolidated expected-version mutation preflight handling across game action, card trade, and join routes.
+
 ## 0.1.033 - 2026-06-05
 
 - Moved live reinforcement placement mutation into the dedicated reinforcement placement engine module.

--- a/backend/routes/game-actions.cts
+++ b/backend/routes/game-actions.cts
@@ -1,7 +1,11 @@
 import type * as HttpTypes from "node:http";
 const { handleAttackGameActionRoute } = require("./game-actions-attack.cjs");
 const { handleBasicGameActionRoute } = require("./game-actions-basic.cjs");
-const { sendVersionConflict } = require("./game-mutation.cjs");
+const {
+  isInvalidExpectedVersion,
+  readExpectedVersionOrSendError,
+  sendVersionConflict
+} = require("./game-mutation.cjs");
 const { handleTurnGameActionRoute } = require("./game-actions-turn.cjs");
 const {
   gameActionEnvelopeSchema,
@@ -109,17 +113,12 @@ async function handleGameActionRoute({
     return;
   }
 
-  if (
-    body.expectedVersion != null &&
-    (!Number.isInteger(Number(body.expectedVersion)) || Number(body.expectedVersion) < 1)
-  ) {
-    sendLocalizedError(
-      res,
-      400,
-      null,
-      "expectedVersion non valida.",
-      "server.invalidExpectedVersion"
-    );
+  const preflightExpectedVersion = readExpectedVersionOrSendError(
+    body,
+    res,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (isInvalidExpectedVersion(preflightExpectedVersion)) {
     return;
   }
 
@@ -140,7 +139,7 @@ async function handleGameActionRoute({
   const currentUser = authContext.user;
   const playerId = parsedEnvelope.playerId;
   const type = parsedEnvelope.type;
-  const expectedVersion = parsedEnvelope.expectedVersion ?? null;
+  const expectedVersion = preflightExpectedVersion;
   const nodeResponse = res as HttpTypes.ServerResponse;
   const sendGameplayMutationJson: SendJson = (targetRes, statusCode, payload, headers) => {
     sendValidatedJson(

--- a/backend/routes/game-cards.cts
+++ b/backend/routes/game-cards.cts
@@ -1,7 +1,12 @@
 import type * as HttpTypes from "node:http";
 const { tradeCardsRequestSchema } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError } = require("../route-validation.cjs");
-const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
+const {
+  isInvalidExpectedVersion,
+  persistBroadcastAndSendMutation,
+  readExpectedVersionOrSendError,
+  sendVersionConflict
+} = require("./game-mutation.cjs");
 
 type SendJson = (
   res: unknown,
@@ -69,17 +74,12 @@ async function handleCardsTradeRoute(
     return;
   }
 
-  if (
-    body.expectedVersion != null &&
-    (!Number.isInteger(Number(body.expectedVersion)) || Number(body.expectedVersion) < 1)
-  ) {
-    sendLocalizedError(
-      res,
-      400,
-      null,
-      "expectedVersion non valida.",
-      "server.invalidExpectedVersion"
-    );
+  const preflightExpectedVersion = readExpectedVersionOrSendError(
+    body,
+    res,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (isInvalidExpectedVersion(preflightExpectedVersion)) {
     return;
   }
 
@@ -105,7 +105,7 @@ async function handleCardsTradeRoute(
     return;
   }
 
-  const requestedVersion = parsedBody.expectedVersion ?? null;
+  const requestedVersion = preflightExpectedVersion;
   if (requestedVersion != null && requestedVersion !== gameContext.version) {
     sendVersionConflict({
       res: nodeResponse,

--- a/backend/routes/game-mutation.cts
+++ b/backend/routes/game-mutation.cts
@@ -36,6 +36,7 @@ type LocalizedPayload = (
   fallbackMessageKey?: string
 ) => Record<string, unknown>;
 type HandleVersionConflict = (error: unknown) => boolean;
+const invalidExpectedVersion = Symbol("invalidExpectedVersion");
 
 type VersionConflictOptions = {
   res: unknown;
@@ -64,6 +65,38 @@ type MutationOptions = {
   handleVersionConflict?: HandleVersionConflict;
   payload?: Record<string, unknown>;
 };
+
+type ExpectedVersionResult = number | null | typeof invalidExpectedVersion;
+
+function readExpectedVersionOrSendError(
+  body: Record<string, unknown>,
+  res: unknown,
+  sendLocalizedError: SendLocalizedError
+): ExpectedVersionResult {
+  if (body.expectedVersion == null) {
+    return null;
+  }
+
+  const expectedVersion = Number(body.expectedVersion);
+  if (!Number.isInteger(expectedVersion) || expectedVersion < 1) {
+    sendLocalizedError(
+      res,
+      400,
+      null,
+      "expectedVersion non valida.",
+      "server.invalidExpectedVersion"
+    );
+    return invalidExpectedVersion;
+  }
+
+  return expectedVersion;
+}
+
+function isInvalidExpectedVersion(
+  expectedVersion: ExpectedVersionResult
+): expectedVersion is typeof invalidExpectedVersion {
+  return expectedVersion === invalidExpectedVersion;
+}
 
 function conflictPayload(options: VersionConflictOptions): Record<string, unknown> {
   const error = options.error || null;
@@ -161,6 +194,8 @@ async function persistBroadcastAndSendMutation(options: MutationOptions): Promis
 }
 
 module.exports = {
+  isInvalidExpectedVersion,
   persistBroadcastAndSendMutation,
+  readExpectedVersionOrSendError,
   sendVersionConflict
 };

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -60,7 +60,12 @@ const {
   startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
-const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
+const {
+  isInvalidExpectedVersion,
+  persistBroadcastAndSendMutation,
+  readExpectedVersionOrSendError,
+  sendVersionConflict
+} = require("./game-mutation.cjs");
 
 async function handleAiJoinRoute(
   req: unknown,
@@ -163,17 +168,12 @@ async function handleJoinRoute(
     return;
   }
 
-  if (
-    body.expectedVersion != null &&
-    (!Number.isInteger(Number(body.expectedVersion)) || Number(body.expectedVersion) < 1)
-  ) {
-    sendLocalizedError(
-      res,
-      400,
-      null,
-      "expectedVersion non valida.",
-      "server.invalidExpectedVersion"
-    );
+  const preflightExpectedVersion = readExpectedVersionOrSendError(
+    body,
+    res,
+    sendLocalizedError as SendLocalizedError
+  );
+  if (isInvalidExpectedVersion(preflightExpectedVersion)) {
     return;
   }
 

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -73,6 +73,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/setup-service.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",
   "../tests/gameplay/regression/game-actions-basic-route.test.cjs",
+  "../tests/gameplay/regression/game-mutation.test.cjs",
   "../tests/gameplay/regression/game-read-auth-boundary.test.cjs",
   "../tests/gameplay/regression/game-read-routes.test.cjs",
   "../tests/gameplay/regression/game-overview-route.test.cjs",

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -160,7 +160,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "card-rule-sets",
     name: "Card Rule Sets",
     kind: "rule-family",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "Card deck, trade-in, and route-facing card rule-set behavior.",
     ownerPaths: ["shared/cards.cts", "backend/routes/game-cards.cts"]
   },
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.033";
+export const appVersion = "0.1.034";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/game-mutation.test.cts
+++ b/tests/gameplay/regression/game-mutation.test.cts
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const {
+  isInvalidExpectedVersion,
+  readExpectedVersionOrSendError
+} = require("../../../backend/routes/game-mutation.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("readExpectedVersionOrSendError returns null when expectedVersion is absent", () => {
+  const result = readExpectedVersionOrSendError({}, {}, () => {
+    throw new Error("sendLocalizedError should not run when expectedVersion is absent.");
+  });
+
+  assert.equal(result, null);
+  assert.equal(isInvalidExpectedVersion(result), false);
+});
+
+register("readExpectedVersionOrSendError returns the numeric expected version", () => {
+  const result = readExpectedVersionOrSendError({ expectedVersion: "8" }, {}, () => {
+    throw new Error("sendLocalizedError should not run for a valid expectedVersion.");
+  });
+
+  assert.equal(result, 8);
+  assert.equal(isInvalidExpectedVersion(result), false);
+});
+
+register("readExpectedVersionOrSendError sends a localized error for invalid versions", () => {
+  let localizedErrorCall: any[] | null = null;
+
+  const result = readExpectedVersionOrSendError({ expectedVersion: 0 }, {}, (...args: any[]) => {
+    localizedErrorCall = args;
+  });
+
+  assert.equal(isInvalidExpectedVersion(result), true);
+  assert.ok(localizedErrorCall);
+  assert.equal(localizedErrorCall?.[1], 400);
+  assert.equal(localizedErrorCall?.[3], "expectedVersion non valida.");
+  assert.equal(localizedErrorCall?.[4], "server.invalidExpectedVersion");
+});


### PR DESCRIPTION
## Summary
- rebased the game mutation preflight helper work onto current `main`
- centralizes `expectedVersion` preflight validation for game action, card trade, and join mutation routes
- adds direct regression coverage for absent, valid string, and invalid `expectedVersion` handling
- bumps app metadata to `0.1.034` and patch-bumps `card-rule-sets` / `setup-flow`

## Validation
- `npm run typecheck`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm run lint`
- `npm run format:check`
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-gameplay-tests.cjs` (`446 gameplay test superati`)

## Risks
- Full gameplay validation requires Node 22 locally because the suite loads `node:sqlite`; the command above used Node 22 explicitly.
- The branch was updated through the GitHub connector because direct `git push` from this environment has no GitHub credentials.