### PR TITLE
Prevent AI display-names from satisfying game membership checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.022 - 2026-05-14
+
+- Prevented AI display names from satisfying human game membership checks for creator-protected games.
+
 ## 0.1.021 - 2026-05-14
 
 - Re-authorized SSE broadcasts with the persisted game creator so lobby listeners are dropped before receiving active-game updates they cannot read.

--- a/backend/authorization.cts
+++ b/backend/authorization.cts
@@ -20,6 +20,7 @@ interface UserLike {
 interface PlayerLike {
   linkedUserId?: string | null;
   name?: string | null;
+  isAi?: boolean;
 }
 
 interface GameLike {
@@ -67,6 +68,7 @@ function canCreateGame(actor: Actor | null): boolean {
 
 function isActorPlayer(player: PlayerLike | null | undefined, actor: Actor) {
   if (!player) return false;
+  if (player.isAi) return false;
   if (player.linkedUserId) return player.linkedUserId === actor.id;
   return player.name === actor.username;
 }

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.021";
+export const appVersion = "0.1.022";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/authorization-rules.test.cts
+++ b/tests/gameplay/regression/authorization-rules.test.cts
@@ -96,6 +96,16 @@ register(
       true
     );
     assert.equal(
+      canOpenGame(
+        alice,
+        { phase: "active", creatorUserId: "host" },
+        {
+          players: [{ linkedUserId: null, name: "Alice", isAi: true }]
+        }
+      ),
+      false
+    );
+    assert.equal(
       canOpenGame(alice, { phase: "active", creatorUserId: null }, { players: null }),
       true
     );
@@ -144,6 +154,16 @@ register(
         }
       ),
       true
+    );
+    assert.equal(
+      canReadGame(
+        alice,
+        { phase: "active", creatorUserId: "host" },
+        {
+          players: [{ linkedUserId: null, name: "Alice", isAi: true }]
+        }
+      ),
+      false
     );
     assert.equal(
       canReadGame(alice, { phase: "active", creatorUserId: null }, { players: null }),


### PR DESCRIPTION
### Motivation
- Fix a high-severity authorization bypass where an attacker registering a predictable AI display-name could open/read creator-protected games because membership was granted by matching `player.name === actor.username` even for AI players.

### Description
- Update `backend/authorization.cts` to extend `PlayerLike` with `isAi?: boolean` and make `isActorPlayer` return `false` for `player.isAi`, so AI players can never satisfy human membership checks.
- Add regression assertions in `tests/gameplay/regression/authorization-rules.test.cts` to verify that `canOpenGame` and `canReadGame` deny access when the only matching player entry is an AI (`isAi: true`).
- Change is minimal and preserves existing linked-user (`linkedUserId`) checks and legacy non-AI name-based fallback for human players.

### Testing
- Attempted `npm run build:ts` and test run via `node .tsbuild/scripts/run-gameplay-tests.cjs tests/gameplay/regression/authorization-rules.test.cjs`, but the environment failed to bootstrap the server/datastore due to `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`, so the project-level build/tests could not complete in this environment.
- Attempted to run the compiled test file with `node --test .tsbuild/tests/gameplay/regression/authorization-rules.test.cjs`, but it is not directly runnable because tests rely on the repository’s custom `register(...)` harness, so the native Node test runner reported `register is not defined`.
- The change is covered by the updated regression test file but full automated execution of the test-suite could not be completed here due to runtime/environment limitations; the modifications are intentionally small and localized to the authorization membership check to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0504fec89c832ca52e664a2fe79bca)