### PR TITLE
🛡️ Sentinel: Add anti-caching headers to JSON API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.010 - 2026-05-10
+
+- Added restrictive anti-caching headers to JSON API responses to protect sensitive user and game data from insecure storage.
+
 ## 0.1.009 - 2026-05-08
 
 - Added the Supabase CLI as a pinned development dependency and scoped the Supabase MCP config to the NetRisk project.

--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -101,6 +101,9 @@ export function sendJson(
 
   res.writeHead(statusCode, {
     "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    "Pragma": "no-cache",
+    "Expires": "0",
     ...headers
   });
   res.end(JSON.stringify(payload));

--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -102,8 +102,8 @@ export function sendJson(
   res.writeHead(statusCode, {
     "Content-Type": "application/json; charset=utf-8",
     "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
-    "Pragma": "no-cache",
-    "Expires": "0",
+    Pragma: "no-cache",
+    Expires: "0",
     ...headers
   });
   res.end(JSON.stringify(payload));

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.009";
+export const appVersion = "0.1.010";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
I have implemented a security enhancement that prevents sensitive API responses from being cached.

By adding `Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`, `Pragma: no-cache`, and `Expires: 0` headers to the `sendJson` utility in `backend/http-response.cts`, we ensure that all JSON API responses are protected by default. This is a standard security best practice to prevent sensitive information from being inadvertently stored in browser caches or shared intermediate proxies.

I verified that this change does not affect the serving of static public assets (images, CSS, etc.) in `backend/server.cts`, preserving their performance benefits while securing the data-rich API endpoints.

Verification:
- Read `backend/http-response.cts` to confirm header implementation.
- Read `backend/server.cts` to confirm `serveStatic` bypasses these headers for public assets.
- Ran `npm test` and all 157 integration tests passed.

---
*PR created automatically by Jules for task [12401171758754877897](https://jules.google.com/task/12401171758754877897) started by @andreame-code*