### PR TITLE
Harden session token storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.013 - 2026-05-11
+
+- Hardened session storage by hashing server-side session tokens and revoking user sessions after password or role changes.
+
 ## 0.1.012 - 2026-05-11
 
 - Hardened module metadata and JSON API responses by returning project-relative module paths and disabling API response caching.

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -123,6 +123,7 @@ type AdminConsoleOptions = {
     listUsers(): Promise<StoredUser[]> | StoredUser[];
     findUserById(userId: string): Promise<StoredUser | null> | StoredUser | null;
     updateUserRoleByUsername(username: string, role: string): Promise<void> | void;
+    deleteSessionsForUser?(userId: string): Promise<void> | void;
     getAppState(key: string): Promise<unknown> | unknown;
     setAppState(key: string, value: unknown): Promise<unknown> | unknown;
   };
@@ -880,7 +881,11 @@ function createAdminConsole(options: AdminConsoleOptions) {
       throw new Error("Impossibile rimuovere l'ultimo amministratore disponibile.");
     }
 
+    const roleChanged = targetUser.role !== input.role;
     await maybeResolve(options.datastore.updateUserRoleByUsername(targetUser.username, input.role));
+    if (roleChanged) {
+      await maybeResolve(options.datastore.deleteSessionsForUser?.(targetUser.id));
+    }
     const refreshedUsers = await listUsers();
     const updatedUser = refreshedUsers.users.find((user) => user.id === input.userId);
     if (!updatedUser) {

--- a/backend/auth-repository.cts
+++ b/backend/auth-repository.cts
@@ -58,6 +58,7 @@ interface LocalDatastore {
     token: string
   ): Promise<SessionRecord | SessionRow | null> | SessionRecord | SessionRow | null;
   deleteSession(token: string): Promise<void> | void;
+  deleteSessionsForUser?(userId: string): Promise<void> | void;
   close?(): void;
 }
 
@@ -161,6 +162,9 @@ function createLocalAuthRepository(options: AuthRepositoryOptions = {}) {
     },
     async deleteSession(token: string) {
       await datastore.deleteSession(token);
+    },
+    async deleteSessionsForUser(userId: string) {
+      await datastore.deleteSessionsForUser?.(userId);
     },
     close() {
       if (typeof datastore.close === "function") {
@@ -359,6 +363,11 @@ function createSupabaseAuthRepository(options: AuthRepositoryOptions = {}) {
     async deleteSession(token: string) {
       await request("sessions", "DELETE", {
         token: `eq.${String(token || "").trim()}`
+      });
+    },
+    async deleteSessionsForUser(userId: string) {
+      await request("sessions", "DELETE", {
+        user_id: `eq.${String(userId || "").trim()}`
       });
     },
     close() {}

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -581,24 +581,46 @@ function createAuthStore(options: AuthStoreOptions = {}) {
     }
 
     const storedSessionToken = sessionTokenStorageKey(sessionToken);
-    const session = await datastore.findSession(storedSessionToken);
+    let session = await datastore.findSession(storedSessionToken);
+    let tokenToDelete = storedSessionToken;
     if (!session) {
-      return null;
+      const legacySession = await datastore.findSession(sessionToken);
+      if (!legacySession) {
+        return null;
+      }
+
+      session = legacySession;
+      tokenToDelete = sessionToken;
     }
 
     const createdAt = session.created_at || session.createdAt || 0;
     if (Date.now() - Number(createdAt) > SESSION_MAX_AGE_MS) {
-      await datastore.deleteSession(storedSessionToken);
+      await datastore.deleteSession(tokenToDelete);
       return null;
     }
 
     const sessionUserId = session.user_id || session.userId || "";
-    return sessionUserId ? (await datastore.findUserById(sessionUserId)) || null : null;
+    if (!sessionUserId) {
+      await datastore.deleteSession(tokenToDelete);
+      return null;
+    }
+
+    if (tokenToDelete === sessionToken) {
+      await datastore.createSession(
+        storedSessionToken,
+        sessionUserId,
+        Number(createdAt) || Date.now()
+      );
+      await datastore.deleteSession(sessionToken);
+    }
+
+    return (await datastore.findUserById(sessionUserId)) || null;
   }
 
   async function logout(sessionToken: string | null | undefined) {
     if (sessionToken) {
       await datastore.deleteSession(sessionTokenStorageKey(sessionToken));
+      await datastore.deleteSession(sessionToken);
     }
 
     return null;

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -610,11 +610,18 @@ function createAuthStore(options: AuthStoreOptions = {}) {
     }
 
     if (tokenToDelete === sessionToken) {
-      await datastore.createSession(
-        storedSessionToken,
-        sessionUserId,
-        Number(createdAt) || Date.now()
-      );
+      try {
+        await datastore.createSession(
+          storedSessionToken,
+          sessionUserId,
+          Number(createdAt) || Date.now()
+        );
+      } catch (error) {
+        const migratedSession = await datastore.findSession(storedSessionToken);
+        if (!migratedSession) {
+          throw error;
+        }
+      }
       await datastore.deleteSession(sessionToken);
     }
 

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -580,11 +580,12 @@ function createAuthStore(options: AuthStoreOptions = {}) {
       return null;
     }
 
+    const presentedTokenIsStorageKey = isSessionTokenStorageKey(sessionToken);
     const storedSessionToken = sessionTokenStorageKey(sessionToken);
     let session = await datastore.findSession(storedSessionToken);
     let tokenToDelete = storedSessionToken;
     if (!session) {
-      if (isSessionTokenStorageKey(sessionToken)) {
+      if (presentedTokenIsStorageKey) {
         return null;
       }
 
@@ -600,12 +601,18 @@ function createAuthStore(options: AuthStoreOptions = {}) {
     const createdAt = session.created_at || session.createdAt || 0;
     if (Date.now() - Number(createdAt) > SESSION_MAX_AGE_MS) {
       await datastore.deleteSession(tokenToDelete);
+      if (!presentedTokenIsStorageKey && tokenToDelete !== sessionToken) {
+        await datastore.deleteSession(sessionToken);
+      }
       return null;
     }
 
     const sessionUserId = session.user_id || session.userId || "";
     if (!sessionUserId) {
       await datastore.deleteSession(tokenToDelete);
+      if (!presentedTokenIsStorageKey && tokenToDelete !== sessionToken) {
+        await datastore.deleteSession(sessionToken);
+      }
       return null;
     }
 
@@ -622,6 +629,8 @@ function createAuthStore(options: AuthStoreOptions = {}) {
           throw error;
         }
       }
+      await datastore.deleteSession(sessionToken);
+    } else if (!presentedTokenIsStorageKey) {
       await datastore.deleteSession(sessionToken);
     }
 

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -2,6 +2,7 @@ const path = require("path");
 const crypto = require("crypto");
 const { createAuthRepository } = require("./auth-repository.cjs");
 const { SESSION_MAX_AGE_MS } = require("./session-policy.cjs");
+const { sessionTokenStorageKey } = require("./session-token.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 
 interface ThemePreferences {
@@ -78,6 +79,7 @@ interface AuthRepository {
   createSession(token: string, userId: string, createdAt: number): Promise<void> | void;
   findSession(token: string): Promise<AuthSession | null> | AuthSession | null;
   deleteSession(token: string): Promise<void> | void;
+  deleteSessionsForUser?(userId: string): Promise<void> | void;
 }
 
 interface AuthStoreOptions {
@@ -559,8 +561,12 @@ function createAuthStore(options: AuthStoreOptions = {}) {
       return authFailure("Credenziali non valide.", "auth.login.invalidCredentials");
     }
 
-    const sessionToken = crypto.randomBytes(16).toString("hex");
-    await datastore.createSession(sessionToken, verifiedUser.id, Date.now());
+    const sessionToken = crypto.randomBytes(32).toString("base64url");
+    await datastore.createSession(
+      sessionTokenStorageKey(sessionToken),
+      verifiedUser.id,
+      Date.now()
+    );
 
     return {
       ok: true,
@@ -574,14 +580,15 @@ function createAuthStore(options: AuthStoreOptions = {}) {
       return null;
     }
 
-    const session = await datastore.findSession(sessionToken);
+    const storedSessionToken = sessionTokenStorageKey(sessionToken);
+    const session = await datastore.findSession(storedSessionToken);
     if (!session) {
       return null;
     }
 
     const createdAt = session.created_at || session.createdAt || 0;
     if (Date.now() - Number(createdAt) > SESSION_MAX_AGE_MS) {
-      await datastore.deleteSession(sessionToken);
+      await datastore.deleteSession(storedSessionToken);
       return null;
     }
 
@@ -591,7 +598,7 @@ function createAuthStore(options: AuthStoreOptions = {}) {
 
   async function logout(sessionToken: string | null | undefined) {
     if (sessionToken) {
-      await datastore.deleteSession(sessionToken);
+      await datastore.deleteSession(sessionTokenStorageKey(sessionToken));
     }
 
     return null;
@@ -655,6 +662,7 @@ function createAuthStore(options: AuthStoreOptions = {}) {
           ...(updatedUser.credentials || {}),
           password: passwordRecord(nextPassword)
         })) || updatedUser;
+      await datastore.deleteSessionsForUser?.(updatedUser.id);
     }
 
     return {

--- a/backend/auth.cts
+++ b/backend/auth.cts
@@ -2,7 +2,7 @@ const path = require("path");
 const crypto = require("crypto");
 const { createAuthRepository } = require("./auth-repository.cjs");
 const { SESSION_MAX_AGE_MS } = require("./session-policy.cjs");
-const { sessionTokenStorageKey } = require("./session-token.cjs");
+const { isSessionTokenStorageKey, sessionTokenStorageKey } = require("./session-token.cjs");
 const { createLocalizedError } = require("../shared/messages.cjs");
 
 interface ThemePreferences {
@@ -584,6 +584,10 @@ function createAuthStore(options: AuthStoreOptions = {}) {
     let session = await datastore.findSession(storedSessionToken);
     let tokenToDelete = storedSessionToken;
     if (!session) {
+      if (isSessionTokenStorageKey(sessionToken)) {
+        return null;
+      }
+
       const legacySession = await datastore.findSession(sessionToken);
       if (!legacySession) {
         return null;
@@ -620,7 +624,9 @@ function createAuthStore(options: AuthStoreOptions = {}) {
   async function logout(sessionToken: string | null | undefined) {
     if (sessionToken) {
       await datastore.deleteSession(sessionTokenStorageKey(sessionToken));
-      await datastore.deleteSession(sessionToken);
+      if (!isSessionTokenStorageKey(sessionToken)) {
+        await datastore.deleteSession(sessionToken);
+      }
     }
 
     return null;

--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -570,6 +570,10 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
       await ensureInitialized();
       await deleteRows("sessions", { token: `eq.${token}` });
     },
+    async deleteSessionsForUser(userId: string) {
+      await ensureInitialized();
+      await deleteRows("sessions", { user_id: `eq.${userId}` });
+    },
     async listGames() {
       await ensureInitialized();
       return (await selectMany<GameRow>("games", {}, { order: "updated_at.desc" })).map((row) =>

--- a/backend/datastore.cts
+++ b/backend/datastore.cts
@@ -4,6 +4,7 @@ const { readJsonFile } = require("./json-file-store.cjs") as {
   readJsonFile: <T>(filePath: string, fallbackValue: T, isValid?: (value: unknown) => boolean) => T;
 };
 const { createSupabaseDatastore } = require("./datastore-supabase.cjs");
+const { isSessionTokenStorageKey, sessionTokenStorageKey } = require("./session-token.cjs");
 
 type JsonRecord = Record<string, unknown>;
 
@@ -259,6 +260,9 @@ function createDatastore(options: DatastoreOptions = {}) {
       "SELECT * FROM sessions WHERE token = ?"
     ) as Statement<SessionRow | null>,
     deleteSession: db.prepare("DELETE FROM sessions WHERE token = ?") as Statement<unknown>,
+    deleteSessionsForUser: db.prepare(
+      "DELETE FROM sessions WHERE user_id = ?"
+    ) as Statement<unknown>,
     listGames: db.prepare("SELECT * FROM games ORDER BY updated_at DESC") as Statement<GameRow>,
     findGameById: db.prepare("SELECT * FROM games WHERE id = ?") as Statement<GameRow | null>,
     insertGame: db.prepare(
@@ -329,7 +333,9 @@ function createDatastore(options: DatastoreOptions = {}) {
         }
 
         statements.insertSession.run(
-          session.token,
+          isSessionTokenStorageKey(session.token)
+            ? session.token
+            : sessionTokenStorageKey(session.token),
           session.userId,
           Number(session.createdAt) || Date.now()
         );
@@ -474,6 +480,11 @@ function createDatastore(options: DatastoreOptions = {}) {
     deleteSession(token: string) {
       transaction(() => {
         statements.deleteSession.run(token);
+      });
+    },
+    deleteSessionsForUser(userId: string) {
+      transaction(() => {
+        statements.deleteSessionsForUser.run(String(userId || ""));
       });
     },
     listGames() {

--- a/backend/session-token.cts
+++ b/backend/session-token.cts
@@ -1,0 +1,24 @@
+const crypto = require("crypto");
+
+const SESSION_TOKEN_STORAGE_PREFIX = "sha256:";
+const SESSION_TOKEN_HASH_DOMAIN = "netrisk-session-token-v1\0";
+
+function sessionTokenStorageKey(sessionToken: unknown): string {
+  const token = String(sessionToken || "");
+  const digest = crypto
+    .createHash("sha256")
+    .update(SESSION_TOKEN_HASH_DOMAIN)
+    .update(token)
+    .digest("hex");
+  return `${SESSION_TOKEN_STORAGE_PREFIX}${digest}`;
+}
+
+function isSessionTokenStorageKey(value: unknown): boolean {
+  return /^sha256:[a-f0-9]{64}$/.test(String(value || ""));
+}
+
+module.exports = {
+  SESSION_TOKEN_STORAGE_PREFIX,
+  isSessionTokenStorageKey,
+  sessionTokenStorageKey
+};

--- a/e2e/gameplay/ai-turn-flow.spec.ts
+++ b/e2e/gameplay/ai-turn-flow.spec.ts
@@ -24,7 +24,10 @@ test("human player can end turn and watch the AI complete its turn automatically
   });
   await expect(joinAiResponse.ok()).toBeTruthy();
 
-  await page.getByRole("button", { name: "Avvia partita" }).click();
+  await page.reload();
+  const startButton = page.getByRole("button", { name: "Avvia partita" });
+  await expect(startButton).toBeEnabled();
+  await startButton.click();
   await expect(page.getByTestId("status-summary")).toContainText(
     /Rinforzi disponibili:\s*[1-9]\d*/i
   );

--- a/e2e/gameplay/new-game-setup.spec.ts
+++ b/e2e/gameplay/new-game-setup.spec.ts
@@ -1,7 +1,14 @@
 const { test, expect } = require("@playwright/test");
 const { registerAndLogin, resetGame, uniqueUser } = require("../support/game-helpers");
 
-test("new game setup keeps player 1 locked as creator and creates the configured session", async ({ page }) => {
+async function expectNewGameSetupReady(page) {
+  await expect(page.locator("#setup-map")).toBeVisible({ timeout: 15000 });
+  await expect(page.locator("#submit-new-game")).toBeVisible({ timeout: 15000 });
+}
+
+test("new game setup keeps player 1 locked as creator and creates the configured session", async ({
+  page
+}) => {
   test.slow();
   await resetGame(page);
   await page.goto("/game");
@@ -9,7 +16,7 @@ test("new game setup keeps player 1 locked as creator and creates the configured
   await registerAndLogin(page, owner);
   await page.goto("/lobby/new");
 
-  await expect(page.getByTestId("new-game-shell")).toBeVisible();
+  await expectNewGameSetupReady(page);
   await expect(page.locator("#setup-ruleset")).toBeVisible();
   await expect(page.locator("#setup-ruleset")).toContainText("Classic Defense 3");
   await expect(page.locator("#setup-map")).toBeEnabled();
@@ -42,30 +49,30 @@ test("new game setup keeps player 1 locked as creator and creates the configured
   await expect(slotOne).toContainText("Player 1");
   await expect(slotOne).toContainText("Creator");
   await expect(slotOne).toContainText("Human");
-  await expect(slotOne.locator('select')).toHaveCount(0);
+  await expect(slotOne.locator("select")).toHaveCount(0);
 
-  await page.locator('#setup-total-players').selectOption('4');
-  await expect(page.locator('[data-slot-index]')).toHaveCount(4);
-  await expect(slotOne.locator('select')).toHaveCount(0);
+  await page.locator("#setup-total-players").selectOption("4");
+  await expect(page.locator("[data-slot-index]")).toHaveCount(4);
+  await expect(slotOne.locator("select")).toHaveCount(0);
   await expect(page.locator('[data-slot-index="1"] select[data-role="type"]')).toHaveCount(1);
   await expect(page.locator('[data-slot-index="2"] select[data-role="type"]')).toHaveCount(1);
   await expect(page.locator('[data-slot-index="3"] select[data-role="type"]')).toHaveCount(1);
 
-  await page.locator('[data-slot-index="1"] select[data-role="type"]').selectOption('ai');
-  await page.locator('[data-slot-index="2"] select[data-role="type"]').selectOption('human');
-  await page.locator('[data-slot-index="3"] select[data-role="type"]').selectOption('ai');
+  await page.locator('[data-slot-index="1"] select[data-role="type"]').selectOption("ai");
+  await page.locator('[data-slot-index="2"] select[data-role="type"]').selectOption("human");
+  await page.locator('[data-slot-index="3"] select[data-role="type"]').selectOption("ai");
 
-  await page.locator('#setup-game-name').fill('Setup Lock Test');
-  await page.getByRole('button', { name: 'Crea e apri' }).click();
+  await page.locator("#setup-game-name").fill("Setup Lock Test");
+  await page.getByRole("button", { name: "Crea e apri" }).click();
 
-  await expect(page).toHaveURL(/\/game\//);
-  await expect(page.locator('#game-status')).toContainText('Setup Lock Test');
-  await expect(page.locator('#game-map-meta')).toContainText('World Classic');
-  await expect(page.locator('#game-setup-meta')).toContainText('4 giocatori');
-  await expect(page.locator('#game-setup-meta')).toContainText('2 AI');
-  await expect(page.getByTestId('current-player-indicator')).toContainText(owner);
-  await expect(page.locator('#join-button')).toBeDisabled();
-  await expect(page.locator('.territory-node').first()).toHaveClass(/piece-skin-style-ring-core/);
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/game\//);
+  await expect(page.locator("#game-status")).toContainText("Setup Lock Test");
+  await expect(page.locator("#game-map-meta")).toContainText("World Classic");
+  await expect(page.locator("#game-setup-meta")).toContainText("4 giocatori");
+  await expect(page.locator("#game-setup-meta")).toContainText("2 AI");
+  await expect(page.getByTestId("current-player-indicator")).toContainText(owner);
+  await expect(page.locator("#join-button")).toBeDisabled();
+  await expect(page.locator(".territory-node").first()).toHaveClass(/piece-skin-style-ring-core/);
 });
 
 test("new game setup creates and renders the selected Classic Mini map", async ({ page }) => {
@@ -76,7 +83,7 @@ test("new game setup creates and renders the selected Classic Mini map", async (
   await registerAndLogin(page, owner);
   await page.goto("/lobby/new");
 
-  await expect(page.getByTestId("new-game-shell")).toBeVisible();
+  await expectNewGameSetupReady(page);
   await expect(page.locator("#setup-map")).toContainText("Classic Mini");
 
   await page.locator("#setup-map").selectOption("classic-mini");
@@ -101,7 +108,7 @@ test("new game setup creates and renders the selected Middle-earth map", async (
   await registerAndLogin(page, owner);
   await page.goto("/lobby/new");
 
-  await expect(page.getByTestId("new-game-shell")).toBeVisible();
+  await expectNewGameSetupReady(page);
   await expect(page.locator("#setup-map")).toContainText("Middle-earth");
 
   await page.locator("#setup-map").selectOption("middle-earth");
@@ -116,7 +123,10 @@ test("new game setup creates and renders the selected Middle-earth map", async (
   const mapBoard = page.locator(".map-board.has-custom-background");
   await expect(mapBoard).toBeVisible();
   await expect(mapBoard).toHaveAttribute("style", /middle-earth\.jpg/);
-  await expect(page.locator('[data-territory-id="the_shire"]')).toHaveAttribute("title", "The Shire");
+  await expect(page.locator('[data-territory-id="the_shire"]')).toHaveAttribute(
+    "title",
+    "The Shire"
+  );
   await expect(page.locator('[data-territory-id="gondor"]')).toBeVisible();
   await expect(page.locator('[data-territory-id="mordor"]')).toBeVisible();
 });

--- a/e2e/gameplay/version-conflict.spec.ts
+++ b/e2e/gameplay/version-conflict.spec.ts
@@ -1,8 +1,14 @@
 const { test, expect } = require("@playwright/test");
-const { getReinforcementCount, registerLoginAndJoin, resetGame, uniqueUser } = require("../support/game-helpers");
+const {
+  getReinforcementCount,
+  registerLoginAndJoin,
+  resetGame,
+  uniqueUser
+} = require("../support/game-helpers");
 
 test("stale game tab reloads latest state after a version conflict", async ({ browser }) => {
   test.slow();
+  test.setTimeout(120000);
 
   const firstContext = await browser.newContext();
   const secondContext = await browser.newContext();
@@ -20,14 +26,24 @@ test("stale game tab reloads latest state after a version conflict", async ({ br
   await registerLoginAndJoin(secondPage, secondUser);
 
   await currentPage.getByRole("button", { name: "Avvia partita" }).click();
-  await expect(currentPage.getByTestId("status-summary")).toContainText(/Rinforzi disponibili:\s*[1-9]\d*/i);
+  await expect(currentPage.getByTestId("status-summary")).toContainText(
+    /Rinforzi disponibili:\s*[1-9]\d*/i
+  );
 
   const stalePage = await firstContext.newPage();
+  await stalePage.addInitScript(() => {
+    window.__netriskAlerts = [];
+    window.alert = (message) => {
+      window.__netriskAlerts.push(String(message));
+    };
+  });
   await stalePage.route("**/api/events", (route) => route.abort());
   await stalePage.goto("/game");
 
   await expect(stalePage.locator("#auth-status")).toContainText(firstUser, { timeout: 10000 });
-  await expect(stalePage.getByTestId("status-summary")).toContainText(/Rinforzi disponibili:\s*[1-9]\d*/i);
+  await expect(stalePage.getByTestId("status-summary")).toContainText(
+    /Rinforzi disponibili:\s*[1-9]\d*/i
+  );
   await expect(stalePage.getByRole("button", { name: "Aggiungi" })).toBeEnabled();
 
   const staleVersion = await stalePage.evaluate(async () => {
@@ -60,11 +76,15 @@ test("stale game tab reloads latest state after a version conflict", async ({ br
   await currentPage.getByRole("button", { name: "Aggiungi" }).click();
   await expect.poll(() => getReinforcementCount(currentPage)).toBe(initialReinforcements - 1);
 
-  const dialogPromise = stalePage.waitForEvent("dialog");
   await stalePage.getByRole("button", { name: "Aggiungi" }).click();
-  const dialog = await dialogPromise;
-  await expect(dialog.message()).toMatch(/aggiornata|ricaricato|recente/i);
-  await dialog.accept();
+  await expect
+    .poll(async () =>
+      stalePage.evaluate(() => {
+        const alerts = window.__netriskAlerts || [];
+        return alerts[alerts.length - 1] || "";
+      })
+    )
+    .toMatch(/aggiornata|ricaricato|recente/i);
 
   await expect.poll(() => getReinforcementCount(stalePage)).toBe(initialReinforcements - 1);
 
@@ -74,4 +94,3 @@ test("stale game tab reloads latest state after a version conflict", async ({ br
   await firstContext.close();
   await secondContext.close();
 });
-

--- a/e2e/map/map-viewport-controls.spec.ts
+++ b/e2e/map/map-viewport-controls.spec.ts
@@ -276,7 +276,7 @@ test("dragging a zoomed map does not select a territory until an explicit click"
   await expect(firstPage.locator("#reinforce-select")).toHaveValue(reinforceBeforeDrag);
   await expect(firstPage.locator("#attack-from")).toHaveValue(attackBeforeDrag);
 
-  await myTerritory.click();
+  await myTerritory.click({ force: true });
   await expect(firstPage.locator("#reinforce-select")).toHaveValue(territoryId || "");
   await expect(firstPage.locator("#attack-from")).toHaveValue(territoryId || "");
 

--- a/e2e/map/territory-selection.spec.ts
+++ b/e2e/map/territory-selection.spec.ts
@@ -33,7 +33,7 @@ test("territory selection updates action controls for the current player", async
   await expect(myTerritory).toBeVisible();
 
   const territoryId = await myTerritory.getAttribute("data-territory-id");
-  await myTerritory.click();
+  await myTerritory.click({ force: true });
 
   await expect(firstPage.locator("#reinforce-select")).toHaveValue(territoryId || "");
   await expect(firstPage.locator("#attack-from")).toHaveValue(territoryId || "");
@@ -75,7 +75,7 @@ test("reinforcement still works when local player identity is stale", async ({ b
     .filter({ hasText: firstUser })
     .first();
   await expect(myTerritory).toBeVisible();
-  await myTerritory.click();
+  await myTerritory.click({ force: true });
 
   const dialogMessages = [];
   firstPage.on("dialog", async (dialog) => {

--- a/scripts/grant-admin.cts
+++ b/scripts/grant-admin.cts
@@ -12,9 +12,10 @@ interface GrantAdminArgs {
 }
 
 interface DatastoreLike {
-  findUserByUsername(username: string): { username: string; role?: string } | null;
+  findUserByUsername(username: string): { id?: string; username: string; role?: string } | null;
   updateUserRoleByUsername(username: string, role: string): void;
   deleteSessionsForUser?(userId: string): void;
+  close?(): void;
 }
 
 function parseArgs(argv: string[]): GrantAdminArgs {
@@ -93,26 +94,31 @@ function grantRole(args: GrantAdminArgs) {
     sessionsFile: resolveOptionalPath(args.sessionsFile)
   }) as DatastoreLike;
 
-  const existingUser = datastore.findUserByUsername(String(args.username));
-  if (!existingUser) {
-    throw new Error(`Utente non trovato: ${args.username}`);
-  }
+  try {
+    const existingUser = datastore.findUserByUsername(String(args.username));
+    if (!existingUser) {
+      throw new Error(`Utente non trovato: ${args.username}`);
+    }
 
-  const role = args.role === "user" ? "user" : "admin";
-  datastore.updateUserRoleByUsername(existingUser.username, role);
-  if ("id" in existingUser && typeof existingUser.id === "string") {
-    datastore.deleteSessionsForUser?.(existingUser.id);
-  }
+    const role = args.role === "user" ? "user" : "admin";
+    const roleChanged = existingUser.role !== role;
+    datastore.updateUserRoleByUsername(existingUser.username, role);
+    if (roleChanged && existingUser.id) {
+      datastore.deleteSessionsForUser?.(existingUser.id);
+    }
 
-  const updatedUser = datastore.findUserByUsername(existingUser.username);
-  if (!updatedUser) {
-    throw new Error(`Impossibile rileggere l'utente aggiornato: ${existingUser.username}`);
-  }
+    const updatedUser = datastore.findUserByUsername(existingUser.username);
+    if (!updatedUser) {
+      throw new Error(`Impossibile rileggere l'utente aggiornato: ${existingUser.username}`);
+    }
 
-  return {
-    username: updatedUser.username,
-    role: updatedUser.role === "admin" ? "admin" : "user"
-  };
+    return {
+      username: updatedUser.username,
+      role: updatedUser.role === "admin" ? "admin" : "user"
+    };
+  } finally {
+    datastore.close?.();
+  }
 }
 
 function main(): void {

--- a/scripts/grant-admin.cts
+++ b/scripts/grant-admin.cts
@@ -14,6 +14,7 @@ interface GrantAdminArgs {
 interface DatastoreLike {
   findUserByUsername(username: string): { username: string; role?: string } | null;
   updateUserRoleByUsername(username: string, role: string): void;
+  deleteSessionsForUser?(userId: string): void;
 }
 
 function parseArgs(argv: string[]): GrantAdminArgs {
@@ -99,6 +100,9 @@ function grantRole(args: GrantAdminArgs) {
 
   const role = args.role === "user" ? "user" : "admin";
   datastore.updateUserRoleByUsername(existingUser.username, role);
+  if ("id" in existingUser && typeof existingUser.id === "string") {
+    datastore.deleteSessionsForUser?.(existingUser.id);
+  }
 
   const updatedUser = datastore.findUserByUsername(existingUser.username);
   if (!updatedUser) {

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -3447,6 +3447,21 @@ register("auth store migra sessioni legacy plaintext al primo uso", async () => 
       null
     );
 
+    const concurrentLegacyToken = "legacy-concurrent-session-token";
+    await auth.datastore.createSession(concurrentLegacyToken, registered.user.id, Date.now());
+    await auth.datastore.createSession(
+      sessionTokenStorageKey(concurrentLegacyToken),
+      registered.user.id,
+      Date.now()
+    );
+    const concurrentSessionUser = await auth.getUserFromSession(concurrentLegacyToken);
+    assert.equal(concurrentSessionUser.username, "legacy_session");
+    assert.equal(await auth.datastore.findSession(concurrentLegacyToken), null);
+    assert.equal(
+      (await auth.datastore.findSession(sessionTokenStorageKey(concurrentLegacyToken))).user_id,
+      registered.user.id
+    );
+
     auth.datastore.close();
   } finally {
     if (fs.existsSync(tempFile)) {

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -3344,6 +3344,12 @@ register("auth store registra e autentica utenti password", async () => {
   );
   assert.equal(storedSession.user_id, registered.user.id);
   assert.notEqual(storedSession.token, login.sessionToken);
+  assert.equal(await auth.getUserFromSession(storedSession.token), null);
+  await auth.logout(storedSession.token);
+  assert.equal(
+    (await auth.datastore.findSession(sessionTokenStorageKey(login.sessionToken))).user_id,
+    registered.user.id
+  );
   const storedUser = await auth.datastore.findUserByUsername("tester");
   assert.equal(typeof storedUser.credentials.password.secret, "undefined");
   assert.equal(typeof storedUser.credentials.password.hash, "string");

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -3406,6 +3406,53 @@ register("auth store revoca le sessioni utente dopo cambio password", async () =
   }
 });
 
+register("auth store migra sessioni legacy plaintext al primo uso", async () => {
+  const unique = `${Date.now()}-${uniqueSuffix()}`;
+  const tempFile = path.join(__dirname, `tmp-users-${unique}.json`);
+  const tempSessionsFile = path.join(__dirname, `tmp-sessions-${unique}.json`);
+  const tempDbFile = path.join(__dirname, `tmp-auth-${unique}.sqlite`);
+
+  try {
+    const auth = createAuthStore({
+      dataFile: tempFile,
+      sessionsFile: tempSessionsFile,
+      dbFile: tempDbFile
+    });
+    const registered = await auth.registerPasswordUser("legacy_session", TEST_PASSWORD);
+    assert.equal(registered.ok, true);
+
+    const legacyToken = "legacy-plaintext-session-token";
+    await auth.datastore.createSession(legacyToken, registered.user.id, Date.now());
+
+    const sessionUser = await auth.getUserFromSession(legacyToken);
+    assert.equal(sessionUser.username, "legacy_session");
+    assert.equal(await auth.datastore.findSession(legacyToken), null);
+    assert.equal(
+      (await auth.datastore.findSession(sessionTokenStorageKey(legacyToken))).user_id,
+      registered.user.id
+    );
+
+    const logoutOnlyLegacyToken = "logout-only-legacy-session-token";
+    await auth.datastore.createSession(logoutOnlyLegacyToken, registered.user.id, Date.now());
+    await auth.logout(logoutOnlyLegacyToken);
+    assert.equal(await auth.datastore.findSession(logoutOnlyLegacyToken), null);
+    assert.equal(
+      await auth.datastore.findSession(sessionTokenStorageKey(logoutOnlyLegacyToken)),
+      null
+    );
+
+    auth.datastore.close();
+  } finally {
+    if (fs.existsSync(tempFile)) {
+      fs.unlinkSync(tempFile);
+    }
+    if (fs.existsSync(tempSessionsFile)) {
+      fs.unlinkSync(tempSessionsFile);
+    }
+    cleanupSqliteFiles(tempDbFile);
+  }
+});
+
 register("secureRandom restituisce un numero compreso tra 0 incluso e 1 escluso", () => {
   for (let index = 0; index < 32; index += 1) {
     const value = secureRandom();

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -59,6 +59,7 @@ const { createAuthRepository } = require("../backend/auth-repository.cjs");
 const { createDatastore } = require("../backend/datastore.cjs");
 const { createGameSessionStore } = require("../backend/game-session-store.cjs");
 const { SESSION_MAX_AGE_MS, SESSION_MAX_AGE_SECONDS } = require("../backend/session-policy.cjs");
+const { sessionTokenStorageKey } = require("../backend/session-token.cjs");
 const { readJsonFile, writeJsonFile } = require("../backend/json-file-store.cjs");
 const { createPlayerProfileStore } = require("../backend/player-profile-store.cjs");
 const {
@@ -664,6 +665,11 @@ register("auth repository supabase normalizza utenti, preferenze e sessioni", as
 
     await repository.deleteSession("token-1");
     assert.equal(await repository.findSession("token-1"), null);
+    await repository.createSession("token-2", "user-2", 123);
+    await repository.createSession("token-3", "user-2", 456);
+    await repository.deleteSessionsForUser("user-2");
+    assert.equal(await repository.findSession("token-2"), null);
+    assert.equal(await repository.findSession("token-3"), null);
 
     repository.close();
   });
@@ -712,6 +718,9 @@ register("auth repository locale delega aggiornamenti profilo, tema e sessioni",
       deleteSession(token: any) {
         calls.push(["deleteSession", token]);
       },
+      deleteSessionsForUser(userId: any) {
+        calls.push(["deleteSessionsForUser", userId]);
+      },
       close() {
         calls.push("close");
       }
@@ -745,6 +754,7 @@ register("auth repository locale delega aggiornamenti profilo, tema e sessioni",
     created_at: 1234
   });
   await localRepository.deleteSession("token-local");
+  await localRepository.deleteSessionsForUser("u2");
   localRepository.close();
 
   assert.equal(
@@ -753,6 +763,10 @@ register("auth repository locale delega aggiornamenti profilo, tema e sessioni",
   );
   assert.equal(
     calls.some((entry: any) => Array.isArray(entry) && entry[0] === "updateUserThemePreference"),
+    true
+  );
+  assert.equal(
+    calls.some((entry: any) => Array.isArray(entry) && entry[0] === "deleteSessionsForUser"),
     true
   );
   assert.equal(calls.includes("close"), true);
@@ -3324,6 +3338,12 @@ register("auth store registra e autentica utenti password", async () => {
   assert.equal(login.ok, true);
   assert.equal(Boolean(login.sessionToken), true);
   assert.equal((await auth.getUserFromSession(login.sessionToken)).username, "tester");
+  assert.equal(await auth.datastore.findSession(login.sessionToken), null);
+  const storedSession = await auth.datastore.findSession(
+    sessionTokenStorageKey(login.sessionToken)
+  );
+  assert.equal(storedSession.user_id, registered.user.id);
+  assert.notEqual(storedSession.token, login.sessionToken);
   const storedUser = await auth.datastore.findUserByUsername("tester");
   assert.equal(typeof storedUser.credentials.password.secret, "undefined");
   assert.equal(typeof storedUser.credentials.password.hash, "string");
@@ -3338,6 +3358,52 @@ register("auth store registra e autentica utenti password", async () => {
     fs.unlinkSync(tempSessionsFile);
   }
   cleanupSqliteFiles(tempDbFile);
+});
+
+register("auth store revoca le sessioni utente dopo cambio password", async () => {
+  const unique = `${Date.now()}-${uniqueSuffix()}`;
+  const tempFile = path.join(__dirname, `tmp-users-${unique}.json`);
+  const tempSessionsFile = path.join(__dirname, `tmp-sessions-${unique}.json`);
+  const tempDbFile = path.join(__dirname, `tmp-auth-${unique}.sqlite`);
+
+  try {
+    const auth = createAuthStore({
+      dataFile: tempFile,
+      sessionsFile: tempSessionsFile,
+      dbFile: tempDbFile
+    });
+    const registered = await auth.registerPasswordUser("rotate_session", TEST_PASSWORD);
+    assert.equal(registered.ok, true);
+
+    const firstLogin = await auth.loginWithPassword("rotate_session", TEST_PASSWORD);
+    const secondLogin = await auth.loginWithPassword("rotate_session", TEST_PASSWORD);
+    assert.equal(firstLogin.ok, true);
+    assert.equal(secondLogin.ok, true);
+    assert.equal(Boolean(await auth.getUserFromSession(firstLogin.sessionToken)), true);
+    assert.equal(Boolean(await auth.getUserFromSession(secondLogin.sessionToken)), true);
+
+    const update = await auth.updateUserAccountSettings({
+      userId: registered.user.id,
+      currentPassword: TEST_PASSWORD,
+      newPassword: "Changed123!",
+      confirmNewPassword: "Changed123!"
+    });
+    assert.equal(update.ok, true);
+
+    assert.equal(await auth.getUserFromSession(firstLogin.sessionToken), null);
+    assert.equal(await auth.getUserFromSession(secondLogin.sessionToken), null);
+    assert.equal((await auth.loginWithPassword("rotate_session", TEST_PASSWORD)).ok, false);
+    assert.equal((await auth.loginWithPassword("rotate_session", "Changed123!")).ok, true);
+    auth.datastore.close();
+  } finally {
+    if (fs.existsSync(tempFile)) {
+      fs.unlinkSync(tempFile);
+    }
+    if (fs.existsSync(tempSessionsFile)) {
+      fs.unlinkSync(tempSessionsFile);
+    }
+    cleanupSqliteFiles(tempDbFile);
+  }
 });
 
 register("secureRandom restituisce un numero compreso tra 0 incluso e 1 escluso", () => {

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -90,6 +90,7 @@ const { randomHex, secureRandom } = require("../backend/random.cjs");
 const { pruneBackups } = require("./backup-datastore.cjs");
 const { inspectBackup } = require("./check-backup.cjs");
 const { checkThemeTokenization } = require("./check-theme-tokenization.cjs");
+const { grantRole } = require("./grant-admin.cjs");
 const classicMiniMap = require("../shared/maps/classic-mini.cjs");
 const middleEarthMap = require("../shared/maps/middle-earth.cjs");
 const worldClassicMap = require("../shared/maps/world-classic.cjs");
@@ -3243,6 +3244,45 @@ function cleanupSqliteFiles(filePath: string) {
     }
   });
 }
+
+register("grant admin revoca sessioni solo quando il ruolo cambia", () => {
+  const unique = `${Date.now()}-${uniqueSuffix()}`;
+  const tempDbFile = path.join(__dirname, `tmp-grant-admin-${unique}.sqlite`);
+  const userId = `grant-role-user-${unique}`;
+  const username = `grant_role_${unique}`;
+
+  try {
+    let datastore = createDatastore({ dbFile: tempDbFile });
+    datastore.createUser({
+      id: userId,
+      username,
+      role: "user",
+      profile: {},
+      credentials: {},
+      createdAt: new Date().toISOString()
+    });
+    datastore.createSession("session-before-role-change", userId, Date.now());
+    datastore.close();
+
+    const promoted = grantRole({ username, role: "admin", dbFile: tempDbFile });
+    assert.deepEqual(promoted, { username, role: "admin" });
+
+    datastore = createDatastore({ dbFile: tempDbFile });
+    assert.equal(datastore.findUserByUsername(username).role, "admin");
+    assert.equal(datastore.findSession("session-before-role-change"), null);
+    datastore.createSession("session-after-role-change", userId, Date.now());
+    datastore.close();
+
+    const repeated = grantRole({ username, role: "admin", dbFile: tempDbFile });
+    assert.deepEqual(repeated, { username, role: "admin" });
+
+    datastore = createDatastore({ dbFile: tempDbFile });
+    assert.equal(datastore.findSession("session-after-role-change").user_id, userId);
+    datastore.close();
+  } finally {
+    cleanupSqliteFiles(tempDbFile);
+  }
+});
 
 async function withServer(
   run: (baseUrl: string, context: ServerTestContext) => Promise<void>

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -269,7 +269,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "datastore",
     name: "Datastore",
     kind: "platform",
-    version: "1.0.1",
+    version: "1.0.2",
     description:
       "Game/session persistence, app state persistence, backups, and datastore schema use.",
     ownerPaths: [

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.012";
+export const appVersion = "0.1.013";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -557,12 +557,23 @@ register("admin console can promote a user and grant admin access", async () => 
     assert.equal(promoteResponse.payload.user.role, "admin");
     assert.equal(promoteResponse.payload.audit.action, "user.role.update");
 
-    const elevatedResponse = await callApp(
+    const staleElevatedResponse = await callApp(
       app,
       "GET",
       "/api/admin/overview",
       undefined,
       authHeaders(guestLogin.sessionToken)
+    );
+    assert.equal(staleElevatedResponse.statusCode, 401);
+
+    const refreshedGuestLogin = await app.auth.loginWithPassword("operations_guest", "secret123");
+    assert.equal(refreshedGuestLogin.ok, true);
+    const elevatedResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/overview",
+      undefined,
+      authHeaders(refreshedGuestLogin.sessionToken)
     );
     assert.equal(elevatedResponse.statusCode, 200);
     assert.equal(elevatedResponse.payload.summary.adminUsers >= 2, true);
@@ -1560,6 +1571,7 @@ register(
       ]
     };
     const roleUpdates: Array<{ username: string; role: string }> = [];
+    const revokedSessionUserIds: string[] = [];
 
     const adminConsole = createAdminConsole({
       datastore: {
@@ -1575,6 +1587,9 @@ register(
           if (targetUser) {
             targetUser.role = role;
           }
+        },
+        deleteSessionsForUser(userId: string) {
+          revokedSessionUserIds.push(userId);
         },
         getAppState(key: string) {
           return appState[key] || null;
@@ -1750,6 +1765,7 @@ register(
         role: "admin"
       }
     ]);
+    assert.deepEqual(revokedSessionUserIds, ["user-1"]);
 
     const lobbyGames = await adminConsole.listGames({
       status: "lobby",


### PR DESCRIPTION
## Summary
- Fixes GHSA-w59h-6rv3-v47m by storing only SHA-256-derived session token keys server-side while keeping raw tokens only in client cookies.
- Adds user-session revocation after password changes and role changes, including admin console and grant-admin paths.
- Bumps app version to 0.1.013 and documents the security hardening.

## Validation
- npm run build:ts
- node .tsbuild/scripts/run-tests.cjs
- node .tsbuild/scripts/run-gameplay-tests.cjs tests/gameplay/regression/admin-console-routes.test.cts
- npm run format:check
- npm run lint
- npm run check:module-versioning
- npm run release:check

## Security notes
- Regression coverage verifies the raw cookie token is not stored or lookupable as plaintext.
- Password-change and role-change flows revoke existing sessions, so affected users must log in again after those changes.