### PR TITLE
Add functional module version compatibility registry

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -35,6 +37,9 @@ jobs:
 
       - name: Run build
         run: npm run build:ts
+
+      - name: Run module versioning check
+        run: node .tsbuild/scripts/check-module-versioning.cjs
 
       - name: Run lint
         run: npm run lint

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,14 +155,29 @@ Categorie modulo gia impostate:
 - temi sito
 - set pedine / palette giocatori
 - skin pedine
-- ruleset dadi
-- ruleset carte
-- ruleset vittoria
-- ruleset setup / preset partita
 - mappe
 - content pack
+- ruleset dadi
+- ruleset carte
+- ruleset combattimento
+- ruleset rinforzo
+- ruleset fortifica
+- ruleset vittoria
+- timeout turno
+- ruleset setup / preset partita
 - profili content/gameplay/ui
 - slot UI
+- runtime moduli
+- moduli admin/autoriali
+- datastore
+- stato pubblico/API read model
+- AI players
+
+Le versioni SemVer di questi moduli funzionali e le loro regole di compatibilita sono dichiarate
+in `shared/module-versions.cts`. Le compatibilita sono machine-readable e collegano ogni modulo a
+versione app, schema salvataggio, schema datastore, module API e dipendenze fra moduli. I manifest
+runtime `module.json` restano metadata locali per discovery/installazione, ma per i moduli
+first-party devono restare allineati alla versione centrale.
 
 Categorie future da trattare con lo stesso modello:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.006 - 2026-05-06
+
+- Added central functional module versioning, compatibility validation, and CI bump protection for module-owned changes.
+
 ## 0.1.005 - 2026-05-06
 
 - Updated the npm dependency group for runtime, testing, and lint tooling packages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,14 +107,29 @@ Default product content belongs in shared registries plus `shared/core-base-cata
 
 1. Create a folder under `modules/<module-id>`.
 2. Add `module.json` with id, version, capabilities, dependencies, and entrypoints. Optional runtime modules should normally depend on `core.base`.
-3. Add `client-manifest.json` for UI slots, profiles, presets, and client-visible content declarations.
-4. Add a server entrypoint only when the module contributes runtime maps, content packs, piece sets, dice rule sets, or server-side profile defaults.
-5. Verify the module through `/api/modules/options` and `/api/game/options`, treating `resolvedCatalog` as the canonical snapshot and the flat top-level arrays as compatibility mirrors.
-6. Verify rescan/enable/disable flows, including the case where a module is still referenced by an active game.
-7. Confirm the module does not expose `core.base` as a toggleable setup/admin option.
-8. Add or extend regression coverage in `tests/gameplay/regression/module-runtime.test.cts`.
+3. If the module is first-party or changes a first-party functional capability, update `shared/module-versions.cts` with its SemVer version, compatibility declaration, and owner paths.
+4. Add `client-manifest.json` for UI slots, profiles, presets, and client-visible content declarations.
+5. Add a server entrypoint only when the module contributes runtime maps, content packs, piece sets, dice rule sets, or server-side profile defaults.
+6. Verify the module through `/api/modules/options` and `/api/game/options`, treating `resolvedCatalog` as the canonical snapshot and the flat top-level arrays as compatibility mirrors.
+7. Verify rescan/enable/disable flows, including the case where a module is still referenced by an active game.
+8. Confirm the module does not expose `core.base` as a toggleable setup/admin option.
+9. Add or extend regression coverage in `tests/gameplay/regression/module-runtime.test.cts`.
 
 Use the existing `modules/demo.command-center` fixture as the baseline shape for manifests and slot declarations.
+
+## Updating functional module versions
+
+Functional module versions and compatibility live in `shared/module-versions.cts`.
+
+When touching a module-owned path, bump the affected module:
+
+- PATCH for internal fixes that preserve behavior, APIs, saved-state compatibility, and module interoperability.
+- MINOR for backward-compatible additions or optional behavior extensions.
+- MAJOR for breaking behavior, saved-state incompatibility, public API/schema changes, or required migrations.
+
+Update the module's compatibility declaration when the supported app version range, save-game schema range, datastore schema range, module API range, or dependent module range changes.
+
+Run `npm run check:module-versioning` before opening a PR when module-owned files changed. The check is path-based, so broad shared files may need manual judgement and more than one module bump.
 
 ## Adding authored Content Studio modules
 
@@ -145,6 +160,7 @@ A good PR for NetRisk is narrow, tested, and explicit about touched boundaries.
 
 - Summarize what changed and why.
 - Bump `appVersion` in `shared/version-manifest.cts` using the long patch format, for example `0.1.001`.
+- Bump any affected functional module versions in `shared/module-versions.cts`.
 - Add a matching `CHANGELOG.md` entry with a short report of the change.
 - List any public API or docs updates.
 - Mention the validation commands you ran.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ NetRisk now treats the default experience as a baseline module platform rather t
 
 For admins, this means a module can now change maps, rule sets, themes, piece skins, presets, profiles, and supported UI slots through normal module enable/disable flows, without requiring dedicated frontend or route logic for each module.
 
+Functional module versions and compatibility are centralized in `shared/module-versions.cts`.
+Run `npm run check:module-versioning` to validate the registry and, when a git base ref is
+available, detect module-owned file changes that did not bump the affected module version.
+
 ## Quick Start
 
 Prerequisites:

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -26,3 +26,66 @@ Every PR that targets `main` must include:
 If a change affects save games, API responses, datastore shape, module manifests, or module compatibility, update the corresponding central compatibility fields in `shared/version-manifest.cts` and call the compatibility impact out in the changelog entry.
 
 The release gate runs in CI and fails when the version does not move forward or the changelog report is missing.
+
+## Functional Module Versions
+
+Functional module versions live in `shared/module-versions.cts`.
+
+A functional module is a maintained game capability or platform surface that can affect setup,
+runtime behavior, saved state compatibility, admin workflows, or public contracts. The current
+registry is derived from the existing codebase and includes runtime packages such as `core.base`
+and `demo.command-center`, content catalogs such as `maps`, `content-packs`, `site-themes`,
+`player-piece-sets`, and `piece-skins`, rule families such as `dice-rule-sets`,
+`card-rule-sets`, `combat-rule-sets`, `reinforcement-rule-sets`, `fortify-rule-sets`, and
+`victory-rule-sets`, plus platform/admin surfaces such as `setup-flow`, `module-runtime`,
+`authored-victory-objectives`, `admin-console`, `datastore`, `public-state`, `turn-timeouts`,
+and `ai-players`.
+
+Each entry defines:
+
+- `id`: stable module id used by compatibility declarations
+- `version`: SemVer-style `MAJOR.MINOR.PATCH`
+- `ownerPaths`: repo paths used by the first-pass version bump detector
+- `description` and `kind`: human-readable context for contributors, Codex, CI, and future admin UI
+
+Runtime modules still keep their `module.json` version because module discovery needs package-local
+metadata. For first-party runtime modules, `scripts/check-module-versioning.cts` verifies that
+`module.json` matches the central version in `shared/module-versions.cts`.
+
+## Module Bump Rules
+
+Use standard SemVer for functional module versions:
+
+- PATCH: internal fixes that do not change public behavior, transport shape, saved-state compatibility, or module interoperability.
+- MINOR: backward-compatible feature additions, optional module behavior extensions, or additive admin/UI capabilities.
+- MAJOR: breaking behavior changes, saved-state incompatibility, public API/schema changes, required migrations, or compatibility changes that older consumers cannot use safely.
+
+If a change touches a module-owned path, bump that module in `shared/module-versions.cts`. If one
+change touches multiple module-owned paths, bump each affected module according to its impact.
+
+## Module Compatibility
+
+Compatibility declarations also live in `shared/module-versions.cts`. They are machine-readable and
+cover:
+
+- compatible app/site version range
+- compatible save-game schema range
+- compatible datastore schema range
+- compatible module API range
+- required dependent modules and accepted version ranges
+
+Use `checkModuleCompatibility(moduleId, version, environment)` to answer whether a module version
+is compatible with an app/save/datastore/module environment. Use `isModuleCompatibleWith(...)` for
+the common pair question: "is module X version A compatible with module Y version C?"
+
+`validateModuleVersionManifest()` and `scripts/check-module-versioning.cts` reject missing module
+compatibility declarations, invalid SemVer values, malformed or impossible ranges, and references
+to modules that do not exist.
+
+## Bump Detection Limitations
+
+The bump detector is intentionally practical rather than magical. It maps changed files to
+`ownerPaths` in `shared/module-versions.cts` and compares module versions with the configured git
+base ref. This catches normal code and content changes, but shared files that affect several
+capabilities may require manual judgement and multiple bumps. When in doubt, bump the module whose
+public behavior, saved state, admin workflow, or compatibility surface changed.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:frontend": "node .tsbuild/scripts/sync-shared-runtime-validation-frontend.cjs && tsc -p tsconfig.frontend.json --incremental false && node .tsbuild/scripts/sync-public-assets.cjs",
     "build:react-shell": "vite build --config frontend/react-shell/vite.config.ts",
     "check:ts-sources": "node .tsbuild/scripts/check-no-js-sources.cjs",
+    "check:module-versioning": "npm run build:ts && node .tsbuild/scripts/check-module-versioning.cjs",
     "dev:react-shell": "vite --config frontend/react-shell/vite.config.ts",
     "lint": "eslint \"backend/**/*.{ts,cts,mts}\" \"frontend/src/**/*.{ts,cts,mts,d.ts}\" \"frontend/react-shell/**/*.{ts,tsx,d.ts}\" \"shared/**/*.{ts,cts,mts,d.ts}\" \"scripts/**/*.{ts,cts,mts}\" \"tests/**/*.{ts,cts,mts,d.ts}\" \"api/**/*.{ts,cts,mts,d.ts}\" \"supabase/**/*.{ts,cts,mts,d.ts}\"",
     "lint:fix": "npm run lint -- --fix",

--- a/scripts/check-module-versioning.cts
+++ b/scripts/check-module-versioning.cts
@@ -78,16 +78,32 @@ function resolveBaseRef(): string | null {
 
 function changedFilesSince(baseRef: string): string[] {
   try {
-    return runGit(["diff", "--name-only", `${baseRef}...HEAD`])
-      .split(/\r?\n/)
-      .map((entry) => entry.trim())
-      .filter(Boolean);
+    return parseChangedFilePathsFromNameStatus(
+      runGit(["diff", "--name-status", "-M", `${baseRef}...HEAD`])
+    );
   } catch {
-    return runGit(["diff", "--name-only", baseRef, "HEAD"])
-      .split(/\r?\n/)
-      .map((entry) => entry.trim())
-      .filter(Boolean);
+    return parseChangedFilePathsFromNameStatus(
+      runGit(["diff", "--name-status", "-M", baseRef, "HEAD"])
+    );
   }
+}
+
+export function parseChangedFilePathsFromNameStatus(output: string): string[] {
+  const paths = new Set<string>();
+
+  output
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const fields = line
+        .split("\t")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      fields.slice(1).forEach((filePath) => paths.add(filePath));
+    });
+
+  return Array.from(paths);
 }
 
 function extractModuleVersions(source: string): Record<string, string> {
@@ -197,4 +213,6 @@ function main(): void {
   );
 }
 
-main();
+if (require.main === module) {
+  main();
+}

--- a/scripts/check-module-versioning.cts
+++ b/scripts/check-module-versioning.cts
@@ -18,6 +18,12 @@ type ModuleVersionChange = {
   currentVersion: string;
 };
 
+type RuntimeManifestModuleEntry = {
+  id: string;
+  version: string;
+  ownerPaths: string[];
+};
+
 const moduleVersionsPath = "shared/module-versions.cts";
 
 function runGit(args: string[]): string {
@@ -183,16 +189,19 @@ export function findNonIncrementingModuleVersionChanges(
   });
 }
 
-function validateRuntimeManifestVersionMirrors(): string[] {
-  return listFunctionalModuleVersions().flatMap((moduleEntry) => {
+export function validateRuntimeManifestVersionMirrors(
+  modules: readonly RuntimeManifestModuleEntry[] = listFunctionalModuleVersions(),
+  rootDir = process.cwd()
+): string[] {
+  return modules.flatMap((moduleEntry) => {
     const runtimeModulePath = `modules/${moduleEntry.id}/`;
     if (!moduleEntry.ownerPaths.includes(runtimeModulePath)) {
       return [];
     }
 
-    const manifestPath = join(process.cwd(), runtimeModulePath, "module.json");
+    const manifestPath = join(rootDir, runtimeModulePath, "module.json");
     if (!existsSync(manifestPath)) {
-      return [];
+      return [`${runtimeModulePath}module.json is missing.`];
     }
 
     try {

--- a/scripts/check-module-versioning.cts
+++ b/scripts/check-module-versioning.cts
@@ -14,7 +14,7 @@ type PushEventPayload = {
 
 type ModuleVersionChange = {
   moduleId: string;
-  baseVersion: string;
+  baseVersion: string | null;
   currentVersion: string;
 };
 
@@ -155,12 +155,10 @@ export function findModuleVersionChanges(
   const baseVersions = baseSource ? extractModuleVersions(baseSource) : {};
 
   return Object.entries(currentVersions)
-    .filter(
-      ([moduleId, version]) => Boolean(baseVersions[moduleId]) && baseVersions[moduleId] !== version
-    )
+    .filter(([moduleId, version]) => baseVersions[moduleId] !== version)
     .map(([moduleId, version]) => ({
       moduleId,
-      baseVersion: baseVersions[moduleId],
+      baseVersion: baseVersions[moduleId] ?? null,
       currentVersion: version
     }));
 }
@@ -177,6 +175,9 @@ export function findNonIncrementingModuleVersionChanges(
   baseSource: string | null
 ): ModuleVersionChange[] {
   return findModuleVersionChanges(currentSource, baseSource).filter((entry) => {
+    if (!entry.baseVersion) {
+      return false;
+    }
     const comparison = compareSemver(entry.currentVersion, entry.baseVersion);
     return comparison === null || comparison <= 0;
   });

--- a/scripts/check-module-versioning.cts
+++ b/scripts/check-module-versioning.cts
@@ -12,6 +12,12 @@ type PushEventPayload = {
   before?: unknown;
 };
 
+type ModuleVersionChange = {
+  moduleId: string;
+  baseVersion: string;
+  currentVersion: string;
+};
+
 const moduleVersionsPath = "shared/module-versions.cts";
 
 function runGit(args: string[]): string {
@@ -119,16 +125,61 @@ function extractModuleVersions(source: string): Record<string, string> {
   return versions;
 }
 
-function changedModuleIdsFromManifestSource(
+function parseSemverParts(version: string): [number, number, number] | null {
+  const match = /^([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)$/.exec(version);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+function compareSemver(left: string, right: string): number | null {
+  const leftParts = parseSemverParts(left);
+  const rightParts = parseSemverParts(right);
+  if (!leftParts || !rightParts) {
+    return null;
+  }
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+export function findModuleVersionChanges(
   currentSource: string,
   baseSource: string | null
-): string[] {
+): ModuleVersionChange[] {
   const currentVersions = extractModuleVersions(currentSource);
   const baseVersions = baseSource ? extractModuleVersions(baseSource) : {};
 
   return Object.entries(currentVersions)
-    .filter(([moduleId, version]) => baseVersions[moduleId] !== version)
-    .map(([moduleId]) => moduleId);
+    .filter(
+      ([moduleId, version]) => Boolean(baseVersions[moduleId]) && baseVersions[moduleId] !== version
+    )
+    .map(([moduleId, version]) => ({
+      moduleId,
+      baseVersion: baseVersions[moduleId],
+      currentVersion: version
+    }));
+}
+
+function changedModuleIdsFromManifestSource(
+  currentSource: string,
+  baseSource: string | null
+): string[] {
+  return findModuleVersionChanges(currentSource, baseSource).map((entry) => entry.moduleId);
+}
+
+export function findNonIncrementingModuleVersionChanges(
+  currentSource: string,
+  baseSource: string | null
+): ModuleVersionChange[] {
+  return findModuleVersionChanges(currentSource, baseSource).filter((entry) => {
+    const comparison = compareSemver(entry.currentVersion, entry.baseVersion);
+    return comparison === null || comparison <= 0;
+  });
 }
 
 function validateRuntimeManifestVersionMirrors(): string[] {
@@ -193,6 +244,20 @@ function main(): void {
 
   const changedFiles = changedFilesSince(baseRef);
   const changedModuleIds = changedModuleIdsFromManifestSource(currentSource, baseSource);
+  const nonIncrementingChanges = findNonIncrementingModuleVersionChanges(currentSource, baseSource);
+
+  if (nonIncrementingChanges.length) {
+    const report = nonIncrementingChanges
+      .map(
+        (entry) =>
+          `- ${entry.moduleId}: ${entry.baseVersion} -> ${entry.currentVersion} is not an increment`
+      )
+      .join("\n");
+    fail(
+      `Module version changes must increment SemVer values in ${moduleVersionsPath}:\n${report}`
+    );
+  }
+
   const requirements = findModuleVersionChangeRequirements(changedFiles, changedModuleIds);
   const missingBumps = requirements.filter((entry) => !entry.versionChanged);
 

--- a/scripts/check-module-versioning.cts
+++ b/scripts/check-module-versioning.cts
@@ -1,0 +1,200 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  assertValidModuleVersionManifest,
+  findModuleVersionChangeRequirements,
+  listFunctionalModuleVersions
+} from "../shared/module-versions.cjs";
+
+type PushEventPayload = {
+  before?: unknown;
+};
+
+const moduleVersionsPath = "shared/module-versions.cts";
+
+function runGit(args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function fileAtRef(ref: string, filePath: string): string | null {
+  try {
+    return runGit(["show", `${ref}:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+function readPushEventBeforeRef(): string | null {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !existsSync(eventPath)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(readFileSync(eventPath, "utf8")) as PushEventPayload;
+    if (
+      typeof payload.before === "string" &&
+      /^[0-9a-f]{40}$/i.test(payload.before) &&
+      !/^0+$/.test(payload.before)
+    ) {
+      return payload.before;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function resolveBaseRef(): string | null {
+  if (process.env.NETRISK_MODULE_VERSION_BASE_REF) {
+    return process.env.NETRISK_MODULE_VERSION_BASE_REF;
+  }
+
+  if (process.env.GITHUB_EVENT_NAME === "pull_request" && process.env.GITHUB_BASE_REF) {
+    return `origin/${process.env.GITHUB_BASE_REF}`;
+  }
+
+  if (process.env.GITHUB_EVENT_NAME === "push") {
+    const beforeRef = readPushEventBeforeRef();
+    if (beforeRef) {
+      return beforeRef;
+    }
+  }
+
+  try {
+    runGit(["rev-parse", "--verify", "origin/main"]);
+    return "origin/main";
+  } catch {
+    return null;
+  }
+}
+
+function changedFilesSince(baseRef: string): string[] {
+  try {
+    return runGit(["diff", "--name-only", `${baseRef}...HEAD`])
+      .split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  } catch {
+    return runGit(["diff", "--name-only", baseRef, "HEAD"])
+      .split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+}
+
+function extractModuleVersions(source: string): Record<string, string> {
+  const versions: Record<string, string> = {};
+  const entryPattern = /\{\s*id:\s*"([^"]+)"[\s\S]*?version:\s*"([^"]+)"/g;
+  let match = entryPattern.exec(source);
+
+  while (match) {
+    versions[match[1]] = match[2];
+    match = entryPattern.exec(source);
+  }
+
+  return versions;
+}
+
+function changedModuleIdsFromManifestSource(
+  currentSource: string,
+  baseSource: string | null
+): string[] {
+  const currentVersions = extractModuleVersions(currentSource);
+  const baseVersions = baseSource ? extractModuleVersions(baseSource) : {};
+
+  return Object.entries(currentVersions)
+    .filter(([moduleId, version]) => baseVersions[moduleId] !== version)
+    .map(([moduleId]) => moduleId);
+}
+
+function validateRuntimeManifestVersionMirrors(): string[] {
+  return listFunctionalModuleVersions().flatMap((moduleEntry) => {
+    const runtimeModulePath = `modules/${moduleEntry.id}/`;
+    if (!moduleEntry.ownerPaths.includes(runtimeModulePath)) {
+      return [];
+    }
+
+    const manifestPath = join(process.cwd(), runtimeModulePath, "module.json");
+    if (!existsSync(manifestPath)) {
+      return [];
+    }
+
+    try {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { version?: unknown };
+      return manifest.version === moduleEntry.version
+        ? []
+        : [
+            `${runtimeModulePath}module.json version ${String(
+              manifest.version
+            )} does not match central version ${moduleEntry.version}.`
+          ];
+    } catch (error: unknown) {
+      return [
+        `${runtimeModulePath}module.json could not be parsed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      ];
+    }
+  });
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function main(): void {
+  assertValidModuleVersionManifest();
+  const runtimeManifestErrors = validateRuntimeManifestVersionMirrors();
+  if (runtimeManifestErrors.length) {
+    fail(
+      `Runtime module manifest versions must match ${moduleVersionsPath}:\n- ${runtimeManifestErrors.join("\n- ")}`
+    );
+  }
+
+  const currentSource = readFileSync(join(process.cwd(), moduleVersionsPath), "utf8");
+  const baseRef = resolveBaseRef();
+  if (!baseRef) {
+    console.log("Module version manifest validation passed. Skipping bump detection: no base ref.");
+    return;
+  }
+
+  const baseSource = fileAtRef(baseRef, moduleVersionsPath);
+  if (!baseSource) {
+    console.log(
+      `Module version manifest validation passed. Skipping bump detection: ${moduleVersionsPath} is not available at ${baseRef}.`
+    );
+    return;
+  }
+
+  const changedFiles = changedFilesSince(baseRef);
+  const changedModuleIds = changedModuleIdsFromManifestSource(currentSource, baseSource);
+  const requirements = findModuleVersionChangeRequirements(changedFiles, changedModuleIds);
+  const missingBumps = requirements.filter((entry) => !entry.versionChanged);
+
+  if (missingBumps.length) {
+    const report = missingBumps
+      .map(
+        (entry) =>
+          `- ${entry.moduleId} (${entry.moduleName}) still at ${entry.version}; changed paths: ${entry.changedPaths.join(", ")}`
+      )
+      .join("\n");
+    fail(
+      `Module-owned files changed without a module version bump in ${moduleVersionsPath}:\n${report}`
+    );
+  }
+
+  console.log(
+    `Module versioning check passed for ${requirements.length} touched module(s). Base: ${baseRef}.`
+  );
+}
+
+main();

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -26,6 +26,7 @@ const gameplayTestModules = [
   "../tests/gameplay/shared/extensions.test.cjs",
   "../tests/gameplay/shared/core-base-catalog.test.cjs",
   "../tests/gameplay/shared/version-registry.test.cjs",
+  "../tests/gameplay/shared/module-versions.test.cjs",
   "../tests/gameplay/shared/runtime-validation.test.cjs",
   "../tests/gameplay/shared/module-registry.test.cjs",
   "../tests/gameplay/ai/ai-player.test.cjs",

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -975,14 +975,14 @@ register("health route usa 503 quando lo snapshot segnala errore", async () => {
 
 register("version registry espone manifest e compatibilita baseline", () => {
   const expectedManifest = {
-    appVersion: "0.1.005",
-    engineVersion: "1.0.0",
-    apiVersion: "1.0.0",
-    datastoreSchemaVersion: 1,
-    saveGameSchemaVersion: 1,
-    moduleApiVersion: "1.0.0",
-    minimumCompatibleSaveGameSchemaVersion: 1,
-    minimumCompatibleModuleApiVersion: "1.0.0"
+    appVersion: versionManifest.appVersion,
+    engineVersion: versionManifest.engineVersion,
+    apiVersion: versionManifest.apiVersion,
+    datastoreSchemaVersion: versionManifest.datastoreSchemaVersion,
+    saveGameSchemaVersion: versionManifest.saveGameSchemaVersion,
+    moduleApiVersion: versionManifest.moduleApiVersion,
+    minimumCompatibleSaveGameSchemaVersion: versionManifest.minimumCompatibleSaveGameSchemaVersion,
+    minimumCompatibleModuleApiVersion: versionManifest.minimumCompatibleModuleApiVersion
   };
 
   assert.deepEqual(versionManifest.versionManifest, expectedManifest);

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -830,6 +830,40 @@ export function checkModuleCompatibility(
     };
   }
 
+  errors.push(
+    ...collectModuleCompatibilitySurfaceErrors(moduleId, moduleVersion, compatibility, environment)
+  );
+
+  compatibility.requires.forEach((requirement) => {
+    const providedVersion = environmentModules[requirement.moduleId];
+    if (!providedVersion) {
+      if (!requirement.optional) {
+        errors.push(`${moduleId} requires ${requirement.moduleId} ${requirement.versions}.`);
+      }
+      return;
+    }
+
+    if (!versionSatisfiesRange(providedVersion, requirement.versions)) {
+      errors.push(
+        `${moduleId} requires ${requirement.moduleId} ${requirement.versions}, received ${providedVersion}.`
+      );
+    }
+  });
+
+  return {
+    compatible: errors.length === 0,
+    errors
+  };
+}
+
+function collectModuleCompatibilitySurfaceErrors(
+  moduleId: string,
+  moduleVersion: string,
+  compatibility: ModuleCompatibilityDeclaration,
+  environment: Omit<ModuleCompatibilityEnvironment, "modules">
+): string[] {
+  const errors: string[] = [];
+
   if (!versionSatisfiesRange(moduleVersion, compatibility.moduleVersions)) {
     errors.push(`${moduleId} version ${moduleVersion} is outside ${compatibility.moduleVersions}.`);
   }
@@ -875,26 +909,7 @@ export function checkModuleCompatibility(
     );
   }
 
-  compatibility.requires.forEach((requirement) => {
-    const providedVersion = environmentModules[requirement.moduleId];
-    if (!providedVersion) {
-      if (!requirement.optional) {
-        errors.push(`${moduleId} requires ${requirement.moduleId} ${requirement.versions}.`);
-      }
-      return;
-    }
-
-    if (!versionSatisfiesRange(providedVersion, requirement.versions)) {
-      errors.push(
-        `${moduleId} requires ${requirement.moduleId} ${requirement.versions}, received ${providedVersion}.`
-      );
-    }
-  });
-
-  return {
-    compatible: errors.length === 0,
-    errors
-  };
+  return errors;
 }
 
 export function isModuleCompatibleWith(
@@ -904,12 +919,29 @@ export function isModuleCompatibleWith(
   otherModuleVersion: string,
   environment: Omit<ModuleCompatibilityEnvironment, "modules"> = {}
 ): boolean {
-  return checkModuleCompatibility(moduleId, moduleVersion, {
-    ...environment,
-    modules: {
-      [otherModuleId]: otherModuleVersion
-    }
-  }).compatible;
+  const compatibility = moduleCompatibility.find((entry) => entry.moduleId === moduleId) || null;
+  if (
+    !compatibility ||
+    !getFunctionalModuleVersion(moduleId) ||
+    !getFunctionalModuleVersion(otherModuleId)
+  ) {
+    return false;
+  }
+
+  const errors = collectModuleCompatibilitySurfaceErrors(
+    moduleId,
+    moduleVersion,
+    compatibility,
+    environment
+  );
+  const requirement = compatibility.requires.find((entry) => entry.moduleId === otherModuleId);
+  if (requirement && !versionSatisfiesRange(otherModuleVersion, requirement.versions)) {
+    errors.push(
+      `${moduleId} requires ${requirement.moduleId} ${requirement.versions}, received ${otherModuleVersion}.`
+    );
+  }
+
+  return errors.length === 0;
 }
 
 function normalizeRepoPath(filePath: string): string {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -817,7 +817,11 @@ function normalizeEnvironmentModules(
   if (Array.isArray(modules)) {
     return modules.reduce<Record<string, string>>((accumulator, entry) => {
       if (isNonEmptyString(entry.moduleId) && isNonEmptyString(entry.versions)) {
-        accumulator[entry.moduleId] = entry.versions;
+        const knownModuleVersion = getFunctionalModuleVersion(entry.moduleId)?.version || null;
+        accumulator[entry.moduleId] =
+          knownModuleVersion && versionSatisfiesRange(knownModuleVersion, entry.versions)
+            ? knownModuleVersion
+            : entry.versions;
       }
       return accumulator;
     }, {});

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -684,6 +684,7 @@ export function validateModuleVersionManifest(
 ): string[] {
   const errors: string[] = [];
   const moduleIds = new Set<string>();
+  const moduleEntriesById = new Map<string, FunctionalModuleVersion>();
   const compatibilityIds = new Set<string>();
 
   modules.forEach((entry) => {
@@ -696,6 +697,7 @@ export function validateModuleVersionManifest(
       errors.push(`Duplicate module version entry "${entry.id}".`);
     }
     moduleIds.add(entry.id);
+    moduleEntriesById.set(entry.id, entry);
 
     if (!isNonEmptyString(entry.name)) {
       errors.push(`${entry.id} is missing a name.`);
@@ -734,6 +736,17 @@ export function validateModuleVersionManifest(
 
     if (!isValidVersionRange(entry.moduleVersions)) {
       errors.push(`${entry.moduleId} has invalid module version range "${entry.moduleVersions}".`);
+    } else {
+      const moduleEntry = moduleEntriesById.get(entry.moduleId);
+      if (
+        moduleEntry &&
+        isValidModuleSemver(moduleEntry.version) &&
+        !versionSatisfiesRange(moduleEntry.version, entry.moduleVersions)
+      ) {
+        errors.push(
+          `${entry.moduleId} version ${moduleEntry.version} is outside declared module version range "${entry.moduleVersions}".`
+        );
+      }
     }
 
     if (!isValidVersionRange(entry.compatibleAppVersions)) {
@@ -920,8 +933,11 @@ export function isModuleCompatibleWith(
   environment: Omit<ModuleCompatibilityEnvironment, "modules"> = {}
 ): boolean {
   const compatibility = moduleCompatibility.find((entry) => entry.moduleId === moduleId) || null;
+  const otherCompatibility =
+    moduleCompatibility.find((entry) => entry.moduleId === otherModuleId) || null;
   if (
     !compatibility ||
+    !otherCompatibility ||
     !getFunctionalModuleVersion(moduleId) ||
     !getFunctionalModuleVersion(otherModuleId)
   ) {
@@ -934,10 +950,27 @@ export function isModuleCompatibleWith(
     compatibility,
     environment
   );
+  errors.push(
+    ...collectModuleCompatibilitySurfaceErrors(
+      otherModuleId,
+      otherModuleVersion,
+      otherCompatibility,
+      environment
+    )
+  );
   const requirement = compatibility.requires.find((entry) => entry.moduleId === otherModuleId);
   if (requirement && !versionSatisfiesRange(otherModuleVersion, requirement.versions)) {
     errors.push(
       `${moduleId} requires ${requirement.moduleId} ${requirement.versions}, received ${otherModuleVersion}.`
+    );
+  }
+
+  const reverseRequirement = otherCompatibility.requires.find(
+    (entry) => entry.moduleId === moduleId
+  );
+  if (reverseRequirement && !versionSatisfiesRange(moduleVersion, reverseRequirement.versions)) {
+    errors.push(
+      `${otherModuleId} requires ${reverseRequirement.moduleId} ${reverseRequirement.versions}, received ${moduleVersion}.`
     );
   }
 

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -471,6 +471,10 @@ export const moduleVersionManifest = Object.freeze({
 });
 
 type VersionParts = [number, number, number];
+type VersionBound = {
+  version: VersionParts;
+  inclusive: boolean;
+};
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -576,23 +580,41 @@ export function isValidVersionRange(range: unknown): range is string {
     return false;
   }
 
-  let lower: VersionParts | null = null;
-  let upper: VersionParts | null = null;
-  comparators.forEach((entry) => {
-    if (!entry) {
-      return;
-    }
-
+  const parsedComparators = comparators as Array<{ operator: string; version: VersionParts }>;
+  let lower: VersionBound | null = null;
+  let upper: VersionBound | null = null;
+  for (const entry of parsedComparators) {
     if (entry.operator === ">" || entry.operator === ">=") {
-      lower = !lower || compareVersionParts(entry.version, lower) > 0 ? entry.version : lower;
+      const inclusive = entry.operator === ">=";
+      const comparison = lower ? compareVersionParts(entry.version, lower.version) : 1;
+      if (!lower || comparison > 0) {
+        lower = { version: entry.version, inclusive };
+      } else if (comparison === 0 && lower.inclusive && !inclusive) {
+        lower = { version: entry.version, inclusive };
+      }
     }
 
     if (entry.operator === "<" || entry.operator === "<=") {
-      upper = !upper || compareVersionParts(entry.version, upper) < 0 ? entry.version : upper;
+      const inclusive = entry.operator === "<=";
+      const comparison = upper ? compareVersionParts(entry.version, upper.version) : -1;
+      if (!upper || comparison < 0) {
+        upper = { version: entry.version, inclusive };
+      } else if (comparison === 0 && upper.inclusive && !inclusive) {
+        upper = { version: entry.version, inclusive };
+      }
     }
-  });
+  }
 
-  return !lower || !upper || compareVersionParts(lower, upper) <= 0;
+  if (!lower || !upper) {
+    return true;
+  }
+
+  const comparison = compareVersionParts(lower.version, upper.version);
+  if (comparison !== 0) {
+    return comparison < 0;
+  }
+
+  return lower.inclusive && upper.inclusive;
 }
 
 export function versionSatisfiesRange(

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -1,0 +1,925 @@
+import {
+  appVersion,
+  datastoreSchemaVersion,
+  minimumCompatibleModuleApiVersion,
+  minimumCompatibleSaveGameSchemaVersion,
+  moduleApiVersion,
+  saveGameSchemaVersion
+} from "./version-manifest.cjs";
+
+export const MODULE_VERSION_MANIFEST_SCHEMA_VERSION = 1;
+
+export type ModuleVersionBumpKind = "patch" | "minor" | "major";
+export type FunctionalModuleKind =
+  | "runtime-package"
+  | "content"
+  | "rule-family"
+  | "gameplay"
+  | "platform"
+  | "admin"
+  | "ui";
+
+export interface SchemaVersionRange {
+  min: number;
+  max: number;
+}
+
+export interface FunctionalModuleVersion {
+  id: string;
+  name: string;
+  kind: FunctionalModuleKind;
+  version: string;
+  description: string;
+  ownerPaths: string[];
+}
+
+export interface ModuleVersionRequirement {
+  moduleId: string;
+  versions: string;
+  optional?: boolean;
+}
+
+export interface ModuleCompatibilityDeclaration {
+  moduleId: string;
+  moduleVersions: string;
+  compatibleAppVersions: string;
+  compatibleSaveGameSchemaVersions: SchemaVersionRange;
+  compatibleDatastoreSchemaVersions: SchemaVersionRange;
+  compatibleModuleApiVersions: string;
+  requires: ModuleVersionRequirement[];
+  notes?: string;
+}
+
+export interface ModuleCompatibilityEnvironment {
+  appVersion?: string;
+  saveGameSchemaVersion?: number;
+  datastoreSchemaVersion?: number;
+  moduleApiVersion?: string;
+  modules?: Record<string, string> | readonly ModuleVersionRequirement[];
+}
+
+export interface ModuleCompatibilityResult {
+  compatible: boolean;
+  errors: string[];
+}
+
+export interface ModuleVersionChangeRequirement {
+  moduleId: string;
+  moduleName: string;
+  version: string;
+  changedPaths: string[];
+  versionChanged: boolean;
+}
+
+export const MODULE_VERSION_BUMP_RULES: Readonly<Record<ModuleVersionBumpKind, string>> =
+  Object.freeze({
+    patch:
+      "Internal fixes that do not change public behavior, transport shape, saved-state compatibility, or module interoperability.",
+    minor:
+      "Backward-compatible feature additions, optional module behavior extensions, or additive admin/UI capabilities.",
+    major:
+      "Breaking behavior changes, saved-state incompatibility, public API/schema changes, required migrations, or compatibility changes that older consumers cannot use safely."
+  });
+
+export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Object.freeze([
+  {
+    id: "core.base",
+    name: "Core Base Runtime Module",
+    kind: "runtime-package",
+    version: "1.0.0",
+    description: "Always-enabled first-party baseline module for official content and UI slots.",
+    ownerPaths: ["modules/core.base/", "shared/core-base-catalog.cts"]
+  },
+  {
+    id: "demo.command-center",
+    name: "Command Center Demo Runtime Module",
+    kind: "runtime-package",
+    version: "1.0.0",
+    description: "Installable demo module for catalog, profile, asset, and UI-slot flows.",
+    ownerPaths: ["modules/demo.command-center/"]
+  },
+  {
+    id: "maps",
+    name: "Maps",
+    kind: "content",
+    version: "1.0.0",
+    description: "Built-in map definitions, territory topology, continent data, and map loaders.",
+    ownerPaths: [
+      "shared/maps/",
+      "shared/map-loader.cts",
+      "shared/continent-loader.cts",
+      "shared/map-graph.cts",
+      "shared/typed-map-data.cts"
+    ]
+  },
+  {
+    id: "content-packs",
+    name: "Content Packs",
+    kind: "content",
+    version: "1.0.0",
+    description: "Composable setup defaults for maps, rules, themes, cards, dice, and pieces.",
+    ownerPaths: [
+      "shared/content-packs.cts",
+      "shared/content/content-packs/",
+      "shared/content-catalog.cts"
+    ]
+  },
+  {
+    id: "site-themes",
+    name: "Site Themes",
+    kind: "ui",
+    version: "1.0.0",
+    description: "Theme catalog entries and client-visible visual theme metadata.",
+    ownerPaths: ["shared/site-themes.cts", "shared/content/site-themes/"]
+  },
+  {
+    id: "player-piece-sets",
+    name: "Player Piece Sets",
+    kind: "content",
+    version: "1.0.0",
+    description: "Player color palettes and piece-set catalog entries.",
+    ownerPaths: ["shared/player-piece-sets.cts", "shared/content/player-piece-sets/"]
+  },
+  {
+    id: "piece-skins",
+    name: "Piece Skins",
+    kind: "ui",
+    version: "1.0.0",
+    description: "Board marker skin options and piece rendering metadata.",
+    ownerPaths: ["shared/extensions.cts"]
+  },
+  {
+    id: "dice-rule-sets",
+    name: "Dice Rule Sets",
+    kind: "rule-family",
+    version: "1.0.0",
+    description: "Dice resolution options shared by setup, runtime modules, and combat.",
+    ownerPaths: ["shared/dice.cts", "backend/engine/combat-dice.cts"]
+  },
+  {
+    id: "card-rule-sets",
+    name: "Card Rule Sets",
+    kind: "rule-family",
+    version: "1.0.0",
+    description: "Card deck, trade-in, and route-facing card rule-set behavior.",
+    ownerPaths: ["shared/cards.cts", "backend/routes/game-cards.cts"]
+  },
+  {
+    id: "combat-rule-sets",
+    name: "Combat Rule Sets",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "Attack validation, combat resolution, conquest, and banzai attack behavior.",
+    ownerPaths: [
+      "shared/combat-rule-sets.cts",
+      "backend/engine/attack-validation.cts",
+      "backend/engine/banzai-attack.cts",
+      "backend/engine/combat-resolution.cts",
+      "backend/engine/conquest-resolution.cts"
+    ]
+  },
+  {
+    id: "reinforcement-rule-sets",
+    name: "Reinforcement Rule Sets",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "Reinforcement calculation and placement behavior.",
+    ownerPaths: [
+      "shared/reinforcement-rule-sets.cts",
+      "backend/engine/reinforcement-calculator.cts",
+      "backend/engine/reinforcement-placement.cts"
+    ]
+  },
+  {
+    id: "fortify-rule-sets",
+    name: "Fortify Rule Sets",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "Fortification and movement rule behavior.",
+    ownerPaths: ["shared/fortify-rule-sets.cts", "backend/engine/fortify-movement.cts"]
+  },
+  {
+    id: "victory-rule-sets",
+    name: "Victory Rule Sets",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "Built-in and runtime-resolved victory detection behavior.",
+    ownerPaths: [
+      "shared/victory-rule-sets.cts",
+      "backend/engine/victory-detection.cts",
+      "backend/engine/victory-objectives.cts"
+    ]
+  },
+  {
+    id: "turn-timeouts",
+    name: "Turn Timeouts",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "Turn timeout policy and timeout engine behavior.",
+    ownerPaths: ["shared/turn-timeouts.cts", "backend/engine/turn-timeout.cts"]
+  },
+  {
+    id: "setup-flow",
+    name: "Setup Flow",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "New-game setup, setup defaults, profiles, and setup route behavior.",
+    ownerPaths: [
+      "backend/engine/game-setup.cts",
+      "backend/routes/game-setup.cts",
+      "backend/routes/setup.cts"
+    ]
+  },
+  {
+    id: "module-runtime",
+    name: "Module Runtime",
+    kind: "platform",
+    version: "1.0.1",
+    description:
+      "Filesystem module discovery, validation, enablement, and resolved catalog output.",
+    ownerPaths: [
+      "backend/module-runtime.cts",
+      "backend/module-runtime-contributions.cts",
+      "backend/routes/modules.cts",
+      "shared/netrisk-modules.cts"
+    ]
+  },
+  {
+    id: "authored-victory-objectives",
+    name: "Authored Victory Objectives",
+    kind: "admin",
+    version: "1.0.0",
+    description:
+      "Content Studio authored victory objective drafts, validation, and runtime output.",
+    ownerPaths: [
+      "backend/authored-modules.cts",
+      "backend/routes/admin-content-studio.cts",
+      "docs/content-studio-victory-objectives.md"
+    ]
+  },
+  {
+    id: "admin-console",
+    name: "Admin Console",
+    kind: "admin",
+    version: "1.0.0",
+    description: "Admin routes and operational admin workflows.",
+    ownerPaths: ["backend/routes/admin.cts", "docs/admin-console.md", "docs/admin-console-plan.md"]
+  },
+  {
+    id: "datastore",
+    name: "Datastore",
+    kind: "platform",
+    version: "1.0.0",
+    description:
+      "Game/session persistence, app state persistence, backups, and datastore schema use.",
+    ownerPaths: [
+      "backend/game-session-store.cts",
+      "backend/datastore.cts",
+      "backend/sqlite-datastore.cts",
+      "scripts/backup-datastore.cts",
+      "scripts/check-backup.cts",
+      "supabase/"
+    ]
+  },
+  {
+    id: "public-state",
+    name: "Public Game State",
+    kind: "platform",
+    version: "1.0.0",
+    description: "Public/read API game state contracts, snapshots, and shared game models.",
+    ownerPaths: [
+      "shared/api-contracts.cts",
+      "shared/models.cts",
+      "shared/core-domain.cts",
+      "backend/routes/game-read.cts",
+      "backend/routes/game-overview.cts"
+    ]
+  },
+  {
+    id: "ai-players",
+    name: "AI Players",
+    kind: "gameplay",
+    version: "1.0.0",
+    description: "AI turn decisions and AI turn recovery behavior.",
+    ownerPaths: ["backend/engine/ai-player.cts", "backend/engine/ai-turn-resume.cts"]
+  }
+] as FunctionalModuleVersion[]);
+
+const currentSchemaRange = Object.freeze({
+  min: minimumCompatibleSaveGameSchemaVersion,
+  max: saveGameSchemaVersion
+});
+
+const currentDatastoreRange = Object.freeze({
+  min: datastoreSchemaVersion,
+  max: datastoreSchemaVersion
+});
+
+const baseCompatibility = {
+  moduleVersions: "1.x",
+  compatibleAppVersions: "0.1.x",
+  compatibleSaveGameSchemaVersions: currentSchemaRange,
+  compatibleDatastoreSchemaVersions: currentDatastoreRange,
+  compatibleModuleApiVersions: `>=${minimumCompatibleModuleApiVersion} <=${moduleApiVersion}`
+};
+
+export const moduleCompatibility: readonly ModuleCompatibilityDeclaration[] = Object.freeze([
+  {
+    moduleId: "core.base",
+    ...baseCompatibility,
+    requires: [],
+    notes: "Baseline module for first-party content and setup compatibility."
+  },
+  {
+    moduleId: "demo.command-center",
+    ...baseCompatibility,
+    requires: [{ moduleId: "core.base", versions: "1.x" }]
+  },
+  {
+    moduleId: "maps",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "content-packs",
+    ...baseCompatibility,
+    requires: [
+      { moduleId: "maps", versions: "1.x" },
+      { moduleId: "site-themes", versions: "1.x" },
+      { moduleId: "player-piece-sets", versions: "1.x" },
+      { moduleId: "dice-rule-sets", versions: "1.x" },
+      { moduleId: "card-rule-sets", versions: "1.x" },
+      { moduleId: "victory-rule-sets", versions: "1.x" }
+    ]
+  },
+  {
+    moduleId: "site-themes",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "player-piece-sets",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "piece-skins",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "dice-rule-sets",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "card-rule-sets",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "combat-rule-sets",
+    ...baseCompatibility,
+    requires: [{ moduleId: "dice-rule-sets", versions: "1.x" }]
+  },
+  {
+    moduleId: "reinforcement-rule-sets",
+    ...baseCompatibility,
+    requires: [{ moduleId: "maps", versions: "1.x" }]
+  },
+  {
+    moduleId: "fortify-rule-sets",
+    ...baseCompatibility,
+    requires: [{ moduleId: "maps", versions: "1.x" }]
+  },
+  {
+    moduleId: "victory-rule-sets",
+    ...baseCompatibility,
+    requires: [{ moduleId: "maps", versions: "1.x", optional: true }]
+  },
+  {
+    moduleId: "turn-timeouts",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "setup-flow",
+    ...baseCompatibility,
+    requires: [
+      { moduleId: "core.base", versions: "1.x" },
+      { moduleId: "content-packs", versions: "1.x" },
+      { moduleId: "maps", versions: "1.x" },
+      { moduleId: "dice-rule-sets", versions: "1.x" },
+      { moduleId: "victory-rule-sets", versions: "1.x" },
+      { moduleId: "site-themes", versions: "1.x" },
+      { moduleId: "piece-skins", versions: "1.x" },
+      { moduleId: "player-piece-sets", versions: "1.x" }
+    ]
+  },
+  {
+    moduleId: "module-runtime",
+    ...baseCompatibility,
+    requires: [{ moduleId: "core.base", versions: "1.x" }]
+  },
+  {
+    moduleId: "authored-victory-objectives",
+    ...baseCompatibility,
+    requires: [
+      { moduleId: "maps", versions: "1.x" },
+      { moduleId: "victory-rule-sets", versions: "1.x" }
+    ]
+  },
+  {
+    moduleId: "admin-console",
+    ...baseCompatibility,
+    requires: [{ moduleId: "module-runtime", versions: "1.x" }]
+  },
+  {
+    moduleId: "datastore",
+    ...baseCompatibility,
+    requires: []
+  },
+  {
+    moduleId: "public-state",
+    ...baseCompatibility,
+    requires: [
+      { moduleId: "core.base", versions: "1.x" },
+      { moduleId: "module-runtime", versions: "1.x" }
+    ]
+  },
+  {
+    moduleId: "ai-players",
+    ...baseCompatibility,
+    requires: [
+      { moduleId: "combat-rule-sets", versions: "1.x" },
+      { moduleId: "reinforcement-rule-sets", versions: "1.x" },
+      { moduleId: "fortify-rule-sets", versions: "1.x" },
+      { moduleId: "victory-rule-sets", versions: "1.x" }
+    ]
+  }
+] as ModuleCompatibilityDeclaration[]);
+
+export const moduleVersionManifest = Object.freeze({
+  schemaVersion: MODULE_VERSION_MANIFEST_SCHEMA_VERSION,
+  appVersion,
+  saveGameSchemaVersion,
+  datastoreSchemaVersion,
+  moduleApiVersion,
+  bumpRules: MODULE_VERSION_BUMP_RULES,
+  modules: functionalModuleVersions,
+  compatibility: moduleCompatibility
+});
+
+type VersionParts = [number, number, number];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseVersionParts(version: string, allowPaddedPatch = false): VersionParts | null {
+  const patchPattern = allowPaddedPatch ? "\\d+" : "0|[1-9]\\d*";
+  const match = version
+    .trim()
+    .match(new RegExp(`^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(${patchPattern})$`));
+  if (!match) {
+    return null;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersionParts(left: VersionParts, right: VersionParts): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = left[index] - right[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+export function isValidModuleSemver(version: unknown): version is string {
+  return typeof version === "string" && parseVersionParts(version) !== null;
+}
+
+function isWildcardRange(range: string): boolean {
+  return range === "*" || /^(\d+)\.x$/.test(range) || /^(\d+)\.(\d+)\.x$/.test(range);
+}
+
+function versionMatchesWildcard(version: string, range: string, allowPaddedPatch = false): boolean {
+  const parts = parseVersionParts(version, allowPaddedPatch);
+  if (!parts) {
+    return false;
+  }
+
+  if (range === "*") {
+    return true;
+  }
+
+  const majorOnly = range.match(/^(\d+)\.x$/);
+  if (majorOnly) {
+    return parts[0] === Number(majorOnly[1]);
+  }
+
+  const minorRange = range.match(/^(\d+)\.(\d+)\.x$/);
+  return Boolean(
+    minorRange && parts[0] === Number(minorRange[1]) && parts[1] === Number(minorRange[2])
+  );
+}
+
+function parseComparator(token: string): { operator: string; version: VersionParts } | null {
+  const match = token.match(/^(>=|>|<=|<)(.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const parsedVersion = parseVersionParts(match[2].trim(), true);
+  return parsedVersion ? { operator: match[1], version: parsedVersion } : null;
+}
+
+function comparatorMatches(
+  version: VersionParts,
+  comparator: { operator: string; version: VersionParts }
+): boolean {
+  const comparison = compareVersionParts(version, comparator.version);
+  switch (comparator.operator) {
+    case ">":
+      return comparison > 0;
+    case ">=":
+      return comparison >= 0;
+    case "<":
+      return comparison < 0;
+    case "<=":
+      return comparison <= 0;
+    default:
+      return false;
+  }
+}
+
+export function isValidVersionRange(range: unknown): range is string {
+  if (!isNonEmptyString(range)) {
+    return false;
+  }
+
+  const normalized = range.trim();
+  if (isWildcardRange(normalized) || parseVersionParts(normalized, true)) {
+    return true;
+  }
+
+  const comparators = normalized.split(/\s+/).map(parseComparator);
+  if (!comparators.length || comparators.some((entry) => !entry)) {
+    return false;
+  }
+
+  let lower: VersionParts | null = null;
+  let upper: VersionParts | null = null;
+  comparators.forEach((entry) => {
+    if (!entry) {
+      return;
+    }
+
+    if (entry.operator === ">" || entry.operator === ">=") {
+      lower = !lower || compareVersionParts(entry.version, lower) > 0 ? entry.version : lower;
+    }
+
+    if (entry.operator === "<" || entry.operator === "<=") {
+      upper = !upper || compareVersionParts(entry.version, upper) < 0 ? entry.version : upper;
+    }
+  });
+
+  return !lower || !upper || compareVersionParts(lower, upper) <= 0;
+}
+
+export function versionSatisfiesRange(
+  version: unknown,
+  range: unknown,
+  options: { allowPaddedPatch?: boolean } = {}
+): boolean {
+  if (!isNonEmptyString(version) || !isNonEmptyString(range) || !isValidVersionRange(range)) {
+    return false;
+  }
+
+  const normalizedRange = range.trim();
+  if (isWildcardRange(normalizedRange)) {
+    return versionMatchesWildcard(version.trim(), normalizedRange, options.allowPaddedPatch);
+  }
+
+  const exact = parseVersionParts(normalizedRange, true);
+  const versionParts = parseVersionParts(version.trim(), options.allowPaddedPatch);
+  if (!versionParts) {
+    return false;
+  }
+
+  if (exact) {
+    return compareVersionParts(versionParts, exact) === 0;
+  }
+
+  return normalizedRange
+    .split(/\s+/)
+    .map(parseComparator)
+    .every((comparator) => Boolean(comparator && comparatorMatches(versionParts, comparator)));
+}
+
+function validateSchemaRange(
+  range: SchemaVersionRange,
+  label: string,
+  moduleId: string,
+  errors: string[]
+): void {
+  if (
+    !isObject(range) ||
+    !Number.isInteger(range.min) ||
+    !Number.isInteger(range.max) ||
+    range.min < 0 ||
+    range.max < range.min
+  ) {
+    errors.push(`${moduleId} has an invalid ${label} schema range.`);
+  }
+}
+
+export function listFunctionalModuleVersions(): FunctionalModuleVersion[] {
+  return functionalModuleVersions.map((entry) => ({
+    ...entry,
+    ownerPaths: [...entry.ownerPaths]
+  }));
+}
+
+export function getFunctionalModuleVersion(
+  moduleId: string | null | undefined
+): FunctionalModuleVersion | null {
+  const match = functionalModuleVersions.find((entry) => entry.id === moduleId) || null;
+  return match ? { ...match, ownerPaths: [...match.ownerPaths] } : null;
+}
+
+export function validateModuleVersionManifest(
+  modules: readonly FunctionalModuleVersion[] = functionalModuleVersions,
+  compatibility: readonly ModuleCompatibilityDeclaration[] = moduleCompatibility
+): string[] {
+  const errors: string[] = [];
+  const moduleIds = new Set<string>();
+  const compatibilityIds = new Set<string>();
+
+  modules.forEach((entry) => {
+    if (!isNonEmptyString(entry.id)) {
+      errors.push("Module version entries require a non-empty id.");
+      return;
+    }
+
+    if (moduleIds.has(entry.id)) {
+      errors.push(`Duplicate module version entry "${entry.id}".`);
+    }
+    moduleIds.add(entry.id);
+
+    if (!isNonEmptyString(entry.name)) {
+      errors.push(`${entry.id} is missing a name.`);
+    }
+
+    if (!isValidModuleSemver(entry.version)) {
+      errors.push(`${entry.id} has invalid SemVer "${String(entry.version)}".`);
+    }
+
+    if (!Array.isArray(entry.ownerPaths) || !entry.ownerPaths.length) {
+      errors.push(`${entry.id} must define at least one owner path.`);
+    } else {
+      entry.ownerPaths.forEach((ownerPath) => {
+        if (
+          !isNonEmptyString(ownerPath) ||
+          ownerPath.includes("\\") ||
+          ownerPath.includes("..") ||
+          ownerPath.startsWith("/")
+        ) {
+          errors.push(`${entry.id} has invalid owner path "${String(ownerPath)}".`);
+        }
+      });
+    }
+  });
+
+  compatibility.forEach((entry) => {
+    if (!moduleIds.has(entry.moduleId)) {
+      errors.push(`Compatibility references unknown module "${entry.moduleId}".`);
+      return;
+    }
+
+    if (compatibilityIds.has(entry.moduleId)) {
+      errors.push(`Duplicate compatibility entry "${entry.moduleId}".`);
+    }
+    compatibilityIds.add(entry.moduleId);
+
+    if (!isValidVersionRange(entry.moduleVersions)) {
+      errors.push(`${entry.moduleId} has invalid module version range "${entry.moduleVersions}".`);
+    }
+
+    if (!isValidVersionRange(entry.compatibleAppVersions)) {
+      errors.push(
+        `${entry.moduleId} has invalid app version range "${entry.compatibleAppVersions}".`
+      );
+    }
+
+    if (!isValidVersionRange(entry.compatibleModuleApiVersions)) {
+      errors.push(
+        `${entry.moduleId} has invalid module API version range "${entry.compatibleModuleApiVersions}".`
+      );
+    }
+
+    validateSchemaRange(
+      entry.compatibleSaveGameSchemaVersions,
+      "save-game",
+      entry.moduleId,
+      errors
+    );
+    validateSchemaRange(
+      entry.compatibleDatastoreSchemaVersions,
+      "datastore",
+      entry.moduleId,
+      errors
+    );
+
+    if (!Array.isArray(entry.requires)) {
+      errors.push(`${entry.moduleId} must define requires as an array.`);
+    } else {
+      entry.requires.forEach((requirement) => {
+        if (!moduleIds.has(requirement.moduleId)) {
+          errors.push(`${entry.moduleId} requires unknown module "${requirement.moduleId}".`);
+        }
+
+        if (!isValidVersionRange(requirement.versions)) {
+          errors.push(
+            `${entry.moduleId} requires ${requirement.moduleId} with invalid range "${requirement.versions}".`
+          );
+        }
+      });
+    }
+  });
+
+  moduleIds.forEach((moduleId) => {
+    if (!compatibilityIds.has(moduleId)) {
+      errors.push(`${moduleId} is missing a compatibility declaration.`);
+    }
+  });
+
+  return errors;
+}
+
+export function assertValidModuleVersionManifest(): void {
+  const errors = validateModuleVersionManifest();
+  if (errors.length) {
+    throw new Error(`Module version manifest is invalid:\n- ${errors.join("\n- ")}`);
+  }
+}
+
+function normalizeEnvironmentModules(
+  modules: ModuleCompatibilityEnvironment["modules"]
+): Record<string, string> {
+  if (!modules) {
+    return {};
+  }
+
+  if (Array.isArray(modules)) {
+    return modules.reduce<Record<string, string>>((accumulator, entry) => {
+      if (isNonEmptyString(entry.moduleId) && isNonEmptyString(entry.versions)) {
+        accumulator[entry.moduleId] = entry.versions;
+      }
+      return accumulator;
+    }, {});
+  }
+
+  return { ...(modules as Record<string, string>) };
+}
+
+export function checkModuleCompatibility(
+  moduleId: string,
+  moduleVersion: string,
+  environment: ModuleCompatibilityEnvironment = {}
+): ModuleCompatibilityResult {
+  const errors: string[] = [];
+  const moduleEntry = getFunctionalModuleVersion(moduleId);
+  const compatibility = moduleCompatibility.find((entry) => entry.moduleId === moduleId) || null;
+  const environmentModules = normalizeEnvironmentModules(environment.modules);
+
+  if (!moduleEntry || !compatibility) {
+    return {
+      compatible: false,
+      errors: [`Unknown module "${moduleId}".`]
+    };
+  }
+
+  if (!versionSatisfiesRange(moduleVersion, compatibility.moduleVersions)) {
+    errors.push(`${moduleId} version ${moduleVersion} is outside ${compatibility.moduleVersions}.`);
+  }
+
+  const requestedAppVersion = environment.appVersion || appVersion;
+  if (
+    !versionSatisfiesRange(requestedAppVersion, compatibility.compatibleAppVersions, {
+      allowPaddedPatch: true
+    })
+  ) {
+    errors.push(
+      `${moduleId} is not compatible with app version ${requestedAppVersion}; expected ${compatibility.compatibleAppVersions}.`
+    );
+  }
+
+  const requestedSaveGameSchemaVersion = environment.saveGameSchemaVersion ?? saveGameSchemaVersion;
+  if (
+    requestedSaveGameSchemaVersion < compatibility.compatibleSaveGameSchemaVersions.min ||
+    requestedSaveGameSchemaVersion > compatibility.compatibleSaveGameSchemaVersions.max
+  ) {
+    errors.push(
+      `${moduleId} is not compatible with save-game schema ${requestedSaveGameSchemaVersion}.`
+    );
+  }
+
+  const requestedDatastoreSchemaVersion =
+    environment.datastoreSchemaVersion ?? datastoreSchemaVersion;
+  if (
+    requestedDatastoreSchemaVersion < compatibility.compatibleDatastoreSchemaVersions.min ||
+    requestedDatastoreSchemaVersion > compatibility.compatibleDatastoreSchemaVersions.max
+  ) {
+    errors.push(
+      `${moduleId} is not compatible with datastore schema ${requestedDatastoreSchemaVersion}.`
+    );
+  }
+
+  const requestedModuleApiVersion = environment.moduleApiVersion || moduleApiVersion;
+  if (
+    !versionSatisfiesRange(requestedModuleApiVersion, compatibility.compatibleModuleApiVersions)
+  ) {
+    errors.push(
+      `${moduleId} is not compatible with module API ${requestedModuleApiVersion}; expected ${compatibility.compatibleModuleApiVersions}.`
+    );
+  }
+
+  compatibility.requires.forEach((requirement) => {
+    const providedVersion = environmentModules[requirement.moduleId];
+    if (!providedVersion) {
+      if (!requirement.optional) {
+        errors.push(`${moduleId} requires ${requirement.moduleId} ${requirement.versions}.`);
+      }
+      return;
+    }
+
+    if (!versionSatisfiesRange(providedVersion, requirement.versions)) {
+      errors.push(
+        `${moduleId} requires ${requirement.moduleId} ${requirement.versions}, received ${providedVersion}.`
+      );
+    }
+  });
+
+  return {
+    compatible: errors.length === 0,
+    errors
+  };
+}
+
+export function isModuleCompatibleWith(
+  moduleId: string,
+  moduleVersion: string,
+  otherModuleId: string,
+  otherModuleVersion: string,
+  environment: Omit<ModuleCompatibilityEnvironment, "modules"> = {}
+): boolean {
+  return checkModuleCompatibility(moduleId, moduleVersion, {
+    ...environment,
+    modules: {
+      [otherModuleId]: otherModuleVersion
+    }
+  }).compatible;
+}
+
+function normalizeRepoPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+export function findModuleVersionChangeRequirements(
+  changedPaths: readonly string[],
+  changedModuleIds: readonly string[],
+  modules: readonly FunctionalModuleVersion[] = functionalModuleVersions
+): ModuleVersionChangeRequirement[] {
+  const changedModuleIdSet = new Set(changedModuleIds);
+  const normalizedChangedPaths = changedPaths.map(normalizeRepoPath);
+
+  return modules
+    .map((moduleEntry) => {
+      const ownedChangedPaths = normalizedChangedPaths.filter((changedPath) =>
+        moduleEntry.ownerPaths.some((ownerPath) => {
+          const normalizedOwnerPath = normalizeRepoPath(ownerPath);
+          return normalizedOwnerPath.endsWith("/")
+            ? changedPath.startsWith(normalizedOwnerPath)
+            : changedPath === normalizedOwnerPath;
+        })
+      );
+
+      return {
+        moduleId: moduleEntry.id,
+        moduleName: moduleEntry.name,
+        version: moduleEntry.version,
+        changedPaths: ownedChangedPaths,
+        versionChanged: changedModuleIdSet.has(moduleEntry.id)
+      };
+    })
+    .filter((entry) => entry.changedPaths.length > 0);
+}

--- a/shared/netrisk-modules.cts
+++ b/shared/netrisk-modules.cts
@@ -8,6 +8,7 @@ import {
   NETRISK_MODULE_CAPABILITY_KIND_VALUES,
   NETRISK_UI_SLOT_ID_VALUES
 } from "./runtime-validation.cjs";
+import { isValidModuleSemver, isValidVersionRange } from "./module-versions.cjs";
 
 export const NETRISK_ENGINE_VERSION = engineVersion;
 export const NETRISK_MODULE_MANIFEST_SCHEMA_VERSION = 1;
@@ -342,9 +343,14 @@ function normalizeDependency(raw: unknown, sourcePath: string): NetRiskModuleDep
     throw new Error(`Invalid module dependency in "${sourcePath}".`);
   }
 
+  const version = isNonEmptyString(raw.version) ? String(raw.version).trim() : null;
+  if (version && !isValidVersionRange(version)) {
+    throw new Error(`Invalid module dependency version range in "${sourcePath}".`);
+  }
+
   return {
     id: String(raw.id).trim(),
-    version: isNonEmptyString(raw.version) ? String(raw.version).trim() : null,
+    version,
     optional: Boolean(raw.optional)
   };
 }
@@ -864,6 +870,10 @@ export function validateNetRiskModuleManifest(
     !isNonEmptyString(raw.engineVersion)
   ) {
     throw new Error(`Module manifest "${sourcePath}" is missing required string fields.`);
+  }
+
+  if (!isValidModuleSemver(String(raw.version).trim())) {
+    throw new Error(`Module manifest "${sourcePath}" has invalid SemVer.`);
   }
 
   return {

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.005";
+export const appVersion = "0.1.006";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -1,0 +1,210 @@
+const assert = require("node:assert/strict");
+
+const {
+  MODULE_VERSION_BUMP_RULES,
+  checkModuleCompatibility,
+  findModuleVersionChangeRequirements,
+  functionalModuleVersions,
+  getFunctionalModuleVersion,
+  isModuleCompatibleWith,
+  isValidModuleSemver,
+  isValidVersionRange,
+  listFunctionalModuleVersions,
+  moduleCompatibility,
+  moduleVersionManifest,
+  validateModuleVersionManifest,
+  versionSatisfiesRange
+} = require("../../../shared/module-versions.cjs");
+const { validateNetRiskModuleManifest } = require("../../../shared/netrisk-modules.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+register("module version manifest centrally lists current functional modules", () => {
+  assert.equal(moduleVersionManifest.schemaVersion, 1);
+  assert.deepEqual(validateModuleVersionManifest(), []);
+
+  const moduleIds = listFunctionalModuleVersions().map((entry: { id: string }) => entry.id);
+  assert.equal(moduleIds.includes("core.base"), true);
+  assert.equal(moduleIds.includes("maps"), true);
+  assert.equal(moduleIds.includes("victory-rule-sets"), true);
+  assert.equal(moduleIds.includes("module-runtime"), true);
+  assert.equal(moduleIds.includes("authored-victory-objectives"), true);
+  assert.equal(moduleIds.includes("datastore"), true);
+  assert.equal(moduleIds.includes("public-state"), true);
+
+  assert.equal(getFunctionalModuleVersion("maps")?.version, "1.0.0");
+  assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.patch), true);
+  assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.minor), true);
+  assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.major), true);
+});
+
+register("module version manifest validation rejects malformed data", () => {
+  const modules = clone(functionalModuleVersions);
+  const compatibility = clone(moduleCompatibility);
+
+  modules[0].version = "1.0";
+  compatibility[1].requires.push({ moduleId: "missing.module", versions: "1.x" });
+  compatibility[2].moduleVersions = ">=2.0.0 <1.0.0";
+  compatibility[3].compatibleSaveGameSchemaVersions = { min: 2, max: 1 };
+
+  const errors = validateModuleVersionManifest(modules, compatibility);
+
+  assert.equal(
+    errors.some((entry: string) => entry.includes("invalid SemVer")),
+    true
+  );
+  assert.equal(
+    errors.some((entry: string) => entry.includes("requires unknown module")),
+    true
+  );
+  assert.equal(
+    errors.some((entry: string) => entry.includes("invalid module version range")),
+    true
+  );
+  assert.equal(
+    errors.some((entry: string) => entry.includes("invalid save-game schema range")),
+    true
+  );
+});
+
+register("module version range helpers support exact, wildcard, and comparator ranges", () => {
+  assert.equal(isValidModuleSemver("1.2.3"), true);
+  assert.equal(isValidModuleSemver("1.2.03"), false);
+  assert.equal(isValidModuleSemver("1.2"), false);
+
+  assert.equal(isValidVersionRange("1.x"), true);
+  assert.equal(isValidVersionRange("1.2.x"), true);
+  assert.equal(isValidVersionRange(">=1.0.0 <2.0.0"), true);
+  assert.equal(isValidVersionRange(">=2.0.0 <1.0.0"), false);
+  assert.equal(isValidVersionRange("not-a-range"), false);
+
+  assert.equal(versionSatisfiesRange("1.4.2", "1.x"), true);
+  assert.equal(versionSatisfiesRange("2.0.0", "1.x"), false);
+  assert.equal(versionSatisfiesRange("1.4.2", ">=1.0.0 <2.0.0"), true);
+  assert.equal(versionSatisfiesRange("2.0.0", ">=1.0.0 <2.0.0"), false);
+  assert.equal(versionSatisfiesRange("0.1.005", "0.1.x", { allowPaddedPatch: true }), true);
+});
+
+register("runtime module manifest validation rejects invalid versions and ranges", () => {
+  const manifest = {
+    schemaVersion: 1,
+    id: "demo.invalid-version",
+    version: "1.0.0",
+    displayName: "Invalid Version Demo",
+    engineVersion: "1.0.0",
+    moduleApiVersion: "1.0.0",
+    minimumCompatibleSaveGameSchemaVersion: 1,
+    maximumCompatibleSaveGameSchemaVersion: 1,
+    kind: "hybrid",
+    dependencies: [{ id: "core.base", version: "1.x" }],
+    conflicts: [],
+    capabilities: [{ kind: "ui-slot", scope: "global" }]
+  };
+
+  assert.equal(validateNetRiskModuleManifest(manifest, "module.json").version, manifest.version);
+
+  assert.throws(
+    () =>
+      validateNetRiskModuleManifest(
+        {
+          ...manifest,
+          version: "1.0"
+        },
+        "module.json"
+      ),
+    /invalid SemVer/
+  );
+
+  assert.throws(
+    () =>
+      validateNetRiskModuleManifest(
+        {
+          ...manifest,
+          dependencies: [{ id: "core.base", version: ">=2.0.0 <1.0.0" }]
+        },
+        "module.json"
+      ),
+    /Invalid module dependency version range/
+  );
+});
+
+register("module compatibility checks app, schema, API, and dependent module versions", () => {
+  const compatible = checkModuleCompatibility("module-runtime", "1.0.0", {
+    modules: {
+      "core.base": "1.0.0"
+    }
+  });
+  assert.deepEqual(compatible, {
+    compatible: true,
+    errors: []
+  });
+
+  const missingDependency = checkModuleCompatibility("module-runtime", "1.0.0");
+  assert.equal(missingDependency.compatible, false);
+  assert.equal(
+    missingDependency.errors.some((entry: string) => entry.includes("requires core.base")),
+    true
+  );
+
+  const wrongDependency = checkModuleCompatibility("module-runtime", "1.0.0", {
+    modules: {
+      "core.base": "2.0.0"
+    }
+  });
+  assert.equal(wrongDependency.compatible, false);
+  assert.equal(
+    wrongDependency.errors.some((entry: string) => entry.includes("received 2.0.0")),
+    true
+  );
+
+  const wrongApp = checkModuleCompatibility("maps", "1.0.0", {
+    appVersion: "0.2.000"
+  });
+  assert.equal(wrongApp.compatible, false);
+  assert.equal(
+    wrongApp.errors.some((entry: string) => entry.includes("app version")),
+    true
+  );
+
+  const wrongSchema = checkModuleCompatibility("maps", "1.0.0", {
+    saveGameSchemaVersion: 2
+  });
+  assert.equal(wrongSchema.compatible, false);
+  assert.equal(
+    wrongSchema.errors.some((entry: string) => entry.includes("save-game schema")),
+    true
+  );
+
+  assert.equal(isModuleCompatibleWith("demo.command-center", "1.0.0", "core.base", "1.0.0"), true);
+  assert.equal(isModuleCompatibleWith("demo.command-center", "1.0.0", "core.base", "2.0.0"), false);
+});
+
+register("module version bump detector maps changed paths to owned functional modules", () => {
+  const requirements = findModuleVersionChangeRequirements(
+    [
+      "shared/maps/world-classic.cts",
+      "backend/engine/victory-detection.cts",
+      "docs/versioning-policy.md"
+    ],
+    ["maps"]
+  );
+
+  const mapsRequirement = requirements.find(
+    (entry: { moduleId: string }) => entry.moduleId === "maps"
+  );
+  const victoryRequirement = requirements.find(
+    (entry: { moduleId: string }) => entry.moduleId === "victory-rule-sets"
+  );
+
+  assert.ok(mapsRequirement);
+  assert.equal(mapsRequirement.versionChanged, true);
+  assert.deepEqual(mapsRequirement.changedPaths, ["shared/maps/world-classic.cts"]);
+
+  assert.ok(victoryRequirement);
+  assert.equal(victoryRequirement.versionChanged, false);
+  assert.deepEqual(victoryRequirement.changedPaths, ["backend/engine/victory-detection.cts"]);
+});

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -16,6 +16,9 @@ const {
   versionSatisfiesRange
 } = require("../../../shared/module-versions.cjs");
 const { validateNetRiskModuleManifest } = require("../../../shared/netrisk-modules.cjs");
+const {
+  parseChangedFilePathsFromNameStatus
+} = require("../../../scripts/check-module-versioning.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
@@ -211,4 +214,31 @@ register("module version bump detector maps changed paths to owned functional mo
   assert.ok(victoryRequirement);
   assert.equal(victoryRequirement.versionChanged, false);
   assert.deepEqual(victoryRequirement.changedPaths, ["backend/engine/victory-detection.cts"]);
+});
+
+register("module version bump detector includes both paths from git rename output", () => {
+  const changedPaths = parseChangedFilePathsFromNameStatus(
+    [
+      "M\tshared/module-versions.cts",
+      "R100\tshared/maps/world-classic.cts\tdocs/world-classic-map.md",
+      "C075\tshared/dice.cts\tshared/dice-copy.cts"
+    ].join("\n")
+  );
+
+  assert.deepEqual(changedPaths, [
+    "shared/module-versions.cts",
+    "shared/maps/world-classic.cts",
+    "docs/world-classic-map.md",
+    "shared/dice.cts",
+    "shared/dice-copy.cts"
+  ]);
+
+  const requirements = findModuleVersionChangeRequirements(changedPaths, []);
+  assert.equal(
+    requirements.some(
+      (entry: { moduleId: string; changedPaths: string[] }) =>
+        entry.moduleId === "maps" && entry.changedPaths.includes("shared/maps/world-classic.cts")
+    ),
+    true
+  );
 });

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -79,7 +79,11 @@ register("module version range helpers support exact, wildcard, and comparator r
   assert.equal(isValidVersionRange("1.x"), true);
   assert.equal(isValidVersionRange("1.2.x"), true);
   assert.equal(isValidVersionRange(">=1.0.0 <2.0.0"), true);
+  assert.equal(isValidVersionRange(">=1.0.0 <=1.0.0"), true);
   assert.equal(isValidVersionRange(">=2.0.0 <1.0.0"), false);
+  assert.equal(isValidVersionRange(">1.0.0 <1.0.0"), false);
+  assert.equal(isValidVersionRange(">1.0.0 <=1.0.0"), false);
+  assert.equal(isValidVersionRange(">=1.0.0 <1.0.0"), false);
   assert.equal(isValidVersionRange("not-a-range"), false);
 
   assert.equal(versionSatisfiesRange("1.4.2", "1.x"), true);

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -17,6 +17,7 @@ const {
 } = require("../../../shared/module-versions.cjs");
 const { validateNetRiskModuleManifest } = require("../../../shared/netrisk-modules.cjs");
 const {
+  findModuleVersionChanges,
   findNonIncrementingModuleVersionChanges,
   parseChangedFilePathsFromNameStatus
 } = require("../../../scripts/check-module-versioning.cjs");
@@ -278,4 +279,21 @@ register("module version bump detector rejects non-incrementing version edits", 
       currentVersion: "1.2.2"
     }
   ]);
+});
+
+register("module version bump detector treats newly added modules as changed", () => {
+  const baseSource = '{ id: "maps", name: "Maps", version: "1.0.0", ownerPaths: ["shared/maps/"] }';
+  const currentSource = [
+    '{ id: "maps", name: "Maps", version: "1.0.0", ownerPaths: ["shared/maps/"] }',
+    '{ id: "new-module", name: "New Module", version: "1.0.0", ownerPaths: ["shared/new-module.cts"] }'
+  ].join("\n");
+
+  assert.deepEqual(findModuleVersionChanges(currentSource, baseSource), [
+    {
+      moduleId: "new-module",
+      baseVersion: null,
+      currentVersion: "1.0.0"
+    }
+  ]);
+  assert.deepEqual(findNonIncrementingModuleVersionChanges(currentSource, baseSource), []);
 });

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -19,7 +19,8 @@ const { validateNetRiskModuleManifest } = require("../../../shared/netrisk-modul
 const {
   findModuleVersionChanges,
   findNonIncrementingModuleVersionChanges,
-  parseChangedFilePathsFromNameStatus
+  parseChangedFilePathsFromNameStatus,
+  validateRuntimeManifestVersionMirrors
 } = require("../../../scripts/check-module-versioning.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
@@ -155,6 +156,14 @@ register("module compatibility checks app, schema, API, and dependent module ver
     }
   });
   assert.deepEqual(compatible, {
+    compatible: true,
+    errors: []
+  });
+
+  const compatibleRangeEnvironment = checkModuleCompatibility("module-runtime", "1.0.0", {
+    modules: [{ moduleId: "core.base", versions: "1.x" }]
+  });
+  assert.deepEqual(compatibleRangeEnvironment, {
     compatible: true,
     errors: []
   });
@@ -296,4 +305,20 @@ register("module version bump detector treats newly added modules as changed", (
     }
   ]);
   assert.deepEqual(findNonIncrementingModuleVersionChanges(currentSource, baseSource), []);
+});
+
+register("module versioning check reports missing first-party runtime manifests", () => {
+  assert.deepEqual(
+    validateRuntimeManifestVersionMirrors(
+      [
+        {
+          id: "missing-runtime",
+          version: "1.0.0",
+          ownerPaths: ["modules/missing-runtime/"]
+        }
+      ],
+      process.cwd()
+    ),
+    ["modules/missing-runtime/module.json is missing."]
+  );
 });

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -53,6 +53,9 @@ register("module version manifest validation rejects malformed data", () => {
   compatibility[1].requires.push({ moduleId: "missing.module", versions: "1.x" });
   compatibility[2].moduleVersions = ">=2.0.0 <1.0.0";
   compatibility[3].compatibleSaveGameSchemaVersions = { min: 2, max: 1 };
+  const versionMismatch = modules.find((entry: { id: string }) => entry.id === "public-state");
+  assert.ok(versionMismatch);
+  versionMismatch.version = "2.0.0";
 
   const errors = validateModuleVersionManifest(modules, compatibility);
 
@@ -70,6 +73,10 @@ register("module version manifest validation rejects malformed data", () => {
   );
   assert.equal(
     errors.some((entry: string) => entry.includes("invalid save-game schema range")),
+    true
+  );
+  assert.equal(
+    errors.some((entry: string) => entry.includes("outside declared module version range")),
     true
   );
 });
@@ -190,6 +197,8 @@ register("module compatibility checks app, schema, API, and dependent module ver
   assert.equal(isModuleCompatibleWith("demo.command-center", "1.0.0", "core.base", "2.0.0"), false);
   assert.equal(isModuleCompatibleWith("setup-flow", "1.0.0", "content-packs", "1.0.0"), true);
   assert.equal(isModuleCompatibleWith("setup-flow", "1.0.0", "content-packs", "2.0.0"), false);
+  assert.equal(isModuleCompatibleWith("maps", "1.0.0", "setup-flow", "not-a-version"), false);
+  assert.equal(isModuleCompatibleWith("maps", "1.0.0", "setup-flow", "2.0.0"), false);
   assert.equal(
     isModuleCompatibleWith("setup-flow", "1.0.0", "content-packs", "1.0.0", {
       appVersion: "0.2.000"

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -188,6 +188,14 @@ register("module compatibility checks app, schema, API, and dependent module ver
 
   assert.equal(isModuleCompatibleWith("demo.command-center", "1.0.0", "core.base", "1.0.0"), true);
   assert.equal(isModuleCompatibleWith("demo.command-center", "1.0.0", "core.base", "2.0.0"), false);
+  assert.equal(isModuleCompatibleWith("setup-flow", "1.0.0", "content-packs", "1.0.0"), true);
+  assert.equal(isModuleCompatibleWith("setup-flow", "1.0.0", "content-packs", "2.0.0"), false);
+  assert.equal(
+    isModuleCompatibleWith("setup-flow", "1.0.0", "content-packs", "1.0.0", {
+      appVersion: "0.2.000"
+    }),
+    false
+  );
 });
 
 register("module version bump detector maps changed paths to owned functional modules", () => {

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -17,6 +17,7 @@ const {
 } = require("../../../shared/module-versions.cjs");
 const { validateNetRiskModuleManifest } = require("../../../shared/netrisk-modules.cjs");
 const {
+  findNonIncrementingModuleVersionChanges,
   parseChangedFilePathsFromNameStatus
 } = require("../../../scripts/check-module-versioning.cjs");
 
@@ -258,4 +259,23 @@ register("module version bump detector includes both paths from git rename outpu
     ),
     true
   );
+});
+
+register("module version bump detector rejects non-incrementing version edits", () => {
+  const baseSource = [
+    '{ id: "maps", name: "Maps", version: "1.2.3", ownerPaths: ["shared/maps/"] }',
+    '{ id: "public-state", name: "Public State", version: "1.0.0", ownerPaths: ["shared/public-state.cts"] }'
+  ].join("\n");
+  const currentSource = [
+    '{ id: "maps", name: "Maps", version: "1.2.2", ownerPaths: ["shared/maps/"] }',
+    '{ id: "public-state", name: "Public State", version: "1.0.1", ownerPaths: ["shared/public-state.cts"] }'
+  ].join("\n");
+
+  assert.deepEqual(findNonIncrementingModuleVersionChanges(currentSource, baseSource), [
+    {
+      moduleId: "maps",
+      baseVersion: "1.2.3",
+      currentVersion: "1.2.2"
+    }
+  ]);
 });


### PR DESCRIPTION
## Summary
- add a central functional module SemVer and compatibility registry in shared/module-versions.cts
- add manifest/range compatibility helpers plus runtime module manifest version/range validation
- add CI/developer module-versioning check with path-based bump detection and docs for bump workflow

## Validation
- npm run test:gameplay
- npm run format:check
- npm run lint
- node .tsbuild/scripts/check-module-versioning.cjs

## Notes
- The bump detector skips historical comparison on this first PR because shared/module-versions.cts does not exist on origin/main yet; subsequent PRs can compare against the base file.