### PR TITLE
[codex] Polish mandatory card trade dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.006 - 2026-05-06
+
+- Polished the mandatory card trade dock with a larger bottom-panel layout, clearer card selection states, and focused forced-trade interaction.
+
 ## 0.1.005 - 2026-05-06
 
 - Updated the npm dependency group for runtime, testing, and lint tooling packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.038 - 2026-06-05
+
+- Polished the mandatory card trade dock with a larger bottom-panel layout, clearer card selection states, and focused forced-trade interaction.
+
 ## 0.1.037 - 2026-06-05
 
 - Moved frontend module catalog helpers onto generated runtime validation transport types.

--- a/e2e/gameplay/card-trade-panel.spec.ts
+++ b/e2e/gameplay/card-trade-panel.spec.ts
@@ -149,27 +149,21 @@ test("game page lets the authenticated player select 3 cards and submit a trade"
   await expect(page.locator("#trade-alert")).toContainText("Scambio obbligatorio");
   await expect(page.locator("#trade-alert")).toContainText("scambiane 3 per continuare");
   await expect(page.locator('[data-testid="actions-panel"] #card-trade-list')).toHaveCount(0);
-  await page.locator(".game-cards-drawer summary").click();
-  await expect(page.locator(".game-cards-modern-drawer")).toContainText("Le tue carte 4/7");
-  await expect(page.locator("#card-trade-group")).toBeVisible();
-  await expect(page.locator("#card-trade-alert")).toBeVisible();
-  await expect(page.locator("#card-trade-alert")).toContainText(
-    "Devi scambiare subito 3 carte prima di poter continuare"
+  await expect(page.locator("#card-trade-dock-list [data-dock-card-id]")).toHaveCount(4);
+  await expect(page.locator("#card-trade-dock-help")).toContainText(
+    "Scegli tre carte dalla tua mano"
   );
-  await expect(page.locator("#card-trade-summary")).toContainText("Carte in mano: 4");
-  await expect(page.locator("#card-trade-bonus")).toContainText("Prossimo scambio: +4 rinforzi");
-  await expect(page.locator("#card-trade-help")).toContainText("Scambio obbligatorio");
-  await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(4);
-  await expect(page.locator("#card-trade-button")).toBeDisabled();
+  await expect(page.locator("#card-trade-dock-button")).toBeDisabled();
 
-  await page.locator('[data-card-id="c1"]').click();
-  await page.locator('[data-card-id="c2"]').click();
-  await page.locator('[data-card-id="c3"]').click();
+  await page.locator('[data-dock-card-id="c1"]').click();
+  await page.locator('[data-dock-card-id="c2"]').click();
+  await page.locator('[data-dock-card-id="c3"]').click();
 
-  await expect(page.locator("#card-trade-button")).toBeEnabled();
-  await page.locator("#card-trade-button").click();
+  await expect(page.locator("#card-trade-dock-button")).toBeEnabled();
+  await page.locator("#card-trade-dock-button").click();
 
   await expect(page.locator("#status-summary")).toContainText("7");
+  await page.locator(".game-cards-drawer summary").click();
   await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(1);
   await expect(page.locator("#card-trade-help")).toContainText("0/3 carte selezionate");
 });
@@ -185,7 +179,11 @@ for (const viewport of [
         { id: "c1", type: "infantry", territoryId: "aurora" },
         { id: "c2", type: "infantry", territoryId: "bastion" },
         { id: "c3", type: "infantry", territoryId: "aurora" },
-        { id: "c4", type: "wild" }
+        { id: "c4", type: "wild" },
+        { id: "c5", type: "cavalry", territoryId: "bastion" },
+        { id: "c6", type: "artillery", territoryId: "aurora" },
+        { id: "c7", type: "infantry", territoryId: "bastion" },
+        { id: "c8", type: "wild" }
       ],
       mustTrade: true
     });
@@ -232,6 +230,12 @@ for (const viewport of [
     await expect(page.locator(".game-command-dock-mandatory-trade")).toBeVisible({
       timeout: 15000
     });
+    await expect(page.locator("#card-trade-dock-list [data-dock-card-id]")).toHaveCount(8);
+    const firstCard = page.locator('[data-dock-card-id="c1"]');
+    const firstCardBoxBefore = await firstCard.boundingBox();
+    await firstCard.click();
+    await expect(firstCard).toHaveAttribute("aria-pressed", "true");
+    const firstCardBoxAfter = await firstCard.boundingBox();
 
     const metrics = await page.evaluate(() => {
       const intersects = (first, second) =>
@@ -259,11 +263,39 @@ for (const viewport of [
 
       const board = boundsFor(".game-map-stage .map-board");
       const dock = boundsFor(".game-command-dock-mandatory-trade");
+      const tray = boundsFor(".game-card-tray");
+      const bonus = boundsFor(".game-exchange-bonus");
+      const scrollContainer = document.querySelector(".game-card-tray-scroll");
+      const row = document.querySelector("#card-trade-dock-list");
+      const cards = Array.from(document.querySelectorAll("[data-dock-card-id]"));
+      const cardRects = cards.map((card) => {
+        const rect = card.getBoundingClientRect();
+        return {
+          bottom: rect.bottom,
+          height: rect.height,
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          width: rect.width
+        };
+      });
+      const adjacentGaps = cardRects
+        .slice(1)
+        .map((rect, index) => rect.left - cardRects[index].right);
+      const cardPairsOverlap = cardRects.some((rect, index) =>
+        cardRects.slice(index + 1).some((other) => intersects(rect, other))
+      );
+      const selectedCount = document.querySelectorAll(
+        '[data-dock-card-id][aria-pressed="true"]'
+      ).length;
       const stage = document.querySelector(".game-map-stage");
       const stageStyles = stage ? window.getComputedStyle(stage) : null;
+      const scrollStyles = scrollContainer ? window.getComputedStyle(scrollContainer) : null;
+      const rowStyles = row ? window.getComputedStyle(row) : null;
       const viewport = { height: window.innerHeight, width: window.innerWidth };
 
       return {
+        adjacentGaps,
         boardClearOfDock: !intersects(board, dock),
         boardHeight: board.height,
         boardInsideViewport:
@@ -272,12 +304,24 @@ for (const viewport of [
           board.right <= viewport.width + 1 &&
           board.bottom <= viewport.height + 1,
         boardWidth: board.width,
+        bonusRightAligned: bonus.left >= tray.right - 1,
+        cardPairsOverlap,
+        cardWidths: cardRects.map((rect) => Math.round(rect.width)),
         dockInsideViewport:
-          dock.left >= -1 &&
-          dock.right <= viewport.width + 1 &&
-          dock.bottom <= viewport.height + 1,
+          dock.left >= -1 && dock.right <= viewport.width + 1 && dock.bottom <= viewport.height + 1,
+        rowDisplay: rowStyles?.display || "",
+        rowFlexWrap: rowStyles?.flexWrap || "",
         safeBottom: stageStyles?.getPropertyValue("--game-map-safe-bottom").trim() || "",
-        safeTop: stageStyles?.getPropertyValue("--game-map-safe-top").trim() || ""
+        safeTop: stageStyles?.getPropertyValue("--game-map-safe-top").trim() || "",
+        scrollHasHorizontalOverflow: scrollContainer
+          ? scrollContainer.scrollWidth > scrollContainer.clientWidth
+          : false,
+        scrollOverflowX: scrollStyles?.overflowX || "",
+        scrollOverflowY: scrollStyles?.overflowY || "",
+        selectedCount,
+        trayVerticalScrollFree: scrollContainer
+          ? scrollContainer.scrollHeight <= scrollContainer.clientHeight + 16
+          : false
       };
     });
 
@@ -287,5 +331,26 @@ for (const viewport of [
     expect(metrics.boardClearOfDock).toBeTruthy();
     expect(metrics.dockInsideViewport).toBeTruthy();
     expect(metrics.safeBottom).toMatch(/^[0-9.]+px$/);
+    expect(metrics.rowDisplay).toBe("flex");
+    expect(metrics.rowFlexWrap).toBe("nowrap");
+    expect(metrics.scrollOverflowX).toBe("auto");
+    expect(metrics.scrollOverflowY).toBe("hidden");
+    expect(metrics.scrollHasHorizontalOverflow).toBeTruthy();
+    expect(metrics.trayVerticalScrollFree).toBeTruthy();
+    expect(metrics.cardPairsOverlap).toBeFalsy();
+    expect(Math.min(...metrics.adjacentGaps)).toBeGreaterThanOrEqual(12);
+    expect(new Set(metrics.cardWidths).size).toBe(1);
+    expect(firstCardBoxBefore).not.toBeNull();
+    expect(firstCardBoxAfter).not.toBeNull();
+    expect(Math.abs((firstCardBoxBefore?.x || 0) - (firstCardBoxAfter?.x || 0))).toBeLessThan(0.5);
+    expect(Math.abs((firstCardBoxBefore?.y || 0) - (firstCardBoxAfter?.y || 0))).toBeLessThan(0.5);
+    expect(
+      Math.abs((firstCardBoxBefore?.width || 0) - (firstCardBoxAfter?.width || 0))
+    ).toBeLessThan(0.5);
+    expect(
+      Math.abs((firstCardBoxBefore?.height || 0) - (firstCardBoxAfter?.height || 0))
+    ).toBeLessThan(0.5);
+    expect(metrics.selectedCount).toBe(1);
+    expect(metrics.bonusRightAligned).toBeTruthy();
   });
 }

--- a/e2e/gameplay/card-trade-panel.spec.ts
+++ b/e2e/gameplay/card-trade-panel.spec.ts
@@ -149,27 +149,21 @@ test("game page lets the authenticated player select 3 cards and submit a trade"
   await expect(page.locator("#trade-alert")).toContainText("Scambio obbligatorio");
   await expect(page.locator("#trade-alert")).toContainText("scambiane 3 per continuare");
   await expect(page.locator('[data-testid="actions-panel"] #card-trade-list')).toHaveCount(0);
-  await page.locator(".game-cards-drawer summary").click();
-  await expect(page.locator(".game-cards-modern-drawer")).toContainText("Le tue carte 4/7");
-  await expect(page.locator("#card-trade-group")).toBeVisible();
-  await expect(page.locator("#card-trade-alert")).toBeVisible();
-  await expect(page.locator("#card-trade-alert")).toContainText(
-    "Devi scambiare subito 3 carte prima di poter continuare"
+  await expect(page.locator("#card-trade-dock-list [data-dock-card-id]")).toHaveCount(4);
+  await expect(page.locator("#card-trade-dock-help")).toContainText(
+    "Scegli tre carte dalla tua mano"
   );
-  await expect(page.locator("#card-trade-summary")).toContainText("Carte in mano: 4");
-  await expect(page.locator("#card-trade-bonus")).toContainText("Prossimo scambio: +4 rinforzi");
-  await expect(page.locator("#card-trade-help")).toContainText("Scambio obbligatorio");
-  await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(4);
-  await expect(page.locator("#card-trade-button")).toBeDisabled();
+  await expect(page.locator("#card-trade-dock-button")).toBeDisabled();
 
-  await page.locator('[data-card-id="c1"]').click();
-  await page.locator('[data-card-id="c2"]').click();
-  await page.locator('[data-card-id="c3"]').click();
+  await page.locator('[data-dock-card-id="c1"]').click();
+  await page.locator('[data-dock-card-id="c2"]').click();
+  await page.locator('[data-dock-card-id="c3"]').click();
 
-  await expect(page.locator("#card-trade-button")).toBeEnabled();
-  await page.locator("#card-trade-button").click();
+  await expect(page.locator("#card-trade-dock-button")).toBeEnabled();
+  await page.locator("#card-trade-dock-button").click();
 
   await expect(page.locator("#status-summary")).toContainText("7");
+  await page.locator(".game-cards-drawer summary").click();
   await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(1);
   await expect(page.locator("#card-trade-help")).toContainText("0/3 carte selezionate");
 });
@@ -185,7 +179,11 @@ for (const viewport of [
         { id: "c1", type: "infantry", territoryId: "aurora" },
         { id: "c2", type: "infantry", territoryId: "bastion" },
         { id: "c3", type: "infantry", territoryId: "aurora" },
-        { id: "c4", type: "wild" }
+        { id: "c4", type: "wild" },
+        { id: "c5", type: "cavalry", territoryId: "bastion" },
+        { id: "c6", type: "artillery", territoryId: "aurora" },
+        { id: "c7", type: "infantry", territoryId: "bastion" },
+        { id: "c8", type: "wild" }
       ],
       mustTrade: true
     });
@@ -232,6 +230,12 @@ for (const viewport of [
     await expect(page.locator(".game-command-dock-mandatory-trade")).toBeVisible({
       timeout: 15000
     });
+    await expect(page.locator("#card-trade-dock-list [data-dock-card-id]")).toHaveCount(8);
+    const firstCard = page.locator('[data-dock-card-id="c1"]');
+    const firstCardBoxBefore = await firstCard.boundingBox();
+    await firstCard.click();
+    await expect(firstCard).toHaveAttribute("aria-pressed", "true");
+    const firstCardBoxAfter = await firstCard.boundingBox();
 
     const metrics = await page.evaluate(() => {
       const intersects = (first, second) =>
@@ -285,11 +289,39 @@ for (const viewport of [
 
       const board = boundsFor(".game-map-stage .map-board");
       const dock = boundsFor(".game-command-dock-mandatory-trade");
+      const tray = boundsFor(".game-card-tray");
+      const bonus = boundsFor(".game-exchange-bonus");
+      const scrollContainer = document.querySelector(".game-card-tray-scroll");
+      const row = document.querySelector("#card-trade-dock-list");
+      const cards = Array.from(document.querySelectorAll("[data-dock-card-id]"));
+      const cardRects = cards.map((card) => {
+        const rect = card.getBoundingClientRect();
+        return {
+          bottom: rect.bottom,
+          height: rect.height,
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          width: rect.width
+        };
+      });
+      const adjacentGaps = cardRects
+        .slice(1)
+        .map((rect, index) => rect.left - cardRects[index].right);
+      const cardPairsOverlap = cardRects.some((rect, index) =>
+        cardRects.slice(index + 1).some((other) => intersects(rect, other))
+      );
+      const selectedCount = document.querySelectorAll(
+        '[data-dock-card-id][aria-pressed="true"]'
+      ).length;
       const stage = document.querySelector(".game-map-stage");
       const stageStyles = stage ? window.getComputedStyle(stage) : null;
+      const scrollStyles = scrollContainer ? window.getComputedStyle(scrollContainer) : null;
+      const rowStyles = row ? window.getComputedStyle(row) : null;
       const viewport = { height: window.innerHeight, width: window.innerWidth };
 
       return {
+        adjacentGaps,
         boardClearOfDock: !intersects(board, dock),
         boardHeight: board.height,
         boardInsideViewport:
@@ -298,16 +330,30 @@ for (const viewport of [
           board.right <= viewport.width + 1 &&
           board.bottom <= viewport.height + 1,
         boardWidth: board.width,
+        bonusRightAligned: bonus.left >= tray.right - 1,
+        cardPairsOverlap,
+        cardWidths: cardRects.map((rect) => Math.round(rect.width)),
         dockInsideViewport:
-          dock.left >= -1 &&
-          dock.right <= viewport.width + 1 &&
-          dock.bottom <= viewport.height + 1,
+          dock.left >= -1 && dock.right <= viewport.width + 1 && dock.bottom <= viewport.height + 1,
+        rowDisplay: rowStyles?.display || "",
+        rowFlexWrap: rowStyles?.flexWrap || "",
         safeBottom:
           stage instanceof HTMLElement
             ? resolvedCssLength(stage, stageStyles, "--game-map-safe-bottom")
             : "",
         safeTop:
-          stage instanceof HTMLElement ? resolvedCssLength(stage, stageStyles, "--game-map-safe-top") : ""
+          stage instanceof HTMLElement
+            ? resolvedCssLength(stage, stageStyles, "--game-map-safe-top")
+            : "",
+        scrollHasHorizontalOverflow: scrollContainer
+          ? scrollContainer.scrollWidth > scrollContainer.clientWidth
+          : false,
+        scrollOverflowX: scrollStyles?.overflowX || "",
+        scrollOverflowY: scrollStyles?.overflowY || "",
+        selectedCount,
+        trayVerticalScrollFree: scrollContainer
+          ? scrollContainer.scrollHeight <= scrollContainer.clientHeight + 16
+          : false
       };
     });
 
@@ -317,5 +363,26 @@ for (const viewport of [
     expect(metrics.boardClearOfDock).toBeTruthy();
     expect(metrics.dockInsideViewport).toBeTruthy();
     expect(metrics.safeBottom).toMatch(/^[0-9.]+px$/);
+    expect(metrics.rowDisplay).toBe("flex");
+    expect(metrics.rowFlexWrap).toBe("nowrap");
+    expect(metrics.scrollOverflowX).toBe("auto");
+    expect(metrics.scrollOverflowY).toBe("hidden");
+    expect(metrics.scrollHasHorizontalOverflow).toBeTruthy();
+    expect(metrics.trayVerticalScrollFree).toBeTruthy();
+    expect(metrics.cardPairsOverlap).toBeFalsy();
+    expect(Math.min(...metrics.adjacentGaps)).toBeGreaterThanOrEqual(12);
+    expect(new Set(metrics.cardWidths).size).toBe(1);
+    expect(firstCardBoxBefore).not.toBeNull();
+    expect(firstCardBoxAfter).not.toBeNull();
+    expect(Math.abs((firstCardBoxBefore?.x || 0) - (firstCardBoxAfter?.x || 0))).toBeLessThan(0.5);
+    expect(Math.abs((firstCardBoxBefore?.y || 0) - (firstCardBoxAfter?.y || 0))).toBeLessThan(0.5);
+    expect(
+      Math.abs((firstCardBoxBefore?.width || 0) - (firstCardBoxAfter?.width || 0))
+    ).toBeLessThan(0.5);
+    expect(
+      Math.abs((firstCardBoxBefore?.height || 0) - (firstCardBoxAfter?.height || 0))
+    ).toBeLessThan(0.5);
+    expect(metrics.selectedCount).toBe(1);
+    expect(metrics.bonusRightAligned).toBeTruthy();
   });
 }

--- a/e2e/smoke/react-shell-gameplay.spec.ts
+++ b/e2e/smoke/react-shell-gameplay.spec.ts
@@ -283,19 +283,19 @@ test("react gameplay handles the forced trade flow on the React route", async ({
 
   await expect(page.getByTestId("react-shell-game-page")).toBeVisible();
   await expect(page.locator("#trade-alert")).toBeVisible();
-  await expect(page.locator('[data-testid="actions-panel"] #card-trade-list')).toHaveCount(0);
+  await expect(
+    page.locator('[data-testid="actions-panel"] #card-trade-dock-list [data-dock-card-id]')
+  ).toHaveCount(4);
   await page.locator(".game-cards-drawer summary").click();
-  await expect(page.locator("#card-trade-group")).toBeVisible();
-  await expect(page.locator("#card-trade-alert")).toContainText(/Devi scambiare subito 3 carte/i);
-  await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(4);
-  await expect(page.locator("#card-trade-button")).toBeDisabled();
+  await expect(page.locator("#card-trade-group")).toBeHidden();
+  await expect(page.locator("#card-trade-dock-button")).toBeDisabled();
 
-  await page.locator('[data-card-id="c1"]').click();
-  await page.locator('[data-card-id="c2"]').click();
-  await page.locator('[data-card-id="c3"]').click();
+  await page.locator('[data-dock-card-id="c1"]').click();
+  await page.locator('[data-dock-card-id="c2"]').click();
+  await page.locator('[data-dock-card-id="c3"]').click();
 
-  await expect(page.locator("#card-trade-button")).toBeEnabled();
-  await page.locator("#card-trade-button").click();
+  await expect(page.locator("#card-trade-dock-button")).toBeEnabled();
+  await page.locator("#card-trade-dock-button").click();
 
   await expect(page.getByTestId("status-summary")).toContainText("7");
   await expect(page.locator("#card-trade-list [data-card-id]")).toHaveCount(1);

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -367,6 +367,7 @@ describe("GameRoute integration", () => {
   });
 
   it("renders mandatory card trade flow in the bottom dock", async () => {
+    const user = userEvent.setup();
     getGameStateMock.mockResolvedValue(
       createGameplayState({
         reinforcementPool: 5,
@@ -397,6 +398,15 @@ describe("GameRoute integration", () => {
     expect(within(dock).getByText("Bonus scambio")).toBeInTheDocument();
     expect(within(dock).getByText("+8")).toBeInTheDocument();
     expect(dock.querySelectorAll("[data-dock-card-id]")).toHaveLength(5);
+    expect(
+      within(dock.querySelector(".game-trade-hand") as HTMLElement).getByText("5")
+    ).toBeInTheDocument();
+    const cardButtons = dock.querySelectorAll("[data-dock-card-id]");
+    expect(cardButtons[0]).toHaveClass("game-card-tone-infantry");
+    expect(cardButtons[1]).toHaveClass("game-card-tone-artillery");
+    await user.click(cardButtons[0] as HTMLElement);
+    expect(cardButtons[0]).toHaveAttribute("aria-pressed", "true");
+    expect(within(dock).getByText("1 / 3 selezionate")).toBeInTheDocument();
     expect(dock.querySelector("#card-trade-dock-button")).toHaveTextContent("Scambia carte");
   });
 

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -397,9 +397,12 @@ describe("GameRoute integration", () => {
     expect(within(dock).getByText("Seleziona 3 carte da scambiare")).toBeInTheDocument();
     expect(within(dock).getByText("Bonus scambio")).toBeInTheDocument();
     expect(within(dock).getByText("+8")).toBeInTheDocument();
+    expect(dock.querySelector(".game-card-tray")).toBeInTheDocument();
+    expect(dock.querySelector(".game-card-row")).toHaveAttribute("data-card-count", "5");
+    expect(dock.querySelector(".game-selected-card-row")).not.toBeInTheDocument();
     expect(dock.querySelectorAll("[data-dock-card-id]")).toHaveLength(5);
     expect(
-      within(dock.querySelector(".game-trade-hand") as HTMLElement).getByText("5")
+      within(dock.querySelector(".game-card-tray") as HTMLElement).getByText("5")
     ).toBeInTheDocument();
     const cardButtons = dock.querySelectorAll("[data-dock-card-id]");
     expect(cardButtons[0]).toHaveClass("game-card-tone-infantry");
@@ -407,8 +410,47 @@ describe("GameRoute integration", () => {
     await user.click(cardButtons[0] as HTMLElement);
     expect(cardButtons[0]).toHaveAttribute("aria-pressed", "true");
     expect(within(dock).getByText("1 / 3 selezionate")).toBeInTheDocument();
+    await user.click(cardButtons[1] as HTMLElement);
+    await user.click(cardButtons[2] as HTMLElement);
+    expect(dock.querySelectorAll("[data-dock-card-id]")).toHaveLength(5);
+    expect(dock.querySelectorAll('[data-dock-card-id][aria-pressed="true"]')).toHaveLength(3);
     expect(dock.querySelector("#card-trade-dock-button")).toHaveTextContent("Scambia carte");
   });
+
+  it.each([3, 5, 6, 8])(
+    "keeps mandatory trade cards in one tray row for %i card hands",
+    async (cardCount) => {
+      getGameStateMock.mockResolvedValue(
+        createGameplayState({
+          reinforcementPool: 5,
+          cardState: {
+            ruleSetId: "standard",
+            tradeCount: 2,
+            deckCount: 12,
+            discardCount: 0,
+            nextTradeBonus: 8,
+            maxHandBeforeForcedTrade: 5,
+            currentPlayerMustTrade: true
+          },
+          playerHand: Array.from({ length: cardCount }, (_, index) => ({
+            id: `card-${index + 1}`,
+            territoryId: `Territory ${index + 1}`,
+            type: index % 3 === 0 ? "infantry" : index % 3 === 1 ? "artillery" : "cavalry"
+          }))
+        })
+      );
+
+      renderReactShell("/react/game/g-1");
+
+      const dock = await screen.findByTestId("actions-panel");
+      const row = dock.querySelector(".game-card-row") as HTMLElement;
+      expect(row).toBeInTheDocument();
+      expect(row).toHaveAttribute("data-card-count", String(cardCount));
+      expect(row.querySelectorAll("[data-dock-card-id]")).toHaveLength(cardCount);
+      expect(dock.querySelector(".game-selected-card-row")).not.toBeInTheDocument();
+      expect(within(dock).getByText("+8")).toBeInTheDocument();
+    }
+  );
 
   it("opens reference drawers and filters the activity log", async () => {
     const user = userEvent.setup();

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -511,6 +511,7 @@ describe("GameRoute integration", () => {
   });
 
   it("renders mandatory card trade flow in the bottom dock", async () => {
+    const user = userEvent.setup();
     getGameStateMock.mockResolvedValue(
       createGameplayState({
         reinforcementPool: 5,
@@ -540,9 +541,62 @@ describe("GameRoute integration", () => {
     expect(within(dock).getByText("Seleziona 3 carte da scambiare")).toBeInTheDocument();
     expect(within(dock).getByText("Bonus scambio")).toBeInTheDocument();
     expect(within(dock).getByText("+8")).toBeInTheDocument();
+    expect(dock.querySelector(".game-card-tray")).toBeInTheDocument();
+    expect(dock.querySelector(".game-card-row")).toHaveAttribute("data-card-count", "5");
+    expect(dock.querySelector(".game-selected-card-row")).not.toBeInTheDocument();
     expect(dock.querySelectorAll("[data-dock-card-id]")).toHaveLength(5);
+    expect(
+      within(dock.querySelector(".game-card-tray") as HTMLElement).getByText("5")
+    ).toBeInTheDocument();
+    const cardButtons = dock.querySelectorAll("[data-dock-card-id]");
+    expect(cardButtons[0]).toHaveClass("game-card-tone-infantry");
+    expect(cardButtons[1]).toHaveClass("game-card-tone-artillery");
+    await user.click(cardButtons[0] as HTMLElement);
+    expect(cardButtons[0]).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(dock.querySelector(".game-card-tray") as HTMLElement).getByText("1 / 3 selezionate")
+    ).toBeInTheDocument();
+    await user.click(cardButtons[1] as HTMLElement);
+    await user.click(cardButtons[2] as HTMLElement);
+    expect(dock.querySelectorAll("[data-dock-card-id]")).toHaveLength(5);
+    expect(dock.querySelectorAll('[data-dock-card-id][aria-pressed="true"]')).toHaveLength(3);
     expect(dock.querySelector("#card-trade-dock-button")).toHaveTextContent("Scambia carte");
   });
+
+  it.each([3, 5, 6, 8])(
+    "keeps mandatory trade cards in one tray row for %i card hands",
+    async (cardCount) => {
+      getGameStateMock.mockResolvedValue(
+        createGameplayState({
+          reinforcementPool: 5,
+          cardState: {
+            ruleSetId: "standard",
+            tradeCount: 2,
+            deckCount: 12,
+            discardCount: 0,
+            nextTradeBonus: 8,
+            maxHandBeforeForcedTrade: 5,
+            currentPlayerMustTrade: true
+          },
+          playerHand: Array.from({ length: cardCount }, (_, index) => ({
+            id: `card-${index + 1}`,
+            territoryId: `Territory ${index + 1}`,
+            type: index % 3 === 0 ? "infantry" : index % 3 === 1 ? "artillery" : "cavalry"
+          }))
+        })
+      );
+
+      renderReactShell("/react/game/g-1");
+
+      const dock = await screen.findByTestId("actions-panel");
+      const row = dock.querySelector(".game-card-row") as HTMLElement;
+      expect(row).toBeInTheDocument();
+      expect(row).toHaveAttribute("data-card-count", String(cardCount));
+      expect(row.querySelectorAll("[data-dock-card-id]")).toHaveLength(cardCount);
+      expect(dock.querySelector(".game-selected-card-row")).not.toBeInTheDocument();
+      expect(within(dock).getByText("+8")).toBeInTheDocument();
+    }
+  );
 
   it("opens reference drawers and filters the activity log", async () => {
     const user = userEvent.setup();

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -5873,13 +5873,13 @@ html[data-theme="war-table"]
 html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-trade {
   bottom: 32px !important;
   width: min(1490px, calc(100vw - 190px)) !important;
-  min-height: 260px !important;
+  min-height: 292px !important;
   max-height: none !important;
   padding: 20px 28px !important;
 }
 
 .game-command-dock-mandatory-trade .game-mandatory-trade-dock {
-  min-height: 218px !important;
+  min-height: 250px !important;
 }
 
 .game-command-dock-mandatory-trade .game-card-tile {
@@ -5914,6 +5914,271 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   min-height: 108px !important;
 }
 
+.game-command-dock-mandatory-trade .game-dock-field-label {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 12px !important;
+  margin-bottom: 12px !important;
+  color: var(--nr-gold) !important;
+}
+
+.game-command-dock-mandatory-trade .game-dock-label-badge,
+.game-command-dock-mandatory-trade .game-dock-field-label span {
+  display: inline-grid !important;
+  place-items: center !important;
+  min-width: 30px !important;
+  height: 26px !important;
+  padding: 0 8px !important;
+  border: 1px solid rgba(151, 178, 194, 0.32) !important;
+  border-radius: 7px !important;
+  background: rgba(8, 20, 31, 0.9) !important;
+  color: #eef5f8 !important;
+  font-size: 0.68rem !important;
+  font-weight: 900 !important;
+  text-transform: none !important;
+}
+
+.game-command-dock-mandatory-trade .game-dock-label-badge {
+  border-color: rgba(87, 190, 99, 0.48) !important;
+  background: rgba(20, 64, 37, 0.82) !important;
+  color: #b9ffb6 !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-grid {
+  grid-template-columns: repeat(5, minmax(118px, 1fr)) !important;
+  gap: 14px !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile {
+  align-content: stretch !important;
+  grid-template-rows: minmax(78px, 1fr) auto auto !important;
+  gap: 7px !important;
+  min-height: 158px !important;
+  padding: 8px 10px 10px !important;
+  overflow: hidden !important;
+  border-color: rgba(178, 202, 218, 0.5) !important;
+  border-radius: 7px !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 14px 24px rgba(0, 0, 0, 0.28) !important;
+  text-align: center !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile.is-selected {
+  border-color: var(--nr-gold) !important;
+  box-shadow:
+    0 0 0 1px rgba(246, 181, 21, 0.48),
+    0 0 24px rgba(246, 181, 21, 0.22),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-visual {
+  position: relative !important;
+  display: grid !important;
+  place-items: end center !important;
+  min-height: 78px !important;
+  border-radius: 5px !important;
+  overflow: hidden !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-silhouette {
+  position: relative !important;
+  z-index: 1 !important;
+  display: grid !important;
+  place-items: center !important;
+  width: 38px !important;
+  height: 58px !important;
+  margin-bottom: 8px !important;
+  border-radius: 20px 20px 8px 8px !important;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(0, 0, 0, 0.34)) !important;
+  color: rgba(255, 236, 200, 0.92) !important;
+  font-size: 1.05rem !important;
+  font-weight: 950 !important;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.7) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-territory-shape {
+  position: absolute !important;
+  right: 12px !important;
+  bottom: 13px !important;
+  width: 56px !important;
+  height: 34px !important;
+  border-radius: 52% 39% 48% 34% !important;
+  background: currentColor !important;
+  opacity: 0.6 !important;
+  transform: rotate(-9deg) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-infantry .game-card-visual {
+  color: #8f5cff !important;
+  background:
+    radial-gradient(circle at 44% 35%, rgba(151, 98, 255, 0.52), transparent 48%),
+    linear-gradient(180deg, rgba(39, 28, 66, 0.94), rgba(15, 14, 31, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-artillery .game-card-visual {
+  color: #ff7a26 !important;
+  background:
+    radial-gradient(circle at 50% 38%, rgba(255, 122, 38, 0.5), transparent 46%),
+    linear-gradient(180deg, rgba(56, 27, 16, 0.95), rgba(18, 12, 13, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-cavalry .game-card-visual {
+  color: #a5d85b !important;
+  background:
+    radial-gradient(circle at 48% 36%, rgba(165, 216, 91, 0.48), transparent 47%),
+    linear-gradient(180deg, rgba(34, 56, 22, 0.95), rgba(11, 17, 12, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-wild .game-card-visual {
+  color: #43d8ee !important;
+  background:
+    radial-gradient(circle at 48% 38%, rgba(67, 216, 238, 0.5), transparent 48%),
+    linear-gradient(180deg, rgba(13, 62, 74, 0.95), rgba(8, 17, 22, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-selected-mark {
+  position: absolute !important;
+  top: 8px !important;
+  right: 8px !important;
+  z-index: 2 !important;
+  display: none !important;
+  width: 28px !important;
+  height: 28px !important;
+  border: 1px solid rgba(255, 220, 143, 0.82) !important;
+  border-radius: 999px !important;
+  background: linear-gradient(180deg, #bd7c10, #73500a) !important;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.42) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-selected-mark::before {
+  content: "" !important;
+  position: absolute !important;
+  left: 8px !important;
+  top: 5px !important;
+  width: 8px !important;
+  height: 14px !important;
+  border-right: 3px solid #fff6d8 !important;
+  border-bottom: 3px solid #fff6d8 !important;
+  transform: rotate(42deg) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile.is-selected .game-card-selected-mark {
+  display: block !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile strong {
+  align-self: end !important;
+  overflow-wrap: anywhere !important;
+  color: #f4f7fb !important;
+  font-size: 0.78rem !important;
+  line-height: 1.08 !important;
+  text-transform: uppercase !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile > span:last-child {
+  color: #f7efe2 !important;
+  font-size: 0.72rem !important;
+  font-weight: 900 !important;
+  line-height: 1.08 !important;
+  text-transform: uppercase !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-hand {
+  display: grid !important;
+  grid-template-rows: auto 1fr auto !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-help {
+  display: flex !important;
+  align-items: center !important;
+  gap: 10px !important;
+  margin: 14px 0 0 !important;
+  color: rgba(232, 241, 247, 0.82) !important;
+  font-size: 0.86rem !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-help::before {
+  content: "i" !important;
+  display: inline-grid !important;
+  place-items: center !important;
+  flex: 0 0 auto !important;
+  width: 22px !important;
+  height: 22px !important;
+  border: 1px solid rgba(232, 241, 247, 0.72) !important;
+  border-radius: 999px !important;
+  color: #e8f1f7 !important;
+  font-size: 0.72rem !important;
+  font-weight: 900 !important;
+}
+
+.game-command-dock-mandatory-trade .game-selected-card-row {
+  grid-template-columns: repeat(3, minmax(126px, 1fr)) !important;
+  align-items: stretch !important;
+  min-height: 158px !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-selection {
+  display: grid !important;
+  grid-template-rows: auto 1fr auto !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-selection .action-help {
+  align-self: center !important;
+  justify-self: start !important;
+  margin: 0 !important;
+  color: rgba(232, 241, 247, 0.66) !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-actions {
+  align-items: center !important;
+  margin-top: 14px !important;
+}
+
+.game-command-dock-mandatory-trade .game-command-secondary-action,
+.game-command-dock-mandatory-trade #card-trade-dock-button {
+  min-height: 54px !important;
+  border-radius: 7px !important;
+  font-size: 0.8rem !important;
+  font-weight: 950 !important;
+  letter-spacing: 0 !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-button {
+  background: linear-gradient(180deg, #d89519, #8b5a0f) !important;
+  color: #fff8df !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 232, 171, 0.35),
+    0 12px 24px rgba(166, 105, 11, 0.28) !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-button:disabled {
+  background: linear-gradient(180deg, rgba(139, 90, 15, 0.76), rgba(82, 58, 20, 0.76)) !important;
+  color: rgba(255, 248, 223, 0.56) !important;
+  box-shadow: none !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus {
+  gap: 10px !important;
+  padding-left: 28px !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus span {
+  color: var(--nr-gold) !important;
+  font-size: 0.72rem !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus strong {
+  font-size: 2.4rem !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus small,
+.game-command-dock-mandatory-trade .game-exchange-bonus p {
+  margin: 0 !important;
+  color: rgba(232, 241, 247, 0.8) !important;
+}
+
 @media (max-width: 1360px) {
   .game-map-first-page .game-map-stage,
   html[data-theme="war-table"] .game-map-first-page .game-map-stage {
@@ -5928,7 +6193,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   }
 
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     width: calc(100vw - 48px) !important;
     height: var(--game-command-dock-height) !important;
     min-height: var(--game-command-dock-height) !important;
@@ -6443,7 +6710,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   }
 
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     bottom: 18px !important;
     height: var(--game-command-dock-height) !important;
     min-height: var(--game-command-dock-height) !important;
@@ -6452,7 +6721,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   }
 
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     width: min(980px, calc(100vw - 260px)) !important;
   }
 
@@ -6556,7 +6827,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
 
 @media (min-width: 1181px) and (max-height: 700px) {
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     width: min(1348px, calc(100vw - 330px)) !important;
   }
 

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -7134,3 +7134,192 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
     column-gap: 16px !important;
   }
 }
+
+.game-command-dock .game-mandatory-trade-dock,
+.game-command-dock-mandatory-trade .game-mandatory-trade-dock,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-mandatory-trade-dock {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) clamp(150px, 14vw, 210px) !important;
+  gap: 28px !important;
+  align-items: stretch !important;
+  min-width: 0 !important;
+}
+
+.game-card-tray {
+  display: grid !important;
+  grid-template-rows: auto minmax(0, 1fr) auto !important;
+  min-width: 0 !important;
+  overflow: hidden !important;
+}
+
+.game-card-tray-header,
+.game-card-tray-footer {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 16px !important;
+  min-width: 0 !important;
+}
+
+.game-card-tray-header {
+  margin-bottom: 12px !important;
+}
+
+.game-card-tray-footer {
+  margin-top: 14px !important;
+}
+
+.game-card-tray .game-dock-field-label {
+  margin-bottom: 0 !important;
+}
+
+.game-dock-selection-label {
+  justify-content: flex-end !important;
+  text-align: right !important;
+}
+
+.game-card-tray-scroll {
+  min-width: 0 !important;
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+  overscroll-behavior-x: contain !important;
+  scrollbar-gutter: stable !important;
+  padding: 2px 4px 12px !important;
+}
+
+.game-card-tray-scroll::-webkit-scrollbar {
+  height: 12px;
+}
+
+.game-card-tray-scroll::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(151, 178, 194, 0.16);
+}
+
+.game-card-tray-scroll::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(232, 241, 247, 0.52);
+}
+
+.game-command-dock-mandatory-trade .game-card-row,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-card-row {
+  display: flex !important;
+  flex-flow: row nowrap !important;
+  align-items: stretch !important;
+  gap: 16px !important;
+  min-width: max-content !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-row .game-card-tile,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-card-row
+  .game-card-tile {
+  position: relative !important;
+  flex: 0 0 clamp(118px, 9.4vw, 150px) !important;
+  width: clamp(118px, 9.4vw, 150px) !important;
+  min-width: 0 !important;
+  max-width: none !important;
+}
+
+.game-command-dock-mandatory-trade,
+html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-trade {
+  overflow: hidden !important;
+}
+
+.game-card-tray #card-trade-dock-help {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+}
+
+.game-card-tray .game-trade-actions {
+  flex: 0 0 auto !important;
+  grid-template-columns: minmax(138px, auto) minmax(190px, auto) !important;
+  margin-top: 0 !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-exchange-bonus {
+  min-width: clamp(150px, 14vw, 210px) !important;
+  padding-left: 28px !important;
+}
+
+@media (max-width: 1180px) {
+  .game-command-dock .game-mandatory-trade-dock,
+  .game-command-dock-mandatory-trade .game-mandatory-trade-dock,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-mandatory-trade-dock {
+    grid-template-columns: minmax(0, 1fr) 156px !important;
+    gap: 18px !important;
+  }
+
+  .game-command-dock-mandatory-trade .game-card-row .game-card-tile,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-card-row
+    .game-card-tile {
+    flex-basis: 118px !important;
+    width: 118px !important;
+  }
+}
+
+@media (max-width: 760px) {
+  .game-command-dock .game-mandatory-trade-dock,
+  .game-command-dock-mandatory-trade .game-mandatory-trade-dock,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-mandatory-trade-dock {
+    grid-template-columns: minmax(0, 1fr) 128px !important;
+    gap: 12px !important;
+  }
+
+  .game-card-tray-header,
+  .game-card-tray-footer {
+    align-items: stretch !important;
+    flex-direction: column !important;
+    gap: 10px !important;
+  }
+
+  .game-dock-selection-label {
+    justify-content: space-between !important;
+    text-align: left !important;
+  }
+
+  .game-command-dock-mandatory-trade .game-card-row .game-card-tile,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-card-row
+    .game-card-tile {
+    flex-basis: 104px !important;
+    width: 104px !important;
+  }
+
+  .game-card-tray .game-trade-actions {
+    grid-template-columns: 1fr !important;
+    width: 100% !important;
+  }
+
+  .game-command-dock-mandatory-trade .game-exchange-bonus,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-exchange-bonus {
+    min-width: 128px !important;
+    padding-left: 12px !important;
+  }
+}

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -5873,13 +5873,13 @@ html[data-theme="war-table"]
 html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-trade {
   bottom: 32px !important;
   width: min(1490px, calc(100vw - 190px)) !important;
-  min-height: 260px !important;
+  min-height: 292px !important;
   max-height: none !important;
   padding: 20px 28px !important;
 }
 
 .game-command-dock-mandatory-trade .game-mandatory-trade-dock {
-  min-height: 218px !important;
+  min-height: 250px !important;
 }
 
 .game-command-dock-mandatory-trade .game-card-tile {
@@ -5912,6 +5912,271 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
 
 .game-command-dock .game-card-tile {
   min-height: 108px !important;
+}
+
+.game-command-dock-mandatory-trade .game-dock-field-label {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 12px !important;
+  margin-bottom: 12px !important;
+  color: var(--nr-gold) !important;
+}
+
+.game-command-dock-mandatory-trade .game-dock-label-badge,
+.game-command-dock-mandatory-trade .game-dock-field-label span {
+  display: inline-grid !important;
+  place-items: center !important;
+  min-width: 30px !important;
+  height: 26px !important;
+  padding: 0 8px !important;
+  border: 1px solid rgba(151, 178, 194, 0.32) !important;
+  border-radius: 7px !important;
+  background: rgba(8, 20, 31, 0.9) !important;
+  color: #eef5f8 !important;
+  font-size: 0.68rem !important;
+  font-weight: 900 !important;
+  text-transform: none !important;
+}
+
+.game-command-dock-mandatory-trade .game-dock-label-badge {
+  border-color: rgba(87, 190, 99, 0.48) !important;
+  background: rgba(20, 64, 37, 0.82) !important;
+  color: #b9ffb6 !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-grid {
+  grid-template-columns: repeat(5, minmax(118px, 1fr)) !important;
+  gap: 14px !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile {
+  align-content: stretch !important;
+  grid-template-rows: minmax(78px, 1fr) auto auto !important;
+  gap: 7px !important;
+  min-height: 158px !important;
+  padding: 8px 10px 10px !important;
+  overflow: hidden !important;
+  border-color: rgba(178, 202, 218, 0.5) !important;
+  border-radius: 7px !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 14px 24px rgba(0, 0, 0, 0.28) !important;
+  text-align: center !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile.is-selected {
+  border-color: var(--nr-gold) !important;
+  box-shadow:
+    0 0 0 1px rgba(246, 181, 21, 0.48),
+    0 0 24px rgba(246, 181, 21, 0.22),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-visual {
+  position: relative !important;
+  display: grid !important;
+  place-items: end center !important;
+  min-height: 78px !important;
+  border-radius: 5px !important;
+  overflow: hidden !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-silhouette {
+  position: relative !important;
+  z-index: 1 !important;
+  display: grid !important;
+  place-items: center !important;
+  width: 38px !important;
+  height: 58px !important;
+  margin-bottom: 8px !important;
+  border-radius: 20px 20px 8px 8px !important;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(0, 0, 0, 0.34)) !important;
+  color: rgba(255, 236, 200, 0.92) !important;
+  font-size: 1.05rem !important;
+  font-weight: 950 !important;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.7) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-territory-shape {
+  position: absolute !important;
+  right: 12px !important;
+  bottom: 13px !important;
+  width: 56px !important;
+  height: 34px !important;
+  border-radius: 52% 39% 48% 34% !important;
+  background: currentColor !important;
+  opacity: 0.6 !important;
+  transform: rotate(-9deg) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-infantry .game-card-visual {
+  color: #8f5cff !important;
+  background:
+    radial-gradient(circle at 44% 35%, rgba(151, 98, 255, 0.52), transparent 48%),
+    linear-gradient(180deg, rgba(39, 28, 66, 0.94), rgba(15, 14, 31, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-artillery .game-card-visual {
+  color: #ff7a26 !important;
+  background:
+    radial-gradient(circle at 50% 38%, rgba(255, 122, 38, 0.5), transparent 46%),
+    linear-gradient(180deg, rgba(56, 27, 16, 0.95), rgba(18, 12, 13, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-cavalry .game-card-visual {
+  color: #a5d85b !important;
+  background:
+    radial-gradient(circle at 48% 36%, rgba(165, 216, 91, 0.48), transparent 47%),
+    linear-gradient(180deg, rgba(34, 56, 22, 0.95), rgba(11, 17, 12, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tone-wild .game-card-visual {
+  color: #43d8ee !important;
+  background:
+    radial-gradient(circle at 48% 38%, rgba(67, 216, 238, 0.5), transparent 48%),
+    linear-gradient(180deg, rgba(13, 62, 74, 0.95), rgba(8, 17, 22, 0.98)) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-selected-mark {
+  position: absolute !important;
+  top: 8px !important;
+  right: 8px !important;
+  z-index: 2 !important;
+  display: none !important;
+  width: 28px !important;
+  height: 28px !important;
+  border: 1px solid rgba(255, 220, 143, 0.82) !important;
+  border-radius: 999px !important;
+  background: linear-gradient(180deg, #bd7c10, #73500a) !important;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.42) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-selected-mark::before {
+  content: "" !important;
+  position: absolute !important;
+  left: 8px !important;
+  top: 5px !important;
+  width: 8px !important;
+  height: 14px !important;
+  border-right: 3px solid #fff6d8 !important;
+  border-bottom: 3px solid #fff6d8 !important;
+  transform: rotate(42deg) !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile.is-selected .game-card-selected-mark {
+  display: block !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile strong {
+  align-self: end !important;
+  overflow-wrap: anywhere !important;
+  color: #f4f7fb !important;
+  font-size: 0.78rem !important;
+  line-height: 1.08 !important;
+  text-transform: uppercase !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-tile > span:last-child {
+  color: #f7efe2 !important;
+  font-size: 0.72rem !important;
+  font-weight: 900 !important;
+  line-height: 1.08 !important;
+  text-transform: uppercase !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-hand {
+  display: grid !important;
+  grid-template-rows: auto 1fr auto !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-help {
+  display: flex !important;
+  align-items: center !important;
+  gap: 10px !important;
+  margin: 14px 0 0 !important;
+  color: rgba(232, 241, 247, 0.82) !important;
+  font-size: 0.86rem !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-help::before {
+  content: "i" !important;
+  display: inline-grid !important;
+  place-items: center !important;
+  flex: 0 0 auto !important;
+  width: 22px !important;
+  height: 22px !important;
+  border: 1px solid rgba(232, 241, 247, 0.72) !important;
+  border-radius: 999px !important;
+  color: #e8f1f7 !important;
+  font-size: 0.72rem !important;
+  font-weight: 900 !important;
+}
+
+.game-command-dock-mandatory-trade .game-selected-card-row {
+  grid-template-columns: repeat(3, minmax(126px, 1fr)) !important;
+  align-items: stretch !important;
+  min-height: 158px !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-selection {
+  display: grid !important;
+  grid-template-rows: auto 1fr auto !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-selection .action-help {
+  align-self: center !important;
+  justify-self: start !important;
+  margin: 0 !important;
+  color: rgba(232, 241, 247, 0.66) !important;
+}
+
+.game-command-dock-mandatory-trade .game-trade-actions {
+  align-items: center !important;
+  margin-top: 14px !important;
+}
+
+.game-command-dock-mandatory-trade .game-command-secondary-action,
+.game-command-dock-mandatory-trade #card-trade-dock-button {
+  min-height: 54px !important;
+  border-radius: 7px !important;
+  font-size: 0.8rem !important;
+  font-weight: 950 !important;
+  letter-spacing: 0 !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-button {
+  background: linear-gradient(180deg, #d89519, #8b5a0f) !important;
+  color: #fff8df !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 232, 171, 0.35),
+    0 12px 24px rgba(166, 105, 11, 0.28) !important;
+}
+
+.game-command-dock-mandatory-trade #card-trade-dock-button:disabled {
+  background: linear-gradient(180deg, rgba(139, 90, 15, 0.76), rgba(82, 58, 20, 0.76)) !important;
+  color: rgba(255, 248, 223, 0.56) !important;
+  box-shadow: none !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus {
+  gap: 10px !important;
+  padding-left: 28px !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus span {
+  color: var(--nr-gold) !important;
+  font-size: 0.72rem !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus strong {
+  font-size: 2.4rem !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus small,
+.game-command-dock-mandatory-trade .game-exchange-bonus p {
+  margin: 0 !important;
+  color: rgba(232, 241, 247, 0.8) !important;
 }
 
 @media (max-width: 1360px) {
@@ -7505,5 +7770,194 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   .game-players-head,
   .game-player-row {
     grid-template-columns: minmax(0, 1fr) 56px 74px !important;
+  }
+}
+
+.game-command-dock .game-mandatory-trade-dock,
+.game-command-dock-mandatory-trade .game-mandatory-trade-dock,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-mandatory-trade-dock {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) clamp(150px, 14vw, 210px) !important;
+  gap: 28px !important;
+  align-items: stretch !important;
+  min-width: 0 !important;
+}
+
+.game-card-tray {
+  display: grid !important;
+  grid-template-rows: auto minmax(0, 1fr) auto !important;
+  min-width: 0 !important;
+  overflow: hidden !important;
+}
+
+.game-card-tray-header,
+.game-card-tray-footer {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 16px !important;
+  min-width: 0 !important;
+}
+
+.game-card-tray-header {
+  margin-bottom: 12px !important;
+}
+
+.game-card-tray-footer {
+  margin-top: 14px !important;
+}
+
+.game-card-tray .game-dock-field-label {
+  margin-bottom: 0 !important;
+}
+
+.game-dock-selection-label {
+  justify-content: flex-end !important;
+  text-align: right !important;
+}
+
+.game-card-tray-scroll {
+  min-width: 0 !important;
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+  overscroll-behavior-x: contain !important;
+  scrollbar-gutter: stable !important;
+  padding: 2px 4px 12px !important;
+}
+
+.game-card-tray-scroll::-webkit-scrollbar {
+  height: 12px;
+}
+
+.game-card-tray-scroll::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(151, 178, 194, 0.16);
+}
+
+.game-card-tray-scroll::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(232, 241, 247, 0.52);
+}
+
+.game-command-dock-mandatory-trade .game-card-row,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-card-row {
+  display: flex !important;
+  flex-flow: row nowrap !important;
+  align-items: stretch !important;
+  gap: 16px !important;
+  min-width: max-content !important;
+}
+
+.game-command-dock-mandatory-trade .game-card-row .game-card-tile,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-card-row
+  .game-card-tile {
+  position: relative !important;
+  flex: 0 0 clamp(118px, 9.4vw, 150px) !important;
+  width: clamp(118px, 9.4vw, 150px) !important;
+  min-width: 0 !important;
+  max-width: none !important;
+}
+
+.game-command-dock-mandatory-trade,
+html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-trade {
+  overflow: hidden !important;
+}
+
+.game-card-tray #card-trade-dock-help {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+}
+
+.game-card-tray .game-trade-actions {
+  flex: 0 0 auto !important;
+  grid-template-columns: minmax(138px, auto) minmax(190px, auto) !important;
+  margin-top: 0 !important;
+}
+
+.game-command-dock-mandatory-trade .game-exchange-bonus,
+html[data-theme="war-table"]
+  .game-map-first-page
+  .game-command-dock-mandatory-trade
+  .game-exchange-bonus {
+  min-width: clamp(150px, 14vw, 210px) !important;
+  padding-left: 28px !important;
+}
+
+@media (max-width: 1180px) {
+  .game-command-dock .game-mandatory-trade-dock,
+  .game-command-dock-mandatory-trade .game-mandatory-trade-dock,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-mandatory-trade-dock {
+    grid-template-columns: minmax(0, 1fr) 156px !important;
+    gap: 18px !important;
+  }
+
+  .game-command-dock-mandatory-trade .game-card-row .game-card-tile,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-card-row
+    .game-card-tile {
+    flex-basis: 118px !important;
+    width: 118px !important;
+  }
+}
+
+@media (max-width: 760px) {
+  .game-command-dock .game-mandatory-trade-dock,
+  .game-command-dock-mandatory-trade .game-mandatory-trade-dock,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-mandatory-trade-dock {
+    grid-template-columns: minmax(0, 1fr) 128px !important;
+    gap: 12px !important;
+  }
+
+  .game-card-tray-header,
+  .game-card-tray-footer {
+    align-items: stretch !important;
+    flex-direction: column !important;
+    gap: 10px !important;
+  }
+
+  .game-dock-selection-label {
+    justify-content: space-between !important;
+    text-align: left !important;
+  }
+
+  .game-command-dock-mandatory-trade .game-card-row .game-card-tile,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-card-row
+    .game-card-tile {
+    flex-basis: 104px !important;
+    width: 104px !important;
+  }
+
+  .game-card-tray .game-trade-actions {
+    grid-template-columns: 1fr !important;
+    width: 100% !important;
+  }
+
+  .game-command-dock-mandatory-trade .game-exchange-bonus,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock-mandatory-trade
+    .game-exchange-bonus {
+    min-width: 128px !important;
+    padding-left: 12px !important;
   }
 }

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -120,6 +120,38 @@ function cardTypeLabel(card: SnapshotCard): string {
   return t("game.runtime.cardType.default");
 }
 
+function dockCardTone(card: SnapshotCard | undefined): string {
+  if (card?.type === "artillery") {
+    return "artillery";
+  }
+
+  if (card?.type === "cavalry") {
+    return "cavalry";
+  }
+
+  if (card?.type === "wild") {
+    return "wild";
+  }
+
+  return "infantry";
+}
+
+function dockCardSymbol(card: SnapshotCard | undefined): string {
+  if (card?.type === "artillery") {
+    return "C";
+  }
+
+  if (card?.type === "cavalry") {
+    return "H";
+  }
+
+  if (card?.type === "wild") {
+    return "*";
+  }
+
+  return "I";
+}
+
 function logEntryMessageKey(entry: unknown): string {
   if (!entry || typeof entry !== "object") {
     return "";
@@ -1079,7 +1111,7 @@ export function GameRoute() {
               />
             ) : null}
 
-            {activeDrawer === "cards" ? (
+            {activeDrawer === "cards" && !mustTradeCards ? (
               <CardsDrawer
                 canTradeCards={canTradeCards}
                 cardState={snapshot.cardState || null}
@@ -1158,16 +1190,25 @@ export function GameRoute() {
           {mustTradeCards ? (
             <div className="game-mandatory-trade-dock" id="card-trade-dock-group">
               <section className="game-trade-hand">
-                <div className="game-dock-field-label">{t("game.commandDock.yourCards")}</div>
+                <div className="game-dock-field-label">
+                  {t("game.commandDock.yourCards")}
+                  <span className="game-dock-label-badge">{playerHand.length}</span>
+                </div>
                 <div id="card-trade-dock-list" className="game-card-grid">
                   {playerHand.map((card) => (
                     <button
                       key={card.id}
                       type="button"
-                      className={`game-card-tile${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
+                      className={`game-card-tile game-card-tone-${dockCardTone(card)}${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
                       data-dock-card-id={card.id}
+                      aria-pressed={selectedTradeCardIds.includes(card.id)}
                       onClick={() => toggleTradeCard(card.id)}
                     >
+                      <span className="game-card-selected-mark" aria-hidden="true" />
+                      <span className="game-card-visual" aria-hidden="true">
+                        <span className="game-card-silhouette">{dockCardSymbol(card)}</span>
+                        <span className="game-card-territory-shape" />
+                      </span>
                       <strong>{card.territoryId || card.id}</strong>
                       <span>{cardTypeLabel(card)}</span>
                     </button>
@@ -1192,9 +1233,15 @@ export function GameRoute() {
                         <button
                           key={cardId}
                           type="button"
-                          className="game-card-tile is-selected"
+                          className={`game-card-tile game-card-tone-${dockCardTone(card)} is-selected`}
+                          aria-pressed="true"
                           onClick={() => toggleTradeCard(cardId)}
                         >
+                          <span className="game-card-selected-mark" aria-hidden="true" />
+                          <span className="game-card-visual" aria-hidden="true">
+                            <span className="game-card-silhouette">{dockCardSymbol(card)}</span>
+                            <span className="game-card-territory-shape" />
+                          </span>
                           <strong>{card?.territoryId || cardId}</strong>
                           <span>{card ? cardTypeLabel(card) : t("game.actions.cards")}</span>
                         </button>

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -1189,87 +1189,77 @@ export function GameRoute() {
         >
           {mustTradeCards ? (
             <div className="game-mandatory-trade-dock" id="card-trade-dock-group">
-              <section className="game-trade-hand">
-                <div className="game-dock-field-label">
-                  {t("game.commandDock.yourCards")}
-                  <span className="game-dock-label-badge">{playerHand.length}</span>
+              <section
+                className="game-card-tray"
+                aria-labelledby="card-trade-dock-heading"
+                aria-describedby="card-trade-dock-help"
+              >
+                <div className="game-card-tray-header">
+                  <div className="game-dock-field-label" id="card-trade-dock-heading">
+                    {t("game.commandDock.yourCards")}
+                    <span className="game-dock-label-badge">{playerHand.length}</span>
+                  </div>
+                  <div className="game-dock-field-label game-dock-selection-label">
+                    {t("game.commandDock.selectCardsToTrade")}
+                    <span>
+                      {t("game.commandDock.cardsSelected", {
+                        selected: selectedTradeCardIds.length
+                      })}
+                    </span>
+                  </div>
                 </div>
-                <div id="card-trade-dock-list" className="game-card-grid">
-                  {playerHand.map((card) => (
+                <div className="game-card-tray-scroll">
+                  <div
+                    id="card-trade-dock-list"
+                    className="game-card-row"
+                    data-card-count={playerHand.length}
+                  >
+                    {playerHand.map((card) => (
+                      <button
+                        key={card.id}
+                        type="button"
+                        className={`game-card-tile game-card-tone-${dockCardTone(card)}${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
+                        data-dock-card-id={card.id}
+                        aria-pressed={selectedTradeCardIds.includes(card.id)}
+                        onClick={() => toggleTradeCard(card.id)}
+                      >
+                        <span className="game-card-selected-mark" aria-hidden="true" />
+                        <span className="game-card-visual" aria-hidden="true">
+                          <span className="game-card-silhouette">{dockCardSymbol(card)}</span>
+                          <span className="game-card-territory-shape" />
+                        </span>
+                        <strong>{card.territoryId || card.id}</strong>
+                        <span>{cardTypeLabel(card)}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="game-card-tray-footer">
+                  <p id="card-trade-dock-help">
+                    {selectedTradeCardIds.length
+                      ? t("game.commandDock.mustTradeToContinue")
+                      : t("game.commandDock.chooseThreeCards")}
+                  </p>
+                  <div className="game-trade-actions">
                     <button
-                      key={card.id}
                       type="button"
-                      className={`game-card-tile game-card-tone-${dockCardTone(card)}${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
-                      data-dock-card-id={card.id}
-                      aria-pressed={selectedTradeCardIds.includes(card.id)}
-                      onClick={() => toggleTradeCard(card.id)}
+                      className="game-command-secondary-action"
+                      onClick={() => setSelectedTradeCardIds([])}
+                      disabled={!selectedTradeCardIds.length || actionPending}
                     >
-                      <span className="game-card-selected-mark" aria-hidden="true" />
-                      <span className="game-card-visual" aria-hidden="true">
-                        <span className="game-card-silhouette">{dockCardSymbol(card)}</span>
-                        <span className="game-card-territory-shape" />
-                      </span>
-                      <strong>{card.territoryId || card.id}</strong>
-                      <span>{cardTypeLabel(card)}</span>
+                      {t("game.commandDock.clearSelection")}
                     </button>
-                  ))}
-                </div>
-                <p id="card-trade-dock-help">{t("game.commandDock.mustTradeToContinue")}</p>
-              </section>
-              <section className="game-trade-selection">
-                <div className="game-dock-field-label">
-                  {t("game.commandDock.selectCardsToTrade")}
-                  <span>
-                    {t("game.commandDock.cardsSelected", {
-                      selected: selectedTradeCardIds.length
-                    })}
-                  </span>
-                </div>
-                <div className="game-selected-card-row">
-                  {selectedTradeCardIds.length ? (
-                    selectedTradeCardIds.map((cardId) => {
-                      const card = playerHand.find((entry) => entry.id === cardId);
-                      return (
-                        <button
-                          key={cardId}
-                          type="button"
-                          className={`game-card-tile game-card-tone-${dockCardTone(card)} is-selected`}
-                          aria-pressed="true"
-                          onClick={() => toggleTradeCard(cardId)}
-                        >
-                          <span className="game-card-selected-mark" aria-hidden="true" />
-                          <span className="game-card-visual" aria-hidden="true">
-                            <span className="game-card-silhouette">{dockCardSymbol(card)}</span>
-                            <span className="game-card-territory-shape" />
-                          </span>
-                          <strong>{card?.territoryId || cardId}</strong>
-                          <span>{card ? cardTypeLabel(card) : t("game.actions.cards")}</span>
-                        </button>
-                      );
-                    })
-                  ) : (
-                    <p className="action-help">{t("game.commandDock.chooseThreeCards")}</p>
-                  )}
-                </div>
-                <div className="game-trade-actions">
-                  <button
-                    type="button"
-                    className="game-command-secondary-action"
-                    onClick={() => setSelectedTradeCardIds([])}
-                    disabled={!selectedTradeCardIds.length || actionPending}
-                  >
-                    {t("game.commandDock.clearSelection")}
-                  </button>
-                  <button
-                    id="card-trade-dock-button"
-                    type="button"
-                    onClick={() => void handleTradeCards()}
-                    disabled={!canTradeCards}
-                  >
-                    {gameplayCommands.isTrading
-                      ? t("game.commandDock.trading")
-                      : t("game.commandDock.tradeCards")}
-                  </button>
+                    <button
+                      id="card-trade-dock-button"
+                      type="button"
+                      onClick={() => void handleTradeCards()}
+                      disabled={!canTradeCards}
+                    >
+                      {gameplayCommands.isTrading
+                        ? t("game.commandDock.trading")
+                        : t("game.commandDock.tradeCards")}
+                    </button>
+                  </div>
                 </div>
               </section>
               <aside className="game-exchange-bonus">

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -132,6 +132,38 @@ function cardTypeLabel(card: SnapshotCard): string {
   return t("game.runtime.cardType.default");
 }
 
+function dockCardTone(card: SnapshotCard | undefined): string {
+  if (card?.type === "artillery") {
+    return "artillery";
+  }
+
+  if (card?.type === "cavalry") {
+    return "cavalry";
+  }
+
+  if (card?.type === "wild") {
+    return "wild";
+  }
+
+  return "infantry";
+}
+
+function dockCardSymbol(card: SnapshotCard | undefined): string {
+  if (card?.type === "artillery") {
+    return "C";
+  }
+
+  if (card?.type === "cavalry") {
+    return "H";
+  }
+
+  if (card?.type === "wild") {
+    return "*";
+  }
+
+  return "I";
+}
+
 function logEntryMessageKey(entry: unknown): string {
   if (!entry || typeof entry !== "object") {
     return "";
@@ -1166,7 +1198,7 @@ export function GameRoute() {
               />
             ) : null}
 
-            {activeDrawer === "cards" ? (
+            {activeDrawer === "cards" && !mustTradeCards ? (
               <CardsDrawer
                 canTradeCards={canTradeCards}
                 cardState={snapshot.cardState || null}
@@ -1247,72 +1279,77 @@ export function GameRoute() {
         >
           {mustTradeCards ? (
             <div className="game-mandatory-trade-dock" id="card-trade-dock-group">
-              <section className="game-trade-hand">
-                <div className="game-dock-field-label">{t("game.commandDock.yourCards")}</div>
-                <div id="card-trade-dock-list" className="game-card-grid">
-                  {playerHand.map((card) => (
+              <section
+                className="game-card-tray"
+                aria-labelledby="card-trade-dock-heading"
+                aria-describedby="card-trade-dock-help"
+              >
+                <div className="game-card-tray-header">
+                  <div className="game-dock-field-label" id="card-trade-dock-heading">
+                    {t("game.commandDock.yourCards")}
+                    <span className="game-dock-label-badge">{playerHand.length}</span>
+                  </div>
+                  <div className="game-dock-field-label game-dock-selection-label">
+                    {t("game.commandDock.selectCardsToTrade")}
+                    <span>
+                      {t("game.commandDock.cardsSelected", {
+                        selected: selectedTradeCardIds.length
+                      })}
+                    </span>
+                  </div>
+                </div>
+                <div className="game-card-tray-scroll">
+                  <div
+                    id="card-trade-dock-list"
+                    className="game-card-row"
+                    data-card-count={playerHand.length}
+                  >
+                    {playerHand.map((card) => (
+                      <button
+                        key={card.id}
+                        type="button"
+                        className={`game-card-tile game-card-tone-${dockCardTone(card)}${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
+                        data-dock-card-id={card.id}
+                        aria-pressed={selectedTradeCardIds.includes(card.id)}
+                        onClick={() => toggleTradeCard(card.id)}
+                      >
+                        <span className="game-card-selected-mark" aria-hidden="true" />
+                        <span className="game-card-visual" aria-hidden="true">
+                          <span className="game-card-silhouette">{dockCardSymbol(card)}</span>
+                          <span className="game-card-territory-shape" />
+                        </span>
+                        <strong>{card.territoryId || card.id}</strong>
+                        <span>{cardTypeLabel(card)}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="game-card-tray-footer">
+                  <p id="card-trade-dock-help">
+                    {selectedTradeCardIds.length
+                      ? t("game.commandDock.mustTradeToContinue")
+                      : t("game.commandDock.chooseThreeCards")}
+                  </p>
+                  <div className="game-trade-actions">
                     <button
-                      key={card.id}
                       type="button"
-                      className={`game-card-tile${selectedTradeCardIds.includes(card.id) ? " is-selected" : ""}`}
-                      data-dock-card-id={card.id}
-                      onClick={() => toggleTradeCard(card.id)}
+                      className="game-command-secondary-action"
+                      onClick={() => setSelectedTradeCardIds([])}
+                      disabled={!selectedTradeCardIds.length || actionPending}
                     >
-                      <strong>{card.territoryId || card.id}</strong>
-                      <span>{cardTypeLabel(card)}</span>
+                      {t("game.commandDock.clearSelection")}
                     </button>
-                  ))}
-                </div>
-                <p id="card-trade-dock-help">{t("game.commandDock.mustTradeToContinue")}</p>
-              </section>
-              <section className="game-trade-selection">
-                <div className="game-dock-field-label">
-                  {t("game.commandDock.selectCardsToTrade")}
-                  <span>
-                    {t("game.commandDock.cardsSelected", {
-                      selected: selectedTradeCardIds.length
-                    })}
-                  </span>
-                </div>
-                <div className="game-selected-card-row">
-                  {selectedTradeCardIds.length ? (
-                    selectedTradeCardIds.map((cardId) => {
-                      const card = playerHand.find((entry) => entry.id === cardId);
-                      return (
-                        <button
-                          key={cardId}
-                          type="button"
-                          className="game-card-tile is-selected"
-                          onClick={() => toggleTradeCard(cardId)}
-                        >
-                          <strong>{card?.territoryId || cardId}</strong>
-                          <span>{card ? cardTypeLabel(card) : t("game.actions.cards")}</span>
-                        </button>
-                      );
-                    })
-                  ) : (
-                    <p className="action-help">{t("game.commandDock.chooseThreeCards")}</p>
-                  )}
-                </div>
-                <div className="game-trade-actions">
-                  <button
-                    type="button"
-                    className="game-command-secondary-action"
-                    onClick={() => setSelectedTradeCardIds([])}
-                    disabled={!selectedTradeCardIds.length || actionPending}
-                  >
-                    {t("game.commandDock.clearSelection")}
-                  </button>
-                  <button
-                    id="card-trade-dock-button"
-                    type="button"
-                    onClick={() => void handleTradeCards()}
-                    disabled={!canTradeCards}
-                  >
-                    {gameplayCommands.isTrading
-                      ? t("game.commandDock.trading")
-                      : t("game.commandDock.tradeCards")}
-                  </button>
+                    <button
+                      id="card-trade-dock-button"
+                      type="button"
+                      onClick={() => void handleTradeCards()}
+                      disabled={!canTradeCards}
+                    >
+                      {gameplayCommands.isTrading
+                        ? t("game.commandDock.trading")
+                        : t("game.commandDock.tradeCards")}
+                    </button>
+                  </div>
                 </div>
               </section>
               <aside className="game-exchange-bonus">

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -975,7 +975,7 @@ register("health route usa 503 quando lo snapshot segnala errore", async () => {
 
 register("version registry espone manifest e compatibilita baseline", () => {
   const expectedManifest = {
-    appVersion: "0.1.005",
+    appVersion: "0.1.006",
     engineVersion: "1.0.0",
     apiVersion: "1.0.0",
     datastoreSchemaVersion: 1,

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.005";
+export const appVersion = "0.1.006";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.037";
+export const appVersion = "0.1.038";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- Polish the mandatory card trade dock into a larger bottom-panel layout with a focused tray for selected cards.
- Improve forced-trade card selection states, dock affordances, and responsive tray behavior.
- Extend React integration and Playwright coverage around mandatory card trade interactions.
- Bump the app release manifest to 0.1.038 and update the changelog.

## Validation
- `npm run typecheck:react-shell`
- `npm run test:react -- frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm run lint`
- `npm run format:check`

## Local E2E note
- `npm exec --yes --package node@22 -- node node_modules/.bin/playwright test e2e/smoke/react-shell-gameplay.spec.ts -g "forced trade"` could not complete locally because Chromium system dependencies are missing (`libnspr4.so` and related native packages). `npx playwright install-deps chromium` was attempted, but this environment requires an interactive sudo password, so browser E2E is left to CI.