### PR TITLE
test: improve turn timeout branch coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.023 - 2026-05-14
+
+- Added branch-focused coverage for turn timeout enforcement saves, AI recovery persistence, legacy version fallback, and session token storage-key validation.
+
 ## 0.1.022 - 2026-05-14
 
 - Prevented AI display names from satisfying human game membership checks for creator-protected games.

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -36,6 +36,7 @@ const gameplayTestModules = [
   "../tests/gameplay/setup/new-game-config.test.cjs",
   "../tests/gameplay/turn-flow/turn-flow.test.cjs",
   "../tests/gameplay/turn-flow/turn-timeout.test.cjs",
+  "../tests/gameplay/turn-flow/turn-timeout-enforcement.test.cjs",
   "../tests/gameplay/reinforcement/reinforcement-calculation.test.cjs",
   "../tests/gameplay/reinforcement/map-continent-bonuses.test.cjs",
   "../tests/gameplay/reinforcement/reinforcement-placement.test.cjs",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.022";
+export const appVersion = "0.1.023";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/all.test.cts
+++ b/tests/gameplay/all.test.cts
@@ -9,6 +9,7 @@ const gameplayTestModules = [
   "./setup/new-game-config.test.cjs",
   "./turn-flow/turn-flow.test.cjs",
   "./turn-flow/turn-timeout.test.cjs",
+  "./turn-flow/turn-timeout-enforcement.test.cjs",
   "./ai/ai-turn-recovery.test.cjs",
   "./reinforcement/reinforcement-calculation.test.cjs",
   "./reinforcement/map-continent-bonuses.test.cjs",

--- a/tests/gameplay/turn-flow/turn-timeout-enforcement.test.cts
+++ b/tests/gameplay/turn-flow/turn-timeout-enforcement.test.cts
@@ -1,0 +1,171 @@
+const assert = require("node:assert/strict");
+const {
+  createInitialState,
+  forceEndTurn,
+  startGame
+} = require("../../../backend/engine/game-engine.cjs");
+const { enforceTurnTimeouts } = require("../../../backend/services/turn-timeout-enforcement.cjs");
+const {
+  isSessionTokenStorageKey,
+  sessionTokenStorageKey
+} = require("../../../backend/session-token.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+type SaveVersion = number | null | undefined;
+
+function createExpiredTimeoutState(options: { aiCurrentPlayer?: boolean } = {}) {
+  const state = createInitialState();
+  state.players = [
+    {
+      id: "p1",
+      name: options.aiCurrentPlayer ? "CPU Alpha" : "Alice",
+      color: "#111111",
+      connected: true,
+      isAi: options.aiCurrentPlayer || undefined
+    },
+    { id: "p2", name: "Bob", color: "#222222", connected: true }
+  ];
+  state.gameConfig = { mapId: "classic-mini", turnTimeoutHours: 24 };
+  startGame(state, () => 0);
+  state.turnStartedAt = new Date("2026-04-12T07:00:00.000Z").toISOString();
+  return state;
+}
+
+register("session token storage keys hash empty and invalid inputs deterministically", () => {
+  const emptyKey = sessionTokenStorageKey(undefined);
+  const nullKey = sessionTokenStorageKey(null);
+  const validKey = sessionTokenStorageKey("plain-session-token");
+
+  assert.equal(emptyKey, nullKey);
+  assert.equal(isSessionTokenStorageKey(emptyKey), true);
+  assert.equal(isSessionTokenStorageKey(validKey), true);
+  assert.equal(isSessionTokenStorageKey("plain-session-token"), false);
+  assert.equal(isSessionTokenStorageKey(undefined), false);
+});
+
+register("turn timeout enforcement skips saves that hit version conflicts", async () => {
+  const state = createExpiredTimeoutState();
+
+  const result = await enforceTurnTimeouts({
+    listGames: () => [{ id: "timeout-conflict", name: "Timeout Conflict", version: 3, state }],
+    saveGame: () => {
+      const error = new Error("stale timeout save");
+      (error as Error & { code?: string }).code = "VERSION_CONFLICT";
+      throw error;
+    },
+    forceEndTurn,
+    now: new Date("2026-04-14T08:00:00.000Z")
+  });
+
+  assert.equal(result.scannedGames, 1);
+  assert.equal(result.expiredGames, 1);
+  assert.equal(result.forcedTurns, 0);
+  assert.equal(result.skippedConflicts, 1);
+});
+
+register(
+  "turn timeout enforcement persists AI recovery and reports the final version",
+  async () => {
+    const state = createExpiredTimeoutState({ aiCurrentPlayer: true });
+    const savedVersions: SaveVersion[] = [];
+    const afterSavePayloads: any[] = [];
+
+    const result = await enforceTurnTimeouts({
+      listGames: () => [{ id: "timeout-ai", name: "Timeout AI", version: 7, state }],
+      saveGame: (
+        _gameId: string,
+        _state: Record<string, unknown>,
+        expectedVersion?: SaveVersion
+      ) => {
+        savedVersions.push(expectedVersion);
+        return { version: savedVersions.length === 1 ? 8 : 9 };
+      },
+      forceEndTurn,
+      recoverAiTurnState: async (_state: Record<string, unknown>, context: any) => {
+        assert.equal(context.now.toISOString(), "2026-04-14T08:00:00.000Z");
+        assert.equal(context.forceEndTurn, forceEndTurn);
+        return {
+          eligible: true,
+          attempted: true,
+          advanced: false,
+          forcedTurn: false,
+          interceptedError: false,
+          shouldPersist: true,
+          reports: []
+        };
+      },
+      afterSave: (payload: any) => {
+        afterSavePayloads.push(payload);
+      },
+      now: new Date("2026-04-14T08:00:00.000Z")
+    });
+
+    assert.deepEqual(savedVersions, [7, 8]);
+    assert.equal(afterSavePayloads.length, 1);
+    assert.equal(afterSavePayloads[0].gameId, "timeout-ai");
+    assert.equal(afterSavePayloads[0].gameName, "Timeout AI");
+    assert.equal(afterSavePayloads[0].state, state);
+    assert.equal(afterSavePayloads[0].version, 9);
+    assert.equal(result.forcedTurns, 1);
+    assert.equal(result.skippedConflicts, 0);
+  }
+);
+
+register("turn timeout enforcement keeps null versions for legacy saves", async () => {
+  const state = createExpiredTimeoutState();
+  const expectedVersions: SaveVersion[] = [];
+  const afterSavePayloads: any[] = [];
+
+  const result = await enforceTurnTimeouts({
+    listGames: () => [{ id: "timeout-legacy-version", name: "Timeout Legacy", state }],
+    saveGame: (_gameId: string, _state: Record<string, unknown>, expectedVersion?: SaveVersion) => {
+      expectedVersions.push(expectedVersion);
+      return null;
+    },
+    forceEndTurn,
+    afterSave: (payload: any) => {
+      afterSavePayloads.push(payload);
+    },
+    now: new Date("2026-04-14T08:00:00.000Z")
+  });
+
+  assert.deepEqual(expectedVersions, [null]);
+  assert.equal(afterSavePayloads.length, 1);
+  assert.equal(afterSavePayloads[0].version, null);
+  assert.equal(result.forcedTurns, 1);
+});
+
+register("turn timeout enforcement propagates unrecoverable save errors", async () => {
+  const state = createExpiredTimeoutState();
+
+  await assert.rejects(
+    () =>
+      enforceTurnTimeouts({
+        listGames: () => [{ id: "timeout-save-error", name: "Timeout", version: 4, state }],
+        saveGame: () => {
+          throw new Error("datastore unavailable");
+        },
+        forceEndTurn,
+        now: new Date("2026-04-14T08:00:00.000Z")
+      }),
+    /datastore unavailable/
+  );
+});
+
+register("turn timeout enforcement propagates engine force failures", async () => {
+  const state = createExpiredTimeoutState();
+
+  await assert.rejects(
+    () =>
+      enforceTurnTimeouts({
+        listGames: () => [{ id: "timeout-engine-failure", name: "Timeout", version: 1, state }],
+        saveGame: () => {
+          throw new Error("save should not be called");
+        },
+        forceEndTurn: () => ({ ok: false }),
+        now: new Date("2026-04-14T08:00:00.000Z")
+      }),
+    /Impossibile forzare il turno della partita timeout-engine-failure/
+  );
+});


### PR DESCRIPTION
## Obiettivo

Aumentare la branch coverage con test utili su logica runtime, senza cambiare comportamento applicativo.

## Aree toccate

- `backend/services/turn-timeout-enforcement.cts` coperto tramite nuovo test gameplay dedicato.
- `backend/session-token.cts` coperto per normalizzazione input vuoti e validazione chiavi hash.
- Registrazione del nuovo modulo nei runner gameplay.
- Release metadata aggiornato a `0.1.023` con voce changelog richiesta dal Release Gate.

## Coverage

Baseline locale prima del cambio:
- Statements: 89.56%
- Branches: 78.24%
- Functions: 79.00%
- Lines: 89.56%

Dopo il cambio:
- Statements: 89.59%
- Branches: 78.32%
- Functions: 79.00%
- Lines: 89.59%

Aree mirate:
- `backend/services/turn-timeout-enforcement`: branches 60.00% -> 95.00%.
- `backend/session-token`: branches 60.00% -> 100%.

## Test aggiunti

- Version conflict durante il salvataggio timeout.
- Persistenza recovery AI e propagazione versione finale.
- Fallback versione `null` per salvataggi legacy.
- Propagazione errori datastore non recuperabili.
- Propagazione fallimenti del motore quando il turno non viene forzato.
- Hash/validazione session token con input vuoti e invalidi.

## Fix minimi

Nessun fix applicativo. Solo test, registrazione runner e release metadata richiesto dal gate.

## Validazione locale

Passati:
- `npm run test`
- `npm run test:gameplay`
- `npm run coverage`
- `npm run coverage:check`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:react`
- `npm run release:check`

Bloccato localmente:
- `npm run test:e2e:smoke` non ha raggiunto i test: manca Chromium Playwright nel profilo locale. Tentativi effettuati:
  - `npx playwright install chromium` fallito per permessi su `C:\Users\andre\AppData\Local\ms-playwright`.
  - `PLAYWRIGHT_BROWSERS_PATH=node_modules\.cache\ms-playwright npx playwright install chromium` fallito per rete sandbox (`connect EACCES` verso CDN Playwright).

## Validazione remota

- Quality: success.
- Coverage: success.
- E2E Smoke: success.
- Release Gate: success.
- CodeQL Advanced: success.
- Vercel PR Deployment Panel: success.
- Vercel preview deployment: success.

## Rischi residui

Nessun rischio noto oltre alla limitazione locale Playwright della sandbox.