### PR TITLE
Fix unsafe module UI routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.014 - 2026-05-11
+
+- Hardened module UI slot routes by rejecting unsafe schemes and external URLs before module links reach the frontend.
+
 ## 0.1.013 - 2026-05-11
 
 - Hardened session storage by hashing server-side session tokens and revoking user sessions after password or role changes.

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -94,6 +94,24 @@ function objectSchema<T extends z.ZodRawShape>(shape: T) {
 }
 
 const passwordSchema = z.string().min(8).max(128);
+const moduleUiRouteBaseUrl = "https://netrisk.local";
+
+export function isSafeModuleUiRoute(route: string): boolean {
+  if (!route.startsWith("/") || route.startsWith("//") || route.includes("\\")) {
+    return false;
+  }
+
+  try {
+    const parsedRoute = new URL(route, moduleUiRouteBaseUrl);
+    return parsedRoute.origin === moduleUiRouteBaseUrl && parsedRoute.pathname.startsWith("/");
+  } catch {
+    return false;
+  }
+}
+
+const moduleUiRouteSchema = z.string().trim().min(1).refine(isSafeModuleUiRoute, {
+  message: "Module UI routes must be same-origin paths."
+});
 
 export function formatValidationPath(path: IssuePathSegment[] | undefined): string {
   if (!Array.isArray(path) || !path.length) {
@@ -342,7 +360,7 @@ export const netRiskUiSlotContributionSchema = objectSchema({
   kind: z.string().min(1),
   order: z.number().optional(),
   description: z.string().min(1).nullable().optional(),
-  route: z.string().min(1).nullable().optional()
+  route: moduleUiRouteSchema.nullable().optional()
 });
 
 export type NetRiskUiSlotContribution = z.infer<typeof netRiskUiSlotContributionSchema>;

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -234,7 +234,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "module-runtime",
     name: "Module Runtime",
     kind: "platform",
-    version: "1.0.2",
+    version: "1.0.3",
     description:
       "Filesystem module discovery, validation, enablement, and resolved catalog output.",
     ownerPaths: [

--- a/shared/netrisk-modules.cts
+++ b/shared/netrisk-modules.cts
@@ -5,6 +5,7 @@ import {
   saveGameSchemaVersion
 } from "./version-manifest.cjs";
 import {
+  isSafeModuleUiRoute,
   NETRISK_MODULE_CAPABILITY_KIND_VALUES,
   NETRISK_UI_SLOT_ID_VALUES
 } from "./runtime-validation.cjs";
@@ -377,6 +378,11 @@ function normalizeUiSlot(raw: unknown, sourcePath: string): NetRiskUiSlotContrib
     throw new Error(`Invalid UI slot kind in "${sourcePath}".`);
   }
 
+  const route = isNonEmptyString(raw.route) ? String(raw.route).trim() : null;
+  if (route && !isSafeModuleUiRoute(route)) {
+    throw new Error(`Invalid UI slot route in "${sourcePath}".`);
+  }
+
   return {
     slotId: String(raw.slotId).trim() as NetRiskUiSlotId,
     itemId: String(raw.itemId).trim(),
@@ -384,7 +390,7 @@ function normalizeUiSlot(raw: unknown, sourcePath: string): NetRiskUiSlotContrib
     kind,
     order: typeof raw.order === "number" && Number.isFinite(raw.order) ? raw.order : 0,
     description: isNonEmptyString(raw.description) ? String(raw.description).trim() : null,
-    route: isNonEmptyString(raw.route) ? String(raw.route).trim() : null
+    route
   };
 }
 

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -93,6 +93,24 @@ function objectSchema<T extends z.ZodRawShape>(shape: T) {
 }
 
 const passwordSchema = z.string().min(8).max(128);
+const moduleUiRouteBaseUrl = "https://netrisk.local";
+
+export function isSafeModuleUiRoute(route: string): boolean {
+  if (!route.startsWith("/") || route.startsWith("//") || route.includes("\\")) {
+    return false;
+  }
+
+  try {
+    const parsedRoute = new URL(route, moduleUiRouteBaseUrl);
+    return parsedRoute.origin === moduleUiRouteBaseUrl && parsedRoute.pathname.startsWith("/");
+  } catch {
+    return false;
+  }
+}
+
+const moduleUiRouteSchema = z.string().trim().min(1).refine(isSafeModuleUiRoute, {
+  message: "Module UI routes must be same-origin paths."
+});
 
 export function formatValidationPath(path: IssuePathSegment[] | undefined): string {
   if (!Array.isArray(path) || !path.length) {
@@ -341,7 +359,7 @@ export const netRiskUiSlotContributionSchema = objectSchema({
   kind: z.string().min(1),
   order: z.number().optional(),
   description: z.string().min(1).nullable().optional(),
-  route: z.string().min(1).nullable().optional()
+  route: moduleUiRouteSchema.nullable().optional()
 });
 
 export type NetRiskUiSlotContribution = z.infer<typeof netRiskUiSlotContributionSchema>;

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.013";
+export const appVersion = "0.1.014";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/module-runtime.test.cts
+++ b/tests/gameplay/regression/module-runtime.test.cts
@@ -757,6 +757,74 @@ register("module runtime non espone slot UI con slotId non supportati", async ()
   );
 });
 
+register("module runtime rejects UI slot routes that are not same-origin paths", async () => {
+  await withModuleServer(
+    [
+      {
+        dir: "unsafe.route",
+        manifest: {
+          schemaVersion: 1,
+          id: "unsafe.route",
+          version: "1.0.0",
+          displayName: "Unsafe Route",
+          engineVersion: "1.0.0",
+          kind: "ui",
+          capabilities: [{ kind: "ui-slot", scope: "global", description: "Unsafe route" }],
+          entrypoints: {
+            clientManifest: "client-manifest.json"
+          }
+        },
+        clientManifest: {
+          ui: {
+            slots: [
+              {
+                slotId: "top-nav-bar",
+                itemId: "unsafe.route.link",
+                title: "Unsafe Route",
+                kind: "nav-item",
+                route: "javascript:alert(1)"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    async ({ app, adminSessionToken }) => {
+      const catalogResponse = await callApp(
+        app,
+        "GET",
+        "/api/modules",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(catalogResponse.statusCode, 200);
+      const unsafeModule = catalogResponse.payload.modules.find(
+        (entry: any) => entry.id === "unsafe.route"
+      );
+      assert.equal(Boolean(unsafeModule), true);
+      assert.equal(
+        unsafeModule.errors.some((entry: string) => entry.includes("Invalid UI slot route")),
+        true
+      );
+
+      const moduleOptionsResponse = await callApp(app, "GET", "/api/modules/options");
+      assert.equal(moduleOptionsResponse.statusCode, 200);
+      assert.equal(
+        moduleOptionsResponse.payload.uiSlots.some(
+          (entry: any) => entry.itemId === "unsafe.route.link"
+        ),
+        false
+      );
+      assert.equal(
+        moduleOptionsResponse.payload.resolvedCatalog.uiSlots.some(
+          (entry: any) => entry.itemId === "unsafe.route.link"
+        ),
+        false
+      );
+    }
+  );
+});
+
 register(
   "module runtime rifiuta client manifest che escono dalla directory del modulo",
   async () => {

--- a/tests/gameplay/shared/runtime-validation.test.cts
+++ b/tests/gameplay/shared/runtime-validation.test.cts
@@ -10,6 +10,7 @@ const {
   loginRequestSchema,
   logoutResponseSchema,
   messagePayloadSchema,
+  netRiskUiSlotContributionSchema,
   parseWithSchema,
   profileResponseSchema,
   registerRequestSchema,
@@ -252,6 +253,38 @@ register("shared runtime validation validates lobby route payload shapes", () =>
     toValidationErrors(invalidJoinResponse.error).map((entry: { path: string }) => entry.path),
     ["user.id"]
   );
+});
+
+register("shared runtime validation constrains module UI slot routes to same-origin paths", () => {
+  const validSlot = parseWithSchema(netRiskUiSlotContributionSchema, {
+    slotId: "top-nav-bar",
+    itemId: "demo.safe-route",
+    title: "Demo Route",
+    kind: "nav-item",
+    route: " /modules/demo.safe?panel=overview#details "
+  });
+  assert.equal(validSlot.route, "/modules/demo.safe?panel=overview#details");
+
+  const invalidRoutes = [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "https://example.test/modules/demo",
+    "//example.test/modules/demo",
+    "/\\example.test/modules/demo"
+  ];
+
+  invalidRoutes.forEach((route) => {
+    const result = netRiskUiSlotContributionSchema.safeParse({
+      slotId: "top-nav-bar",
+      itemId: `demo.unsafe-route.${route.length}`,
+      title: "Unsafe Route",
+      kind: "nav-item",
+      route
+    });
+
+    assert.equal(result.success, false, `Expected route to be rejected: ${route}`);
+  });
 });
 
 register("shared runtime validation rejects passwords exceeding 128 characters", () => {


### PR DESCRIPTION
## Summary
- Fixes GHSA-3h22-w36h-ww58 by constraining module UI slot routes to same-origin app paths.
- Shares the route safety check between runtime validation and module manifest normalization.
- Adds regression coverage for unsafe schemes and verifies unsafe module routes are not exposed in module options.

## Validation
- PASS: npm run build:ts
- PASS: node .tsbuild/scripts/run-gameplay-tests.cjs
- PASS: npm run test:react
- PASS: npm run check:module-versioning
- PASS: node .tsbuild/scripts/run-tests.cjs
- PASS: npm run lint
- PASS: npm run format:check
- PASS: npm run coverage
- PASS: npm run coverage:check
- PASS: node .tsbuild/scripts/run-e2e.cjs e2e/00-visual e2e/profile e2e/smoke --reporter=line --output=test-results/visual-profile-rerun
- PARTIAL: npm run test:e2e:split passed gameplay and layout-map, but visual-profile had 4 transient loading/profile failures under parallel grouped execution; rerunning the same visual-profile group alone passed 46/46.

## Security proof
- `javascript:`, `data:`, `vbscript:`, absolute external URLs, protocol-relative URLs, and backslash-normalized protocol-relative paths are rejected by the shared UI slot schema.
- The module runtime now rejects unsafe client manifest slot routes before they can reach `/api/modules/options` or frontend `href` rendering.