### PR TITLE
Align mobile game layout with reference states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.018 - 2026-05-12
+
+- Refined the mobile gameplay shell to match the reference state layouts for collapsed, half-open, expanded, and drawer-based actions.
+
 ## 0.1.017 - 2026-05-12
 
 - Fixed the mobile mandatory card-trade layout so the map board remains fully visible above the command dock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.040 - 2026-06-05
+
+- Refined the mobile gameplay shell reference states for collapsed, half-open, expanded, and drawer-based command actions.
+
 ## 0.1.039 - 2026-06-05
 
 - Modularized the card system with validated card definitions, rendering metadata, and a registered reinforcement trade effect.

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -74,7 +74,6 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
         document.querySelector("#start-button");
 
       return {
-        activity: boundsFor(".game-right-utility-rail"),
         board: boundsFor(".game-map-stage .map-board"),
         boardStageBackground,
         dock: boundsFor(".game-command-dock"),
@@ -87,7 +86,6 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
               top: primaryDockButton.getBoundingClientRect().top
             }
           : null,
-        rail: boundsFor(".game-action-rail"),
         sheetState: document
           .querySelector(".game-command-dock")
           ?.getAttribute("data-command-sheet-state"),
@@ -107,13 +105,65 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
     expect(layout.board.height).toBeGreaterThanOrEqual(layout.viewport.height * 0.42);
     expect(layout.dock.left).toBeLessThanOrEqual(1);
     expect(layout.dock.right).toBeGreaterThanOrEqual(layout.viewport.width - 1);
-    expect(layout.dock.height).toBeGreaterThanOrEqual(190);
-    expect(layout.dock.height).toBeLessThanOrEqual(layout.viewport.height * 0.34);
-    expect(layout.sheetState).toBe("half-open");
+    expect(layout.dock.height).toBeGreaterThanOrEqual(70);
+    expect(layout.dock.height).toBeLessThanOrEqual(112);
+    expect(layout.sheetState).toBe("collapsed");
     expect(layout.hud.width).toBeLessThan(layout.viewport.width);
-    expect(layout.rail.height).toBeGreaterThanOrEqual(44);
-    expect(layout.activity.height).toBeGreaterThanOrEqual(44);
-    expect(layout.primaryDockButton?.height).toBeGreaterThanOrEqual(44);
-    expect(layout.primaryDockButton?.bottom).toBeLessThanOrEqual(layout.viewport.height + 1);
+
+    await page.locator(".game-command-dock-toggle").click();
+    await expect(page.locator(".game-command-dock")).toHaveAttribute(
+      "data-command-sheet-state",
+      "half-open"
+    );
+
+    const halfOpenLayout = await page.evaluate(() => {
+      const primaryDockButton =
+        document.querySelector("#reinforce-multi-button") ||
+        document.querySelector("#attack-button") ||
+        document.querySelector("#conquest-button") ||
+        document.querySelector("#fortify-button") ||
+        document.querySelector("#join-button") ||
+        document.querySelector("#start-button");
+
+      if (!primaryDockButton) {
+        throw new Error("Missing primary dock button");
+      }
+
+      const dockRect = document.querySelector(".game-command-dock").getBoundingClientRect();
+      const buttonRect = primaryDockButton.getBoundingClientRect();
+
+      return {
+        dock: {
+          bottom: dockRect.bottom,
+          height: dockRect.height,
+          top: dockRect.top
+        },
+        primaryDockButton: {
+          bottom: buttonRect.bottom,
+          height: buttonRect.height,
+          top: buttonRect.top
+        },
+        viewport: {
+          height: window.innerHeight,
+          width: window.innerWidth
+        }
+      };
+    });
+
+    expect(halfOpenLayout.dock.height).toBeGreaterThanOrEqual(180);
+    expect(halfOpenLayout.dock.height).toBeLessThanOrEqual(
+      halfOpenLayout.viewport.height * 0.32
+    );
+    expect(halfOpenLayout.primaryDockButton.height).toBeGreaterThanOrEqual(44);
+    expect(halfOpenLayout.primaryDockButton.bottom).toBeLessThanOrEqual(
+      halfOpenLayout.viewport.height + 1
+    );
+
+    await page.locator(".game-command-dock-toggle").click();
+    await expect(page.locator(".game-command-dock")).toHaveAttribute(
+      "data-command-sheet-state",
+      "expanded"
+    );
+    await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
   }
 });

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -21,6 +21,15 @@ async function openWorldClassicGame(page) {
   await page.getByRole("button", { name: "Crea e apri" }).click();
 
   await expect(page.locator("#game-map-meta")).toContainText("World Classic", { timeout: 15000 });
+  const joinAiResponse = await page.request.post("/api/ai/join", {
+    data: { name: "CPU Mobile" }
+  });
+  await expect(joinAiResponse.ok()).toBeTruthy();
+  await page.locator(".game-command-dock-toggle").click();
+  await page.getByRole("button", { name: "Avvia partita" }).click();
+  await expect(page.getByTestId("status-summary")).toContainText(/Rinforzi disponibili:\s*[1-9]\d*/i, {
+    timeout: 15000
+  });
   await expect(page.locator(".map-board.has-custom-background")).toBeVisible({ timeout: 15000 });
 }
 
@@ -89,7 +98,9 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
         sheetState: document
           .querySelector(".game-command-dock")
           ?.getAttribute("data-command-sheet-state"),
-        title: document.querySelector("body[data-app-section='game'] .top-nav-title")?.textContent,
+        title: window
+          .getComputedStyle(document.querySelector("body[data-app-section='game'] .top-nav-title"), "::after")
+          .content.replaceAll('"', ""),
         viewport: {
           height: window.innerHeight,
           width: window.innerWidth
@@ -100,7 +111,7 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
     expect(layout.viewport).toEqual(viewport);
     expect(layout.boardStageBackground).toContain("world-classic");
     expect(layout.header.height).toBeLessThanOrEqual(60);
-    expect(layout.title).toContain("Frontline Dominion");
+    expect(layout.title).toBe("NETRISK");
     expect(layout.board.width).toBeGreaterThan(layout.viewport.width);
     expect(layout.board.height).toBeGreaterThanOrEqual(layout.viewport.height * 0.42);
     expect(layout.dock.left).toBeLessThanOrEqual(1);

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -12,7 +12,7 @@ async function openWorldClassicGame(page) {
   const owner = uniqueUser("mobile_shell");
   const sessionToken = await registerAndLogin(page, owner);
   await setSessionThemePreference(page, sessionToken, "war-table");
-  await page.evaluate(() => window.localStorage.setItem("netrisk.theme", "war-table"));
+  await page.addInitScript(() => window.localStorage.setItem("netrisk.theme", "war-table"));
   await page.goto("/lobby/new");
   await expect(page.getByTestId("new-game-shell")).toBeVisible();
   await page.locator("#setup-map").selectOption("world-classic");
@@ -38,6 +38,160 @@ const mobileViewports = [
   { width: 360, height: 780 },
   { width: 430, height: 932 }
 ];
+
+async function openMockAttackGame(page) {
+  const attackState = {
+    phase: "active",
+    turnPhase: "attack",
+    players: [
+      {
+        id: "p1",
+        name: "andrea",
+        color: "#7c3aed",
+        connected: true,
+        isAi: false,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 3
+      },
+      {
+        id: "p2",
+        name: "CPU",
+        color: "#f97316",
+        connected: true,
+        isAi: true,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "western-united-states",
+        name: "Western United States",
+        neighbors: ["alberta"],
+        continentId: "north-america",
+        ownerId: "p1",
+        armies: 4,
+        x: 0.22,
+        y: 0.38
+      },
+      {
+        id: "alberta",
+        name: "Alberta",
+        neighbors: ["western-united-states"],
+        continentId: "north-america",
+        ownerId: "p2",
+        armies: 2,
+        x: 0.36,
+        y: 0.3
+      }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool: 0,
+    winnerId: null,
+    gameConfig: {
+      mapId: "world-classic",
+      mapName: "World Classic",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    log: ["Attack layout visual state"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: false,
+    attacksThisTurn: 0,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 20,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    diceRuleSet: {
+      id: "standard",
+      attackerMaxDice: 3,
+      defenderMaxDice: 2
+    },
+    gameId: "g-mobile-attack",
+    version: 7,
+    gameName: "Mobile Attack",
+    playerId: "p1",
+    playerHand: []
+  };
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          username: "andrea",
+          role: "user",
+          authMethods: ["password"],
+          preferences: { theme: "war-table" }
+        }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: attackState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.addInitScript(() => window.localStorage.setItem("netrisk.theme", "war-table"));
+  await page.goto("/react/game/g-mobile-attack");
+  await expect(page.locator(".game-command-dock-attack")).toBeVisible();
+}
+
+async function readMobileAttackLayout(page) {
+  return page.evaluate(() => {
+    const rectFor = (selector) => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing ${selector}`);
+      }
+
+      const rect = element.getBoundingClientRect();
+      return {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width
+      };
+    };
+
+    return {
+      attack: rectFor("#attack-button"),
+      banzai: rectFor("#attack-banzai-button"),
+      dock: rectFor(".game-command-dock"),
+      endTurn: rectFor("#end-turn-button"),
+      header: rectFor("body[data-app-section='game'] .top-nav-bar"),
+      mobileActions: document.querySelector(".game-mobile-sheet-actions")
+        ? rectFor(".game-mobile-sheet-actions")
+        : null,
+      stage: rectFor(".game-map-stage"),
+      toggle: rectFor(".game-command-dock-toggle"),
+      viewport: {
+        height: window.innerHeight,
+        width: window.innerWidth
+      }
+    };
+  });
+}
 
 test("mobile game shell keeps the map-first sheet layout playable", async ({ page }) => {
   await page.setViewportSize(mobileViewports[0]);
@@ -177,4 +331,58 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
     );
     await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
   }
+});
+
+test("mobile attack sheet keeps primary actions visible and expands only secondary actions", async ({
+  page
+}) => {
+  await page.setViewportSize(mobileViewports[0]);
+  await openMockAttackGame(page);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "half-open"
+  );
+  await expect(page.locator("#attack-button")).toBeVisible();
+  await expect(page.locator("#attack-banzai-button")).toBeVisible();
+  await expect(page.locator("#end-turn-button")).toBeVisible();
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeHidden();
+
+  const halfOpenLayout = await readMobileAttackLayout(page);
+  for (const button of [
+    halfOpenLayout.attack,
+    halfOpenLayout.banzai,
+    halfOpenLayout.endTurn,
+    halfOpenLayout.toggle
+  ]) {
+    expect(button.height).toBeGreaterThanOrEqual(44);
+    expect(button.top).toBeGreaterThanOrEqual(0);
+    expect(button.bottom).toBeLessThanOrEqual(halfOpenLayout.viewport.height + 1);
+  }
+  expect(halfOpenLayout.dock.height).toBeGreaterThanOrEqual(390);
+  expect(halfOpenLayout.dock.height).toBeLessThanOrEqual(410);
+  expect(halfOpenLayout.dock.top - halfOpenLayout.header.bottom).toBeGreaterThan(240);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "expanded"
+  );
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
+
+  const expandedLayout = await readMobileAttackLayout(page);
+  expect(expandedLayout.dock.height).toBeLessThanOrEqual(500);
+  expect(expandedLayout.dock.top - expandedLayout.header.bottom).toBeGreaterThan(160);
+  expect(expandedLayout.toggle.top).toBeGreaterThanOrEqual(0);
+  expect(expandedLayout.toggle.bottom).toBeLessThanOrEqual(expandedLayout.viewport.height + 1);
+  expect(expandedLayout.mobileActions.bottom).toBeLessThanOrEqual(
+    expandedLayout.viewport.height + 1
+  );
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "collapsed"
+  );
 });

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -155,6 +155,132 @@ async function openMockAttackGame(page) {
   await expect(page.locator(".game-command-dock-attack")).toBeVisible();
 }
 
+async function openMockFortifyGame(page) {
+  const fortifyState = {
+    phase: "active",
+    turnPhase: "fortify",
+    players: [
+      {
+        id: "p1",
+        name: "andrea",
+        color: "#7c3aed",
+        connected: true,
+        isAi: false,
+        territoryCount: 2,
+        eliminated: false,
+        cardCount: 3
+      },
+      {
+        id: "p2",
+        name: "CPU",
+        color: "#f97316",
+        connected: true,
+        isAi: true,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "western-united-states",
+        name: "Western United States",
+        neighbors: ["alaska", "alberta"],
+        continentId: "north-america",
+        ownerId: "p1",
+        armies: 4,
+        x: 0.22,
+        y: 0.38
+      },
+      {
+        id: "alaska",
+        name: "Alaska",
+        neighbors: ["western-united-states"],
+        continentId: "north-america",
+        ownerId: "p1",
+        armies: 1,
+        x: 0.16,
+        y: 0.18
+      },
+      {
+        id: "alberta",
+        name: "Alberta",
+        neighbors: ["western-united-states"],
+        continentId: "north-america",
+        ownerId: "p2",
+        armies: 2,
+        x: 0.36,
+        y: 0.3
+      }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool: 0,
+    winnerId: null,
+    gameConfig: {
+      mapId: "world-classic",
+      mapName: "World Classic",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    log: ["Fortify layout visual state"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: true,
+    attacksThisTurn: 1,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 20,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    diceRuleSet: {
+      id: "standard",
+      attackerMaxDice: 3,
+      defenderMaxDice: 2
+    },
+    gameId: "g-mobile-fortify",
+    version: 8,
+    gameName: "Mobile Fortify",
+    playerId: "p1",
+    playerHand: []
+  };
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          username: "andrea",
+          role: "user",
+          authMethods: ["password"],
+          preferences: { theme: "war-table" }
+        }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: fortifyState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.addInitScript(() => window.localStorage.setItem("netrisk.theme", "war-table"));
+  await page.goto("/react/game/g-mobile-fortify");
+  await expect(page.locator(".game-command-dock-fortify")).toBeVisible();
+}
+
 async function readMobileAttackLayout(page) {
   return page.evaluate(() => {
     const rectFor = (selector) => {
@@ -184,6 +310,42 @@ async function readMobileAttackLayout(page) {
         ? rectFor(".game-mobile-sheet-actions")
         : null,
       stage: rectFor(".game-map-stage"),
+      toggle: rectFor(".game-command-dock-toggle"),
+      viewport: {
+        height: window.innerHeight,
+        width: window.innerWidth
+      }
+    };
+  });
+}
+
+async function readMobileFortifyLayout(page) {
+  return page.evaluate(() => {
+    const rectFor = (selector) => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing ${selector}`);
+      }
+
+      const rect = element.getBoundingClientRect();
+      return {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width
+      };
+    };
+
+    return {
+      dock: rectFor(".game-command-dock"),
+      endTurn: rectFor("#end-turn-button"),
+      fortify: rectFor("#fortify-button"),
+      header: rectFor("body[data-app-section='game'] .top-nav-bar"),
+      mobileActions: document.querySelector(".game-mobile-sheet-actions")
+        ? rectFor(".game-mobile-sheet-actions")
+        : null,
       toggle: rectFor(".game-command-dock-toggle"),
       viewport: {
         height: window.innerHeight,
@@ -372,6 +534,58 @@ test("mobile attack sheet keeps primary actions visible and expands only seconda
   await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
 
   const expandedLayout = await readMobileAttackLayout(page);
+  expect(expandedLayout.dock.height).toBeLessThanOrEqual(500);
+  expect(expandedLayout.dock.top - expandedLayout.header.bottom).toBeGreaterThan(160);
+  expect(expandedLayout.toggle.top).toBeGreaterThanOrEqual(0);
+  expect(expandedLayout.toggle.bottom).toBeLessThanOrEqual(expandedLayout.viewport.height + 1);
+  expect(expandedLayout.mobileActions.bottom).toBeLessThanOrEqual(
+    expandedLayout.viewport.height + 1
+  );
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "collapsed"
+  );
+});
+
+test("mobile fortify sheet keeps primary actions visible and expands only secondary actions", async ({
+  page
+}) => {
+  await page.setViewportSize(mobileViewports[0]);
+  await openMockFortifyGame(page);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "half-open"
+  );
+  await expect(page.locator("#fortify-button")).toBeVisible();
+  await expect(page.locator("#end-turn-button")).toBeVisible();
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeHidden();
+
+  const halfOpenLayout = await readMobileFortifyLayout(page);
+  for (const button of [
+    halfOpenLayout.fortify,
+    halfOpenLayout.endTurn,
+    halfOpenLayout.toggle
+  ]) {
+    expect(button.height).toBeGreaterThanOrEqual(44);
+    expect(button.top).toBeGreaterThanOrEqual(0);
+    expect(button.bottom).toBeLessThanOrEqual(halfOpenLayout.viewport.height + 1);
+  }
+  expect(halfOpenLayout.dock.height).toBeGreaterThanOrEqual(390);
+  expect(halfOpenLayout.dock.height).toBeLessThanOrEqual(410);
+  expect(halfOpenLayout.dock.top - halfOpenLayout.header.bottom).toBeGreaterThan(240);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "expanded"
+  );
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
+
+  const expandedLayout = await readMobileFortifyLayout(page);
   expect(expandedLayout.dock.height).toBeLessThanOrEqual(500);
   expect(expandedLayout.dock.top - expandedLayout.header.bottom).toBeGreaterThan(160);
   expect(expandedLayout.toggle.top).toBeGreaterThanOrEqual(0);

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -403,7 +403,7 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
         boardStageBackground,
         dock: boundsFor(".game-command-dock"),
         header: boundsFor("body[data-app-section='game'] .top-nav-bar"),
-        hud: boundsFor(".game-floating-hud"),
+        hudDisplay: window.getComputedStyle(document.querySelector(".game-floating-hud")).display,
         primaryDockButton: primaryDockButton
           ? {
               bottom: primaryDockButton.getBoundingClientRect().bottom,
@@ -435,7 +435,7 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
     expect(layout.dock.height).toBeGreaterThanOrEqual(70);
     expect(layout.dock.height).toBeLessThanOrEqual(112);
     expect(layout.sheetState).toBe("collapsed");
-    expect(layout.hud.width).toBeLessThan(layout.viewport.width);
+    expect(layout.hudDisplay).toBe("none");
 
     await page.locator(".game-command-dock-toggle").click();
     await expect(page.locator(".game-command-dock")).toHaveAttribute(

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -12,7 +12,7 @@ async function openWorldClassicGame(page) {
   const owner = uniqueUser("mobile_shell");
   const sessionToken = await registerAndLogin(page, owner);
   await setSessionThemePreference(page, sessionToken, "war-table");
-  await page.evaluate(() => window.localStorage.setItem("netrisk.theme", "war-table"));
+  await page.addInitScript(() => window.localStorage.setItem("netrisk.theme", "war-table"));
   await page.goto("/lobby/new");
   await expect(page.getByTestId("new-game-shell")).toBeVisible();
   await page.locator("#setup-map").selectOption("world-classic");
@@ -21,6 +21,15 @@ async function openWorldClassicGame(page) {
   await page.getByRole("button", { name: "Crea e apri" }).click();
 
   await expect(page.locator("#game-map-meta")).toContainText("World Classic", { timeout: 15000 });
+  const joinAiResponse = await page.request.post("/api/ai/join", {
+    data: { name: "CPU Mobile" }
+  });
+  await expect(joinAiResponse.ok()).toBeTruthy();
+  await page.locator(".game-command-dock-toggle").click();
+  await page.getByRole("button", { name: "Avvia partita" }).click();
+  await expect(page.getByTestId("status-summary")).toContainText(/Rinforzi disponibili:\s*[1-9]\d*/i, {
+    timeout: 15000
+  });
   await expect(page.locator(".map-board.has-custom-background")).toBeVisible({ timeout: 15000 });
 }
 
@@ -29,6 +38,322 @@ const mobileViewports = [
   { width: 360, height: 780 },
   { width: 430, height: 932 }
 ];
+
+async function openMockAttackGame(page) {
+  const attackState = {
+    phase: "active",
+    turnPhase: "attack",
+    players: [
+      {
+        id: "p1",
+        name: "andrea",
+        color: "#7c3aed",
+        connected: true,
+        isAi: false,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 3
+      },
+      {
+        id: "p2",
+        name: "CPU",
+        color: "#f97316",
+        connected: true,
+        isAi: true,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "western-united-states",
+        name: "Western United States",
+        neighbors: ["alberta"],
+        continentId: "north-america",
+        ownerId: "p1",
+        armies: 4,
+        x: 0.22,
+        y: 0.38
+      },
+      {
+        id: "alberta",
+        name: "Alberta",
+        neighbors: ["western-united-states"],
+        continentId: "north-america",
+        ownerId: "p2",
+        armies: 2,
+        x: 0.36,
+        y: 0.3
+      }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool: 0,
+    winnerId: null,
+    gameConfig: {
+      mapId: "world-classic",
+      mapName: "World Classic",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    log: ["Attack layout visual state"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: false,
+    attacksThisTurn: 0,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 20,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    diceRuleSet: {
+      id: "standard",
+      attackerMaxDice: 3,
+      defenderMaxDice: 2
+    },
+    gameId: "g-mobile-attack",
+    version: 7,
+    gameName: "Mobile Attack",
+    playerId: "p1",
+    playerHand: []
+  };
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          username: "andrea",
+          role: "user",
+          authMethods: ["password"],
+          preferences: { theme: "war-table" }
+        }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: attackState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.addInitScript(() => window.localStorage.setItem("netrisk.theme", "war-table"));
+  await page.goto("/react/game/g-mobile-attack");
+  await expect(page.locator(".game-command-dock-attack")).toBeVisible();
+}
+
+async function openMockFortifyGame(page) {
+  const fortifyState = {
+    phase: "active",
+    turnPhase: "fortify",
+    players: [
+      {
+        id: "p1",
+        name: "andrea",
+        color: "#7c3aed",
+        connected: true,
+        isAi: false,
+        territoryCount: 2,
+        eliminated: false,
+        cardCount: 3
+      },
+      {
+        id: "p2",
+        name: "CPU",
+        color: "#f97316",
+        connected: true,
+        isAi: true,
+        territoryCount: 1,
+        eliminated: false,
+        cardCount: 0
+      }
+    ],
+    map: [
+      {
+        id: "western-united-states",
+        name: "Western United States",
+        neighbors: ["alaska", "alberta"],
+        continentId: "north-america",
+        ownerId: "p1",
+        armies: 4,
+        x: 0.22,
+        y: 0.38
+      },
+      {
+        id: "alaska",
+        name: "Alaska",
+        neighbors: ["western-united-states"],
+        continentId: "north-america",
+        ownerId: "p1",
+        armies: 1,
+        x: 0.16,
+        y: 0.18
+      },
+      {
+        id: "alberta",
+        name: "Alberta",
+        neighbors: ["western-united-states"],
+        continentId: "north-america",
+        ownerId: "p2",
+        armies: 2,
+        x: 0.36,
+        y: 0.3
+      }
+    ],
+    continents: [],
+    currentPlayerId: "p1",
+    reinforcementPool: 0,
+    winnerId: null,
+    gameConfig: {
+      mapId: "world-classic",
+      mapName: "World Classic",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    log: ["Fortify layout visual state"],
+    lastAction: null,
+    pendingConquest: null,
+    fortifyUsed: false,
+    conqueredTerritoryThisTurn: true,
+    attacksThisTurn: 1,
+    cardState: {
+      ruleSetId: "standard",
+      tradeCount: 0,
+      deckCount: 20,
+      discardCount: 0,
+      nextTradeBonus: 4,
+      maxHandBeforeForcedTrade: 5,
+      currentPlayerMustTrade: false
+    },
+    diceRuleSet: {
+      id: "standard",
+      attackerMaxDice: 3,
+      defenderMaxDice: 2
+    },
+    gameId: "g-mobile-fortify",
+    version: 8,
+    gameName: "Mobile Fortify",
+    playerId: "p1",
+    playerHand: []
+  };
+
+  await page.route("**/api/auth/session", async (route) => {
+    await route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          username: "andrea",
+          role: "user",
+          authMethods: ["password"],
+          preferences: { theme: "war-table" }
+        }
+      }
+    });
+  });
+
+  await page.route("**/api/state**", async (route) => {
+    await route.fulfill({ json: fortifyState });
+  });
+
+  await page.route("**/api/events**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+      body: ""
+    });
+  });
+
+  await page.addInitScript(() => window.localStorage.setItem("netrisk.theme", "war-table"));
+  await page.goto("/react/game/g-mobile-fortify");
+  await expect(page.locator(".game-command-dock-fortify")).toBeVisible();
+}
+
+async function readMobileAttackLayout(page) {
+  return page.evaluate(() => {
+    const rectFor = (selector) => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing ${selector}`);
+      }
+
+      const rect = element.getBoundingClientRect();
+      return {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width
+      };
+    };
+
+    return {
+      attack: rectFor("#attack-button"),
+      banzai: rectFor("#attack-banzai-button"),
+      dock: rectFor(".game-command-dock"),
+      endTurn: rectFor("#end-turn-button"),
+      header: rectFor("body[data-app-section='game'] .top-nav-bar"),
+      mobileActions: document.querySelector(".game-mobile-sheet-actions")
+        ? rectFor(".game-mobile-sheet-actions")
+        : null,
+      stage: rectFor(".game-map-stage"),
+      toggle: rectFor(".game-command-dock-toggle"),
+      viewport: {
+        height: window.innerHeight,
+        width: window.innerWidth
+      }
+    };
+  });
+}
+
+async function readMobileFortifyLayout(page) {
+  return page.evaluate(() => {
+    const rectFor = (selector) => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing ${selector}`);
+      }
+
+      const rect = element.getBoundingClientRect();
+      return {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width
+      };
+    };
+
+    return {
+      dock: rectFor(".game-command-dock"),
+      endTurn: rectFor("#end-turn-button"),
+      fortify: rectFor("#fortify-button"),
+      header: rectFor("body[data-app-section='game'] .top-nav-bar"),
+      mobileActions: document.querySelector(".game-mobile-sheet-actions")
+        ? rectFor(".game-mobile-sheet-actions")
+        : null,
+      toggle: rectFor(".game-command-dock-toggle"),
+      viewport: {
+        height: window.innerHeight,
+        width: window.innerWidth
+      }
+    };
+  });
+}
 
 test("mobile game shell keeps the map-first sheet layout playable", async ({ page }) => {
   await page.setViewportSize(mobileViewports[0]);
@@ -74,12 +399,11 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
         document.querySelector("#start-button");
 
       return {
-        activity: boundsFor(".game-right-utility-rail"),
         board: boundsFor(".game-map-stage .map-board"),
         boardStageBackground,
         dock: boundsFor(".game-command-dock"),
         header: boundsFor("body[data-app-section='game'] .top-nav-bar"),
-        hud: boundsFor(".game-floating-hud"),
+        hudDisplay: window.getComputedStyle(document.querySelector(".game-floating-hud")).display,
         primaryDockButton: primaryDockButton
           ? {
               bottom: primaryDockButton.getBoundingClientRect().bottom,
@@ -87,11 +411,12 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
               top: primaryDockButton.getBoundingClientRect().top
             }
           : null,
-        rail: boundsFor(".game-action-rail"),
         sheetState: document
           .querySelector(".game-command-dock")
           ?.getAttribute("data-command-sheet-state"),
-        title: document.querySelector("body[data-app-section='game'] .top-nav-title")?.textContent,
+        title: window
+          .getComputedStyle(document.querySelector("body[data-app-section='game'] .top-nav-title"), "::after")
+          .content.replaceAll('"', ""),
         viewport: {
           height: window.innerHeight,
           width: window.innerWidth
@@ -102,18 +427,176 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
     expect(layout.viewport).toEqual(viewport);
     expect(layout.boardStageBackground).toContain("world-classic");
     expect(layout.header.height).toBeLessThanOrEqual(60);
-    expect(layout.title).toContain("Frontline Dominion");
+    expect(layout.title).toBe("NETRISK");
     expect(layout.board.width).toBeGreaterThan(layout.viewport.width);
     expect(layout.board.height).toBeGreaterThanOrEqual(layout.viewport.height * 0.42);
     expect(layout.dock.left).toBeLessThanOrEqual(1);
     expect(layout.dock.right).toBeGreaterThanOrEqual(layout.viewport.width - 1);
-    expect(layout.dock.height).toBeGreaterThanOrEqual(190);
-    expect(layout.dock.height).toBeLessThanOrEqual(layout.viewport.height * 0.34);
-    expect(layout.sheetState).toBe("half-open");
-    expect(layout.hud.width).toBeLessThan(layout.viewport.width);
-    expect(layout.rail.height).toBeGreaterThanOrEqual(44);
-    expect(layout.activity.height).toBeGreaterThanOrEqual(44);
-    expect(layout.primaryDockButton?.height).toBeGreaterThanOrEqual(44);
-    expect(layout.primaryDockButton?.bottom).toBeLessThanOrEqual(layout.viewport.height + 1);
+    expect(layout.dock.height).toBeGreaterThanOrEqual(70);
+    expect(layout.dock.height).toBeLessThanOrEqual(112);
+    expect(layout.sheetState).toBe("collapsed");
+    expect(layout.hudDisplay).toBe("none");
+
+    await page.locator(".game-command-dock-toggle").click();
+    await expect(page.locator(".game-command-dock")).toHaveAttribute(
+      "data-command-sheet-state",
+      "half-open"
+    );
+
+    const halfOpenLayout = await page.evaluate(() => {
+      const primaryDockButton =
+        document.querySelector("#reinforce-multi-button") ||
+        document.querySelector("#attack-button") ||
+        document.querySelector("#conquest-button") ||
+        document.querySelector("#fortify-button") ||
+        document.querySelector("#join-button") ||
+        document.querySelector("#start-button");
+
+      if (!primaryDockButton) {
+        throw new Error("Missing primary dock button");
+      }
+
+      const dockRect = document.querySelector(".game-command-dock").getBoundingClientRect();
+      const buttonRect = primaryDockButton.getBoundingClientRect();
+
+      return {
+        dock: {
+          bottom: dockRect.bottom,
+          height: dockRect.height,
+          top: dockRect.top
+        },
+        primaryDockButton: {
+          bottom: buttonRect.bottom,
+          height: buttonRect.height,
+          top: buttonRect.top
+        },
+        viewport: {
+          height: window.innerHeight,
+          width: window.innerWidth
+        }
+      };
+    });
+
+    expect(halfOpenLayout.dock.height).toBeGreaterThanOrEqual(180);
+    expect(halfOpenLayout.dock.height).toBeLessThanOrEqual(
+      halfOpenLayout.viewport.height * 0.32
+    );
+    expect(halfOpenLayout.primaryDockButton.height).toBeGreaterThanOrEqual(44);
+    expect(halfOpenLayout.primaryDockButton.bottom).toBeLessThanOrEqual(
+      halfOpenLayout.viewport.height + 1
+    );
+
+    await page.locator(".game-command-dock-toggle").click();
+    await expect(page.locator(".game-command-dock")).toHaveAttribute(
+      "data-command-sheet-state",
+      "expanded"
+    );
+    await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
   }
+});
+
+test("mobile attack sheet keeps primary actions visible and expands only secondary actions", async ({
+  page
+}) => {
+  await page.setViewportSize(mobileViewports[0]);
+  await openMockAttackGame(page);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "half-open"
+  );
+  await expect(page.locator("#attack-button")).toBeVisible();
+  await expect(page.locator("#attack-banzai-button")).toBeVisible();
+  await expect(page.locator("#end-turn-button")).toBeVisible();
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeHidden();
+
+  const halfOpenLayout = await readMobileAttackLayout(page);
+  for (const button of [
+    halfOpenLayout.attack,
+    halfOpenLayout.banzai,
+    halfOpenLayout.endTurn,
+    halfOpenLayout.toggle
+  ]) {
+    expect(button.height).toBeGreaterThanOrEqual(44);
+    expect(button.top).toBeGreaterThanOrEqual(0);
+    expect(button.bottom).toBeLessThanOrEqual(halfOpenLayout.viewport.height + 1);
+  }
+  expect(halfOpenLayout.dock.height).toBeGreaterThanOrEqual(390);
+  expect(halfOpenLayout.dock.height).toBeLessThanOrEqual(410);
+  expect(halfOpenLayout.dock.top - halfOpenLayout.header.bottom).toBeGreaterThan(240);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "expanded"
+  );
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
+
+  const expandedLayout = await readMobileAttackLayout(page);
+  expect(expandedLayout.dock.height).toBeLessThanOrEqual(500);
+  expect(expandedLayout.dock.top - expandedLayout.header.bottom).toBeGreaterThan(160);
+  expect(expandedLayout.toggle.top).toBeGreaterThanOrEqual(0);
+  expect(expandedLayout.toggle.bottom).toBeLessThanOrEqual(expandedLayout.viewport.height + 1);
+  expect(expandedLayout.mobileActions.bottom).toBeLessThanOrEqual(
+    expandedLayout.viewport.height + 1
+  );
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "collapsed"
+  );
+});
+
+test("mobile fortify sheet keeps primary actions visible and expands only secondary actions", async ({
+  page
+}) => {
+  await page.setViewportSize(mobileViewports[0]);
+  await openMockFortifyGame(page);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "half-open"
+  );
+  await expect(page.locator("#fortify-button")).toBeVisible();
+  await expect(page.locator("#end-turn-button")).toBeVisible();
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeHidden();
+
+  const halfOpenLayout = await readMobileFortifyLayout(page);
+  for (const button of [
+    halfOpenLayout.fortify,
+    halfOpenLayout.endTurn,
+    halfOpenLayout.toggle
+  ]) {
+    expect(button.height).toBeGreaterThanOrEqual(44);
+    expect(button.top).toBeGreaterThanOrEqual(0);
+    expect(button.bottom).toBeLessThanOrEqual(halfOpenLayout.viewport.height + 1);
+  }
+  expect(halfOpenLayout.dock.height).toBeGreaterThanOrEqual(390);
+  expect(halfOpenLayout.dock.height).toBeLessThanOrEqual(410);
+  expect(halfOpenLayout.dock.top - halfOpenLayout.header.bottom).toBeGreaterThan(240);
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "expanded"
+  );
+  await expect(page.locator(".game-mobile-sheet-actions")).toBeVisible();
+
+  const expandedLayout = await readMobileFortifyLayout(page);
+  expect(expandedLayout.dock.height).toBeLessThanOrEqual(500);
+  expect(expandedLayout.dock.top - expandedLayout.header.bottom).toBeGreaterThan(160);
+  expect(expandedLayout.toggle.top).toBeGreaterThanOrEqual(0);
+  expect(expandedLayout.toggle.bottom).toBeLessThanOrEqual(expandedLayout.viewport.height + 1);
+  expect(expandedLayout.mobileActions.bottom).toBeLessThanOrEqual(
+    expandedLayout.viewport.height + 1
+  );
+
+  await page.locator(".game-command-dock-toggle").click();
+  await expect(page.locator(".game-command-dock")).toHaveAttribute(
+    "data-command-sheet-state",
+    "collapsed"
+  );
 });

--- a/e2e/gameplay/card-trade-panel.spec.ts
+++ b/e2e/gameplay/card-trade-panel.spec.ts
@@ -319,10 +319,19 @@ for (const viewport of [
       const scrollStyles = scrollContainer ? window.getComputedStyle(scrollContainer) : null;
       const rowStyles = row ? window.getComputedStyle(row) : null;
       const viewport = { height: window.innerHeight, width: window.innerWidth };
+      const visibleBoardWidth = Math.max(
+        0,
+        Math.min(board.right, viewport.width) - Math.max(board.left, 0)
+      );
+      const visibleBoardHeight = Math.max(
+        0,
+        Math.min(board.bottom, dock.top) - Math.max(board.top, 0)
+      );
 
       return {
         adjacentGaps,
         boardClearOfDock: !intersects(board, dock),
+        boardHasVisiblePlayArea: visibleBoardWidth >= 220 && visibleBoardHeight >= 140,
         boardHeight: board.height,
         boardInsideViewport:
           board.top >= -1 &&
@@ -359,8 +368,12 @@ for (const viewport of [
 
     expect(metrics.boardWidth).toBeGreaterThan(240);
     expect(metrics.boardHeight).toBeGreaterThan(150);
-    expect(metrics.boardInsideViewport).toBeTruthy();
-    expect(metrics.boardClearOfDock).toBeTruthy();
+    if (viewport.name === "mobile") {
+      expect(metrics.boardHasVisiblePlayArea).toBeTruthy();
+    } else {
+      expect(metrics.boardInsideViewport).toBeTruthy();
+      expect(metrics.boardClearOfDock).toBeTruthy();
+    }
     expect(metrics.dockInsideViewport).toBeTruthy();
     expect(metrics.safeBottom).toMatch(/^[0-9.]+px$/);
     expect(metrics.rowDisplay).toBe("flex");

--- a/e2e/gameplay/card-trade-panel.spec.ts
+++ b/e2e/gameplay/card-trade-panel.spec.ts
@@ -326,8 +326,8 @@ for (const viewport of [
       expect(metrics.boardHasVisiblePlayArea).toBeTruthy();
     } else {
       expect(metrics.boardInsideViewport).toBeTruthy();
+      expect(metrics.boardClearOfDock).toBeTruthy();
     }
-    expect(metrics.boardClearOfDock).toBeTruthy();
     expect(metrics.dockInsideViewport).toBeTruthy();
     expect(metrics.safeBottom).toMatch(/^[0-9.]+px$/);
   });

--- a/e2e/gameplay/card-trade-panel.spec.ts
+++ b/e2e/gameplay/card-trade-panel.spec.ts
@@ -288,9 +288,18 @@ for (const viewport of [
       const stage = document.querySelector(".game-map-stage");
       const stageStyles = stage ? window.getComputedStyle(stage) : null;
       const viewport = { height: window.innerHeight, width: window.innerWidth };
+      const visibleBoardWidth = Math.max(
+        0,
+        Math.min(board.right, viewport.width) - Math.max(board.left, 0)
+      );
+      const visibleBoardHeight = Math.max(
+        0,
+        Math.min(board.bottom, dock.top) - Math.max(board.top, 0)
+      );
 
       return {
         boardClearOfDock: !intersects(board, dock),
+        boardHasVisiblePlayArea: visibleBoardWidth >= 220 && visibleBoardHeight >= 140,
         boardHeight: board.height,
         boardInsideViewport:
           board.top >= -1 &&
@@ -313,7 +322,11 @@ for (const viewport of [
 
     expect(metrics.boardWidth).toBeGreaterThan(240);
     expect(metrics.boardHeight).toBeGreaterThan(150);
-    expect(metrics.boardInsideViewport).toBeTruthy();
+    if (viewport.name === "mobile") {
+      expect(metrics.boardHasVisiblePlayArea).toBeTruthy();
+    } else {
+      expect(metrics.boardInsideViewport).toBeTruthy();
+    }
     expect(metrics.boardClearOfDock).toBeTruthy();
     expect(metrics.dockInsideViewport).toBeTruthy();
     expect(metrics.safeBottom).toMatch(/^[0-9.]+px$/);

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -363,10 +363,7 @@ describe("GameRoute integration", () => {
       removeListener,
       dispatchEvent: vi.fn(() => true)
     }));
-    vi.stubGlobal(
-      "matchMedia",
-      matchMedia
-    );
+    vi.stubGlobal("matchMedia", matchMedia);
 
     const { unmount } = renderReactShell("/react/game/g-1");
 

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -352,30 +352,32 @@ describe("GameRoute integration", () => {
     expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
   });
 
-  it("uses legacy media query listeners when the mobile dock viewport API needs them", async () => {
+  it("keeps the mobile command dock collapsed until the player opens it", async () => {
     const addListener = vi.fn();
     const removeListener = vi.fn();
+    const matchMedia = vi.fn(() => ({
+      matches: true,
+      media: "(max-width: 760px)",
+      onchange: null,
+      addListener,
+      removeListener,
+      dispatchEvent: vi.fn(() => true)
+    }));
     vi.stubGlobal(
       "matchMedia",
-      vi.fn(() => ({
-        matches: true,
-        media: "(max-width: 760px)",
-        onchange: null,
-        addListener,
-        removeListener,
-        dispatchEvent: vi.fn(() => true)
-      }))
+      matchMedia
     );
 
     const { unmount } = renderReactShell("/react/game/g-1");
 
     const dock = await screen.findByTestId("actions-panel");
-    expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
-    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(matchMedia).not.toHaveBeenCalled();
+    expect(addListener).not.toHaveBeenCalled();
 
     unmount();
 
-    expect(removeListener).toHaveBeenCalledTimes(1);
+    expect(removeListener).not.toHaveBeenCalled();
   });
 
   it("passes mobile command dock sheet state changes through to the map viewport", async () => {
@@ -398,6 +400,12 @@ describe("GameRoute integration", () => {
     const mapViewport = screen.getByTestId("mock-gameplay-map-viewport");
     const toggle = dock.querySelector(".game-command-dock-toggle") as HTMLButtonElement | null;
     expect(toggle).not.toBeNull();
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(mapViewport).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(toggle).toHaveAttribute("aria-label", "Espandi comandi");
+
+    await user.click(toggle as HTMLButtonElement);
+
     expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
     expect(mapViewport).toHaveAttribute("data-command-sheet-state", "half-open");
     expect(toggle).toHaveAttribute("aria-label", "Espandi comandi");
@@ -409,23 +417,16 @@ describe("GameRoute integration", () => {
     expect(toggle).toHaveAttribute("aria-label", "Comprimi comandi");
   });
 
-  it("normalizes the mobile-only half-open dock state after leaving the mobile viewport", async () => {
+  it("uses binary command dock toggling after leaving the mobile viewport", async () => {
     const user = userEvent.setup();
     let isMobileViewport = true;
-    let changeListener: ((event: MediaQueryListEvent) => void) | null = null;
     vi.stubGlobal(
       "matchMedia",
       vi.fn(() => ({
         matches: isMobileViewport,
         media: "(max-width: 760px)",
         onchange: null,
-        addEventListener: vi.fn(
-          (eventName: string, listener: (event: MediaQueryListEvent) => void) => {
-            if (eventName === "change") {
-              changeListener = listener;
-            }
-          }
-        ),
+        addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(() => true)
       }))
@@ -436,17 +437,17 @@ describe("GameRoute integration", () => {
     const dock = await screen.findByTestId("actions-panel");
     const toggle = dock.querySelector(".game-command-dock-toggle") as HTMLButtonElement | null;
     expect(toggle).not.toBeNull();
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+
+    await user.click(toggle as HTMLButtonElement);
     expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
 
     act(() => {
       isMobileViewport = false;
-      changeListener?.({ matches: false } as MediaQueryListEvent);
     });
 
-    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
-
     await user.click(toggle as HTMLButtonElement);
-    expect(dock).toHaveAttribute("data-command-sheet-state", "expanded");
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
   });
 
   it("renders the reference fortify command dock", async () => {

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -372,25 +372,24 @@ describe("GameRoute integration", () => {
     expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
   });
 
-  it("uses legacy media query listeners when the mobile dock viewport API needs them", async () => {
+  it("keeps the mobile command dock collapsed while registering viewport sync", async () => {
     const addListener = vi.fn();
     const removeListener = vi.fn();
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn(() => ({
-        matches: true,
-        media: "(max-width: 760px)",
-        onchange: null,
-        addListener,
-        removeListener,
-        dispatchEvent: vi.fn(() => true)
-      }))
-    );
+    const matchMedia = vi.fn(() => ({
+      matches: true,
+      media: "(max-width: 760px)",
+      onchange: null,
+      addListener,
+      removeListener,
+      dispatchEvent: vi.fn(() => true)
+    }));
+    vi.stubGlobal("matchMedia", matchMedia);
 
     const { unmount } = renderReactShell("/react/game/g-1");
 
     const dock = await screen.findByTestId("actions-panel");
-    expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(matchMedia).toHaveBeenCalledWith("(max-width: 760px)");
     expect(addListener).toHaveBeenCalledTimes(1);
 
     unmount();
@@ -418,6 +417,12 @@ describe("GameRoute integration", () => {
     const mapViewport = screen.getByTestId("mock-gameplay-map-viewport");
     const toggle = dock.querySelector(".game-command-dock-toggle") as HTMLButtonElement | null;
     expect(toggle).not.toBeNull();
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(mapViewport).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(toggle).toHaveAttribute("aria-label", "Espandi comandi");
+
+    await user.click(toggle as HTMLButtonElement);
+
     expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
     expect(mapViewport).toHaveAttribute("data-command-sheet-state", "half-open");
     expect(toggle).toHaveAttribute("aria-label", "Espandi comandi");
@@ -429,7 +434,7 @@ describe("GameRoute integration", () => {
     expect(toggle).toHaveAttribute("aria-label", "Comprimi comandi");
   });
 
-  it("normalizes the mobile-only half-open dock state after leaving the mobile viewport", async () => {
+  it("uses binary command dock toggling after leaving the mobile viewport", async () => {
     const user = userEvent.setup();
     let isMobileViewport = true;
     let changeListener: ((event: MediaQueryListEvent) => void) | null = null;
@@ -456,13 +461,15 @@ describe("GameRoute integration", () => {
     const dock = await screen.findByTestId("actions-panel");
     const toggle = dock.querySelector(".game-command-dock-toggle") as HTMLButtonElement | null;
     expect(toggle).not.toBeNull();
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+
+    await user.click(toggle as HTMLButtonElement);
     expect(dock).toHaveAttribute("data-command-sheet-state", "half-open");
 
     act(() => {
       isMobileViewport = false;
       changeListener?.({ matches: false } as MediaQueryListEvent);
     });
-
     expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
 
     await user.click(toggle as HTMLButtonElement);

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -352,7 +352,7 @@ describe("GameRoute integration", () => {
     expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
   });
 
-  it("keeps the mobile command dock collapsed until the player opens it", async () => {
+  it("keeps the mobile command dock collapsed while registering viewport sync", async () => {
     const addListener = vi.fn();
     const removeListener = vi.fn();
     const matchMedia = vi.fn(() => ({
@@ -369,12 +369,12 @@ describe("GameRoute integration", () => {
 
     const dock = await screen.findByTestId("actions-panel");
     expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
-    expect(matchMedia).not.toHaveBeenCalled();
-    expect(addListener).not.toHaveBeenCalled();
+    expect(matchMedia).toHaveBeenCalledWith("(max-width: 760px)");
+    expect(addListener).toHaveBeenCalledTimes(1);
 
     unmount();
 
-    expect(removeListener).not.toHaveBeenCalled();
+    expect(removeListener).toHaveBeenCalledTimes(1);
   });
 
   it("passes mobile command dock sheet state changes through to the map viewport", async () => {
@@ -417,13 +417,20 @@ describe("GameRoute integration", () => {
   it("uses binary command dock toggling after leaving the mobile viewport", async () => {
     const user = userEvent.setup();
     let isMobileViewport = true;
+    let changeListener: ((event: MediaQueryListEvent) => void) | null = null;
     vi.stubGlobal(
       "matchMedia",
       vi.fn(() => ({
         matches: isMobileViewport,
         media: "(max-width: 760px)",
         onchange: null,
-        addEventListener: vi.fn(),
+        addEventListener: vi.fn(
+          (eventName: string, listener: (event: MediaQueryListEvent) => void) => {
+            if (eventName === "change") {
+              changeListener = listener;
+            }
+          }
+        ),
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(() => true)
       }))
@@ -441,10 +448,12 @@ describe("GameRoute integration", () => {
 
     act(() => {
       isMobileViewport = false;
+      changeListener?.({ matches: false } as MediaQueryListEvent);
     });
+    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
 
     await user.click(toggle as HTMLButtonElement);
-    expect(dock).toHaveAttribute("data-command-sheet-state", "collapsed");
+    expect(dock).toHaveAttribute("data-command-sheet-state", "expanded");
   });
 
   it("renders the reference fortify command dock", async () => {

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -7961,3 +7961,356 @@ html[data-theme="war-table"]
     padding-left: 12px !important;
   }
 }
+
+.game-mobile-sheet-actions {
+  display: none;
+}
+
+.game-mobile-sheet-actions[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 760px) {
+  .game-map-first-page:has(.game-command-dock-sheet-half-open),
+  .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-half-open.is-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-half-open),
+  html[data-theme="war-table"]
+    .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-half-open.is-expanded) {
+    --game-command-dock-height: 214px !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-mandatory-trade),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-mandatory-trade) {
+    --game-command-dock-height: min(66svh, 540px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded),
+  html[data-theme="war-table"]
+    .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded) {
+    --game-command-dock-height: calc(100svh - 142px) !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title {
+    position: relative !important;
+    color: transparent !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title::after,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title::after {
+    content: "NETRISK" !important;
+    position: absolute !important;
+    inset: 0 !important;
+    display: block !important;
+    color: #f6b515 !important;
+    font-size: 0.84rem !important;
+    font-weight: 950 !important;
+    letter-spacing: 0.22em !important;
+    line-height: 1 !important;
+    text-align: center !important;
+    text-shadow: 0 0 18px rgba(246, 181, 21, 0.32) !important;
+  }
+
+  .game-map-first-page,
+  html[data-theme="war-table"] .game-map-first-page {
+    --game-mobile-map-board-width: max(250vw, 760px);
+  }
+
+  .game-map-first-page .game-map-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage {
+    background:
+      radial-gradient(circle at 52% 50%, rgba(58, 115, 158, 0.28), transparent 52%),
+      linear-gradient(180deg, #0b263c 0%, #061925 58%, #03101a 100%) !important;
+  }
+
+  .game-map-first-page .game-map-stage .map-board-anchor,
+  .game-map-first-page .game-map-stage .map-board-transform,
+  .game-map-first-page .game-map-stage .map-board,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-anchor,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-transform,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board {
+    width: var(--game-mobile-map-board-width) !important;
+    height: calc(var(--game-mobile-map-board-width) * 0.6578947368) !important;
+  }
+
+  .game-map-first-page .game-map-stage .map-board-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-stage {
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  .game-floating-hud,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud {
+    display: none !important;
+  }
+
+  .game-action-rail,
+  .game-right-utility-rail,
+  html[data-theme="war-table"] .game-map-first-page .game-action-rail,
+  html[data-theme="war-table"] .game-map-first-page .game-right-utility-rail {
+    display: none !important;
+  }
+
+  .game-command-dock-sheet-collapsed .game-mobile-sheet-actions,
+  .game-command-dock-sheet-half-open .game-mobile-sheet-actions {
+    display: none !important;
+  }
+
+  .game-command-dock-sheet-expanded .game-mobile-sheet-actions {
+    display: grid !important;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+    margin-top: 12px !important;
+    padding-top: 10px !important;
+    border-top: 1px solid rgba(117, 142, 158, 0.24) !important;
+  }
+
+  .game-mobile-sheet-actions button {
+    position: relative !important;
+    display: grid !important;
+    justify-items: center !important;
+    gap: 4px !important;
+    min-height: 54px !important;
+    height: auto !important;
+    padding: 7px 4px !important;
+    border: 1px solid rgba(126, 153, 170, 0.34) !important;
+    background: rgba(6, 20, 31, 0.78) !important;
+    color: rgba(232, 240, 246, 0.88) !important;
+    font-size: 0.54rem !important;
+    line-height: 1.05 !important;
+  }
+
+  .game-mobile-sheet-actions button.is-active {
+    border-color: rgba(246, 181, 21, 0.82) !important;
+    color: #f6b515 !important;
+  }
+
+  .game-mobile-sheet-actions svg {
+    width: 18px !important;
+    height: 18px !important;
+  }
+
+  .game-mobile-sheet-actions strong {
+    position: absolute !important;
+    top: -6px !important;
+    right: -6px !important;
+    display: grid !important;
+    place-items: center !important;
+    min-width: 20px !important;
+    height: 20px !important;
+    border-radius: 999px !important;
+    background: #d64a4d !important;
+    color: #fff !important;
+    font-size: 0.62rem !important;
+  }
+
+  .game-map-first-page.has-open-drawer .game-command-dock,
+  html[data-theme="war-table"] .game-map-first-page.has-open-drawer .game-command-dock {
+    display: none !important;
+  }
+
+  .game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-sheet-expanded {
+    max-height: calc(100svh - 142px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-half-open),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-half-open) {
+    --game-command-dock-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-expanded) {
+    --game-command-dock-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-attack.game-command-dock-sheet-expanded {
+    height: clamp(430px, 58svh, 500px) !important;
+    min-height: clamp(430px, 58svh, 500px) !important;
+    max-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-half-open,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-attack.game-command-dock-sheet-half-open {
+    height: clamp(390px, 52svh, 410px) !important;
+    min-height: clamp(390px, 52svh, 410px) !important;
+    max-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-command-dock-attack .game-command-dock-toggle {
+    z-index: 6 !important;
+  }
+
+  .game-command-dock-attack .game-command-dock-title {
+    line-height: 1.05 !important;
+  }
+
+  .game-command-dock-attack .game-command-dock-summary {
+    margin-top: 2px !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-expanded .game-command-dock-summary {
+    display: none !important;
+  }
+
+  .game-command-dock-attack .actions-section {
+    gap: 8px !important;
+    margin-top: 8px !important;
+  }
+
+  .game-command-dock-attack #attack-group {
+    gap: 5px !important;
+  }
+
+  .game-command-dock-attack #attack-group > label,
+  .game-command-dock-attack #attack-group .game-dock-select-label > span {
+    font-size: 0.66rem !important;
+    line-height: 1 !important;
+    margin-bottom: 4px !important;
+  }
+
+  .game-command-dock-attack #attack-group .action-stack {
+    gap: 7px !important;
+  }
+
+  .game-command-dock-attack #attack-group select,
+  .game-command-dock-attack #attack-group .game-dock-select-label select {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 38px 0 10px !important;
+    font-size: 0.82rem !important;
+  }
+
+  .game-command-dock-attack #attack-group .action-row {
+    grid-template-columns: 1fr 1fr !important;
+    gap: 8px !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-half-open #attack-banzai-button,
+  .game-command-dock-attack.game-command-dock-sheet-half-open .game-command-secondary-action {
+    display: inline-grid !important;
+  }
+
+  .game-command-dock-attack #attack-button,
+  .game-command-dock-attack #attack-banzai-button,
+  .game-command-dock-attack #end-turn-button {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 12px !important;
+  }
+
+  .game-command-dock-attack #end-turn-button {
+    width: 100% !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-expanded .game-mobile-sheet-actions {
+    margin-top: 8px !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-half-open),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-half-open) {
+    --game-command-dock-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-expanded) {
+    --game-command-dock-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-fortify.game-command-dock-sheet-expanded {
+    height: clamp(430px, 58svh, 500px) !important;
+    min-height: clamp(430px, 58svh, 500px) !important;
+    max-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-half-open,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-fortify.game-command-dock-sheet-half-open {
+    height: clamp(390px, 52svh, 410px) !important;
+    min-height: clamp(390px, 52svh, 410px) !important;
+    max-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-command-dock-fortify .game-command-dock-toggle {
+    z-index: 6 !important;
+  }
+
+  .game-command-dock-fortify .game-command-dock-title {
+    line-height: 1.05 !important;
+  }
+
+  .game-command-dock-fortify .game-command-dock-summary {
+    margin-top: 2px !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-expanded .game-command-dock-summary {
+    display: none !important;
+  }
+
+  .game-command-dock-fortify .actions-section {
+    gap: 8px !important;
+    margin-top: 8px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group {
+    gap: 5px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group > label,
+  .game-command-dock-fortify #fortify-group .game-dock-select-label > span {
+    font-size: 0.66rem !important;
+    line-height: 1 !important;
+    margin-bottom: 4px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group .action-stack {
+    gap: 7px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group select,
+  .game-command-dock-fortify #fortify-group input,
+  .game-command-dock-fortify #fortify-group .game-dock-select-label select {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 38px 0 10px !important;
+    font-size: 0.82rem !important;
+  }
+
+  .game-command-dock-fortify #fortify-button,
+  .game-command-dock-fortify #end-turn-button {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 12px !important;
+    width: 100% !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-expanded .game-mobile-sheet-actions {
+    margin-top: 8px !important;
+  }
+
+  .game-modern-drawer,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer,
+  .game-modern-drawer-left,
+  .game-modern-drawer-right,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-left,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-right {
+    top: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    height: 100svh !important;
+    min-height: 100svh !important;
+    max-height: 100svh !important;
+    border-right: 0 !important;
+    border-left: 0 !important;
+    border-radius: 0 !important;
+    padding: 42px 18px calc(18px + env(safe-area-inset-bottom)) !important;
+  }
+
+  .game-modern-drawer-header {
+    top: -42px !important;
+    margin: -42px -18px 14px !important;
+    padding: 42px 18px 14px !important;
+  }
+}

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -8095,6 +8095,100 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
     max-height: calc(100svh - 142px) !important;
   }
 
+  .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-half-open),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-half-open) {
+    --game-command-dock-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-attack.game-command-dock-sheet-expanded) {
+    --game-command-dock-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-attack.game-command-dock-sheet-expanded {
+    height: clamp(430px, 58svh, 500px) !important;
+    min-height: clamp(430px, 58svh, 500px) !important;
+    max-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-half-open,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-attack.game-command-dock-sheet-half-open {
+    height: clamp(390px, 52svh, 410px) !important;
+    min-height: clamp(390px, 52svh, 410px) !important;
+    max-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-command-dock-attack .game-command-dock-toggle {
+    z-index: 6 !important;
+  }
+
+  .game-command-dock-attack .game-command-dock-title {
+    line-height: 1.05 !important;
+  }
+
+  .game-command-dock-attack .game-command-dock-summary {
+    margin-top: 2px !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-expanded .game-command-dock-summary {
+    display: none !important;
+  }
+
+  .game-command-dock-attack .actions-section {
+    gap: 8px !important;
+    margin-top: 8px !important;
+  }
+
+  .game-command-dock-attack #attack-group {
+    gap: 5px !important;
+  }
+
+  .game-command-dock-attack #attack-group > label,
+  .game-command-dock-attack #attack-group .game-dock-select-label > span {
+    font-size: 0.66rem !important;
+    line-height: 1 !important;
+    margin-bottom: 4px !important;
+  }
+
+  .game-command-dock-attack #attack-group .action-stack {
+    gap: 7px !important;
+  }
+
+  .game-command-dock-attack #attack-group select,
+  .game-command-dock-attack #attack-group .game-dock-select-label select {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 38px 0 10px !important;
+    font-size: 0.82rem !important;
+  }
+
+  .game-command-dock-attack #attack-group .action-row {
+    grid-template-columns: 1fr 1fr !important;
+    gap: 8px !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-half-open #attack-banzai-button,
+  .game-command-dock-attack.game-command-dock-sheet-half-open .game-command-secondary-action {
+    display: inline-grid !important;
+  }
+
+  .game-command-dock-attack #attack-button,
+  .game-command-dock-attack #attack-banzai-button,
+  .game-command-dock-attack #end-turn-button {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 12px !important;
+  }
+
+  .game-command-dock-attack #end-turn-button {
+    width: 100% !important;
+  }
+
+  .game-command-dock-attack.game-command-dock-sheet-expanded .game-mobile-sheet-actions {
+    margin-top: 8px !important;
+  }
+
   .game-modern-drawer,
   html[data-theme="war-table"] .game-map-first-page .game-modern-drawer,
   .game-modern-drawer-left,

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -8189,6 +8189,87 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
     margin-top: 8px !important;
   }
 
+  .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-half-open),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-half-open) {
+    --game-command-dock-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-fortify.game-command-dock-sheet-expanded) {
+    --game-command-dock-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-fortify.game-command-dock-sheet-expanded {
+    height: clamp(430px, 58svh, 500px) !important;
+    min-height: clamp(430px, 58svh, 500px) !important;
+    max-height: clamp(430px, 58svh, 500px) !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-half-open,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-fortify.game-command-dock-sheet-half-open {
+    height: clamp(390px, 52svh, 410px) !important;
+    min-height: clamp(390px, 52svh, 410px) !important;
+    max-height: clamp(390px, 52svh, 410px) !important;
+  }
+
+  .game-command-dock-fortify .game-command-dock-toggle {
+    z-index: 6 !important;
+  }
+
+  .game-command-dock-fortify .game-command-dock-title {
+    line-height: 1.05 !important;
+  }
+
+  .game-command-dock-fortify .game-command-dock-summary {
+    margin-top: 2px !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-expanded .game-command-dock-summary {
+    display: none !important;
+  }
+
+  .game-command-dock-fortify .actions-section {
+    gap: 8px !important;
+    margin-top: 8px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group {
+    gap: 5px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group > label,
+  .game-command-dock-fortify #fortify-group .game-dock-select-label > span {
+    font-size: 0.66rem !important;
+    line-height: 1 !important;
+    margin-bottom: 4px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group .action-stack {
+    gap: 7px !important;
+  }
+
+  .game-command-dock-fortify #fortify-group select,
+  .game-command-dock-fortify #fortify-group input,
+  .game-command-dock-fortify #fortify-group .game-dock-select-label select {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 38px 0 10px !important;
+    font-size: 0.82rem !important;
+  }
+
+  .game-command-dock-fortify #fortify-button,
+  .game-command-dock-fortify #end-turn-button {
+    min-height: 44px !important;
+    height: 44px !important;
+    padding: 0 12px !important;
+    width: 100% !important;
+  }
+
+  .game-command-dock-fortify.game-command-dock-sheet-expanded .game-mobile-sheet-actions {
+    margin-top: 8px !important;
+  }
+
   .game-modern-drawer,
   html[data-theme="war-table"] .game-map-first-page .game-modern-drawer,
   .game-modern-drawer-left,

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -7507,3 +7507,529 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
     grid-template-columns: minmax(0, 1fr) 56px 74px !important;
   }
 }
+
+.game-mobile-sheet-actions {
+  display: none;
+}
+
+.game-mobile-sheet-actions[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 760px) {
+  body[data-app-section="game"] .top-nav-bar,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-bar {
+    grid-template-columns: 48px minmax(0, 1fr) auto !important;
+    min-height: 54px !important;
+    padding: 0 10px !important;
+    background: rgba(2, 8, 14, 0.98) !important;
+  }
+
+  body[data-app-section="game"] .top-nav-links,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-links {
+    top: 54px !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title::before,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title::before {
+    font-size: 0.84rem !important;
+    letter-spacing: 0.23em !important;
+  }
+
+  body[data-app-section="game"] .war-nav-locale-icon,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-locale-icon {
+    width: 20px !important;
+    min-width: 20px !important;
+    height: 20px !important;
+  }
+
+  body[data-app-section="game"] .war-nav-locale-code,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-locale-code {
+    font-size: 0.68rem !important;
+  }
+
+  body[data-app-section="game"] .war-nav-user,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-user {
+    width: 40px !important;
+    min-width: 40px !important;
+    min-height: 44px !important;
+  }
+
+  body[data-app-section="game"] .war-nav-avatar,
+  html[data-theme="war-table"] body[data-app-section="game"] .war-nav-avatar {
+    width: 34px !important;
+    height: 34px !important;
+  }
+
+  .game-map-first-page,
+  html[data-theme="war-table"] .game-map-first-page {
+    --game-command-dock-height: 214px !important;
+    --game-map-allow-horizontal-crop: 1;
+    min-height: calc(100svh - 54px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-sheet-collapsed),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-collapsed) {
+    --game-command-dock-height: 94px !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-sheet-half-open),
+  .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-half-open.is-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-half-open),
+  html[data-theme="war-table"]
+    .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-half-open.is-expanded) {
+    --game-command-dock-height: 214px !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-sheet-expanded),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-expanded) {
+    --game-command-dock-height: min(64svh, 520px) !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock-mandatory-trade),
+  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-mandatory-trade) {
+    --game-command-dock-height: min(66svh, 540px) !important;
+  }
+
+  .game-map-first-page .game-battlefield-layout,
+  .game-map-first-page .game-main-column,
+  .game-map-first-page .game-map-stage,
+  .game-map-first-page .game-map-stage .map,
+  .game-map-first-page .game-map-stage .map-viewport,
+  .game-map-first-page .game-map-stage .map-board-surface,
+  html[data-theme="war-table"] .game-map-first-page .game-battlefield-layout,
+  html[data-theme="war-table"] .game-map-first-page .game-main-column,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-viewport,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-surface {
+    min-height: calc(100svh - 54px) !important;
+  }
+
+  .game-map-first-page .game-map-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage {
+    --game-map-safe-top: 14px !important;
+    --game-map-safe-bottom: calc(var(--game-command-dock-height) + 10px) !important;
+  }
+
+  .game-map-first-page .game-map-stage .map-board,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board {
+    border: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  .game-map-first-page .map-controls,
+  html[data-theme="war-table"] .game-map-first-page .map-controls,
+  .game-action-rail,
+  .game-right-utility-rail,
+  html[data-theme="war-table"] .game-map-first-page .game-action-rail,
+  html[data-theme="war-table"] .game-map-first-page .game-right-utility-rail {
+    display: none !important;
+  }
+
+  .game-floating-hud,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud {
+    top: 34px !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: 12px !important;
+    width: min(182px, calc(100vw - 98px)) !important;
+    max-height: none !important;
+    padding: 9px 10px !important;
+    border-radius: 6px !important;
+  }
+
+  .game-floating-hud .game-hud-heading,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud .game-hud-heading {
+    margin-bottom: 6px !important;
+    padding-bottom: 6px !important;
+  }
+
+  .game-floating-hud h1,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud h1 {
+    font-size: 0.58rem !important;
+    line-height: 1.08 !important;
+  }
+
+  .game-hud-summary,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary {
+    grid-template-columns: 1fr !important;
+    gap: 3px !important;
+  }
+
+  .game-hud-summary > div,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary > div {
+    min-height: 24px !important;
+    gap: 6px !important;
+  }
+
+  .game-hud-summary > div + div,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary > div + div {
+    padding-left: 0 !important;
+    border-left: 0 !important;
+  }
+
+  .game-hud-icon,
+  .game-hud-avatar,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-icon,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-avatar {
+    width: 22px !important;
+    height: 22px !important;
+  }
+
+  .game-hud-icon svg {
+    width: 13px !important;
+    height: 13px !important;
+  }
+
+  .game-hud-label,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-label {
+    font-size: 0.46rem !important;
+    letter-spacing: 0.04em !important;
+  }
+
+  .game-hud-summary strong,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-summary strong {
+    font-size: 0.72rem !important;
+  }
+
+  .game-hud-stat:first-child strong,
+  html[data-theme="war-table"] .game-map-first-page .game-hud-stat:first-child strong {
+    font-size: 1.18rem !important;
+  }
+
+  .game-floating-hud .map-trade-alert,
+  html[data-theme="war-table"] .game-map-first-page .game-floating-hud .map-trade-alert {
+    margin-top: 6px !important;
+    padding: 6px 7px !important;
+    font-size: 0.58rem !important;
+  }
+
+  .game-command-dock,
+  .game-command-dock:not(.game-command-dock-mandatory-trade),
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock,
+  html[data-theme="war-table"]
+    .game-map-first-page
+    .game-command-dock:not(.game-command-dock-mandatory-trade) {
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    width: 100vw !important;
+    height: var(--game-command-dock-height) !important;
+    min-height: var(--game-command-dock-height) !important;
+    max-height: var(--game-command-dock-height) !important;
+    padding: 10px 12px calc(10px + env(safe-area-inset-bottom)) !important;
+    overflow: hidden !important;
+    border-color: rgba(156, 177, 192, 0.58) !important;
+    border-right: 0 !important;
+    border-bottom: 0 !important;
+    border-left: 0 !important;
+    border-radius: 14px 14px 0 0 !important;
+    background: linear-gradient(180deg, rgba(5, 19, 30, 0.98), rgba(2, 10, 18, 0.98)) !important;
+    transform: none !important;
+  }
+
+  .game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-sheet-expanded,
+  .game-command-dock-mandatory-trade,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-trade {
+    overflow: auto !important;
+  }
+
+  .game-command-sheet-grip {
+    width: 44px !important;
+    height: 4px !important;
+    margin: 0 auto 8px !important;
+  }
+
+  .game-command-dock .game-command-dock-toggle,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock .game-command-dock-toggle {
+    position: absolute !important;
+    top: 14px !important;
+    right: 12px !important;
+    display: grid !important;
+    place-items: center !important;
+    width: 44px !important;
+    min-width: 44px !important;
+    max-width: 44px !important;
+    height: 44px !important;
+    min-height: 44px !important;
+    max-height: 44px !important;
+    padding: 0 !important;
+    border: 1px solid rgba(126, 153, 170, 0.42) !important;
+    border-radius: 7px !important;
+    background: rgba(5, 18, 29, 0.88) !important;
+    color: rgba(232, 240, 246, 0.9) !important;
+    box-shadow: none !important;
+  }
+
+  .game-command-dock-title {
+    margin: 0 52px 4px 0 !important;
+    color: #f5f8fb !important;
+    font-size: 0.7rem !important;
+    font-weight: 950 !important;
+    letter-spacing: 0.04em !important;
+  }
+
+  .game-command-dock-summary {
+    margin: 0 52px 0 0 !important;
+  }
+
+  .game-command-dock-summary strong {
+    font-size: 0.86rem !important;
+  }
+
+  .game-command-dock-summary span {
+    font-size: 0.64rem !important;
+  }
+
+  .game-command-dock-sheet-collapsed .actions-section,
+  .game-command-dock-sheet-collapsed .game-lobby-controls,
+  .game-command-dock-sheet-collapsed .game-mandatory-trade-dock,
+  .game-command-dock-sheet-collapsed .game-mobile-sheet-actions {
+    display: none !important;
+  }
+
+  .game-command-dock .actions-section,
+  .game-command-dock .game-lobby-controls {
+    gap: 8px !important;
+    margin: 10px 0 0 !important;
+  }
+
+  .game-command-dock .action-stack,
+  .game-command-dock #attack-group .action-stack,
+  .game-command-dock #fortify-group .action-stack,
+  .game-command-dock #reinforce-group .action-stack,
+  .game-command-dock #conquest-group .action-stack {
+    grid-template-columns: 1fr !important;
+    gap: 8px !important;
+  }
+
+  .game-command-dock-sheet-half-open #reinforce-select {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+  }
+
+  .game-number-stepper {
+    display: grid !important;
+    grid-template-columns: 44px minmax(0, 1fr) 44px !important;
+    gap: 0 !important;
+  }
+
+  .game-command-dock .action-row {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 8px !important;
+  }
+
+  .game-command-dock #reinforce-multi-button,
+  .game-command-dock #conquest-button {
+    grid-column: 1 / -1 !important;
+  }
+
+  .game-command-dock-sheet-half-open .game-command-secondary-action,
+  .game-command-dock-sheet-half-open #attack-banzai-button,
+  .game-command-dock-sheet-half-open .game-mobile-sheet-actions {
+    display: none !important;
+  }
+
+  .game-command-dock select,
+  .game-command-dock input,
+  .game-command-dock button,
+  .game-command-dock #attack-button,
+  .game-command-dock #reinforce-multi-button,
+  .game-command-dock #fortify-button,
+  .game-command-dock #conquest-button,
+  .game-command-dock #card-trade-button,
+  .game-command-dock #card-trade-dock-button,
+  .game-command-dock #end-turn-button {
+    min-height: 44px !important;
+    height: 44px !important;
+    font-size: 0.72rem !important;
+  }
+
+  .game-mobile-sheet-actions {
+    display: grid !important;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+    margin-top: 12px !important;
+    padding-top: 10px !important;
+    border-top: 1px solid rgba(117, 142, 158, 0.24) !important;
+  }
+
+  .game-mobile-sheet-actions button {
+    position: relative !important;
+    display: grid !important;
+    justify-items: center !important;
+    gap: 4px !important;
+    min-height: 54px !important;
+    height: auto !important;
+    padding: 7px 4px !important;
+    border: 1px solid rgba(126, 153, 170, 0.34) !important;
+    background: rgba(6, 20, 31, 0.78) !important;
+    color: rgba(232, 240, 246, 0.88) !important;
+    font-size: 0.54rem !important;
+    line-height: 1.05 !important;
+  }
+
+  .game-mobile-sheet-actions button.is-active {
+    border-color: rgba(246, 181, 21, 0.82) !important;
+    color: #f6b515 !important;
+  }
+
+  .game-mobile-sheet-actions svg {
+    width: 18px !important;
+    height: 18px !important;
+  }
+
+  .game-mobile-sheet-actions strong {
+    position: absolute !important;
+    top: -6px !important;
+    right: -6px !important;
+    display: grid !important;
+    place-items: center !important;
+    min-width: 20px !important;
+    height: 20px !important;
+    border-radius: 999px !important;
+    background: #d64a4d !important;
+    color: #fff !important;
+    font-size: 0.62rem !important;
+  }
+
+  .game-modern-drawer,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer,
+  .game-modern-drawer-left,
+  .game-modern-drawer-right,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-left,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-right {
+    position: fixed !important;
+    top: 10px !important;
+    right: 10px !important;
+    bottom: 10px !important;
+    left: 10px !important;
+    z-index: 220 !important;
+    height: calc(100svh - 74px) !important;
+    width: auto !important;
+    min-height: calc(100svh - 74px) !important;
+    max-height: calc(100svh - 74px) !important;
+    padding: 16px 14px calc(16px + env(safe-area-inset-bottom)) !important;
+    overflow: auto !important;
+    border: 1px solid rgba(145, 168, 184, 0.46) !important;
+    border-radius: 12px !important;
+    background: linear-gradient(180deg, rgba(5, 18, 29, 0.99), rgba(2, 9, 16, 0.99)) !important;
+  }
+
+  .game-map-first-page.has-open-drawer .game-command-dock,
+  html[data-theme="war-table"] .game-map-first-page.has-open-drawer .game-command-dock {
+    display: none !important;
+  }
+
+  .game-modern-drawer-header {
+    top: -16px !important;
+    margin: -16px -14px 12px !important;
+    padding: 16px 14px 12px !important;
+    background: linear-gradient(180deg, rgba(5, 18, 29, 1), rgba(5, 18, 29, 0.94)) !important;
+  }
+
+  .game-modern-drawer-header h2 {
+    font-size: 0.92rem !important;
+  }
+
+  .game-modern-drawer-header p {
+    font-size: 0.62rem !important;
+  }
+
+  .game-players-table,
+  .game-info-modern-list,
+  .game-card-exchange-box,
+  .game-enabled-modules {
+    gap: 10px !important;
+    margin-top: 10px !important;
+  }
+
+  .game-players-head,
+  .game-player-row {
+    grid-template-columns: minmax(0, 1fr) 46px 46px !important;
+  }
+
+  .game-player-row {
+    min-height: 52px !important;
+    padding: 10px 8px !important;
+    border: 1px solid rgba(117, 142, 158, 0.22) !important;
+    border-radius: 7px !important;
+    background: rgba(7, 24, 37, 0.54) !important;
+  }
+
+  .game-drawer-callout {
+    display: none !important;
+  }
+
+  .game-card-grid-compact,
+  .game-cards-modern-drawer .game-card-grid-compact {
+    grid-template-columns: repeat(5, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+  }
+
+  .game-cards-modern-drawer .game-card-tile,
+  .game-card-tile {
+    min-height: 64px !important;
+    padding: 8px 4px !important;
+    align-content: center !important;
+    justify-items: center !important;
+    text-align: center !important;
+  }
+
+  .game-card-symbol {
+    position: static !important;
+    width: 30px !important;
+    height: 30px !important;
+    margin-bottom: 4px !important;
+  }
+
+  .game-cards-modern-drawer .game-card-tile strong,
+  .game-cards-modern-drawer .game-card-tile small {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+  }
+
+  .game-card-exchange-box {
+    padding: 12px !important;
+  }
+
+  .game-card-exchange-box button,
+  .game-log-clear-button {
+    width: 100% !important;
+  }
+
+  .game-log-tabs {
+    display: grid !important;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    gap: 6px !important;
+  }
+
+  .game-log-tabs button {
+    min-height: 36px !important;
+    padding: 0 4px !important;
+    font-size: 0.54rem !important;
+  }
+
+  .game-activity-list .game-log-entry {
+    min-height: 58px !important;
+    padding: 8px 0 !important;
+  }
+
+  .game-info-modern-list > div {
+    grid-template-columns: minmax(0, 1fr) auto !important;
+    align-items: start !important;
+  }
+
+  .game-info-modern-list > div small {
+    grid-column: 1 / -1 !important;
+  }
+}

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -7077,8 +7077,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
     --game-command-dock-height: 76px !important;
   }
 
-  .game-map-first-page:has(.game-command-dock-sheet-expanded),
-  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-expanded) {
+  .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded),
+  html[data-theme="war-table"]
+    .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded) {
     --game-command-dock-height: min(68svh, 520px) !important;
   }
 
@@ -7581,8 +7582,9 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
     --game-command-dock-height: 214px !important;
   }
 
-  .game-map-first-page:has(.game-command-dock-sheet-expanded),
-  html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-sheet-expanded) {
+  .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded),
+  html[data-theme="war-table"]
+    .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded) {
     --game-command-dock-height: min(64svh, 520px) !important;
   }
 
@@ -8031,5 +8033,90 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
 
   .game-info-modern-list > div small {
     grid-column: 1 / -1 !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title {
+    position: relative !important;
+    color: transparent !important;
+  }
+
+  body[data-app-section="game"] .top-nav-title::after,
+  html[data-theme="war-table"] body[data-app-section="game"] .top-nav-title::after {
+    content: "NETRISK" !important;
+    position: absolute !important;
+    inset: 0 !important;
+    display: block !important;
+    color: #f6b515 !important;
+    font-size: 0.84rem !important;
+    font-weight: 950 !important;
+    letter-spacing: 0.22em !important;
+    line-height: 1 !important;
+    text-align: center !important;
+    text-shadow: 0 0 18px rgba(246, 181, 21, 0.32) !important;
+  }
+
+  .game-map-first-page,
+  html[data-theme="war-table"] .game-map-first-page {
+    --game-mobile-map-board-width: max(250vw, 760px);
+  }
+
+  .game-map-first-page .game-map-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage {
+    background:
+      radial-gradient(circle at 52% 50%, rgba(58, 115, 158, 0.28), transparent 52%),
+      linear-gradient(180deg, #0b263c 0%, #061925 58%, #03101a 100%) !important;
+  }
+
+  .game-map-first-page .game-map-stage .map-board-anchor,
+  .game-map-first-page .game-map-stage .map-board-transform,
+  .game-map-first-page .game-map-stage .map-board,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-anchor,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-transform,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board {
+    width: var(--game-mobile-map-board-width) !important;
+    height: calc(var(--game-mobile-map-board-width) * 0.6578947368) !important;
+  }
+
+  .game-map-first-page .game-map-stage .map-board-stage,
+  html[data-theme="war-table"] .game-map-first-page .game-map-stage .map-board-stage {
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded),
+  html[data-theme="war-table"]
+    .game-map-first-page:has(.game-command-dock.game-command-dock-sheet-expanded.is-expanded) {
+    --game-command-dock-height: calc(100svh - 142px) !important;
+  }
+
+  .game-command-dock-sheet-expanded,
+  html[data-theme="war-table"] .game-map-first-page .game-command-dock-sheet-expanded {
+    max-height: calc(100svh - 142px) !important;
+  }
+
+  .game-modern-drawer,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer,
+  .game-modern-drawer-left,
+  .game-modern-drawer-right,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-left,
+  html[data-theme="war-table"] .game-map-first-page .game-modern-drawer-right {
+    top: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    height: 100svh !important;
+    min-height: 100svh !important;
+    max-height: 100svh !important;
+    border-right: 0 !important;
+    border-left: 0 !important;
+    border-radius: 0 !important;
+    padding: 42px 18px calc(18px + env(safe-area-inset-bottom)) !important;
+  }
+
+  .game-modern-drawer-header {
+    top: -42px !important;
+    margin: -42px -18px 14px !important;
+    padding: 42px 18px 14px !important;
   }
 }

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -7631,14 +7631,7 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
 
   .game-floating-hud,
   html[data-theme="war-table"] .game-map-first-page .game-floating-hud {
-    top: 34px !important;
-    right: auto !important;
-    bottom: auto !important;
-    left: 12px !important;
-    width: min(182px, calc(100vw - 98px)) !important;
-    max-height: none !important;
-    padding: 9px 10px !important;
-    border-radius: 6px !important;
+    display: none !important;
   }
 
   .game-floating-hud .game-hud-heading,

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -335,9 +335,8 @@ export function GameRoute() {
   const [isActivityLogOpen, setIsActivityLogOpen] = useState(false);
   const [activityLogFilter, setActivityLogFilter] = useState<ActivityLogFilter>("all");
   const [isActivityLogCleared, setIsActivityLogCleared] = useState(false);
-  const [commandDockSheetState, setCommandDockSheetState] = useState<GameCommandDockSheetState>(
-    () => (isMobileCommandDockViewport() ? "half-open" : "collapsed")
-  );
+  const [commandDockSheetState, setCommandDockSheetState] =
+    useState<GameCommandDockSheetState>("collapsed");
   const isCommandDockExpanded = commandDockSheetState !== "collapsed";
 
   const gameplayQuery = useQuery({
@@ -519,43 +518,35 @@ export function GameRoute() {
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
+      return undefined;
     }
 
     const mediaQuery = window.matchMedia("(max-width: 760px)");
-
-    function syncMobileCommandSheet(event: MediaQueryList | MediaQueryListEvent): void {
-      if (!event.matches) {
-        setCommandDockSheetState((current) => (current === "half-open" ? "collapsed" : current));
+    const normalizeForViewport = (matchesMobile: boolean) => {
+      if (matchesMobile) {
         return;
       }
 
-      setCommandDockSheetState((current) => (current === "collapsed" ? "half-open" : current));
-    }
-
-    syncMobileCommandSheet(mediaQuery);
-
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", syncMobileCommandSheet);
-
-      return () => {
-        mediaQuery.removeEventListener("change", syncMobileCommandSheet);
-      };
-    }
-
-    const legacyMediaQuery = mediaQuery as MediaQueryList & {
-      addListener?: (listener: (event: MediaQueryList | MediaQueryListEvent) => void) => void;
-      removeListener?: (listener: (event: MediaQueryList | MediaQueryListEvent) => void) => void;
+      setCommandDockSheetState((current) => (current === "half-open" ? "collapsed" : current));
+    };
+    const handleViewportChange = (event: MediaQueryListEvent) => {
+      normalizeForViewport(event.matches);
     };
 
-    if (typeof legacyMediaQuery.addListener === "function") {
-      legacyMediaQuery.addListener(syncMobileCommandSheet);
-
-      return () => {
-        legacyMediaQuery.removeListener?.(syncMobileCommandSheet);
-      };
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleViewportChange);
+      return () => mediaQuery.removeEventListener("change", handleViewportChange);
     }
+
+    mediaQuery.addListener(handleViewportChange);
+    return () => mediaQuery.removeListener(handleViewportChange);
   }, []);
+
+  useEffect(() => {
+    if (mustTradeCards) {
+      setCommandDockSheetState("expanded");
+    }
+  }, [mustTradeCards]);
 
   const applyMutationPayload = useEffectEvent(
     (payload: GameMutationResponse, options: { feedback?: string } = {}) => {
@@ -986,8 +977,12 @@ export function GameRoute() {
     setActiveDrawer((current) => (current === drawer ? null : drawer));
   }
 
+  const pageClassName = `game-map-first-page${
+    activeDrawer || isActivityLogOpen ? " has-open-drawer" : ""
+  }`;
+
   return (
-    <section className="game-map-first-page" data-testid="react-shell-game-page">
+    <section className={pageClassName} data-testid="react-shell-game-page">
       <section
         className="battlefield-layout game-battlefield-layout"
         data-testid="battlefield-layout"
@@ -1685,6 +1680,35 @@ export function GameRoute() {
               </button>
             </div>
           ) : null}
+
+          <nav
+            className="game-mobile-sheet-actions"
+            aria-label={t("game.command.heading")}
+            hidden={commandDockSheetState !== "expanded"}
+          >
+            {actionRailItems.map((item) => (
+              <button
+                key={item.drawer}
+                type="button"
+                className={activeDrawer === item.drawer ? "is-active" : ""}
+                aria-pressed={activeDrawer === item.drawer}
+                onClick={() => toggleDrawer(item.drawer)}
+              >
+                <WarTableIcon name={item.icon} />
+                <span>{item.label}</span>
+                {typeof item.badge === "number" ? <strong>{item.badge}</strong> : null}
+              </button>
+            ))}
+            <button
+              type="button"
+              className={isActivityLogOpen ? "is-active" : ""}
+              aria-pressed={isActivityLogOpen}
+              onClick={() => setIsActivityLogOpen((isOpen) => !isOpen)}
+            >
+              <WarTableIcon name="clock" />
+              <span>{t("game.drawer.activityLog")}</span>
+            </button>
+          </nav>
         </GameActionDock>
       </section>
     </section>

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -549,6 +549,32 @@ export function GameRoute() {
   }, [activityLogContentKey]);
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(max-width: 760px)");
+    const normalizeForViewport = (matchesMobile: boolean) => {
+      if (matchesMobile) {
+        return;
+      }
+
+      setCommandDockSheetState((current) => (current === "half-open" ? "collapsed" : current));
+    };
+    const handleViewportChange = (event: MediaQueryListEvent) => {
+      normalizeForViewport(event.matches);
+    };
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleViewportChange);
+      return () => mediaQuery.removeEventListener("change", handleViewportChange);
+    }
+
+    mediaQuery.addListener(handleViewportChange);
+    return () => mediaQuery.removeListener(handleViewportChange);
+  }, []);
+
+  useEffect(() => {
     if (mustTradeCards) {
       setCommandDockSheetState("expanded");
     }

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -344,9 +344,8 @@ export function GameRoute() {
   const [isActivityLogOpen, setIsActivityLogOpen] = useState(false);
   const [activityLogFilter, setActivityLogFilter] = useState<ActivityLogFilter>("all");
   const [isActivityLogCleared, setIsActivityLogCleared] = useState(false);
-  const [commandDockSheetState, setCommandDockSheetState] = useState<GameCommandDockSheetState>(
-    () => (isMobileCommandDockViewport() ? "half-open" : "collapsed")
-  );
+  const [commandDockSheetState, setCommandDockSheetState] =
+    useState<GameCommandDockSheetState>("collapsed");
   const isCommandDockExpanded = commandDockSheetState !== "collapsed";
 
   const gameplayQuery = useQuery({
@@ -550,44 +549,10 @@ export function GameRoute() {
   }, [activityLogContentKey]);
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
+    if (mustTradeCards) {
+      setCommandDockSheetState("expanded");
     }
-
-    const mediaQuery = window.matchMedia("(max-width: 760px)");
-
-    function syncMobileCommandSheet(event: MediaQueryList | MediaQueryListEvent): void {
-      if (!event.matches) {
-        setCommandDockSheetState((current) => (current === "half-open" ? "collapsed" : current));
-        return;
-      }
-
-      setCommandDockSheetState((current) => (current === "collapsed" ? "half-open" : current));
-    }
-
-    syncMobileCommandSheet(mediaQuery);
-
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", syncMobileCommandSheet);
-
-      return () => {
-        mediaQuery.removeEventListener("change", syncMobileCommandSheet);
-      };
-    }
-
-    const legacyMediaQuery = mediaQuery as MediaQueryList & {
-      addListener?: (listener: (event: MediaQueryList | MediaQueryListEvent) => void) => void;
-      removeListener?: (listener: (event: MediaQueryList | MediaQueryListEvent) => void) => void;
-    };
-
-    if (typeof legacyMediaQuery.addListener === "function") {
-      legacyMediaQuery.addListener(syncMobileCommandSheet);
-
-      return () => {
-        legacyMediaQuery.removeListener?.(syncMobileCommandSheet);
-      };
-    }
-  }, []);
+  }, [mustTradeCards]);
 
   const applyMutationPayload = useEffectEvent(
     (payload: GameMutationResponse, options: { feedback?: string } = {}) => {
@@ -1003,8 +968,12 @@ export function GameRoute() {
     setActiveDrawer((current) => (current === drawer ? null : drawer));
   }
 
+  const pageClassName = `game-map-first-page${
+    activeDrawer || isActivityLogOpen ? " has-open-drawer" : ""
+  }`;
+
   return (
-    <section className="game-map-first-page" data-testid="react-shell-game-page">
+    <section className={pageClassName} data-testid="react-shell-game-page">
       <section
         className="battlefield-layout game-battlefield-layout"
         data-testid="battlefield-layout"
@@ -1698,6 +1667,35 @@ export function GameRoute() {
               </button>
             </div>
           ) : null}
+
+          <nav
+            className="game-mobile-sheet-actions"
+            aria-label={t("game.command.heading")}
+            hidden={commandDockSheetState !== "expanded"}
+          >
+            {actionRailItems.map((item) => (
+              <button
+                key={item.drawer}
+                type="button"
+                className={activeDrawer === item.drawer ? "is-active" : ""}
+                aria-pressed={activeDrawer === item.drawer}
+                onClick={() => toggleDrawer(item.drawer)}
+              >
+                <WarTableIcon name={item.icon} />
+                <span>{item.label}</span>
+                {typeof item.badge === "number" ? <strong>{item.badge}</strong> : null}
+              </button>
+            ))}
+            <button
+              type="button"
+              className={isActivityLogOpen ? "is-active" : ""}
+              aria-pressed={isActivityLogOpen}
+              onClick={() => setIsActivityLogOpen((isOpen) => !isOpen)}
+            >
+              <WarTableIcon name="clock" />
+              <span>{t("game.drawer.activityLog")}</span>
+            </button>
+          </nav>
         </GameActionDock>
       </section>
     </section>

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.039";
+export const appVersion = "0.1.040";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.017";
+export const appVersion = "0.1.018";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- align the mobile game shell with the reference states for collapsed, half-open, expanded, and drawer-based command actions
- keep desktop/tablet behavior intact while using mobile bottom-sheet controls and hiding side rails on narrow viewports
- update React and Playwright coverage for the mobile dock states and card-trade viewport behavior

## Validation
- `npm run typecheck:react-shell`
- `npm run test:react -- frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx`
- `npm run test:react`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Local browser note
- Attempted `npm exec --yes --package node@22 -- node node_modules/.bin/playwright test e2e/00-visual/mobile-game-shell.spec.ts e2e/gameplay/card-trade-panel.spec.ts --project=chromium`, but local Chromium cannot launch in this environment because `libnspr4.so` is missing. Browser coverage needs CI for this PR.