### PR TITLE
[codex] Use generated catalog transport types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.037 - 2026-06-05
+
+- Moved frontend module catalog helpers onto generated runtime validation transport types.
+
 ## 0.1.036 - 2026-06-05
 
 - Extracted module runtime catalog projection into a focused helper with direct coverage.

--- a/frontend/src/core/module-catalog.mts
+++ b/frontend/src/core/module-catalog.mts
@@ -6,7 +6,7 @@ import type {
   NetRiskModuleProfile,
   NetRiskUiSlotContribution,
   ResolvedModuleCatalog
-} from "./types.mjs";
+} from "../generated/shared-runtime-validation.mjs";
 
 type CatalogCarrier = {
   resolvedCatalog?: ResolvedModuleCatalog;

--- a/frontend/src/core/module-slots.mts
+++ b/frontend/src/core/module-slots.mts
@@ -1,7 +1,10 @@
 import { setMarkup } from "./dom.mjs";
 import { getModuleOptionsOrNull } from "./api/client.mjs";
 import { resolvedUiSlots } from "./module-catalog.mjs";
-import type { ModuleOptionsResponse, NetRiskUiSlotContribution } from "./types.mjs";
+import type {
+  ModuleOptionsResponse,
+  NetRiskUiSlotContribution
+} from "../generated/shared-runtime-validation.mjs";
 
 type MountModuleSlotSectionOptions = {
   slotId: string;

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.036";
+export const appVersion = "0.1.037";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- moves frontend module catalog helpers to schema-generated transport types
- updates the module slot consumer to use the same generated module option and slot types
- leaves legacy hand-maintained core types in place for remaining callers so this stays reviewable
- bumps app release metadata to `0.1.037`

## Validation
- `npm run typecheck:frontend`
- `npm run typecheck:react-shell`
- `npm run test:react -- module-style-assets`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm run lint`
- `npm run format:check`

## Test coverage note
- No new executable test was added because this slice is type-only: it changes DTO import sources, not runtime behavior. The generated-type contract is covered by frontend/React typechecks and the existing React module asset test.

## Risks
- This is a first consolidation slice. More hand-maintained transport types remain in `frontend/src/core/types.mts` and should be retired gradually.