### PR TITLE
test: improve branch coverage for auth and AI join routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.024 - 2026-05-15
+
+- Added branch-focused coverage for auth throttling edge cases and AI lobby join route behavior.
+
 ## 0.1.023 - 2026-05-14
 
 - Added branch-focused coverage for turn timeout enforcement saves, AI recovery persistence, legacy version fallback, and session token storage-key validation.

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.023";
+export const appVersion = "0.1.024";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/account-validation-routes.test.cts
+++ b/tests/gameplay/regression/account-validation-routes.test.cts
@@ -11,7 +11,8 @@ const {
 } = require("../../../backend/routes/password-auth.cjs");
 const {
   createAuthAttemptThrottle,
-  createAuthThrottleKey
+  createAuthThrottleKey,
+  resolveRequestIp
 } = require("../../../backend/auth-attempt-throttle.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
@@ -153,6 +154,105 @@ register("auth attempt throttle ignores spoofed forwarded IPs unless trusted", (
     createAuthThrottleKey("login", req, "alice", { trustProxyHeaders: true }).ip,
     "203.0.113.22"
   );
+});
+
+register("auth attempt throttle resolves trusted proxy IP fallbacks deterministically", () => {
+  const previousVercelEnv = process.env.VERCEL_ENV;
+  try {
+    delete process.env.VERCEL_ENV;
+
+    assert.equal(resolveRequestIp({ headers: {}, socket: {} }), "unknown");
+    assert.equal(
+      resolveRequestIp(
+        {
+          headers: {
+            "x-real-ip": "203.0.113.24"
+          },
+          socket: {
+            remoteAddress: "198.51.100.45"
+          }
+        },
+        { trustProxyHeaders: true }
+      ),
+      "203.0.113.24"
+    );
+
+    process.env.VERCEL_ENV = "preview";
+    assert.equal(
+      resolveRequestIp({
+        headers: {
+          "x-forwarded-for": ["203.0.113.25", "198.51.100.46"]
+        },
+        socket: {
+          remoteAddress: "198.51.100.47"
+        }
+      }),
+      "203.0.113.25"
+    );
+  } finally {
+    if (previousVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = previousVercelEnv;
+    }
+  }
+});
+
+register("auth attempt throttle expires lockouts after the configured window", () => {
+  let timestamp = 1_000;
+  const throttle = createAuthAttemptThrottle({
+    cleanupIntervalMs: 1,
+    lockoutMs: 100,
+    maxAttempts: 2,
+    maxIpAttempts: 20,
+    windowMs: 50,
+    now: () => timestamp
+  });
+  const key = createAuthThrottleKey(
+    "login",
+    { socket: { remoteAddress: "198.51.100.50" } },
+    "commander"
+  );
+
+  throttle.recordFailure(key);
+  const locked = throttle.recordFailure(key);
+
+  assert.equal(locked.allowed, false);
+  assert.equal(locked.retryAfterSeconds, 1);
+
+  timestamp = 1_201;
+  assert.deepEqual(throttle.check(key), {
+    allowed: true,
+    retryAfterSeconds: 0
+  });
+});
+
+register("auth attempt throttle doubles lockout duration up to the configured cap", () => {
+  const throttle = createAuthAttemptThrottle({
+    lockoutMs: 1_000,
+    maxAttempts: 1,
+    maxIpAttempts: 20,
+    maxLockoutMs: 2_000,
+    now: () => 1_000
+  });
+  const key = createAuthThrottleKey(
+    "login",
+    { socket: { remoteAddress: "198.51.100.51" } },
+    "commander"
+  );
+
+  assert.deepEqual(throttle.recordFailure(key), {
+    allowed: false,
+    retryAfterSeconds: 1
+  });
+  assert.deepEqual(throttle.recordFailure(key), {
+    allowed: false,
+    retryAfterSeconds: 2
+  });
+  assert.deepEqual(throttle.recordFailure(key), {
+    allowed: false,
+    retryAfterSeconds: 2
+  });
 });
 
 register("account routes return early when auth is missing", async () => {

--- a/tests/gameplay/regression/game-management-routes.test.cts
+++ b/tests/gameplay/regression/game-management-routes.test.cts
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const { handleOpenGameRoute } = require("../../../backend/routes/game-management.cjs");
+const { handleAiJoinRoute } = require("../../../backend/routes/game-setup.cjs");
 
 declare function register(name: string, fn: () => void | Promise<void>): void;
 
@@ -104,5 +105,151 @@ register("handleOpenGameRoute returns the per-user snapshot for the opener", asy
       }
     },
     playerId: "p-1"
+  });
+});
+
+register("handleAiJoinRoute maps authorization failures before mutating the lobby", async () => {
+  let localizedErrorCall: any[] | null = null;
+  let loadCalls = 0;
+  let addPlayerCalls = 0;
+
+  await handleAiJoinRoute(
+    {},
+    {},
+    { name: "CPU" },
+    new URL("http://localhost/api/ai/join?gameId=g-1"),
+    async () => ({
+      user: {
+        id: "u-1",
+        username: "host"
+      }
+    }),
+    async () => {
+      loadCalls += 1;
+      throw new Error("loadGameContext should not run after failed authorization.");
+    },
+    () => "g-1",
+    async () => {
+      throw new Error("not authorized");
+    },
+    () => {
+      throw Object.assign(new Error("forbidden"), { statusCode: 403 });
+    },
+    () => {
+      addPlayerCalls += 1;
+      return { ok: false };
+    },
+    async () => {
+      throw new Error("persistGameContext should not run.");
+    },
+    () => {
+      throw new Error("broadcastGame should not run.");
+    },
+    () => {
+      throw new Error("snapshotForState should not run.");
+    },
+    () => {
+      throw new Error("sendJson should not run.");
+    },
+    (...args: any[]) => {
+      localizedErrorCall = args;
+    }
+  );
+
+  assert.equal(loadCalls, 0);
+  assert.equal(addPlayerCalls, 0);
+  assert.equal(localizedErrorCall?.[1], 403);
+  assert.equal(localizedErrorCall?.[3], "Aggiunta AI non autorizzata.");
+  assert.equal(localizedErrorCall?.[4], "server.game.aiJoinUnauthorized");
+});
+
+register("handleAiJoinRoute returns 200 when an existing AI rejoins the lobby", async () => {
+  const state = { phase: "lobby" };
+  let persisted = false;
+  let broadcasted = false;
+  let sentStatusCode: number | null = null;
+  let sentPayload: any = null;
+
+  await handleAiJoinRoute(
+    {},
+    {},
+    { name: "CPU" },
+    new URL("http://localhost/api/ai/join?gameId=g-1"),
+    async () => ({
+      user: {
+        id: "u-1",
+        username: "host"
+      }
+    }),
+    async () => ({
+      state,
+      gameId: "g-1",
+      version: 7,
+      gameName: "AI Lobby"
+    }),
+    () => "g-1",
+    async () => ({
+      game: {
+        id: "g-1"
+      }
+    }),
+    () => undefined,
+    (lobbyState: any, name: string, options: Record<string, unknown>) => {
+      assert.equal(lobbyState, state);
+      assert.equal(name, "CPU");
+      assert.equal(options.isAi, true);
+      return {
+        ok: true,
+        rejoined: true,
+        player: {
+          id: "ai-1",
+          name: "CPU",
+          isAi: true
+        }
+      };
+    },
+    async (gameContext: any) => {
+      assert.equal(gameContext.state, state);
+      persisted = true;
+      return gameContext;
+    },
+    (gameContext: any) => {
+      assert.equal(gameContext.state, state);
+      broadcasted = true;
+    },
+    (
+      _snapshotState: any,
+      gameId: string | null,
+      version: number | null,
+      gameName: string | null
+    ) => ({
+      gameId,
+      version,
+      gameName
+    }),
+    (_res: unknown, statusCode: number, payload: any) => {
+      sentStatusCode = statusCode;
+      sentPayload = payload;
+    },
+    () => {
+      throw new Error("sendLocalizedError should not run for a rejoined AI.");
+    }
+  );
+
+  assert.equal(persisted, true);
+  assert.equal(broadcasted, true);
+  assert.equal(sentStatusCode, 200);
+  assert.deepEqual(sentPayload, {
+    playerId: "ai-1",
+    state: {
+      gameId: "g-1",
+      version: 7,
+      gameName: "AI Lobby"
+    },
+    player: {
+      id: "ai-1",
+      name: "CPU",
+      isAi: true
+    }
   });
 });


### PR DESCRIPTION
## Obiettivo

Aumentare la branch coverage con test comportamentali mirati, senza cambiare codice applicativo.

## Aree toccate

- `tests/gameplay/regression/account-validation-routes.test.cts`
  - fallback IP e trust proxy del throttle auth
  - scadenza lockout dopo finestra configurata
  - raddoppio lockout fino al cap configurato
- `tests/gameplay/regression/game-management-routes.test.cts`
  - `handleAiJoinRoute` su autorizzazione negata prima di mutare la lobby
  - rientro AI esistente con status 200, persist e broadcast
- `shared/version-manifest.cts` / `CHANGELOG.md`
  - bump `0.1.024` richiesto dal Release Gate per ogni merge su `main`

## Coverage

Baseline locale prima:
- Statements: 89.56%
- Branches: 78.24%
- Functions: 79.00%
- Lines: 89.56%

Dopo:
- Statements: 89.57%
- Branches: 78.29%
- Functions: 79.00%
- Lines: 89.57%

Dettaglio utile: `backend/auth-attempt-throttle` branch coverage sale da 79.62% a 86.44%.

## Fix minimi

- Bump `appVersion` a `0.1.024` e voce changelog per soddisfare `release:check`.

## Validazione locale

Passati:
- `npm run coverage`
- `npm run typecheck`
- `npm run typecheck:react-shell`
- `npm run lint`
- `npm run build:ts`
- `npm run test:react`
- `npm run format:check`
- `npm run test:gameplay`
- `npm run test:all`
- `NETRISK_RELEASE_BASE_REF=origin/main npm run release:check`

Non completato localmente:
- `npm run test:e2e:smoke` non arriva ai test perché manca il browser Playwright `chromium_headless_shell-1223`; `npx playwright install chromium` è andato in timeout nell'ambiente locale con rete bloccata.

## Rischi residui

- Lo smoke E2E va verificato in CI, dove il workflow installa Chromium con `npx playwright install --with-deps chromium`.
- Commit/branch creati via connettore GitHub perché il worktree locale non ha permessi di scrittura su `.git\refs`, `.git\objects` e `.git\worktrees\Playground9\index.lock`.