### PR TITLE
🛡️ Sentinel: harden SSE headers and remove wildcard CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.018 - 2026-05-13
+
+- Hardened the game event stream (SSE) by removing overly permissive CORS headers and enforcing strict anti-caching security policies.
+
 ## 0.1.017 - 2026-05-12
 
 - Fixed the mobile mandatory card-trade layout so the map board remains fully visible above the command dock.

--- a/backend/routes/game-read.cts
+++ b/backend/routes/game-read.cts
@@ -144,9 +144,10 @@ async function handleEventsRoute(
 
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-    "Access-Control-Allow-Origin": "*"
+    "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    Pragma: "no-cache",
+    Expires: "0",
+    Connection: "keep-alive"
   });
   res.write("data: " + JSON.stringify(initialPayloadResult.data) + "\n\n");
   const key = gameContext.gameId || "__default__";

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -6827,6 +6827,26 @@ register("GET /api/state risponde con lo stato pubblico", async () => {
   });
 });
 
+register("GET /api/events espone header di sicurezza restrittivi", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/events`);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "text/event-stream");
+    assert.equal(
+      response.headers.get("cache-control"),
+      "no-store, no-cache, must-revalidate, proxy-revalidate"
+    );
+    assert.equal(response.headers.get("pragma"), "no-cache");
+    assert.equal(response.headers.get("expires"), "0");
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+
+    // We must close the connection to avoid hanging the test
+    if (typeof (response as any).body?.cancel === "function") {
+      await (response as any).body.cancel();
+    }
+  });
+});
+
 register("GET /api/health espone lo stato sintetico del server", async () => {
   await withServer(async (baseUrl) => {
     const response = await fetch(`${baseUrl}/api/health`);

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -285,7 +285,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "public-state",
     name: "Public Game State",
     kind: "platform",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "Public/read API game state contracts, snapshots, and shared game models.",
     ownerPaths: [
       "shared/api-contracts.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.017";
+export const appVersion = "0.1.018";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Overly permissive CORS and weak caching on Server-Sent Events (SSE).
🎯 Impact: The wildcard CORS header could allow unauthorized origins to read the event stream if not properly blocked by browsers (which usually reject '*' for credentialed requests, but it remains a security risk/misconfiguration). Weak caching could lead to sensitive real-time data being stored in intermediate or browser caches.
🔧 Fix: Removed the wildcard CORS header and applied strict anti-caching security headers to the /api/events endpoint.
✅ Verification: Added a new regression test in scripts/run-tests.cts and verified it passes along with the existing test suite.

---
*PR created automatically by Jules for task [6483810478851744514](https://jules.google.com/task/6483810478851744514) started by @andreame-code*