### PR TITLE
Handle auth-required game deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.023 - 2026-05-14
+
+- Fixed signed-out game deep links so auth-required game reads offer login and registration paths back to the requested game.
+
 ## 0.1.022 - 2026-05-14
 
 - Prevented AI display names from satisfying human game membership checks for creator-protected games.

--- a/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/gameplay-route.integration.test.tsx
@@ -80,6 +80,12 @@ function createSession(theme = "command"): AuthSessionResponse {
   };
 }
 
+function createAuthRequiredError(): Error & { code: string } {
+  const error = new Error("Sign in to continue.") as Error & { code: string };
+  error.code = "AUTH_REQUIRED";
+  return error;
+}
+
 function emptyModuleOptions(): ModuleOptionsResponse {
   return {
     modules: [],
@@ -214,6 +220,20 @@ describe("GameRoute integration", () => {
   afterEach(() => {
     streamHandlers = null;
     vi.unstubAllGlobals();
+  });
+
+  it("offers auth actions when a deep-linked game read requires login", async () => {
+    getSessionMock.mockRejectedValue(createAuthRequiredError());
+    getGameStateMock.mockRejectedValue(createAuthRequiredError());
+
+    renderReactShell("/react/game/g-1");
+
+    const errorPanel = await screen.findByTestId("react-shell-game-error");
+    const authLinks = within(errorPanel).getAllByRole("link");
+    expect(errorPanel).toBeInTheDocument();
+    expect(authLinks[0]).toHaveAttribute("href", "/react/login?next=%2Fgame%2Fg-1");
+    expect(authLinks[1]).toHaveAttribute("href", "/react/register?next=%2Fgame%2Fg-1");
+    expect(subscribeToGameEventsMock).not.toHaveBeenCalled();
   });
 
   it("falls back to polling after an invalid stream payload and returns to live updates after recovery", async () => {

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useEffectEvent, useState } from "react";
-import { Link, Navigate, useParams } from "react-router-dom";
+import { Link, Navigate, useLocation, useParams } from "react-router-dom";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -28,7 +28,9 @@ import {
 import { LoadingAnimation } from "@react-shell/loading-animation";
 import { readCurrentPlayerId, storeCurrentPlayerId } from "@react-shell/player-session";
 import {
+  buildLoginHref,
   buildLobbyPath,
+  buildRegisterHref,
   buildRegisterPath,
   useShellNamespace
 } from "@react-shell/public-auth-paths";
@@ -256,6 +258,10 @@ function translateGameplayError(error: unknown, fallback: string): string {
   return messageFromError(error, fallback);
 }
 
+function isAuthRequiredError(error: unknown): boolean {
+  return error instanceof Error && (error as ApiClientError).code === "AUTH_REQUIRED";
+}
+
 function selectedProfileIds(gameConfig: GameSnapshot["gameConfig"] | null | undefined): string[] {
   return [
     gameConfig?.contentProfileId,
@@ -309,6 +315,7 @@ function gameMetaModuleLabels(gameConfig: GameSnapshot["gameConfig"] | null | un
 
 export function GameRoute() {
   const { gameId } = useParams();
+  const location = useLocation();
   const { state, signIn } = useAuth();
   const namespace = useShellNamespace();
   const queryClient = useQueryClient();
@@ -317,9 +324,10 @@ export function GameRoute() {
   const shouldLoadGameState =
     Boolean(routeGameId) || state.status === "authenticated" || state.status === "error";
   const shouldRedirectGuestGameRoot = !routeGameId && state.status === "unauthenticated";
+  const shouldOpenGameEventStream = shouldLoadGameState && state.status === "authenticated";
   const queryKey = gameplayStateQueryKey(routeGameId || "current");
   const streamStatus = useGameEventStream({
-    enabled: shouldLoadGameState,
+    enabled: shouldOpenGameEventStream,
     gameId: routeGameId,
     queryKey
   });
@@ -364,6 +372,7 @@ export function GameRoute() {
 
   const snapshot = gameplayQuery.data || null;
   const resolvedGameId = snapshot?.gameId || routeGameId;
+  const currentLocationPath = `${location.pathname}${location.search}`;
   const authenticatedUser = state.status === "authenticated" ? state.user : null;
 
   const playersById: Record<string, SnapshotPlayer> = {};
@@ -902,6 +911,8 @@ export function GameRoute() {
   }
 
   if (gameplayQuery.isError && !snapshot) {
+    const authRequired = isAuthRequiredError(gameplayQuery.error);
+
     return (
       <section className="status-panel status-panel-error" data-testid="react-shell-game-error">
         <p className="status-label">{t("game.title")}</p>
@@ -910,16 +921,29 @@ export function GameRoute() {
           {translateGameplayError(gameplayQuery.error, t("game.errors.loadActiveGame"))}
         </p>
         <div className="shell-actions">
-          <button
-            type="button"
-            className="refresh-button"
-            onClick={() => void gameplayQuery.refetch()}
-          >
-            Retry game
-          </button>
-          <Link className="ghost-action" to={lobbyHref}>
-            {t("nav.lobby")}
-          </Link>
+          {authRequired ? (
+            <>
+              <Link className="refresh-button" to={buildLoginHref(currentLocationPath, namespace)}>
+                {t("auth.login")}
+              </Link>
+              <Link className="ghost-action" to={buildRegisterHref(currentLocationPath, namespace)}>
+                {t("auth.register")}
+              </Link>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="refresh-button"
+                onClick={() => void gameplayQuery.refetch()}
+              >
+                Retry game
+              </button>
+              <Link className="ghost-action" to={lobbyHref}>
+                {t("nav.lobby")}
+              </Link>
+            </>
+          )}
         </div>
       </section>
     );

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.022";
+export const appVersion = "0.1.023";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- Fix unauthenticated /react/game/:gameId deep links after authenticated game-read hardening.
- Show login/register actions that preserve the current game path when /api/state returns AUTH_REQUIRED.
- Delay the game SSE stream until an authenticated session is known, avoiding an eager unauthorized stream on deep links.
- Add a React integration regression for the auth-required deep-link state.
- Bump release metadata to 0.1.023 for the release gate.

## Evidence
- Commit 4af2b24 requires auth for game state/event reads, so signed-out game deep links can receive AUTH_REQUIRED from /api/state.
- Before this patch, the no-snapshot GameRoute error branch only offered retry/lobby.

## Validation
- npm run test:react -- gameplay-route.integration.test.tsx
- npm run test:react
- npm run release:check
- git diff --check

## Risks
- Full e2e was not rerun locally; remote e2e-smoke is expected to cover the main browser path.