### PR TITLE
[codex] Extract module catalog projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.036 - 2026-06-05
+
+- Extracted module runtime catalog projection into a focused helper with direct coverage.
+
 ## 0.1.035 - 2026-06-05
 
 - Extracted React gameplay view-state derivation into a focused helper with unit coverage.

--- a/backend/module-runtime-catalog-projection.cts
+++ b/backend/module-runtime-catalog-projection.cts
@@ -1,0 +1,76 @@
+import type { NetRiskInstalledModule } from "../shared/netrisk-modules.cjs";
+
+type RuntimeContributionEntry = {
+  moduleId: string;
+};
+
+export type RuntimeCatalogProjection<
+  TMapEntry extends RuntimeContributionEntry,
+  TContentPackEntry extends RuntimeContributionEntry,
+  TPlayerPieceSetEntry extends RuntimeContributionEntry,
+  TDiceRuleSetEntry extends RuntimeContributionEntry,
+  TSiteThemeEntry extends RuntimeContributionEntry
+> = {
+  enabledModules: NetRiskInstalledModule[];
+  enabledRuntimeMapEntries: TMapEntry[];
+  enabledRuntimeContentPackEntries: TContentPackEntry[];
+  enabledRuntimePlayerPieceSetEntries: TPlayerPieceSetEntry[];
+  enabledRuntimeDiceRuleSetEntries: TDiceRuleSetEntry[];
+  enabledRuntimeSiteThemeEntries: TSiteThemeEntry[];
+};
+
+function enabledModuleIds(modules: NetRiskInstalledModule[]): Set<string> {
+  return new Set(
+    modules
+      .filter((moduleEntry) => moduleEntry.enabled && moduleEntry.compatible)
+      .map((moduleEntry) => moduleEntry.id)
+  );
+}
+
+function entriesForEnabledModules<TEntry extends RuntimeContributionEntry>(
+  entries: TEntry[],
+  enabledIds: Set<string>
+): TEntry[] {
+  return entries.filter((entry) => enabledIds.has(entry.moduleId));
+}
+
+export function projectRuntimeCatalogInputs<
+  TMapEntry extends RuntimeContributionEntry,
+  TContentPackEntry extends RuntimeContributionEntry,
+  TPlayerPieceSetEntry extends RuntimeContributionEntry,
+  TDiceRuleSetEntry extends RuntimeContributionEntry,
+  TSiteThemeEntry extends RuntimeContributionEntry
+>(
+  modules: NetRiskInstalledModule[],
+  runtimeMapEntries: TMapEntry[],
+  runtimeContentPackEntries: TContentPackEntry[],
+  runtimePlayerPieceSetEntries: TPlayerPieceSetEntry[],
+  runtimeDiceRuleSetEntries: TDiceRuleSetEntry[],
+  runtimeSiteThemeEntries: TSiteThemeEntry[]
+): RuntimeCatalogProjection<
+  TMapEntry,
+  TContentPackEntry,
+  TPlayerPieceSetEntry,
+  TDiceRuleSetEntry,
+  TSiteThemeEntry
+> {
+  const enabledIds = enabledModuleIds(modules);
+
+  return {
+    enabledModules: modules.filter((moduleEntry) => enabledIds.has(moduleEntry.id)),
+    enabledRuntimeMapEntries: entriesForEnabledModules(runtimeMapEntries, enabledIds),
+    enabledRuntimeContentPackEntries: entriesForEnabledModules(
+      runtimeContentPackEntries,
+      enabledIds
+    ),
+    enabledRuntimePlayerPieceSetEntries: entriesForEnabledModules(
+      runtimePlayerPieceSetEntries,
+      enabledIds
+    ),
+    enabledRuntimeDiceRuleSetEntries: entriesForEnabledModules(
+      runtimeDiceRuleSetEntries,
+      enabledIds
+    ),
+    enabledRuntimeSiteThemeEntries: entriesForEnabledModules(runtimeSiteThemeEntries, enabledIds)
+  };
+}

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -5,6 +5,8 @@ const {
   ensureAllowedContentId,
   moduleEntriesForSelection
 } = require("./module-runtime-contributions.cjs");
+const { projectRuntimeCatalogInputs } =
+  require("./module-runtime-catalog-projection.cjs") as typeof import("./module-runtime-catalog-projection.cjs");
 const { listCardRuleSets } = require("../shared/cards.cjs");
 const {
   findCoreBaseSupportedMap,
@@ -963,23 +965,20 @@ function buildResolvedModuleCatalog(
   authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = []
 ): NetRiskResolvedModuleCatalog {
   const clonedModules = modules.map(cloneInstalledModule);
-  const enabled = clonedModules.filter(
-    (moduleEntry) => moduleEntry.enabled && moduleEntry.compatible
-  );
-  const enabledRuntimeMapEntries = runtimeMapEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimeContentPackEntries = runtimeContentPackEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimePlayerPieceSetEntries = runtimePlayerPieceSetEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimeDiceRuleSetEntries = runtimeDiceRuleSetEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimeSiteThemeEntries = runtimeSiteThemeEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
+  const {
+    enabledModules: enabled,
+    enabledRuntimeMapEntries,
+    enabledRuntimeContentPackEntries,
+    enabledRuntimePlayerPieceSetEntries,
+    enabledRuntimeDiceRuleSetEntries,
+    enabledRuntimeSiteThemeEntries
+  } = projectRuntimeCatalogInputs(
+    clonedModules,
+    runtimeMapEntries,
+    runtimeContentPackEntries,
+    runtimePlayerPieceSetEntries,
+    runtimeDiceRuleSetEntries,
+    runtimeSiteThemeEntries
   );
   const content = aggregateContentContribution(
     enabled,

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -5,6 +5,9 @@ const {
   ensureAllowedContentId,
   moduleEntriesForSelection
 } = require("./module-runtime-contributions.cjs");
+import type * as RuntimeCatalogProjectionModule from "./module-runtime-catalog-projection.cjs";
+const { projectRuntimeCatalogInputs } =
+  require("./module-runtime-catalog-projection.cjs") as typeof RuntimeCatalogProjectionModule;
 const { listCardRuleSets } = require("../shared/cards.cjs");
 const {
   findCoreBaseSupportedMap,
@@ -970,23 +973,20 @@ function buildResolvedModuleCatalog(
   authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = []
 ): NetRiskResolvedModuleCatalog {
   const clonedModules = modules.map(cloneInstalledModule);
-  const enabled = clonedModules.filter(
-    (moduleEntry) => moduleEntry.enabled && moduleEntry.compatible
-  );
-  const enabledRuntimeMapEntries = runtimeMapEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimeContentPackEntries = runtimeContentPackEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimePlayerPieceSetEntries = runtimePlayerPieceSetEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimeDiceRuleSetEntries = runtimeDiceRuleSetEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
-  );
-  const enabledRuntimeSiteThemeEntries = runtimeSiteThemeEntries.filter((entry) =>
-    enabled.some((moduleEntry) => moduleEntry.id === entry.moduleId)
+  const {
+    enabledModules: enabled,
+    enabledRuntimeMapEntries,
+    enabledRuntimeContentPackEntries,
+    enabledRuntimePlayerPieceSetEntries,
+    enabledRuntimeDiceRuleSetEntries,
+    enabledRuntimeSiteThemeEntries
+  } = projectRuntimeCatalogInputs(
+    clonedModules,
+    runtimeMapEntries,
+    runtimeContentPackEntries,
+    runtimePlayerPieceSetEntries,
+    runtimeDiceRuleSetEntries,
+    runtimeSiteThemeEntries
   );
   const content = aggregateContentContribution(
     enabled,

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -54,6 +54,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/game-management-routes.test.cjs",
   "../tests/gameplay/regression/game-summary-stores.test.cjs",
   "../tests/gameplay/regression/module-runtime.test.cjs",
+  "../tests/gameplay/regression/module-runtime-catalog-projection.test.cjs",
   "../tests/gameplay/regression/admin-console-routes.test.cjs",
   "../tests/gameplay/regression/admin-content-studio-routes.test.cjs",
   "../tests/gameplay/regression/admin-route-validation.test.cjs",

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -234,11 +234,12 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "module-runtime",
     name: "Module Runtime",
     kind: "platform",
-    version: "1.0.3",
+    version: "1.0.4",
     description:
       "Filesystem module discovery, validation, enablement, and resolved catalog output.",
     ownerPaths: [
       "backend/module-runtime.cts",
+      "backend/module-runtime-catalog-projection.cts",
       "backend/module-runtime-contributions.cts",
       "backend/routes/modules.cts",
       "shared/netrisk-modules.cts"

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.035";
+export const appVersion = "0.1.036";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/module-runtime-catalog-projection.test.cts
+++ b/tests/gameplay/regression/module-runtime-catalog-projection.test.cts
@@ -1,0 +1,101 @@
+const assert = require("node:assert/strict");
+
+import type * as RuntimeCatalogProjectionModule from "../../../backend/module-runtime-catalog-projection.cjs";
+const { projectRuntimeCatalogInputs } =
+  require("../../../backend/module-runtime-catalog-projection.cjs") as typeof RuntimeCatalogProjectionModule;
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type ContributionEntry = {
+  id: string;
+  moduleId: string;
+};
+
+function installedModule(
+  id: string,
+  options: { enabled?: boolean; compatible?: boolean } = {}
+): any {
+  return {
+    id,
+    version: "1.0.0",
+    displayName: id,
+    description: null,
+    kind: "hybrid",
+    sourcePath: `/modules/${id}`,
+    status: "loaded",
+    enabled: options.enabled ?? true,
+    compatible: options.compatible ?? true,
+    manifest: null,
+    capabilities: [],
+    warnings: [],
+    errors: []
+  };
+}
+
+function contribution(moduleId: string, id: string): ContributionEntry {
+  return { id, moduleId };
+}
+
+register("module runtime catalog projection include solo moduli abilitati e compatibili", () => {
+  const projection = projectRuntimeCatalogInputs(
+    [
+      installedModule("enabled"),
+      installedModule("disabled", { enabled: false }),
+      installedModule("incompatible", { compatible: false })
+    ],
+    [],
+    [],
+    [],
+    [],
+    []
+  );
+
+  assert.deepEqual(
+    projection.enabledModules.map((moduleEntry) => moduleEntry.id),
+    ["enabled"]
+  );
+});
+
+register("module runtime catalog projection filtra i contributi per modulo abilitato", () => {
+  const mapEntries = [
+    contribution("enabled", "map-enabled"),
+    contribution("disabled", "map-disabled"),
+    contribution("incompatible", "map-incompatible"),
+    contribution("missing", "map-missing")
+  ];
+  const contentPackEntries = [
+    contribution("enabled", "pack-enabled"),
+    contribution("disabled", "pack-disabled")
+  ];
+  const playerPieceSetEntries = [
+    contribution("enabled", "pieces-enabled"),
+    contribution("incompatible", "pieces-incompatible")
+  ];
+  const diceRuleSetEntries = [
+    contribution("enabled", "dice-enabled"),
+    contribution("missing", "dice-missing")
+  ];
+  const siteThemeEntries = [
+    contribution("enabled", "theme-enabled"),
+    contribution("disabled", "theme-disabled")
+  ];
+
+  const projection = projectRuntimeCatalogInputs(
+    [
+      installedModule("enabled"),
+      installedModule("disabled", { enabled: false }),
+      installedModule("incompatible", { compatible: false })
+    ],
+    mapEntries,
+    contentPackEntries,
+    playerPieceSetEntries,
+    diceRuleSetEntries,
+    siteThemeEntries
+  );
+
+  assert.deepEqual(projection.enabledRuntimeMapEntries, [mapEntries[0]]);
+  assert.deepEqual(projection.enabledRuntimeContentPackEntries, [contentPackEntries[0]]);
+  assert.deepEqual(projection.enabledRuntimePlayerPieceSetEntries, [playerPieceSetEntries[0]]);
+  assert.deepEqual(projection.enabledRuntimeDiceRuleSetEntries, [diceRuleSetEntries[0]]);
+  assert.deepEqual(projection.enabledRuntimeSiteThemeEntries, [siteThemeEntries[0]]);
+});


### PR DESCRIPTION
## Summary
- extracts enabled module/runtime contribution projection into `module-runtime-catalog-projection`
- keeps `buildResolvedModuleCatalog` focused on shaping the resolved catalog payload
- adds direct regression coverage for enabled/compatible module and contribution filtering
- bumps app release metadata to `0.1.036` and `module-runtime` to `1.0.4`

## Validation
- `npm run typecheck`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm run lint`
- `npm run format:check`
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-gameplay-tests.cjs` (448 gameplay tests)

## Risks
- This is a catalog-internal refactor; behavior should stay unchanged, but module option payloads are compatibility-sensitive and should get careful review.