### PR TITLE
[codex] Improve AI turn resume branch coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.016 - 2026-05-12
+
+- Added branch-focused coverage for AI turn resume guards, stale AI handoff, and localized AI failure handling.
+
 ## 0.1.015 - 2026-05-11
 
 - Added the mobile map-first gameplay shell with a compact header, floating HUD, bottom-sheet commands, and phone viewport coverage.

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -30,6 +30,7 @@ const gameplayTestModules = [
   "../tests/gameplay/shared/runtime-validation.test.cjs",
   "../tests/gameplay/shared/module-registry.test.cjs",
   "../tests/gameplay/ai/ai-player.test.cjs",
+  "../tests/gameplay/ai/ai-turn-resume.test.cjs",
   "../tests/gameplay/ai/ai-turn-recovery.test.cjs",
   "../tests/gameplay/setup/game-setup.test.cjs",
   "../tests/gameplay/setup/new-game-config.test.cjs",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.015";
+export const appVersion = "0.1.016";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/ai/ai-turn-resume.test.cts
+++ b/tests/gameplay/ai/ai-turn-resume.test.cts
@@ -63,7 +63,10 @@ function createResumeState(options: {
       ])
   }) as ResumeState;
 
-  state.mapTerritories = [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])] ;
+  state.mapTerritories = [
+    makeTerritory("a", ["b"], { name: "Resume Alpha" }),
+    makeTerritory("b", ["a"], { name: "Resume Beta" })
+  ];
   return state;
 }
 

--- a/tests/gameplay/ai/ai-turn-resume.test.cts
+++ b/tests/gameplay/ai/ai-turn-resume.test.cts
@@ -1,0 +1,187 @@
+const assert = require("node:assert/strict");
+const { runAiTurnsIfNeeded } = require("../../../backend/engine/ai-turn-resume.cjs");
+const {
+  TurnPhase,
+  makePlayers,
+  makeState,
+  makeTerritory,
+  territoryStates
+} = require("../helpers/state-builder.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function withPatchedAdvanceTurn<T>(
+  advanceTurn: (state: unknown) => void,
+  run: (patchedRunAiTurnsIfNeeded: typeof runAiTurnsIfNeeded) => T
+): T {
+  const gameEnginePath = require.resolve("../../../backend/engine/game-engine.cjs");
+  const aiTurnResumePath = require.resolve("../../../backend/engine/ai-turn-resume.cjs");
+  const gameEngine = require(gameEnginePath);
+  const originalAdvanceTurn = gameEngine.advanceTurn;
+  const originalAiTurnResumeModule = require.cache[aiTurnResumePath];
+
+  gameEngine.advanceTurn = advanceTurn;
+  delete require.cache[aiTurnResumePath];
+
+  try {
+    const patchedRunAiTurnsIfNeeded = require(aiTurnResumePath).runAiTurnsIfNeeded;
+    return run(patchedRunAiTurnsIfNeeded);
+  } finally {
+    gameEngine.advanceTurn = originalAdvanceTurn;
+    delete require.cache[aiTurnResumePath];
+    if (originalAiTurnResumeModule) {
+      require.cache[aiTurnResumePath] = originalAiTurnResumeModule;
+    }
+  }
+}
+
+function createResumeState(options: {
+  players?: ReturnType<typeof makePlayers>;
+  phase?: string;
+  winnerId?: string | null;
+  currentTurnIndex?: number;
+  territories?: ReturnType<typeof territoryStates>;
+}) {
+  const state = makeState({
+    players: options.players || [
+      { ...makePlayers(["CPU Alpha", "Bob"])[0], isAi: true },
+      makePlayers(["CPU Alpha", "Bob"])[1]
+    ],
+    phase: options.phase || "active",
+    winnerId: options.winnerId || null,
+    currentTurnIndex: options.currentTurnIndex || 0,
+    turnPhase: TurnPhase.REINFORCEMENT,
+    territories:
+      options.territories ||
+      territoryStates([
+        { id: "a", ownerId: "p1", armies: 3 },
+        { id: "b", ownerId: "p2", armies: 2 }
+      ])
+  });
+
+  (state as typeof state & { mapTerritories: ReturnType<typeof makeTerritory>[] }).mapTerritories =
+    [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])
+  ];
+  return state;
+}
+
+register("runAiTurnsIfNeeded does not invoke the runner outside active AI turns", () => {
+  const humanTurnState = createResumeState({
+    players: makePlayers(["Alice", "Bob"]),
+    currentTurnIndex: 0
+  });
+  const lobbyState = createResumeState({ phase: "lobby" });
+  const finishedState = createResumeState({ winnerId: "p1" });
+  let runnerCalls = 0;
+  const runAiTurn = () => {
+    runnerCalls += 1;
+    return { ok: true };
+  };
+
+  assert.deepEqual(runAiTurnsIfNeeded(humanTurnState, { runAiTurn }), []);
+  assert.deepEqual(runAiTurnsIfNeeded(lobbyState, { runAiTurn }), []);
+  assert.deepEqual(runAiTurnsIfNeeded(finishedState, { runAiTurn }), []);
+  assert.equal(runnerCalls, 0);
+});
+
+register("runAiTurnsIfNeeded skips surrendered stale AI turns before running AI logic", () => {
+  const players = makePlayers(["CPU Alpha", "Bob", "Carla"]);
+  players[0].isAi = true;
+  players[0].surrendered = true;
+  const state = createResumeState({
+    players,
+    territories: territoryStates([
+      { id: "a", ownerId: "p2", armies: 3 },
+      { id: "b", ownerId: "p3", armies: 2 }
+    ])
+  });
+
+  const reports = runAiTurnsIfNeeded(state, {
+    runAiTurn: () => {
+      throw new Error("runAiTurn should not run for a surrendered AI player.");
+    }
+  });
+
+  assert.deepEqual(reports, []);
+  assert.equal(state.currentTurnIndex, 1);
+  assert.equal(state.players[state.currentTurnIndex].id, "p2");
+});
+
+register("runAiTurnsIfNeeded throws when a stale AI turn cannot advance", () => {
+  const players = makePlayers(["CPU Alpha"]);
+  players[0].isAi = true;
+  players[0].surrendered = true;
+  const state = createResumeState({
+    players,
+    territories: territoryStates([{ id: "a", ownerId: "p1", armies: 3 }])
+  });
+
+  withPatchedAdvanceTurn(
+    () => {},
+    (patchedRunAiTurnsIfNeeded) => {
+      assert.throws(
+        () => patchedRunAiTurnsIfNeeded(state),
+        (error: Error & { messageKey?: string | null }) => {
+          assert.equal(error.messageKey, "server.aiTurn.failed");
+          assert.match(error.message, /turno corrente non puo avanzare/i);
+          return true;
+        }
+      );
+    }
+  );
+  assert.equal(state.currentTurnIndex, 0);
+});
+
+register("runAiTurnsIfNeeded preserves AI failure localization details", () => {
+  const state = createResumeState({});
+
+  assert.throws(
+    () =>
+      runAiTurnsIfNeeded(state, {
+        runAiTurn: () => ({
+          ok: false,
+          error: "AI policy rejected the turn.",
+          errorKey: "server.aiTurn.policyRejected",
+          errorParams: { policyId: "strict-ai" }
+        })
+      }),
+    (error: Error & { messageKey?: string | null; messageParams?: Record<string, unknown> }) => {
+      assert.equal(error.message, "AI policy rejected the turn.");
+      assert.equal(error.messageKey, "server.aiTurn.policyRejected");
+      assert.deepEqual(error.messageParams, { policyId: "strict-ai" });
+      return true;
+    }
+  );
+});
+
+register("runAiTurnsIfNeeded returns reports from each resumed AI turn", () => {
+  const players = makePlayers(["CPU Alpha", "CPU Beta", "Alice"]);
+  players[0].isAi = true;
+  players[1].isAi = true;
+  const state = createResumeState({
+    players,
+    territories: territoryStates([
+      { id: "a", ownerId: "p1", armies: 3 },
+      { id: "b", ownerId: "p2", armies: 3 }
+    ])
+  });
+  const random = () => 0.5;
+  const seenRandomValues: number[] = [];
+
+  const reports = runAiTurnsIfNeeded(state, {
+    random,
+    runAiTurn: (targetState: typeof state, options?: { random?: () => number }) => {
+      seenRandomValues.push(options?.random?.() ?? -1);
+      const playerId = targetState.players[targetState.currentTurnIndex].id;
+      targetState.currentTurnIndex += 1;
+      return { ok: true, playerId };
+    }
+  });
+
+  assert.deepEqual(reports, [
+    { ok: true, playerId: "p1" },
+    { ok: true, playerId: "p2" }
+  ]);
+  assert.deepEqual(seenRandomValues, [0.5, 0.5]);
+  assert.equal(state.currentTurnIndex, 2);
+});

--- a/tests/gameplay/ai/ai-turn-resume.test.cts
+++ b/tests/gameplay/ai/ai-turn-resume.test.cts
@@ -60,8 +60,7 @@ function createResumeState(options: {
   });
 
   (state as typeof state & { mapTerritories: ReturnType<typeof makeTerritory>[] }).mapTerritories =
-    [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])
-  ];
+    [makeTerritory("a", ["b"]), makeTerritory("b", ["a"]));
   return state;
 }
 

--- a/tests/gameplay/ai/ai-turn-resume.test.cts
+++ b/tests/gameplay/ai/ai-turn-resume.test.cts
@@ -10,6 +10,10 @@ const {
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
+type ResumeState = ReturnType<typeof makeState> & {
+  mapTerritories: ReturnType<typeof makeTerritory>[];
+};
+
 function withPatchedAdvanceTurn<T>(
   advanceTurn: (state: unknown) => void,
   run: (patchedRunAiTurnsIfNeeded: typeof runAiTurnsIfNeeded) => T
@@ -57,10 +61,9 @@ function createResumeState(options: {
         { id: "a", ownerId: "p1", armies: 3 },
         { id: "b", ownerId: "p2", armies: 2 }
       ])
-  });
+  }) as ResumeState;
 
-  (state as typeof state & { mapTerritories: ReturnType<typeof makeTerritory>[] }).mapTerritories =
-    [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])] ;
+  state.mapTerritories = [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])] ;
   return state;
 }
 

--- a/tests/gameplay/ai/ai-turn-resume.test.cts
+++ b/tests/gameplay/ai/ai-turn-resume.test.cts
@@ -60,7 +60,7 @@ function createResumeState(options: {
   });
 
   (state as typeof state & { mapTerritories: ReturnType<typeof makeTerritory>[] }).mapTerritories =
-    [makeTerritory("a", ["b"]), makeTerritory("b", ["a"]));
+    [makeTerritory("a", ["b"]), makeTerritory("b", ["a"])] ;
   return state;
 }
 


### PR DESCRIPTION
## Obiettivo

Aumentare la branch coverage in un punto di logica backend reale: il resume automatico dei turni AI.

## Aree toccate

- `tests/gameplay/ai/ai-turn-resume.test.cts`: nuovo test file dedicato a guardie, stale AI turns, error handling localizzato e resume multi-AI.
- `scripts/run-gameplay-tests.cts`: registrazione del nuovo test nel runner gameplay.
- `shared/version-manifest.cts` e `CHANGELOG.md`: bump/report minimo richiesto dal Release Gate.

## Coverage

Baseline temporanea locale senza il nuovo test:

- Statements: 89.47%
- Branches: 78.06%
- Functions: 79.00%
- Lines: 89.47%
- `backend/engine/ai-turn-resume`: statements 85.18%, branches 65.00%, functions 100.00%, lines 85.18%

Dopo il nuovo test:

- Statements: 89.49%
- Branches: 78.12%
- Functions: 79.00%
- Lines: 89.49%
- `backend/engine/ai-turn-resume`: statements 96.29%, branches 83.33%, functions 100.00%, lines 96.29%

## Fix minimi

Nessun comportamento applicativo modificato. Aggiunto solo il bump di release richiesto dal gate CI.

## Validazione locale

- `npm run build:ts`
- `npm run typecheck`
- `npm run typecheck:react-shell`
- `npm run lint`
- `npm run format:check`
- `npm run test:gameplay`
- `npm run test:react`
- `npm run coverage`
- `npm run coverage:check`
- `npm run test:e2e:smoke`
- `npm run release:check`

Nota: `npm ci` senza opzioni e fallito localmente per blocco rete sul postinstall Supabase CLI verso GitHub; ho usato `npm ci --ignore-scripts` solo per installare la toolchain locale. Non sono state modificate configurazioni CI.

## Rischi residui

Bassi. Il test con patch temporanea di `advanceTurn` copre il ramo difensivo in cui un turno AI stale non riesce ad avanzare, senza cambiare codice produttivo.