### PR TITLE
[codex] Implement mobile map-first game layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.014 - 2026-05-11
+
+- Added the mobile map-first gameplay shell with a compact header, floating HUD, bottom-sheet commands, and phone viewport coverage.
+
 ## 0.1.013 - 2026-05-11
 
 - Hardened session storage by hashing server-side session tokens and revoking user sessions after password or role changes.

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -16,9 +16,7 @@ async function openWorldClassicGame(page) {
   await page.goto("/lobby/new");
   await expect(page.getByTestId("new-game-shell")).toBeVisible();
   await page.locator("#setup-map").selectOption("world-classic");
-  await page
-    .locator("#setup-game-name")
-    .fill(`Mobile Shell ${Date.now().toString(36).slice(-4)}`);
+  await page.locator("#setup-game-name").fill(`Mobile Shell ${Date.now().toString(36).slice(-4)}`);
   await expect(page.locator("#submit-new-game")).toBeEnabled();
   await page.getByRole("button", { name: "Crea e apri" }).click();
 
@@ -26,60 +24,96 @@ async function openWorldClassicGame(page) {
   await expect(page.locator(".map-board.has-custom-background")).toBeVisible({ timeout: 15000 });
 }
 
-function intersects(first, second) {
-  return !(
-    first.right <= second.left ||
-    second.right <= first.left ||
-    first.bottom <= second.top ||
-    second.bottom <= first.top
-  );
-}
+const mobileViewports = [
+  { width: 390, height: 844 },
+  { width: 360, height: 780 },
+  { width: 430, height: 932 }
+];
 
-test("mobile game shell keeps the map playable", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
+test("mobile game shell keeps the map-first sheet layout playable", async ({ page }) => {
+  await page.setViewportSize(mobileViewports[0]);
   await openWorldClassicGame(page);
 
-  const layout = await page.evaluate(() => {
-    const boundsFor = (selector) => {
-      const element = document.querySelector(selector);
-      if (!element) {
-        throw new Error(`Missing ${selector}`);
-      }
+  for (const viewport of mobileViewports) {
+    await page.setViewportSize(viewport);
+    await page.reload();
+    await expect(page.locator(".map-board.has-custom-background")).toBeVisible({
+      timeout: 15000
+    });
 
-      const rect = element.getBoundingClientRect();
-      return {
-        bottom: rect.bottom,
-        height: rect.height,
-        left: rect.left,
-        right: rect.right,
-        top: rect.top,
-        width: rect.width
+    const layout = await page.evaluate(() => {
+      const boundsFor = (selector) => {
+        const element = document.querySelector(selector);
+        if (!element) {
+          throw new Error(`Missing ${selector}`);
+        }
+
+        const rect = element.getBoundingClientRect();
+        return {
+          bottom: rect.bottom,
+          height: rect.height,
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          width: rect.width
+        };
       };
-    };
 
-    const boardStage = document.querySelector(".map-board.has-custom-background .map-board-stage");
-    const boardStageBackground = boardStage ? window.getComputedStyle(boardStage).backgroundImage : "";
+      const boardStage = document.querySelector(
+        ".map-board.has-custom-background .map-board-stage"
+      );
+      const boardStageBackground = boardStage
+        ? window.getComputedStyle(boardStage).backgroundImage
+        : "";
+      const primaryDockButton =
+        document.querySelector("#reinforce-multi-button") ||
+        document.querySelector("#attack-button") ||
+        document.querySelector("#conquest-button") ||
+        document.querySelector("#fortify-button") ||
+        document.querySelector("#join-button") ||
+        document.querySelector("#start-button");
 
-    return {
-      activity: boundsFor(".game-right-utility-rail"),
-      board: boundsFor(".game-map-stage .map-board"),
-      boardStageBackground,
-      dock: boundsFor(".game-command-dock"),
-      rail: boundsFor(".game-action-rail"),
-      viewport: {
-        height: window.innerHeight,
-        width: window.innerWidth
-      }
-    };
-  });
+      return {
+        activity: boundsFor(".game-right-utility-rail"),
+        board: boundsFor(".game-map-stage .map-board"),
+        boardStageBackground,
+        dock: boundsFor(".game-command-dock"),
+        header: boundsFor("body[data-app-section='game'] .top-nav-bar"),
+        hud: boundsFor(".game-floating-hud"),
+        primaryDockButton: primaryDockButton
+          ? {
+              bottom: primaryDockButton.getBoundingClientRect().bottom,
+              height: primaryDockButton.getBoundingClientRect().height,
+              top: primaryDockButton.getBoundingClientRect().top
+            }
+          : null,
+        rail: boundsFor(".game-action-rail"),
+        sheetState: document
+          .querySelector(".game-command-dock")
+          ?.getAttribute("data-command-sheet-state"),
+        title: document.querySelector("body[data-app-section='game'] .top-nav-title")?.textContent,
+        viewport: {
+          height: window.innerHeight,
+          width: window.innerWidth
+        }
+      };
+    });
 
-  expect(layout.boardStageBackground).toContain("world-classic");
-  expect(layout.board.left).toBeGreaterThanOrEqual(-1);
-  expect(layout.board.right).toBeLessThanOrEqual(layout.viewport.width + 1);
-  expect(layout.board.width).toBeGreaterThanOrEqual(320);
-  expect(layout.dock.left).toBeLessThanOrEqual(1);
-  expect(layout.dock.right).toBeGreaterThanOrEqual(layout.viewport.width - 1);
-  expect(intersects(layout.board, layout.rail)).toBe(false);
-  expect(intersects(layout.board, layout.activity)).toBe(false);
-  expect(intersects(layout.board, layout.dock)).toBe(false);
+    expect(layout.viewport).toEqual(viewport);
+    expect(layout.boardStageBackground).toContain("world-classic");
+    expect(layout.header.height).toBeLessThanOrEqual(60);
+    expect(layout.title).toContain("Frontline Dominion");
+    expect(layout.board.width).toBeGreaterThan(layout.viewport.width);
+    expect(layout.board.height).toBeGreaterThanOrEqual(layout.viewport.height * 0.42);
+    expect(layout.dock.left).toBeLessThanOrEqual(1);
+    expect(layout.dock.right).toBeGreaterThanOrEqual(layout.viewport.width - 1);
+    expect(layout.dock.height).toBeGreaterThanOrEqual(190);
+    expect(layout.dock.height).toBeLessThanOrEqual(layout.viewport.height * 0.34);
+    expect(layout.sheetState).toBe("half-open");
+    expect(layout.hud.width).toBeLessThan(layout.viewport.width);
+    expect(layout.rail.height).toBeGreaterThanOrEqual(44);
+    expect(layout.activity.height).toBeGreaterThanOrEqual(44);
+    expect(layout.primaryDockButton?.height).toBeGreaterThanOrEqual(44);
+    expect(layout.primaryDockButton?.bottom).toBeLessThanOrEqual(layout.viewport.height + 1);
+  }
 });

--- a/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
+++ b/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateFittedBoardSize } from "@react-shell/gameplay-map-viewport";
+
+describe("GameplayMapViewport fitting", () => {
+  it("keeps portrait maps within the available height when horizontal crop is enabled", () => {
+    const frame = calculateFittedBoardSize({
+      allowsHorizontalCrop: true,
+      aspectRatio: 463 / 800,
+      availableHeight: 640,
+      availableWidth: 390,
+      stagePaddingY: 24
+    });
+
+    expect(frame.width).toBeLessThan(390);
+    expect(frame.height).toBeLessThanOrEqual(640);
+  });
+
+  it("allows horizontal crop for wide maps that can still fit vertically", () => {
+    const frame = calculateFittedBoardSize({
+      allowsHorizontalCrop: true,
+      aspectRatio: 16 / 9,
+      availableHeight: 640,
+      availableWidth: 390,
+      stagePaddingY: 24
+    });
+
+    expect(frame.width).toBeGreaterThan(390);
+    expect(frame.width).toBeLessThanOrEqual(390 * 1.9);
+    expect(frame.height).toBeLessThanOrEqual(640);
+  });
+});

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -40,7 +40,16 @@ vi.mock("@frontend-core/api/client.mts", () => ({
 }));
 
 vi.mock("@react-shell/gameplay-map-viewport", () => ({
-  GameplayMapViewport: () => <div data-testid="mock-gameplay-map-viewport" />
+  GameplayMapViewport: ({
+    commandDockSheetState
+  }: {
+    commandDockSheetState: "collapsed" | "half-open" | "expanded";
+  }) => (
+    <div
+      data-testid="mock-gameplay-map-viewport"
+      data-command-sheet-state={commandDockSheetState}
+    />
+  )
 }));
 
 const getGameStateMock = vi.mocked(getGameState);
@@ -367,6 +376,75 @@ describe("GameRoute integration", () => {
     unmount();
 
     expect(removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes mobile command dock sheet state changes through to the map viewport", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        media: "(max-width: 760px)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true)
+      }))
+    );
+
+    renderReactShell("/react/game/g-1");
+
+    const dock = await screen.findByTestId("actions-panel");
+    const mapViewport = screen.getByTestId("mock-gameplay-map-viewport");
+    const toggle = dock.querySelector(".game-command-dock-toggle") as HTMLButtonElement | null;
+    expect(toggle).not.toBeNull();
+    expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
+    expect(mapViewport).toHaveAttribute("data-command-sheet-state", "half-open");
+
+    await user.click(toggle as HTMLButtonElement);
+
+    expect(dock).toHaveAttribute("data-command-sheet-state", "expanded");
+    expect(mapViewport).toHaveAttribute("data-command-sheet-state", "expanded");
+  });
+
+  it("normalizes the mobile-only half-open dock state after leaving the mobile viewport", async () => {
+    const user = userEvent.setup();
+    let isMobileViewport = true;
+    let changeListener: ((event: MediaQueryListEvent) => void) | null = null;
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: isMobileViewport,
+        media: "(max-width: 760px)",
+        onchange: null,
+        addEventListener: vi.fn(
+          (eventName: string, listener: (event: MediaQueryListEvent) => void) => {
+            if (eventName === "change") {
+              changeListener = listener;
+            }
+          }
+        ),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true)
+      }))
+    );
+
+    renderReactShell("/react/game/g-1");
+
+    const dock = await screen.findByTestId("actions-panel");
+    const toggle = dock.querySelector(".game-command-dock-toggle") as HTMLButtonElement | null;
+    expect(toggle).not.toBeNull();
+    expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
+
+    act(() => {
+      isMobileViewport = false;
+      changeListener?.({ matches: false } as MediaQueryListEvent);
+    });
+
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+
+    await user.click(toggle as HTMLButtonElement);
+    expect(dock).toHaveAttribute("data-command-sheet-state", "expanded");
   });
 
   it("renders the reference fortify command dock", async () => {

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -400,11 +400,13 @@ describe("GameRoute integration", () => {
     expect(toggle).not.toBeNull();
     expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
     expect(mapViewport).toHaveAttribute("data-command-sheet-state", "half-open");
+    expect(toggle).toHaveAttribute("aria-label", "Espandi comandi");
 
     await user.click(toggle as HTMLButtonElement);
 
     expect(dock).toHaveAttribute("data-command-sheet-state", "expanded");
     expect(mapViewport).toHaveAttribute("data-command-sheet-state", "expanded");
+    expect(toggle).toHaveAttribute("aria-label", "Comprimi comandi");
   });
 
   it("normalizes the mobile-only half-open dock state after leaving the mobile viewport", async () => {

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -343,6 +343,32 @@ describe("GameRoute integration", () => {
     expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
   });
 
+  it("uses legacy media query listeners when the mobile dock viewport API needs them", async () => {
+    const addListener = vi.fn();
+    const removeListener = vi.fn();
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        media: "(max-width: 760px)",
+        onchange: null,
+        addListener,
+        removeListener,
+        dispatchEvent: vi.fn(() => true)
+      }))
+    );
+
+    const { unmount } = renderReactShell("/react/game/g-1");
+
+    const dock = await screen.findByTestId("actions-panel");
+    expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
+    expect(addListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the reference fortify command dock", async () => {
     getGameStateMock.mockResolvedValue(
       createGameplayState({

--- a/frontend/react-shell/src/app-shell-layout.tsx
+++ b/frontend/react-shell/src/app-shell-layout.tsx
@@ -142,6 +142,7 @@ export function AppShellLayout({ children }: { children: ReactNode }) {
   const [loginError, setLoginError] = useState("");
   const [isSubmittingLogin, setIsSubmittingLogin] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
   const moduleOptionsQuery = useQuery({
     queryKey: ["shell", "module-options"],
@@ -173,6 +174,11 @@ export function AppShellLayout({ children }: { children: ReactNode }) {
     document.body.dataset.shellKind = "app";
     document.body.dataset.appSection = section;
   }, [section]);
+
+  useEffect(() => {
+    setIsMobileNavOpen(false);
+    setIsUserMenuOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     if (!moduleOptionsQuery.data) {
@@ -276,13 +282,27 @@ export function AppShellLayout({ children }: { children: ReactNode }) {
   const content = (
     <div className="shell-header" style={{ display: "contents" }}>
       <header className="panel top-nav-bar campaign-nav">
+        <button
+          type="button"
+          className="mobile-nav-toggle"
+          aria-controls="primary-top-nav"
+          aria-expanded={isMobileNavOpen}
+          aria-label="Toggle menu"
+          onClick={() => setIsMobileNavOpen((isOpen) => !isOpen)}
+        >
+          <span aria-hidden="true" />
+          <span aria-hidden="true" />
+          <span aria-hidden="true" />
+        </button>
+
         <Link className="top-nav-zone top-nav-brand brand-link" to={lobbyHref}>
           <p className="eyebrow">{t("app.brand")}</p>
           <span className="top-nav-title">{t("app.title")}</span>
         </Link>
 
         <nav
-          className="top-nav-zone top-nav-links"
+          id="primary-top-nav"
+          className={`top-nav-zone top-nav-links${isMobileNavOpen ? " is-mobile-open" : ""}`}
           aria-label={t("nav.aria.primary")}
           data-testid="react-shell-nav"
         >

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -5928,7 +5928,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   }
 
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     width: calc(100vw - 48px) !important;
     height: var(--game-command-dock-height) !important;
     min-height: var(--game-command-dock-height) !important;
@@ -6443,7 +6445,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   }
 
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     bottom: 18px !important;
     height: var(--game-command-dock-height) !important;
     min-height: var(--game-command-dock-height) !important;
@@ -6452,7 +6456,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   }
 
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     width: min(980px, calc(100vw - 260px)) !important;
   }
 
@@ -6556,7 +6562,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
 
 @media (min-width: 1181px) and (max-height: 700px) {
   .game-command-dock:not(.game-command-dock-mandatory-trade),
-  html[data-theme="war-table"] .game-map-first-page .game-command-dock:not(.game-command-dock-mandatory-trade) {
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
     width: min(1348px, calc(100vw - 330px)) !important;
   }
 
@@ -6859,5 +6867,641 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
       minmax(198px, 0.88fr)
       minmax(166px, 0.72fr) !important;
     column-gap: 16px !important;
+  }
+}
+
+/* Mobile phone layout: normal 360-430px wide viewports, map-first with sheet controls. */
+.mobile-nav-toggle {
+  display: none;
+}
+
+.game-command-sheet-grip,
+.game-command-dock-summary {
+  display: none;
+}
+
+@media (max-width: 760px) {
+  body[data-app-section="game"] .top-nav-bar,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-bar {
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 140 !important;
+    display: grid !important;
+    grid-template-columns: 44px minmax(0, 1fr) auto !important;
+    grid-auto-rows: 58px !important;
+    align-items: center !important;
+    height: 58px !important;
+    min-height: 58px !important;
+    max-height: 58px !important;
+    padding: 0 10px !important;
+    background: rgba(2, 7, 13, 0.98) !important;
+  }
+
+  body[data-app-section="game"] .mobile-nav-toggle,
+  html[data-theme="war-table"] body[data-app-section="game"] .mobile-nav-toggle {
+    display: grid !important;
+    grid-column: 1 !important;
+    grid-row: 1 !important;
+    grid-template-rows: repeat(3, 2px) !important;
+    gap: 5px !important;
+    align-content: center !important;
+    justify-content: center !important;
+    width: 44px !important;
+    min-width: 44px !important;
+    height: 44px !important;
+    min-height: 44px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+    color: #f4f7fa !important;
+  }
+
+  body[data-app-section="game"] .mobile-nav-toggle span {
+    width: 22px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+  }
+
+  body[data-app-section="game"] .top-nav-brand,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-brand {
+    position: static !important;
+    grid-column: 2 !important;
+    grid-row: 1 !important;
+    justify-self: center !important;
+    min-width: 0 !important;
+    padding: 0 !important;
+  }
+
+  body[data-app-section="game"] .top-nav-brand .eyebrow {
+    display: none !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title {
+    display: block !important;
+    color: #f6b515 !important;
+    font-size: 0 !important;
+    font-weight: 950 !important;
+    letter-spacing: 0.18em !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title::after,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title::after {
+    content: none !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title::before,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title::before {
+    content: "NETRISK" !important;
+    color: #f6b515 !important;
+    font-size: 1.08rem !important;
+    font-weight: 950 !important;
+    letter-spacing: 0.22em !important;
+  }
+
+  body[data-app-section="game"] .top-nav-links,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-links {
+    position: fixed !important;
+    top: 58px !important;
+    right: 10px !important;
+    left: 10px !important;
+    z-index: 150 !important;
+    display: none !important;
+    height: auto !important;
+    min-height: 0 !important;
+    padding: 8px !important;
+    border: 1px solid rgba(132, 159, 178, 0.34) !important;
+    border-radius: 8px !important;
+    background: rgba(3, 13, 22, 0.98) !important;
+    box-shadow: 0 18px 42px rgba(0, 0, 0, 0.48) !important;
+  }
+
+  body[data-app-section="game"] .top-nav-links.is-mobile-open,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-links.is-mobile-open {
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+  }
+
+  body[data-app-section="game"] .top-nav-bar .nav-link,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-bar .nav-link {
+    min-height: 44px !important;
+    justify-content: center !important;
+    padding: 0 8px !important;
+    border-radius: 6px !important;
+    font-size: 0.72rem !important;
+  }
+
+  body[data-app-section="game"] .top-nav-actions,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-actions {
+    position: static !important;
+    grid-column: 3 !important;
+    grid-row: 1 !important;
+    display: flex !important;
+    align-items: center !important;
+    align-self: center !important;
+    justify-self: end !important;
+    gap: 8px !important;
+    min-width: 0 !important;
+    margin: 0 !important;
+  }
+
+  body[data-app-section="game"] .war-nav-locale-icon,
+  body[data-app-section="game"] .war-nav-locale-code,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-locale-icon,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-locale-code {
+    display: grid !important;
+  }
+
+  body[data-app-section="game"] .war-nav-locale-icon,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-locale-icon {
+    width: 24px !important;
+    min-width: 24px !important;
+    height: 24px !important;
+    color: #f5f8fb !important;
+  }
+
+  body[data-app-section="game"] .war-nav-locale-code,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-locale-code {
+    font-size: 0.74rem !important;
+    font-weight: 900 !important;
+  }
+
+  body[data-app-section="game"] .war-nav-user,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-user {
+    display: grid !important;
+    width: 44px !important;
+    min-width: 44px !important;
+    min-height: 44px !important;
+    padding: 0 !important;
+    border: 0 !important;
+  }
+
+  body[data-app-section="game"] .war-nav-user .war-table-icon,
+  body[data-app-section="game"] .war-nav-user-name,
+  body[data-app-section="game"] .war-nav-notifications,
+  body[data-app-section="game"] .top-nav-locale,
+  body[data-app-section="game"] .top-nav-module-slots,
+  body[data-app-section="game"] .top-nav-auth-form,
+  body[data-app-section="game"] .top-nav-logout,
+  body[data-app-section="game"] .nav-avatar,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-user .war-table-icon,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-user-name,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-notifications,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-locale,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-module-slots,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-auth-form,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-logout,
+  html[data-theme="war-table"] body[data-app-section="game"] .nav-avatar {
+    display: none !important;
+  }
+
+  body[data-app-section="game"] .war-nav-avatar,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-avatar {
+    width: 38px !important;
+    height: 38px !important;
+  }
+
+  .game-map-first-page,
+  html[data-theme="war-table"] .game-map-first-page {
+    --game-command-dock-height: 224px !important;
+    --game-map-allow-horizontal-crop: 1;
+    min-height: calc(100svh - 58px) !important;
+    overflow: hidden !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-sheet-collapsed),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-collapsed) {
+    --game-command-dock-height: 76px !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-sheet-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-expanded) {
+    --game-command-dock-height: min(68svh, 520px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-mandatory-trade),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-mandatory-trade) {
+    --game-command-dock-height: min(62svh, 500px) !important;
+  }
+
+  .game-map-first-page .game-battlefield-layout,
+  .game-map-first-page .game-main-column,
+  .game-map-first-page .game-map-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-battlefield-layout,
+  html[data-theme="war-table"] .game-map-first-page .game-main-column,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage {
+    min-height: calc(100svh - 58px) !important;
+  }
+
+  .game-map-first-page .game-map-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage {
+    --game-map-safe-top: 8px !important;
+    --game-map-safe-bottom: calc(var(--game-command-dock-height, 224px) + 12px) !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+  }
+
+  .game-map-first-page .game-map-stage .map,
+  .game-map-first-page .game-map-stage .map-viewport,
+  .game-map-first-page .game-map-stage .map-board-surface,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-viewport,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-surface {
+    min-height: calc(100svh - 58px) !important;
+  }
+
+  .game-map-first-page .game-map-stage .map-board,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board {
+    border-radius: 0 !important;
+  }
+
+  .game-floating-hud,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud {
+    top: 10px !important;
+    right: 64px !important;
+    bottom: auto !important;
+    left: 10px !important;
+    width: auto !important;
+    min-height: 0 !important;
+    max-height: 112px !important;
+    padding: 9px 10px !important;
+    overflow: hidden !important;
+    border-radius: 7px !important;
+    pointer-events: none !important;
+  }
+
+  .game-floating-hud .game-hud-heading,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud .game-hud-heading {
+    margin: 0 0 7px !important;
+    padding-bottom: 7px !important;
+  }
+
+  .game-floating-hud h1,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud h1 {
+    font-size: 0.72rem !important;
+    line-height: 1.1 !important;
+  }
+
+  .game-hud-summary,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary {
+    grid-template-columns: 1fr 1fr !important;
+  }
+
+  .game-hud-summary > div,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary > div {
+    min-height: 30px !important;
+    gap: 7px !important;
+  }
+
+  .game-hud-icon,
+  .game-hud-avatar,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-icon,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-avatar {
+    width: 28px !important;
+    height: 28px !important;
+  }
+
+  .game-hud-label,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-label {
+    font-size: 0.5rem !important;
+  }
+
+  .game-hud-summary strong,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary strong {
+    font-size: 0.78rem !important;
+  }
+
+  .game-floating-hud .map-trade-alert,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud .map-trade-alert {
+    margin: 7px 0 0 !important;
+    padding: 7px 8px !important;
+    font-size: 0.68rem !important;
+  }
+
+  .game-map-first-page .map-controls,
+  html[data-theme="war-table"] .game-map-first-page .map-controls {
+    top: 80px !important;
+    right: 10px !important;
+    gap: 6px !important;
+    z-index: 96 !important;
+  }
+
+  .game-map-first-page .map-control-button,
+  html[data-theme="war-table"] .game-map-first-page .map-control-button {
+    width: 44px !important;
+    min-width: 44px !important;
+    height: 44px !important;
+    min-height: 44px !important;
+    border-radius: 7px !important;
+    font-size: 1rem !important;
+  }
+
+  .game-action-rail,
+  html[data-theme="war-table"] .game-map-first-page .game-action-rail {
+    top: auto !important;
+    right: 66px !important;
+    bottom: calc(var(--game-command-dock-height, 224px) + 10px) !important;
+    left: 10px !important;
+    display: grid !important;
+    grid-template-columns: repeat(3, 48px) !important;
+    gap: 8px !important;
+    width: auto !important;
+    height: 48px !important;
+    z-index: 96 !important;
+  }
+
+  .game-action-rail .game-action-rail-button,
+  .game-action-rail .game-cards-drawer,
+  .game-action-rail .game-info-drawer,
+  .game-action-rail .game-players-drawer,
+  html[data-theme="war-table"] .game-map-first-page .game-action-rail .game-action-rail-button {
+    width: 48px !important;
+    min-height: 48px !important;
+    padding: 0 !important;
+  }
+
+  .game-action-rail .game-action-rail-button > summary,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-action-rail
+    .game-action-rail-button
+    > summary {
+    grid-template-columns: 48px !important;
+    min-height: 48px !important;
+    padding: 0 !important;
+  }
+
+  .game-action-rail-button > summary > span:not(.game-action-rail-icon):not(.game-action-badge),
+  .game-activity-trigger span {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    white-space: nowrap !important;
+  }
+
+  .game-action-rail-icon,
+  html[data-theme="war-table"] .game-map-first-page .game-action-rail-icon {
+    width: 48px !important;
+    height: 48px !important;
+    border-right: 0 !important;
+  }
+
+  .game-action-badge {
+    right: -7px !important;
+    top: -7px !important;
+  }
+
+  .game-right-utility-rail,
+  html[data-theme="war-table"] .game-map-first-page .game-right-utility-rail {
+    top: auto !important;
+    right: 10px !important;
+    bottom: calc(var(--game-command-dock-height, 224px) + 10px) !important;
+    width: 48px !important;
+    transform: none !important;
+    z-index: 96 !important;
+  }
+
+  .game-activity-trigger,
+  html[data-theme="war-table"] .game-map-first-page .game-activity-trigger {
+    width: 48px !important;
+    min-height: 48px !important;
+    padding: 0 !important;
+  }
+
+  .game-command-dock,
+  .game-command-dock:not(.game-command-dock-mandatory-trade),
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    display: block !important;
+    box-sizing: border-box !important;
+    width: 100vw !important;
+    max-width: none !important;
+    height: var(--game-command-dock-height, 224px) !important;
+    min-height: var(--game-command-dock-height, 224px) !important;
+    max-height: var(--game-command-dock-height, 224px) !important;
+    padding: 14px 14px calc(14px + env(safe-area-inset-bottom)) !important;
+    overflow: hidden !important;
+    border-right: 0 !important;
+    border-bottom: 0 !important;
+    border-left: 0 !important;
+    border-radius: 14px 14px 0 0 !important;
+    transform: none !important;
+    z-index: 110 !important;
+  }
+
+  .game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-sheet-expanded,
+  .game-command-dock-mandatory-trade,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-trade {
+    overflow: auto !important;
+  }
+
+  .game-command-sheet-grip {
+    display: block !important;
+    width: 48px !important;
+    height: 5px !important;
+    margin: -4px auto 8px !important;
+    border-radius: 999px !important;
+    background: rgba(222, 233, 242, 0.72) !important;
+  }
+
+  .game-command-dock-toggle {
+    top: 8px !important;
+    right: 12px !important;
+    width: 44px !important;
+    min-width: 44px !important;
+    height: 44px !important;
+    min-height: 44px !important;
+    border-radius: 7px !important;
+  }
+
+  .game-command-dock-title {
+    position: static !important;
+    margin: 0 48px 6px 0 !important;
+    color: #f6b515 !important;
+    font-size: 0.72rem !important;
+    line-height: 1.1 !important;
+  }
+
+  .game-command-dock-summary {
+    display: grid !important;
+    gap: 3px !important;
+    margin-right: 48px !important;
+    color: rgba(222, 233, 242, 0.78) !important;
+  }
+
+  .game-command-dock-summary strong {
+    overflow: hidden !important;
+    color: #f5f8fb !important;
+    font-size: 0.96rem !important;
+    font-weight: 950 !important;
+    line-height: 1.14 !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+  }
+
+  .game-command-dock-summary span {
+    overflow: hidden !important;
+    font-size: 0.68rem !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+  }
+
+  .game-command-dock-sheet-collapsed .actions-section,
+  .game-command-dock-sheet-collapsed .game-lobby-controls,
+  .game-command-dock-sheet-collapsed .game-mandatory-trade-dock {
+    display: none !important;
+  }
+
+  .game-command-dock .actions-section,
+  .game-command-dock .game-lobby-controls,
+  .game-command-dock .action-stack,
+  .game-command-dock #attack-group .action-stack,
+  .game-command-dock #fortify-group .action-stack,
+  .game-command-dock #reinforce-group .action-stack,
+  .game-command-dock #conquest-group .action-stack,
+  .game-command-dock .game-mandatory-trade-dock {
+    grid-template-columns: 1fr !important;
+  }
+
+  .game-command-dock .actions-section,
+  .game-command-dock .game-lobby-controls {
+    display: grid !important;
+    gap: 10px !important;
+    margin: 10px 0 0 !important;
+    padding: 0 !important;
+    overflow: visible !important;
+  }
+
+  .game-command-dock .action-stack {
+    display: grid !important;
+    gap: 8px !important;
+  }
+
+  .game-command-dock #reinforce-group .action-stack,
+  .game-command-dock #conquest-group .action-stack {
+    grid-template-columns: minmax(0, 1fr) 132px !important;
+  }
+
+  .game-command-dock #reinforce-group .action-row,
+  .game-command-dock #conquest-group .action-row {
+    grid-column: 1 / -1 !important;
+  }
+
+  .game-command-dock #attack-group .action-stack,
+  .game-command-dock #fortify-group .action-stack {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
+  }
+
+  .game-command-dock #attack-group .action-row,
+  .game-command-dock #fortify-button {
+    grid-column: 1 / -1 !important;
+  }
+
+  .game-command-dock #end-turn-button {
+    grid-column: auto !important;
+  }
+
+  .game-command-dock .compact-group > label,
+  .game-command-dock .game-dock-select-label > span,
+  .game-dock-field-label {
+    margin-bottom: 4px !important;
+    font-size: 0.58rem !important;
+    line-height: 1.1 !important;
+  }
+
+  .game-command-dock select,
+  .game-command-dock input,
+  .game-command-dock button,
+  .game-command-dock #attack-button,
+  .game-command-dock #reinforce-multi-button,
+  .game-command-dock #fortify-button,
+  .game-command-dock #conquest-button,
+  .game-command-dock #card-trade-button,
+  .game-command-dock #card-trade-dock-button,
+  .game-command-dock #end-turn-button {
+    width: 100% !important;
+    min-width: 0 !important;
+    min-height: 44px !important;
+    height: 44px !important;
+    font-size: 0.74rem !important;
+  }
+
+  .game-command-dock .action-row {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.76fr) !important;
+    gap: 8px !important;
+  }
+
+  .game-command-dock-sheet-half-open .game-command-secondary-action,
+  .game-command-dock-sheet-half-open #attack-banzai-button {
+    display: none !important;
+  }
+
+  .game-command-dock .game-card-grid {
+    grid-template-columns: repeat(3, minmax(96px, 1fr)) !important;
+    overflow-x: auto !important;
+  }
+
+  .game-command-dock .game-card-tile {
+    min-height: 108px !important;
+  }
+
+  .game-modern-drawer,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer,
+  .game-modern-drawer-left,
+  .game-modern-drawer-right,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-left,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-right {
+    position: fixed !important;
+    top: auto !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    z-index: 130 !important;
+    box-sizing: border-box !important;
+    width: 100vw !important;
+    max-height: min(78svh, 680px) !important;
+    padding: 16px 14px calc(16px + env(safe-area-inset-bottom)) !important;
+    overflow: auto !important;
+    border-right: 0 !important;
+    border-bottom: 0 !important;
+    border-left: 0 !important;
+    border-radius: 14px 14px 0 0 !important;
+  }
+
+  .game-modern-drawer-header {
+    position: sticky !important;
+    top: -16px !important;
+    z-index: 2 !important;
+    margin: -16px -14px 12px !important;
+    padding: 16px 14px 12px !important;
+    background: linear-gradient(180deg, rgba(6, 20, 32, 0.98), rgba(6, 20, 32, 0.92)) !important;
+  }
+
+  .game-drawer-close {
+    width: 44px !important;
+    min-width: 44px !important;
+    height: 44px !important;
+    min-height: 44px !important;
+  }
+
+  .game-card-grid-compact,
+  .game-cards-modern-drawer .game-card-grid-compact {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+
+  .game-players-head,
+  .game-player-row {
+    grid-template-columns: minmax(0, 1fr) 56px 74px !important;
   }
 }

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -6940,10 +6940,15 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   body[data-app-section="game"] .top-nav-title,
   html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title {
     display: block !important;
+    max-width: 48vw !important;
+    overflow: hidden !important;
     color: #f6b515 !important;
-    font-size: 0 !important;
+    font-size: 0.86rem !important;
     font-weight: 950 !important;
-    letter-spacing: 0.18em !important;
+    letter-spacing: 0.06em !important;
+    text-align: center !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
   }
 
   body[data-app-section="game"] .top-nav-title::after,
@@ -6953,11 +6958,7 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
 
   body[data-app-section="game"] .top-nav-title::before,
   html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title::before {
-    content: "NETRISK" !important;
-    color: #f6b515 !important;
-    font-size: 1.08rem !important;
-    font-weight: 950 !important;
-    letter-spacing: 0.22em !important;
+    content: none !important;
   }
 
   body[data-app-section="game"] .top-nav-links,

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -62,6 +62,14 @@ type BoardFrame = {
   height: number;
 };
 
+type FittedBoardSizeInput = {
+  allowsHorizontalCrop: boolean;
+  aspectRatio: number;
+  availableHeight: number;
+  availableWidth: number;
+  stagePaddingY: number;
+};
+
 type GameplayMapViewportProps = {
   attackFromId: string;
   attackToId: string;
@@ -157,6 +165,27 @@ function resolveMapImageUrl(imageUrl: string): string {
 function readCssPixelValue(styles: CSSStyleDeclaration, propertyName: string): number {
   const value = Number.parseFloat(styles.getPropertyValue(propertyName) || "0");
   return Number.isFinite(value) ? value : 0;
+}
+
+export function calculateFittedBoardSize({
+  allowsHorizontalCrop,
+  aspectRatio,
+  availableHeight,
+  availableWidth,
+  stagePaddingY
+}: FittedBoardSizeInput): { width: number; height: number } {
+  const widthFromHeight = Math.max(0, (availableHeight - stagePaddingY) * aspectRatio);
+  const fittedWidth = Math.min(availableWidth, widthFromHeight);
+  const width = allowsHorizontalCrop
+    ? widthFromHeight >= availableWidth
+      ? Math.min(widthFromHeight, availableWidth * 1.9)
+      : fittedWidth
+    : fittedWidth;
+
+  return {
+    width: Math.floor(width),
+    height: Math.ceil(width / aspectRatio)
+  };
 }
 
 function territoryOwnerName(
@@ -470,17 +499,16 @@ export function GameplayMapViewport({
       const aspectRatio = aspectRatioMatch
         ? Number.parseFloat(aspectRatioMatch[1]) / Number.parseFloat(aspectRatioMatch[2])
         : 760 / 500;
-      const widthFromHeight = Math.max(0, (availableHeight - stagePaddingY) * aspectRatio);
       const allowsHorizontalCrop =
         stageStyles.getPropertyValue("--game-map-allow-horizontal-crop").trim() === "1";
-      const width = allowsHorizontalCrop
-        ? Math.min(Math.max(availableWidth, widthFromHeight), availableWidth * 1.9)
-        : Math.min(availableWidth, widthFromHeight);
-      const height = width / aspectRatio;
-
       setFittedBoardFrame({
-        width: Math.floor(width),
-        height: Math.ceil(height)
+        ...calculateFittedBoardSize({
+          allowsHorizontalCrop,
+          aspectRatio,
+          availableHeight,
+          availableWidth,
+          stagePaddingY
+        })
       });
     }
 

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -471,7 +471,11 @@ export function GameplayMapViewport({
         ? Number.parseFloat(aspectRatioMatch[1]) / Number.parseFloat(aspectRatioMatch[2])
         : 760 / 500;
       const widthFromHeight = Math.max(0, (availableHeight - stagePaddingY) * aspectRatio);
-      const width = Math.min(availableWidth, widthFromHeight);
+      const allowsHorizontalCrop =
+        stageStyles.getPropertyValue("--game-map-allow-horizontal-crop").trim() === "1";
+      const width = allowsHorizontalCrop
+        ? Math.min(Math.max(availableWidth, widthFromHeight), availableWidth * 1.9)
+        : Math.min(availableWidth, widthFromHeight);
       const height = width / aspectRatio;
 
       setFittedBoardFrame({

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -65,7 +65,7 @@ type BoardFrame = {
 type GameplayMapViewportProps = {
   attackFromId: string;
   attackToId: string;
-  commandDockExpanded: boolean;
+  commandDockSheetState: "collapsed" | "half-open" | "expanded";
   fortifyFromId: string;
   fortifyToId: string;
   myPlayerId: string | null;
@@ -184,7 +184,7 @@ function territoryPosition(territory: SnapshotTerritory): { x: number; y: number
 export function GameplayMapViewport({
   attackFromId,
   attackToId,
-  commandDockExpanded,
+  commandDockSheetState,
   fortifyFromId,
   fortifyToId,
   myPlayerId,
@@ -504,7 +504,7 @@ export function GameplayMapViewport({
       window.removeEventListener("resize", fitBoardToViewport);
     };
   }, [
-    commandDockExpanded,
+    commandDockSheetState,
     snapshot.cardState?.currentPlayerMustTrade,
     snapshot.mapVisual?.aspectRatio?.height,
     snapshot.mapVisual?.aspectRatio?.width,

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -565,11 +565,27 @@ export function GameRoute() {
     }
 
     syncMobileCommandSheet(mediaQuery);
-    mediaQuery.addEventListener("change", syncMobileCommandSheet);
 
-    return () => {
-      mediaQuery.removeEventListener("change", syncMobileCommandSheet);
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", syncMobileCommandSheet);
+
+      return () => {
+        mediaQuery.removeEventListener("change", syncMobileCommandSheet);
+      };
+    }
+
+    const legacyMediaQuery = mediaQuery as MediaQueryList & {
+      addListener?: (listener: (event: MediaQueryList | MediaQueryListEvent) => void) => void;
+      removeListener?: (listener: (event: MediaQueryList | MediaQueryListEvent) => void) => void;
     };
+
+    if (typeof legacyMediaQuery.addListener === "function") {
+      legacyMediaQuery.addListener(syncMobileCommandSheet);
+
+      return () => {
+        legacyMediaQuery.removeListener?.(syncMobileCommandSheet);
+      };
+    }
   }, []);
 
   const applyMutationPayload = useEffectEvent(

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -47,6 +47,7 @@ import {
   PlayersDrawer,
   type ActivityLogEntry,
   type ActivityLogFilter,
+  type GameCommandDockSheetState,
   type GameDrawerKey
 } from "@react-shell/gameplay-ui-panels";
 
@@ -335,7 +336,13 @@ export function GameRoute() {
   const [isActivityLogOpen, setIsActivityLogOpen] = useState(false);
   const [activityLogFilter, setActivityLogFilter] = useState<ActivityLogFilter>("all");
   const [isActivityLogCleared, setIsActivityLogCleared] = useState(false);
-  const [isCommandDockExpanded, setIsCommandDockExpanded] = useState(false);
+  const [commandDockSheetState, setCommandDockSheetState] = useState<GameCommandDockSheetState>(
+    () =>
+      typeof window !== "undefined" && window.matchMedia("(max-width: 760px)").matches
+        ? "half-open"
+        : "collapsed"
+  );
+  const isCommandDockExpanded = commandDockSheetState !== "collapsed";
 
   const gameplayQuery = useQuery({
     queryKey,
@@ -536,6 +543,29 @@ export function GameRoute() {
   useEffect(() => {
     setIsActivityLogCleared(false);
   }, [activityLogContentKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(max-width: 760px)");
+
+    function syncMobileCommandSheet(event: MediaQueryList | MediaQueryListEvent): void {
+      if (!event.matches) {
+        return;
+      }
+
+      setCommandDockSheetState((current) => (current === "collapsed" ? "half-open" : current));
+    }
+
+    syncMobileCommandSheet(mediaQuery);
+    mediaQuery.addEventListener("change", syncMobileCommandSheet);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncMobileCommandSheet);
+    };
+  }, []);
 
   const applyMutationPayload = useEffectEvent(
     (payload: GameMutationResponse, options: { feedback?: string } = {}) => {
@@ -894,6 +924,36 @@ export function GameRoute() {
               : "idle";
   const commandDockTitle =
     dockMode === "mandatory-trade" ? t("game.commandMode.tradeCards") : commandActionTitle;
+  const commandDockSummaryTerritory =
+    (showReinforceGroup && reinforceTerritoryId
+      ? territoriesById[reinforceTerritoryId]
+      : showAttackGroup && attackFromId
+        ? territoriesById[attackFromId]
+        : showConquestGroup && snapshot.pendingConquest?.toId
+          ? territoriesById[snapshot.pendingConquest.toId]
+          : showFortifyGroup && fortifyFromId
+            ? territoriesById[fortifyFromId]
+            : null) || null;
+  const commandDockSummaryTitle = commandDockSummaryTerritory?.name || commandDockTitle;
+  const commandDockSummaryDetail =
+    dockMode === "mandatory-trade"
+      ? t("game.commandDock.cardsSelected", { selected: selectedTradeCardIds.length })
+      : `${phaseBadgeLabel} · ${t("game.hud.reinforcements")} ${snapshot.reinforcementPool}`;
+
+  function cycleCommandDockSheet(): void {
+    setCommandDockSheetState((current) => {
+      if (current === "collapsed") {
+        return "half-open";
+      }
+
+      if (current === "half-open") {
+        return "expanded";
+      }
+
+      return "collapsed";
+    });
+  }
+
   const actionRailItems = [
     {
       drawer: "players" as const,
@@ -1153,7 +1213,10 @@ export function GameRoute() {
           commandTitle={commandDockTitle}
           expanded={isCommandDockExpanded}
           mode={dockMode}
-          onToggleExpanded={() => setIsCommandDockExpanded((isExpanded) => !isExpanded)}
+          sheetState={commandDockSheetState}
+          summaryDetail={commandDockSummaryDetail}
+          summaryTitle={commandDockSummaryTitle}
+          onToggleExpanded={cycleCommandDockSheet}
         >
           {mustTradeCards ? (
             <div className="game-mandatory-trade-dock" id="card-trade-dock-group">

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -79,6 +79,14 @@ function turnPhaseLabel(turnPhase: string | null | undefined): string {
   return phaseLabel(turnPhase);
 }
 
+function isMobileCommandDockViewport(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(max-width: 760px)").matches
+  );
+}
+
 function territoryOwnerName(
   territory: SnapshotTerritory,
   playersById: Record<string, SnapshotPlayer>
@@ -337,10 +345,7 @@ export function GameRoute() {
   const [activityLogFilter, setActivityLogFilter] = useState<ActivityLogFilter>("all");
   const [isActivityLogCleared, setIsActivityLogCleared] = useState(false);
   const [commandDockSheetState, setCommandDockSheetState] = useState<GameCommandDockSheetState>(
-    () =>
-      typeof window !== "undefined" && window.matchMedia("(max-width: 760px)").matches
-        ? "half-open"
-        : "collapsed"
+    () => (isMobileCommandDockViewport() ? "half-open" : "collapsed")
   );
   const isCommandDockExpanded = commandDockSheetState !== "collapsed";
 
@@ -545,7 +550,7 @@ export function GameRoute() {
   }, [activityLogContentKey]);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
       return;
     }
 

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -558,6 +558,7 @@ export function GameRoute() {
 
     function syncMobileCommandSheet(event: MediaQueryList | MediaQueryListEvent): void {
       if (!event.matches) {
+        setCommandDockSheetState((current) => (current === "half-open" ? "collapsed" : current));
         return;
       }
 
@@ -1016,7 +1017,7 @@ export function GameRoute() {
             <GameplayMapViewport
               attackFromId={attackFromId}
               attackToId={attackToId}
-              commandDockExpanded={isCommandDockExpanded}
+              commandDockSheetState={commandDockSheetState}
               fortifyFromId={fortifyFromId}
               fortifyToId={fortifyToId}
               myPlayerId={myPlayerId}

--- a/frontend/react-shell/src/gameplay-ui-panels.tsx
+++ b/frontend/react-shell/src/gameplay-ui-panels.tsx
@@ -14,6 +14,7 @@ import { WarTableIcon, type WarTableIconName } from "@react-shell/war-table-icon
 
 export type GameDrawerKey = "players" | "cards" | "gameInfo";
 export type ActivityLogFilter = "all" | "combat" | "cards" | "turn";
+export type GameCommandDockSheetState = "collapsed" | "half-open" | "expanded";
 
 export type ActivityLogEntry = {
   category: Exclude<ActivityLogFilter, "all">;
@@ -115,6 +116,9 @@ type GameActionDockProps = {
   commandTitle: string;
   expanded: boolean;
   mode: "attack" | "reinforcement" | "fortify" | "conquest" | "lobby" | "idle" | "mandatory-trade";
+  sheetState: GameCommandDockSheetState;
+  summaryDetail: string;
+  summaryTitle: string;
   onToggleExpanded(): void;
 };
 
@@ -789,26 +793,37 @@ export function GameActionDock({
   commandTitle,
   expanded,
   mode,
+  sheetState,
+  summaryDetail,
+  summaryTitle,
   onToggleExpanded
 }: GameActionDockProps) {
+  const isSheetOpen = sheetState !== "collapsed";
+
   return (
     <aside
-      className={`right-rail panel game-actions-rail game-command-dock campaign-shell game-command-dock-${mode} ${expanded ? "is-expanded" : "is-collapsed"} ${className}`.trim()}
+      className={`right-rail panel game-actions-rail game-command-dock campaign-shell game-command-dock-${mode} ${expanded ? "is-expanded" : "is-collapsed"} game-command-dock-sheet-${sheetState} ${className}`.trim()}
       data-testid="actions-panel"
       data-command-dock-expanded={expanded ? "true" : "false"}
       data-command-mode={mode}
+      data-command-sheet-state={sheetState}
     >
+      <span className="game-command-sheet-grip" aria-hidden="true" />
       <button
         type="button"
         className="game-command-dock-toggle"
-        aria-expanded={expanded}
-        aria-label={expanded ? t("game.commandDock.collapse") : t("game.commandDock.expand")}
+        aria-expanded={isSheetOpen}
+        aria-label={isSheetOpen ? t("game.commandDock.collapse") : t("game.commandDock.expand")}
         onClick={onToggleExpanded}
       >
-        <span aria-hidden="true">{expanded ? "v" : "^"}</span>
+        <span aria-hidden="true">{sheetState === "expanded" ? "v" : "^"}</span>
       </button>
       <div className="game-command-dock-title">
         <span>{commandTitle}</span>
+      </div>
+      <div className="game-command-dock-summary" aria-hidden={isSheetOpen ? "true" : "false"}>
+        <strong>{summaryTitle}</strong>
+        <span>{summaryDetail}</span>
       </div>
       {children}
     </aside>

--- a/frontend/react-shell/src/gameplay-ui-panels.tsx
+++ b/frontend/react-shell/src/gameplay-ui-panels.tsx
@@ -799,6 +799,8 @@ export function GameActionDock({
   onToggleExpanded
 }: GameActionDockProps) {
   const isSheetOpen = sheetState !== "collapsed";
+  const toggleLabel =
+    sheetState === "expanded" ? t("game.commandDock.collapse") : t("game.commandDock.expand");
 
   return (
     <aside
@@ -813,7 +815,7 @@ export function GameActionDock({
         type="button"
         className="game-command-dock-toggle"
         aria-expanded={isSheetOpen}
-        aria-label={isSheetOpen ? t("game.commandDock.collapse") : t("game.commandDock.expand")}
+        aria-label={toggleLabel}
         onClick={onToggleExpanded}
       >
         <span aria-hidden="true">{sheetState === "expanded" ? "v" : "^"}</span>

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.013";
+export const appVersion = "0.1.014";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- Implements a phone-sized, map-first gameplay layout with compact header, floating HUD, icon drawer triggers, and bottom-sheet command controls.
- Adds explicit command sheet states for collapsed, half-open, and expanded mobile behavior.
- Updates the mobile visual e2e coverage for 390x844, 360x780, and 430x932 viewports.

## Validation
- npm run typecheck:react-shell
- npm run build:ts
- npx playwright test e2e/00-visual/mobile-game-shell.spec.ts --project=chromium
- In-app Browser check at 390x844 on a built local e2e server; no console errors/warnings observed.

## Notes
- Desktop and tablet layout rules are preserved outside the mobile breakpoint.
- Full e2e suite was not run.
