### PR TITLE
Harden Supabase datastore access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.008 - 2026-05-08
+
+- Hardened Supabase datastore access by requiring the service-role key and enabling RLS guardrails for Supabase-backed tables.
+
 ## 0.1.007 - 2026-05-07
 
 - Hardened request handling in the custom HTTP server against malformed Host headers and prioritized security header application.

--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -212,12 +212,7 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
       requiredEnv("NEXT_PUBLIC_SUPABASE_URL")
   ).replace(/\/$/, "");
   const supabaseKey = String(
-    options.supabaseServiceRoleKey ||
-      process.env.SUPABASE_SERVICE_ROLE_KEY ||
-      process.env.SUPABASE_ANON_KEY ||
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ||
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-      ""
+    options.supabaseServiceRoleKey || process.env.SUPABASE_SERVICE_ROLE_KEY || ""
   ).trim();
 
   if (!supabaseKey) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -269,7 +269,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "datastore",
     name: "Datastore",
     kind: "platform",
-    version: "1.0.0",
+    version: "1.0.1",
     description:
       "Game/session persistence, app state persistence, backups, and datastore schema use.",
     ownerPaths: [

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.007";
+export const appVersion = "0.1.008";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/supabase/schema.cts
+++ b/supabase/schema.cts
@@ -35,6 +35,22 @@ create table if not exists public.app_state (
   key text primary key,
   value_json jsonb not null
 );
+
+alter table public.users enable row level security;
+alter table public.sessions enable row level security;
+alter table public.games enable row level security;
+alter table public.app_state enable row level security;
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    revoke all on table public.users, public.sessions, public.games, public.app_state from anon;
+  end if;
+
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    revoke all on table public.users, public.sessions, public.games, public.app_state from authenticated;
+  end if;
+end $$;
 `.trim() + "\n";
 
 export function getSupabaseSchemaSql(): string {

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const { createSupabaseDatastore } = require("../../../backend/datastore-supabase.cjs");
 const { checkSupabaseConnection } = require("../../../scripts/check-supabase-connection.cjs");
+const { getSupabaseSchemaSql } = require("../../../supabase/schema.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
@@ -102,6 +103,56 @@ register("Supabase connection check fails clearly when REST auth is invalid", as
         tables: ["users"]
       }),
     /Supabase connection check failed for table users \(401\)/
+  );
+});
+
+register("Supabase datastore ignores public keys and requires the service role key", () => {
+  const previousEnv = {
+    SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY:
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY
+  };
+
+  try {
+    process.env.SUPABASE_ANON_KEY = "anon-key";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY = "publishable-key";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "next-public-anon-key";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    assert.throws(
+      () =>
+        createSupabaseDatastore({
+          supabaseUrl: "https://example.supabase.co"
+        }),
+      /SUPABASE_SERVICE_ROLE_KEY/
+    );
+  } finally {
+    Object.entries(previousEnv).forEach(([key, value]) => {
+      if (typeof value === "undefined") {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    });
+  }
+});
+
+register("Supabase schema enables RLS and revokes browser role table access", () => {
+  const schemaSql = getSupabaseSchemaSql();
+
+  ["users", "sessions", "games", "app_state"].forEach((table) => {
+    assert.match(schemaSql, new RegExp(`alter table public\\.${table} enable row level security;`));
+  });
+
+  assert.match(
+    schemaSql,
+    /revoke all on table public\.users, public\.sessions, public\.games, public\.app_state from anon;/
+  );
+  assert.match(
+    schemaSql,
+    /revoke all on table public\.users, public\.sessions, public\.games, public\.app_state from authenticated;/
   );
 });
 


### PR DESCRIPTION
## Summary
- require `SUPABASE_SERVICE_ROLE_KEY` for the backend Supabase datastore instead of accepting anon or `NEXT_PUBLIC_*` keys
- enable RLS for the Supabase `users`, `sessions`, `games`, and `app_state` tables
- revoke browser role table access from `anon` and `authenticated` when those Supabase roles exist
- add regression coverage for the service-role requirement and RLS schema guardrails
- align the branch with current `main`, bump the datastore module version, and add the release entry required by CI

## Security
- Addresses the private draft advisory `GHSA-q2fm-g77c-hq36`.
- No save-game or API response shape change.
- Supabase-backed deployments must provide `SUPABASE_SERVICE_ROLE_KEY`; public keys are no longer accepted by the backend datastore path.

## Validation
- `npm ci` (0 vulnerabilities reported by npm audit during install)
- `npm run build:ts`
- `node .tsbuild/scripts/check-module-versioning.cjs`
- `node .tsbuild/scripts/check-release-gate.cjs`
- `npm run test:gameplay` (399 gameplay tests passed)
- `npm run test:react` (136 React tests passed)
- `npm run lint`
- `npm run format:check`
- `npm audit --omit=dev` (0 vulnerabilities)
- `git diff --check`

## Notes
- Build still emits the existing runtime asset-resolution warnings for `/assets/maps/world-classic.png` and `/assets/maps/middle-earth.jpg`.
- Gameplay tests still emit the expected audit-store failure log from the regression that verifies that path.