### PR TITLE
Improve branch coverage for game validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.011 - 2026-05-11
+
+- Added branch-focused regression tests for map data validation, reinforcement adjustments, and conquest resolution edge cases.
+
 ## 0.1.010 - 2026-05-09
 
 - Hardened authentication flow against timing-based username enumeration by ensuring consistent password hashing execution paths for all users.

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.010";
+export const appVersion = "0.1.011";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/conquest/conquest-resolution.test.cts
+++ b/tests/gameplay/conquest/conquest-resolution.test.cts
@@ -104,6 +104,15 @@ register("resolveConquest throws when the attacker territory state is missing", 
   assert.throws(() => resolveConquest(state, makeCombatResult(), 2), /attacker territory state/i);
 });
 
+register("resolveConquest throws when the defender territory state is missing", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 4 }])
+  });
+
+  assert.throws(() => resolveConquest(state, makeCombatResult(), 2), /defender territory state/i);
+});
+
 register("resolveConquest rejects moves that leave the source empty", () => {
   const state = makeState({
     players: makePlayers(["Alice", "Bob"]),
@@ -177,3 +186,64 @@ register(
     assert.equal(state.territories.b.armies, 1);
   }
 );
+
+register(
+  "resolveConquest applies configured conquest minimum and clamps it to available armies",
+  () => {
+    const state = makeState({
+      players: makePlayers(["Alice", "Bob"]),
+      territories: territoryStates([
+        { id: "a", ownerId: "p1", armies: 4 },
+        { id: "b", ownerId: "p2", armies: 0 }
+      ])
+    });
+    state.gameConfig = {
+      gameplayEffects: {
+        conquestMinimumArmies: 10
+      }
+    };
+
+    const belowMinimum = resolveConquest(state, makeCombatResult(), 2);
+    assert.equal(belowMinimum.ok, false);
+    assert.equal(belowMinimum.code, "MOVE_BELOW_MINIMUM");
+    assert.equal(belowMinimum.details.minimumMove, 3);
+    assert.equal(state.territories.a.armies, 4);
+    assert.equal(state.territories.b.ownerId, "p2");
+
+    const resolved = resolveConquest(state, makeCombatResult(), 3);
+    assert.equal(resolved.ok, true);
+    assert.equal(resolved.conquest.minimumMove, 3);
+    assert.equal(state.territories.a.armies, 1);
+    assert.equal(state.territories.b.armies, 3);
+  }
+);
+
+register("resolveConquest rejects malformed state and combat result inputs", () => {
+  const state = makeState({
+    players: makePlayers(["Alice", "Bob"]),
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 4 },
+      { id: "b", ownerId: "p2", armies: 0 }
+    ])
+  });
+
+  assert.throws(() => resolveConquest(null, makeCombatResult(), 2), /valid game state/i);
+  assert.throws(() => resolveConquest(state, null, 2), /valid combat result/i);
+  assert.throws(
+    () =>
+      resolveConquest(
+        state,
+        {
+          details: { playerId: "p1" },
+          combat: {
+            fromTerritoryId: "",
+            toTerritoryId: "b",
+            attackDiceCount: 2,
+            defenderReducedToZero: true
+          }
+        },
+        2
+      ),
+    /missing conquest territory identifiers/i
+  );
+});

--- a/tests/gameplay/reinforcement/reinforcement-calculation.test.cts
+++ b/tests/gameplay/reinforcement/reinforcement-calculation.test.cts
@@ -100,7 +100,86 @@ register("calculateReinforcements applica adjustment modulari persistiti nel gam
   assert.equal(result.totalReinforcements, 6);
 });
 
+register("calculateReinforcements filtra adjustment modulari incompleti o non positivi", () => {
+  const players = makePlayers(["Alice", "Bob"]);
+  const state = makeState({
+    players,
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 1 },
+      { id: "b", ownerId: "p1", armies: 1 },
+      { id: "c", ownerId: "p2", armies: 1 }
+    ])
+  });
+  state.gameConfig = {
+    gameplayEffects: {
+      reinforcementAdjustments: [
+        null,
+        [],
+        { id: "ignored.no-label", label: "", flatBonus: 5 },
+        { id: "ignored.negative", label: "Penalty", flatBonus: -1, minimumTotal: 0 },
+        { id: 42, label: "Trimmed supply", flatBonus: 1, minimumTotal: 4 }
+      ]
+    }
+  };
+
+  const result = calculateReinforcements(state, "p1");
+  assert.deepEqual(result.moduleAdjustments, [
+    {
+      id: null,
+      label: "Trimmed supply",
+      flatBonus: 1,
+      minimumTotal: 4
+    }
+  ]);
+  assert.equal(result.moduleBonusTotal, 1);
+  assert.equal(result.moduleMinimumTotal, 4);
+  assert.equal(result.totalReinforcements, 4);
+});
+
 register("calculateReinforcements rejects unknown players", () => {
   const state = makeState({ players: makePlayers(["Alice"]) });
   assert.throws(() => calculateReinforcements(state, "missing"), /unknown player/i);
+});
+
+register("calculateReinforcements rejects malformed game state and continent entries", () => {
+  assert.throws(() => calculateReinforcements(null, "p1"), /valid game state/i);
+  assert.throws(
+    () => calculateReinforcements({ players: [], territories: {}, continents: [] }, "p1"),
+    /at least one player/i
+  );
+  assert.throws(
+    () =>
+      calculateReinforcements(
+        {
+          players: makePlayers(["Alice"]),
+          territories: null,
+          continents: []
+        },
+        "p1"
+      ),
+    /territory ownership data/i
+  );
+  assert.throws(
+    () =>
+      calculateReinforcements(
+        {
+          players: makePlayers(["Alice"]),
+          territories: {},
+          continents: null
+        },
+        "p1"
+      ),
+    /continents as an array/i
+  );
+
+  const state = makeState({
+    players: makePlayers(["Alice"]),
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 1 }]),
+    continents: [null]
+  });
+  assert.throws(() => calculateReinforcements(state, "p1"), /continent entry at index 0/i);
+
+  state.continents = [{ id: "north", name: "North", bonus: 2, territoryIds: null }];
+  assert.throws(() => calculateReinforcements(state, "p1"), /must define territoryIds/i);
+  assert.throws(() => calculateReinforcements(state, ""), /requires a player id/i);
 });

--- a/tests/gameplay/shared/typed-map-data.test.cts
+++ b/tests/gameplay/shared/typed-map-data.test.cts
@@ -1,5 +1,8 @@
 const assert = require("node:assert/strict");
-const { buildMapDefinition } = require("../../../shared/typed-map-data.cjs");
+const {
+  buildContinentDefinition,
+  buildMapDefinition
+} = require("../../../shared/typed-map-data.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
@@ -46,5 +49,130 @@ register("buildMapDefinition rejects unknown neighbors", () => {
         }
       ]),
     /unknown neighbor "missing"/i
+  );
+});
+
+register("buildMapDefinition rejects invalid territory fields before building adjacency", () => {
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "",
+          name: "Missing Id",
+          continentId: "north",
+          x: 0.1,
+          y: 0.2,
+          neighbors: []
+        }
+      ]),
+    /territory without id/i
+  );
+
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "alpha",
+          name: "",
+          continentId: "north",
+          x: 0.1,
+          y: 0.2,
+          neighbors: []
+        }
+      ]),
+    /missing a name/i
+  );
+
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "alpha",
+          name: "Alpha",
+          continentId: "north",
+          x: Number.POSITIVE_INFINITY,
+          y: 0.2,
+          neighbors: []
+        }
+      ]),
+    /invalid x coordinate/i
+  );
+
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "alpha",
+          name: "Alpha",
+          continentId: "north",
+          x: 0.1,
+          y: 1.2,
+          neighbors: []
+        }
+      ]),
+    /between 0 and 1/i
+  );
+});
+
+register("buildMapDefinition rejects duplicate territory ids", () => {
+  assert.throws(
+    () =>
+      buildMapDefinition("test-map", [
+        {
+          id: "alpha",
+          name: "Alpha",
+          continentId: "north",
+          x: 0.1,
+          y: 0.2,
+          neighbors: []
+        },
+        {
+          id: "alpha",
+          name: "Duplicate Alpha",
+          continentId: "south",
+          x: 0.3,
+          y: 0.4,
+          neighbors: []
+        }
+      ]),
+    /duplicate territory id "alpha"/i
+  );
+});
+
+register("buildContinentDefinition validates required fields and unknown territories", () => {
+  assert.throws(() => buildContinentDefinition("empty-continents", []), /at least one continent/i);
+
+  assert.throws(
+    () =>
+      buildContinentDefinition("test-continents", [
+        { id: "", name: "Missing Id", bonus: 2, territoryIds: [] }
+      ]),
+    /continent without id/i
+  );
+
+  assert.throws(
+    () =>
+      buildContinentDefinition("test-continents", [
+        { id: "north", name: "", bonus: 2, territoryIds: [] }
+      ]),
+    /missing a name/i
+  );
+
+  assert.throws(
+    () =>
+      buildContinentDefinition("test-continents", [
+        { id: "north", name: "North", bonus: Number.NaN, territoryIds: [] }
+      ]),
+    /invalid bonus value/i
+  );
+
+  assert.throws(
+    () =>
+      buildContinentDefinition(
+        "test-continents",
+        [{ id: "north", name: "North", bonus: 2, territoryIds: ["missing"] }],
+        { validTerritoryIds: ["alpha"] }
+      ),
+    /references unknown territory "missing"/i
   );
 });


### PR DESCRIPTION
## Obiettivo

Aumentare la branch coverage con test utili su logica shared/engine senza cambiare comportamento applicativo.

## Aree toccate

- `tests/gameplay/shared/typed-map-data.test.cts`: validazioni mappe/continenti per campi mancanti, coordinate invalide, duplicati e riferimenti sconosciuti.
- `tests/gameplay/reinforcement/reinforcement-calculation.test.cts`: game state malformati, continenti invalidi e filtraggio adjustment modulari.
- `tests/gameplay/conquest/conquest-resolution.test.cts`: defender mancante, input malformati e minimo conquista modulare clampato.
- `shared/version-manifest.cts` / `CHANGELOG.md`: bump appVersion a `0.1.011` richiesto dal release gate.

## Coverage

- Prima: Statements 89.52%, Branches 77.43%, Functions 78.93%, Lines 89.52%.
- Dopo: Statements 89.66%, Branches 77.90%, Functions 78.93%, Lines 89.66%.

## Fix minimi

Nessun fix comportamentale applicato. Solo test e release metadata richiesto dal CI.

## Validazione locale

- `npm run typecheck` ✅
- `npm run typecheck:react-shell` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run build:ts` ✅
- `npm run test:all` ✅
- `npm run coverage` ✅
- `npm run coverage:check` ✅
- `npm run release:check` ✅
- `npm run test:e2e:smoke` ✅ 29 passed

## Validazione remota

- Quality ✅
- Coverage ✅
- E2E Smoke ✅
- Release Gate ✅
- CodeQL Advanced / Analyze ✅
- Vercel PR Deployment Panel ✅
- Vercel preview status ✅

## Rischi residui

- Commit/branch locale non creati via Git CLI perché la gitdir della worktree non permette `index.lock`/ref lock; branch e commit sono stati creati via GitHub API.
- Nessun rischio di comportamento noto: solo test e release metadata.