### PR TITLE
fix: keep mandatory trade map in mobile viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.017 - 2026-05-12
+
+- Fixed the mobile mandatory card-trade layout so the map board remains fully visible above the command dock.
+
 ## 0.1.016 - 2026-05-12
 
 - Added branch-focused coverage for AI turn resume guards, stale AI handoff, and localized AI failure handling.

--- a/e2e/gameplay/card-trade-panel.spec.ts
+++ b/e2e/gameplay/card-trade-panel.spec.ts
@@ -256,6 +256,32 @@ for (const viewport of [
           width: rect.width
         };
       };
+      const resolvedCssLength = (
+        element: HTMLElement,
+        styles: CSSStyleDeclaration | null,
+        propertyName: string
+      ) => {
+        const rawValue = styles?.getPropertyValue(propertyName).trim() || "";
+        if (!rawValue) {
+          return "";
+        }
+
+        const measurement = document.createElement("div");
+        measurement.style.position = "absolute";
+        measurement.style.visibility = "hidden";
+        measurement.style.pointerEvents = "none";
+        measurement.style.boxSizing = "border-box";
+        measurement.style.width = rawValue;
+        measurement.style.height = "0";
+        measurement.style.margin = "0";
+        measurement.style.padding = "0";
+        measurement.style.border = "0";
+        element.appendChild(measurement);
+        const measuredWidth = measurement.getBoundingClientRect().width;
+        measurement.remove();
+
+        return Number.isFinite(measuredWidth) ? `${measuredWidth}px` : "";
+      };
 
       const board = boundsFor(".game-map-stage .map-board");
       const dock = boundsFor(".game-command-dock-mandatory-trade");
@@ -276,8 +302,12 @@ for (const viewport of [
           dock.left >= -1 &&
           dock.right <= viewport.width + 1 &&
           dock.bottom <= viewport.height + 1,
-        safeBottom: stageStyles?.getPropertyValue("--game-map-safe-bottom").trim() || "",
-        safeTop: stageStyles?.getPropertyValue("--game-map-safe-top").trim() || ""
+        safeBottom:
+          stage instanceof HTMLElement
+            ? resolvedCssLength(stage, stageStyles, "--game-map-safe-bottom")
+            : "",
+        safeTop:
+          stage instanceof HTMLElement ? resolvedCssLength(stage, stageStyles, "--game-map-safe-top") : ""
       };
     });
 

--- a/frontend/react-shell/src/game-layout.css
+++ b/frontend/react-shell/src/game-layout.css
@@ -7085,6 +7085,7 @@ html[data-theme="war-table"] .game-map-first-page .game-command-dock-mandatory-t
   .game-map-first-page:has(.game-command-dock-mandatory-trade),
   html[data-theme="war-table"] .game-map-first-page:has(.game-command-dock-mandatory-trade) {
     --game-command-dock-height: min(62svh, 500px) !important;
+    --game-map-allow-horizontal-crop: 0;
   }
 
   .game-map-first-page .game-battlefield-layout,

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -162,9 +162,47 @@ function resolveMapImageUrl(imageUrl: string): string {
   return imageUrl;
 }
 
-function readCssPixelValue(styles: CSSStyleDeclaration, propertyName: string): number {
-  const value = Number.parseFloat(styles.getPropertyValue(propertyName) || "0");
-  return Number.isFinite(value) ? value : 0;
+function readCssLengthPixelValue(
+  element: HTMLElement,
+  styles: CSSStyleDeclaration,
+  propertyName: string
+): number {
+  const rawValue = styles.getPropertyValue(propertyName).trim();
+  if (!rawValue) {
+    return 0;
+  }
+
+  if (rawValue === "0") {
+    return 0;
+  }
+
+  const pixelMatch = rawValue.match(/^(-?\d+(?:\.\d+)?)px$/);
+  if (pixelMatch) {
+    const value = Number.parseFloat(pixelMatch[1]);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  const measurement = document.createElement("div");
+  measurement.style.position = "absolute";
+  measurement.style.visibility = "hidden";
+  measurement.style.pointerEvents = "none";
+  measurement.style.boxSizing = "border-box";
+  measurement.style.width = rawValue;
+  measurement.style.height = "0";
+  measurement.style.margin = "0";
+  measurement.style.padding = "0";
+  measurement.style.border = "0";
+
+  element.appendChild(measurement);
+  const measuredWidth = measurement.getBoundingClientRect().width;
+  measurement.remove();
+
+  if (Number.isFinite(measuredWidth) && measuredWidth >= 0) {
+    return measuredWidth;
+  }
+
+  const fallback = Number.parseFloat(rawValue);
+  return Number.isFinite(fallback) ? fallback : 0;
 }
 
 export function calculateFittedBoardSize({
@@ -475,8 +513,8 @@ export function GameplayMapViewport({
       const stagePaddingY =
         Number.parseFloat(stageStyles.paddingTop || "0") +
         Number.parseFloat(stageStyles.paddingBottom || "0");
-      const safeTop = readCssPixelValue(stageStyles, "--game-map-safe-top");
-      const safeBottom = readCssPixelValue(stageStyles, "--game-map-safe-bottom");
+      const safeTop = readCssLengthPixelValue(mapStage, stageStyles, "--game-map-safe-top");
+      const safeBottom = readCssLengthPixelValue(mapStage, stageStyles, "--game-map-safe-bottom");
       const availableWidth = Math.max(0, mapStage.clientWidth - stagePaddingX);
       const stageRect = mapStage.getBoundingClientRect();
       const availableHeight = Math.max(

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.016";
+export const appVersion = "0.1.017";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Obiettivo

Correggere il layout mobile del trade obbligatorio: la board della mappa deve restare interamente nel viewport, libera dal dock carte, senza indebolire l'E2E.

## Aree toccate

- `frontend/react-shell/src/gameplay-map-viewport.tsx`: risoluzione reale in pixel delle custom property CSS usate dal fit della mappa, anche quando contengono `calc(...)`, `min(...)`, `clamp(...)`, `svh` o `var(...)`.
- `frontend/react-shell/src/game-layout.css`: su mobile con dock trade obbligatorio disabilita il crop orizzontale della mappa.
- `e2e/gameplay/card-trade-panel.spec.ts`: misura la safe area risolta in pixel mantenendo rigide le assertion su board e dock nel viewport.
- `shared/version-manifest.cts` e `CHANGELOG.md`: bump minimo `0.1.017` richiesto dal Release Gate.

## Validazione

- `npm run build:ts`
- `npm run format:check`
- `node .tsbuild/scripts/run-e2e.cjs e2e/gameplay/card-trade-panel.spec.ts`
- `node .tsbuild/scripts/run-e2e.cjs e2e/layout/game-map-fit.spec.ts e2e/00-visual/mobile-game-shell.spec.ts`
- `npm run test:react`
- `node .tsbuild/scripts/run-e2e.cjs` (99/99 passed)
- `npm run lint`
- `npm run release:check`

## Rischi residui

Bassi. La modifica e limitata al fit frontend della mappa e al caso mobile con trade obbligatorio; non cambia regole di gioco, API o persistenza.