### PR TITLE
[codex] Extract gameplay view state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.035 - 2026-06-05
+
+- Extracted React gameplay view-state derivation into a focused helper with unit coverage.
+
 ## 0.1.034 - 2026-06-05
 
 - Consolidated expected-version mutation preflight handling across game action, card trade, and join routes.

--- a/frontend/react-shell/src/__tests__/gameplay-view-state.test.ts
+++ b/frontend/react-shell/src/__tests__/gameplay-view-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type { GameSnapshot } from "@frontend-generated/shared-runtime-validation.mts";
+
+import { buildGameplayViewState } from "@react-shell/gameplay-view-state";
+
+function activeSnapshot(overrides: Partial<GameSnapshot> = {}): GameSnapshot {
+  return {
+    gameId: "game-1",
+    version: 7,
+    phase: "active",
+    turnPhase: "attack",
+    currentPlayerId: "p1",
+    winnerId: null,
+    players: [
+      { id: "p1", name: "Alice", color: "#f00" },
+      { id: "p2", name: "Bob", color: "#00f" }
+    ],
+    map: [
+      { id: "a", name: "Alpha", ownerId: "p1", armies: 4, neighbors: ["b"] },
+      { id: "b", name: "Beta", ownerId: "p2", armies: 2, neighbors: ["a"] }
+    ],
+    reinforcementPool: 0,
+    playerHand: [],
+    ...overrides
+  };
+}
+
+describe("buildGameplayViewState", () => {
+  it("indexes players and exposes current player command state", () => {
+    const viewState = buildGameplayViewState(activeSnapshot(), "p1");
+
+    expect(viewState.playersById.p1?.name).toBe("Alice");
+    expect(viewState.territoriesById.a?.armies).toBe(4);
+    expect(viewState.me?.id).toBe("p1");
+    expect(viewState.activePlayer?.id).toBe("p1");
+    expect(viewState.myTerritories.map((territory) => territory.id)).toEqual(["a"]);
+    expect(viewState.currentVersion).toBe(7);
+    expect(viewState.isMyTurn).toBe(true);
+    expect(viewState.showAttackGroup).toBe(true);
+    expect(viewState.showEndTurn).toBe(true);
+    expect(viewState.showSurrender).toBe(true);
+  });
+
+  it("blocks attack commands while conquest movement is pending", () => {
+    const viewState = buildGameplayViewState(
+      activeSnapshot({
+        pendingConquest: {
+          fromId: "a",
+          toId: "b",
+          minArmies: 1,
+          maxArmies: 3
+        }
+      }),
+      "p1"
+    );
+
+    expect(viewState.showAttackGroup).toBe(false);
+    expect(viewState.showConquestGroup).toBe(true);
+  });
+
+  it("detects mandatory card trade presentation state", () => {
+    const viewState = buildGameplayViewState(
+      activeSnapshot({
+        turnPhase: "reinforcement",
+        reinforcementPool: 3,
+        cardState: {
+          currentPlayerMustTrade: true,
+          currentPlayerCardCount: 6
+        },
+        playerHand: [
+          { id: "c1", territoryId: "a", type: "infantry" },
+          { id: "c2", territoryId: "b", type: "cavalry" }
+        ]
+      }),
+      "p1"
+    );
+
+    expect(viewState.mustTradeCards).toBe(true);
+    expect(viewState.showReinforceGroup).toBe(true);
+  });
+});

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -25,6 +25,7 @@ import {
   parsePositiveInteger,
   selectOrFallback
 } from "@react-shell/gameplay-selections";
+import { buildGameplayViewState } from "@react-shell/gameplay-view-state";
 import { LoadingAnimation } from "@react-shell/loading-animation";
 import { readCurrentPlayerId, storeCurrentPlayerId } from "@react-shell/player-session";
 import {
@@ -354,57 +355,34 @@ export function GameRoute() {
   const resolvedGameId = snapshot?.gameId || routeGameId;
   const authenticatedUser = state.status === "authenticated" ? state.user : null;
 
-  const playersById: Record<string, SnapshotPlayer> = {};
-  for (const player of snapshot?.players || []) {
-    playersById[player.id] = player;
-  }
-
-  const territoriesById: Record<string, SnapshotTerritory> = {};
-  for (const territory of snapshot?.map || []) {
-    territoriesById[territory.id] = territory;
-  }
-
   const storedPlayerId = readCurrentPlayerId(resolvedGameId || null);
   const myPlayerId = snapshot?.playerId || storedPlayerId || null;
-  const me = myPlayerId ? playersById[myPlayerId] || null : null;
-  const activePlayer = snapshot?.currentPlayerId
-    ? playersById[snapshot.currentPlayerId] || null
-    : null;
-  const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
-  const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];
+  const {
+    playersById,
+    territoriesById,
+    me,
+    activePlayer,
+    winner,
+    playerHand,
+    myTerritories,
+    currentVersion,
+    isMyTurn,
+    mustTradeCards,
+    showLobbyControls,
+    showJoinLobby,
+    showStartGame,
+    showReinforceGroup,
+    showAttackGroup,
+    showConquestGroup,
+    showFortifyGroup,
+    showEndTurn,
+    showSurrender
+  } = buildGameplayViewState(snapshot, myPlayerId);
   const assignedVictoryObjective = snapshot?.assignedVictoryObjective || null;
   const activityLogEntries = activityLogEntriesForSnapshot(snapshot);
   const activityLogContentKey = activityLogEntries
     .map((entry) => `${entry.category}:${entry.text.length}:${entry.text}`)
     .join("|");
-  const myTerritories = (snapshot?.map || []).filter(
-    (territory) => territory.ownerId === myPlayerId
-  );
-  const currentVersion =
-    snapshot && Number.isInteger(snapshot.version) ? snapshot.version : undefined;
-  const isMyTurn = Boolean(
-    snapshot?.phase === "active" && myPlayerId && snapshot.currentPlayerId === myPlayerId
-  );
-  const mustTradeCards = Boolean(
-    isMyTurn && snapshot?.cardState?.currentPlayerMustTrade && playerHand.length
-  );
-  const showLobbyControls = snapshot?.phase === "lobby";
-  const showJoinLobby = snapshot?.phase === "lobby" && !myPlayerId;
-  const showStartGame = snapshot?.phase === "lobby" && Boolean(myPlayerId);
-  const showReinforceGroup = Boolean(
-    isMyTurn &&
-    snapshot?.turnPhase === "reinforcement" &&
-    Number(snapshot?.reinforcementPool || 0) > 0
-  );
-  const showAttackGroup = Boolean(
-    isMyTurn && snapshot?.turnPhase === "attack" && !snapshot?.pendingConquest
-  );
-  const showConquestGroup = Boolean(isMyTurn && snapshot?.pendingConquest);
-  const showFortifyGroup = Boolean(isMyTurn && snapshot?.turnPhase === "fortify");
-  const showEndTurn = Boolean(
-    isMyTurn && snapshot?.phase === "active" && snapshot?.turnPhase !== "reinforcement"
-  );
-  const showSurrender = Boolean(myPlayerId && snapshot?.phase === "active");
   const reinforceTerritoryId = selectOrFallback(
     selectedReinforceTerritoryId,
     myTerritories,

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -25,6 +25,7 @@ import {
   parsePositiveInteger,
   selectOrFallback
 } from "@react-shell/gameplay-selections";
+import { buildGameplayViewState } from "@react-shell/gameplay-view-state";
 import { LoadingAnimation } from "@react-shell/loading-animation";
 import { readCurrentPlayerId, storeCurrentPlayerId } from "@react-shell/player-session";
 import {
@@ -375,57 +376,33 @@ export function GameRoute() {
   const currentLocationPath = `${location.pathname}${location.search}`;
   const authenticatedUser = state.status === "authenticated" ? state.user : null;
 
-  const playersById: Record<string, SnapshotPlayer> = {};
-  for (const player of snapshot?.players || []) {
-    playersById[player.id] = player;
-  }
-
-  const territoriesById: Record<string, SnapshotTerritory> = {};
-  for (const territory of snapshot?.map || []) {
-    territoriesById[territory.id] = territory;
-  }
-
   const storedPlayerId = readCurrentPlayerId(resolvedGameId || null);
   const myPlayerId = snapshot?.playerId || storedPlayerId || null;
-  const me = myPlayerId ? playersById[myPlayerId] || null : null;
-  const activePlayer = snapshot?.currentPlayerId
-    ? playersById[snapshot.currentPlayerId] || null
-    : null;
-  const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
-  const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];
+  const {
+    playersById,
+    territoriesById,
+    me,
+    activePlayer,
+    winner,
+    playerHand,
+    myTerritories,
+    currentVersion,
+    mustTradeCards,
+    showLobbyControls,
+    showJoinLobby,
+    showStartGame,
+    showReinforceGroup,
+    showAttackGroup,
+    showConquestGroup,
+    showFortifyGroup,
+    showEndTurn,
+    showSurrender
+  } = buildGameplayViewState(snapshot, myPlayerId);
   const assignedVictoryObjective = snapshot?.assignedVictoryObjective || null;
   const activityLogEntries = activityLogEntriesForSnapshot(snapshot);
   const activityLogContentKey = activityLogEntries
     .map((entry) => `${entry.category}:${entry.text.length}:${entry.text}`)
     .join("|");
-  const myTerritories = (snapshot?.map || []).filter(
-    (territory) => territory.ownerId === myPlayerId
-  );
-  const currentVersion =
-    snapshot && Number.isInteger(snapshot.version) ? snapshot.version : undefined;
-  const isMyTurn = Boolean(
-    snapshot?.phase === "active" && myPlayerId && snapshot.currentPlayerId === myPlayerId
-  );
-  const mustTradeCards = Boolean(
-    isMyTurn && snapshot?.cardState?.currentPlayerMustTrade && playerHand.length
-  );
-  const showLobbyControls = snapshot?.phase === "lobby";
-  const showJoinLobby = snapshot?.phase === "lobby" && !myPlayerId;
-  const showStartGame = snapshot?.phase === "lobby" && Boolean(myPlayerId);
-  const showReinforceGroup = Boolean(
-    isMyTurn &&
-    snapshot?.turnPhase === "reinforcement" &&
-    Number(snapshot?.reinforcementPool || 0) > 0
-  );
-  const showAttackGroup = Boolean(
-    isMyTurn && snapshot?.turnPhase === "attack" && !snapshot?.pendingConquest
-  );
-  const showConquestGroup = Boolean(isMyTurn && snapshot?.pendingConquest);
-  const showFortifyGroup = Boolean(isMyTurn && snapshot?.turnPhase === "fortify");
-  const showEndTurn = Boolean(
-    isMyTurn && snapshot?.phase === "active" && snapshot?.turnPhase !== "reinforcement"
-  );
-  const showSurrender = Boolean(myPlayerId && snapshot?.phase === "active");
   const reinforceTerritoryId = selectOrFallback(
     selectedReinforceTerritoryId,
     myTerritories,

--- a/frontend/react-shell/src/gameplay-view-state.ts
+++ b/frontend/react-shell/src/gameplay-view-state.ts
@@ -1,0 +1,118 @@
+import type {
+  GameSnapshot,
+  SnapshotCard,
+  SnapshotPlayer,
+  SnapshotTerritory
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+export type GameplayViewState = {
+  playersById: Record<string, SnapshotPlayer>;
+  territoriesById: Record<string, SnapshotTerritory>;
+  me: SnapshotPlayer | null;
+  activePlayer: SnapshotPlayer | null;
+  winner: SnapshotPlayer | null;
+  playerHand: SnapshotCard[];
+  myTerritories: SnapshotTerritory[];
+  currentVersion: number | undefined;
+  latestCombatKey: string;
+  isMyTurn: boolean;
+  mustTradeCards: boolean;
+  showLobbyControls: boolean;
+  showJoinLobby: boolean;
+  showStartGame: boolean;
+  showReinforceGroup: boolean;
+  showAttackGroup: boolean;
+  showConquestGroup: boolean;
+  showFortifyGroup: boolean;
+  showEndTurn: boolean;
+  showSurrender: boolean;
+};
+
+function indexPlayersById(snapshot: GameSnapshot | null): Record<string, SnapshotPlayer> {
+  const playersById: Record<string, SnapshotPlayer> = {};
+  for (const player of snapshot?.players || []) {
+    playersById[player.id] = player;
+  }
+  return playersById;
+}
+
+function indexTerritoriesById(snapshot: GameSnapshot | null): Record<string, SnapshotTerritory> {
+  const territoriesById: Record<string, SnapshotTerritory> = {};
+  for (const territory of snapshot?.map || []) {
+    territoriesById[territory.id] = territory;
+  }
+  return territoriesById;
+}
+
+function combatKey(snapshot: GameSnapshot | null): string {
+  return snapshot?.lastCombat
+    ? [
+        snapshot.lastCombat.fromTerritoryId,
+        snapshot.lastCombat.toTerritoryId,
+        snapshot.lastCombat.attackerRolls?.join(",") || "",
+        snapshot.lastCombat.defenderRolls?.join(",") || "",
+        snapshot.lastCombat.comparisons?.map((comparison) => comparison.winner).join(",") || "",
+        snapshot.lastCombat.conqueredTerritory ? "conquered" : "",
+        snapshot.lastCombat.defenderReducedToZero ? "defense-broken" : ""
+      ].join(":")
+    : "";
+}
+
+export function buildGameplayViewState(
+  snapshot: GameSnapshot | null,
+  myPlayerId: string | null
+): GameplayViewState {
+  const playersById = indexPlayersById(snapshot);
+  const territoriesById = indexTerritoriesById(snapshot);
+  const me = myPlayerId ? playersById[myPlayerId] || null : null;
+  const activePlayer = snapshot?.currentPlayerId
+    ? playersById[snapshot.currentPlayerId] || null
+    : null;
+  const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
+  const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];
+  const myTerritories = (snapshot?.map || []).filter(
+    (territory) => territory.ownerId === myPlayerId
+  );
+  const currentVersion =
+    snapshot && typeof snapshot.version === "number" && Number.isInteger(snapshot.version)
+      ? snapshot.version
+      : undefined;
+  const latestCombatKey = combatKey(snapshot);
+  const isMyTurn = Boolean(
+    snapshot?.phase === "active" && myPlayerId && snapshot.currentPlayerId === myPlayerId
+  );
+  const mustTradeCards = Boolean(
+    isMyTurn && snapshot?.cardState?.currentPlayerMustTrade && playerHand.length
+  );
+
+  return {
+    playersById,
+    territoriesById,
+    me,
+    activePlayer,
+    winner,
+    playerHand,
+    myTerritories,
+    currentVersion,
+    latestCombatKey,
+    isMyTurn,
+    mustTradeCards,
+    showLobbyControls: snapshot?.phase === "lobby",
+    showJoinLobby: snapshot?.phase === "lobby" && !myPlayerId,
+    showStartGame: snapshot?.phase === "lobby" && Boolean(myPlayerId),
+    showReinforceGroup: Boolean(
+      isMyTurn &&
+        snapshot?.turnPhase === "reinforcement" &&
+        Number(snapshot?.reinforcementPool || 0) > 0
+    ),
+    showAttackGroup: Boolean(
+      isMyTurn && snapshot?.turnPhase === "attack" && !snapshot?.pendingConquest
+    ),
+    showConquestGroup: Boolean(isMyTurn && snapshot?.pendingConquest),
+    showFortifyGroup: Boolean(isMyTurn && snapshot?.turnPhase === "fortify"),
+    showEndTurn: Boolean(
+      isMyTurn && snapshot?.phase === "active" && snapshot?.turnPhase !== "reinforcement"
+    ),
+    showSurrender: Boolean(myPlayerId && snapshot?.phase === "active")
+  };
+}

--- a/frontend/react-shell/src/gameplay-view-state.ts
+++ b/frontend/react-shell/src/gameplay-view-state.ts
@@ -1,0 +1,118 @@
+import type {
+  GameSnapshot,
+  SnapshotCard,
+  SnapshotPlayer,
+  SnapshotTerritory
+} from "@frontend-generated/shared-runtime-validation.mts";
+
+export type GameplayViewState = {
+  playersById: Record<string, SnapshotPlayer>;
+  territoriesById: Record<string, SnapshotTerritory>;
+  me: SnapshotPlayer | null;
+  activePlayer: SnapshotPlayer | null;
+  winner: SnapshotPlayer | null;
+  playerHand: SnapshotCard[];
+  myTerritories: SnapshotTerritory[];
+  currentVersion: number | undefined;
+  latestCombatKey: string;
+  isMyTurn: boolean;
+  mustTradeCards: boolean;
+  showLobbyControls: boolean;
+  showJoinLobby: boolean;
+  showStartGame: boolean;
+  showReinforceGroup: boolean;
+  showAttackGroup: boolean;
+  showConquestGroup: boolean;
+  showFortifyGroup: boolean;
+  showEndTurn: boolean;
+  showSurrender: boolean;
+};
+
+function indexPlayersById(snapshot: GameSnapshot | null): Record<string, SnapshotPlayer> {
+  const playersById: Record<string, SnapshotPlayer> = {};
+  for (const player of snapshot?.players || []) {
+    playersById[player.id] = player;
+  }
+  return playersById;
+}
+
+function indexTerritoriesById(snapshot: GameSnapshot | null): Record<string, SnapshotTerritory> {
+  const territoriesById: Record<string, SnapshotTerritory> = {};
+  for (const territory of snapshot?.map || []) {
+    territoriesById[territory.id] = territory;
+  }
+  return territoriesById;
+}
+
+function combatKey(snapshot: GameSnapshot | null): string {
+  return snapshot?.lastCombat
+    ? [
+        snapshot.lastCombat.fromTerritoryId,
+        snapshot.lastCombat.toTerritoryId,
+        snapshot.lastCombat.attackerRolls?.join(",") || "",
+        snapshot.lastCombat.defenderRolls?.join(",") || "",
+        snapshot.lastCombat.comparisons?.map((comparison) => comparison.winner).join(",") || "",
+        snapshot.lastCombat.conqueredTerritory ? "conquered" : "",
+        snapshot.lastCombat.defenderReducedToZero ? "defense-broken" : ""
+      ].join(":")
+    : "";
+}
+
+export function buildGameplayViewState(
+  snapshot: GameSnapshot | null,
+  myPlayerId: string | null
+): GameplayViewState {
+  const playersById = indexPlayersById(snapshot);
+  const territoriesById = indexTerritoriesById(snapshot);
+  const me = myPlayerId ? playersById[myPlayerId] || null : null;
+  const activePlayer = snapshot?.currentPlayerId
+    ? playersById[snapshot.currentPlayerId] || null
+    : null;
+  const winner = snapshot?.winnerId ? playersById[snapshot.winnerId] || null : null;
+  const playerHand = Array.isArray(snapshot?.playerHand) ? snapshot.playerHand : [];
+  const myTerritories = (snapshot?.map || []).filter(
+    (territory) => territory.ownerId === myPlayerId
+  );
+  const currentVersion =
+    snapshot && typeof snapshot.version === "number" && Number.isInteger(snapshot.version)
+      ? snapshot.version
+      : undefined;
+  const latestCombatKey = combatKey(snapshot);
+  const isMyTurn = Boolean(
+    snapshot?.phase === "active" && myPlayerId && snapshot.currentPlayerId === myPlayerId
+  );
+  const mustTradeCards = Boolean(
+    isMyTurn && snapshot?.cardState?.currentPlayerMustTrade && playerHand.length
+  );
+
+  return {
+    playersById,
+    territoriesById,
+    me,
+    activePlayer,
+    winner,
+    playerHand,
+    myTerritories,
+    currentVersion,
+    latestCombatKey,
+    isMyTurn,
+    mustTradeCards,
+    showLobbyControls: snapshot?.phase === "lobby",
+    showJoinLobby: snapshot?.phase === "lobby" && !myPlayerId,
+    showStartGame: snapshot?.phase === "lobby" && Boolean(myPlayerId),
+    showReinforceGroup: Boolean(
+      isMyTurn &&
+      snapshot?.turnPhase === "reinforcement" &&
+      Number(snapshot?.reinforcementPool || 0) > 0
+    ),
+    showAttackGroup: Boolean(
+      isMyTurn && snapshot?.turnPhase === "attack" && !snapshot?.pendingConquest
+    ),
+    showConquestGroup: Boolean(isMyTurn && snapshot?.pendingConquest),
+    showFortifyGroup: Boolean(isMyTurn && snapshot?.turnPhase === "fortify"),
+    showEndTurn: Boolean(
+      isMyTurn && snapshot?.phase === "active" && snapshot?.turnPhase !== "reinforcement"
+    ),
+    showSurrender: Boolean(myPlayerId && snapshot?.phase === "active")
+  };
+}

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.034";
+export const appVersion = "0.1.035";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- extracts gameplay snapshot indexing and command visibility derivation into `gameplay-view-state`
- wires `GameRoute` to consume the derived presentation state instead of keeping the full calculation inline
- adds focused React-shell unit coverage for turn/action/card-trade presentation state
- bumps app metadata to `0.1.035`

## Validation
- `npm run typecheck:react-shell`
- `npm run test:react -- gameplay-view-state`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm run lint`
- `npm run format:check`

## Risks
- Presentation-only refactor; backend rule validation remains unchanged.
- `check:module-versioning` reported 0 touched functional modules, so no module version bump was needed.
- The branch was updated through the GitHub connector because direct `git push` from this environment has no GitHub credentials.