### PR TITLE
Improve branch coverage for fortify and Supabase checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.025 - 2026-05-18
+
+- Added branch-focused coverage for fortify movement validation and Supabase connection check edge cases.
+
 ## 0.1.024 - 2026-05-15
 
 - Added branch-focused coverage for auth throttling edge cases and AI lobby join route behavior.

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.024";
+export const appVersion = "0.1.025";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/fortify/fortify-movement.test.cts
+++ b/tests/gameplay/fortify/fortify-movement.test.cts
@@ -51,6 +51,30 @@ register("moveFortifyArmies fails outside fortify phase", () => {
   assert.equal(result.code, "INVALID_PHASE");
 });
 
+register("moveFortifyArmies rejects invalid state and graph inputs", () => {
+  const { graph, state } = setupFortifyState();
+
+  assert.throws(() => moveFortifyArmies(null, graph, "p1", "a", "c", 1), /valid game state/);
+  assert.throws(() => moveFortifyArmies(state, {}, "p1", "a", "c", 1), /valid map graph/);
+  assert.throws(() => moveFortifyArmies(state, graph, "", "a", "c", 1), /requires player/);
+});
+
+register("moveFortifyArmies rejects non-active games and non-current players", () => {
+  const { graph, state } = setupFortifyState();
+
+  state.phase = "lobby";
+  const inactive = moveFortifyArmies(state, graph, "p1", "a", "c", 1);
+  assert.equal(inactive.ok, false);
+  assert.equal(inactive.code, "GAME_NOT_ACTIVE");
+
+  state.phase = "active";
+  state.currentTurnIndex = 1;
+  const wrongPlayer = moveFortifyArmies(state, graph, "p1", "a", "c", 1);
+  assert.equal(wrongPlayer.ok, false);
+  assert.equal(wrongPlayer.code, "NOT_CURRENT_PLAYER");
+  assert.deepEqual(wrongPlayer.details, { currentPlayerId: "p2" });
+});
+
 register("moveFortifyArmies fails without a connected owned path", () => {
   const territories = [
     makeTerritory("a", ["b"]),
@@ -83,12 +107,76 @@ register("moveFortifyArmies blocks a repeated fortify in the same turn", () => {
   assert.equal(result.code, "FORTIFY_ALREADY_USED");
 });
 
+register("moveFortifyArmies allows repeated moves when single-move enforcement is disabled", () => {
+  const { graph, state } = setupFortifyState();
+  state.fortifyMoveUsed = true;
+
+  const result = moveFortifyArmies(state, graph, "p1", "a", "b", 1, {
+    enforceSingleMove: false
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.fortify.fortifyMoveUsed, true);
+  assert.equal(state.territories.a.armies, 3);
+  assert.equal(state.territories.b.armies, 3);
+});
+
 register("moveFortifyArmies rejects moves within the same territory", () => {
   const { graph, state } = setupFortifyState();
   const result = moveFortifyArmies(state, graph, "p1", "a", "a", 1);
 
   assert.equal(result.ok, false);
   assert.equal(result.code, "SAME_TERRITORY");
+});
+
+register("moveFortifyArmies validates territory existence and ownership before moving", () => {
+  const { graph, state } = setupFortifyState();
+
+  const unknownSource = moveFortifyArmies(state, graph, "p1", "missing", "c", 1);
+  assert.equal(unknownSource.ok, false);
+  assert.equal(unknownSource.code, "UNKNOWN_SOURCE_TERRITORY");
+
+  const unknownTarget = moveFortifyArmies(state, graph, "p1", "a", "missing", 1);
+  assert.equal(unknownTarget.ok, false);
+  assert.equal(unknownTarget.code, "UNKNOWN_TARGET_TERRITORY");
+
+  delete state.territories.c;
+  const missingState = moveFortifyArmies(state, graph, "p1", "a", "c", 1);
+  assert.equal(missingState.ok, false);
+  assert.equal(missingState.code, "MISSING_TERRITORY_STATE");
+
+  state.territories.c = { ownerId: "p2", armies: 1 };
+  const notOwned = moveFortifyArmies(state, graph, "p1", "a", "c", 1);
+  assert.equal(notOwned.ok, false);
+  assert.equal(notOwned.code, "TERRITORY_NOT_OWNED");
+  assert.deepEqual(notOwned.details, { fromOwnerId: "p1", toOwnerId: "p2" });
+});
+
+register("moveFortifyArmies validates whole army counts and source capacity", () => {
+  const { graph, state } = setupFortifyState();
+
+  const fractional = moveFortifyArmies(state, graph, "p1", "a", "c", 1.5);
+  assert.equal(fractional.ok, false);
+  assert.equal(fractional.code, "INVALID_ARMY_COUNT");
+
+  const zero = moveFortifyArmies(state, graph, "p1", "a", "c", 0);
+  assert.equal(zero.ok, false);
+  assert.equal(zero.code, "INVALID_ARMY_COUNT");
+
+  state.territories.a.armies = 1;
+  const insufficient = moveFortifyArmies(state, graph, "p1", "a", "c", 1);
+  assert.equal(insufficient.ok, false);
+  assert.equal(insufficient.code, "INSUFFICIENT_SOURCE_ARMIES");
+
+  state.territories.a.armies = 4;
+  const tooMany = moveFortifyArmies(state, graph, "p1", "a", "c", 4);
+  assert.equal(tooMany.ok, false);
+  assert.equal(tooMany.code, "MOVE_EXCEEDS_AVAILABLE");
+  assert.deepEqual(tooMany.details, {
+    maxMove: 3,
+    requestedArmies: 4,
+    sourceArmies: 4
+  });
 });
 
 register("moveFortifyArmies applica il minimo modulare durante la fortifica", () => {

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -106,6 +106,76 @@ register("Supabase connection check fails clearly when REST auth is invalid", as
   );
 });
 
+register("Supabase connection check validates required environment before probing", async () => {
+  await assert.rejects(
+    () =>
+      checkSupabaseConnection({
+        env: {
+          SUPABASE_SERVICE_ROLE_KEY: "service-role"
+        },
+        fetchImpl: async () => new Response("[]", { status: 200 })
+      }),
+    /Missing Supabase connection env: SUPABASE_URL/
+  );
+
+  await assert.rejects(
+    () =>
+      checkSupabaseConnection({
+        env: {
+          SUPABASE_URL: "https://example.supabase.co",
+          SUPABASE_SERVICE_ROLE_KEY: "   "
+        },
+        fetchImpl: async () => new Response("[]", { status: 200 })
+      }),
+    /Missing Supabase connection env: SUPABASE_SERVICE_ROLE_KEY/
+  );
+});
+
+register("Supabase connection check defaults schema and reports invalid hosts safely", async () => {
+  const requestedHeaders: Array<Record<string, string>> = [];
+  const fetchImpl = async (_input: unknown, init: RequestInit = {}) => {
+    requestedHeaders.push(init.headers as Record<string, string>);
+    return new Response("[]", { status: 200 });
+  };
+
+  const result = await checkSupabaseConnection({
+    env: {
+      SUPABASE_URL: "not-a-valid-url/",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role",
+      SUPABASE_DB_SCHEMA: "   "
+    },
+    fetchImpl,
+    tables: []
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.urlHost, "invalid-url");
+  assert.equal(result.schema, "public");
+  assert.deepEqual(result.checkedTables, []);
+  assert.equal(requestedHeaders.length, 0);
+});
+
+register("Supabase connection check falls back to status text for empty error bodies", async () => {
+  const fetchImpl = async () =>
+    new Response("", {
+      status: 503,
+      statusText: "Service unavailable"
+    });
+
+  await assert.rejects(
+    () =>
+      checkSupabaseConnection({
+        env: {
+          SUPABASE_URL: "https://example.supabase.co/",
+          SUPABASE_SERVICE_ROLE_KEY: "service-role"
+        },
+        fetchImpl,
+        tables: ["games"]
+      }),
+    /games \(503\): Service unavailable/
+  );
+});
+
 register("Supabase datastore ignores public keys and requires the service role key", () => {
   const previousEnv = {
     SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,


### PR DESCRIPTION
## Obiettivo
Aumentare la branch coverage con test comportamentali su aree con logica reale, senza modificare il comportamento applicativo.

## Aree toccate
- `tests/gameplay/fortify/fortify-movement.test.cts`: copertura di validazioni input, stato non attivo, player non corrente, single-move enforcement disabilitato, territori mancanti/non posseduti e limiti armate.
- `tests/gameplay/regression/tooling-and-supabase-regressions.test.cts`: copertura di env mancanti, schema default, URL host invalidi e fallback su status text per errori Supabase REST.
- `shared/version-manifest.cts` e `CHANGELOG.md`: bump/release note minimo richiesto da Release Gate.

## Coverage
Baseline locale prima:
- Statements: 89.56%
- Branches: 78.24%
- Functions: 79.00%
- Lines: 89.56%

Dopo:
- Statements: 89.68%
- Branches: 78.45%
- Functions: 79.00%
- Lines: 89.68%

Aree mirate:
- `backend/engine/fortify-movement.cjs` branch: 71.15% -> 93.93%
- `scripts/check-supabase-connection.cjs` branch: 50.00% -> 75.00%

## Fix minimi
Nessun fix applicativo. Aggiunto solo il bump `0.1.025` con changelog per soddisfare il gate di release.

## Validazione locale
- `npm ci` bloccato dal postinstall Supabase CLI per rete EACCES; completato con `npm ci --ignore-scripts` per installare dipendenze JS locali.
- `npm run test:gameplay`: passed, 426 gameplay test.
- `npm run coverage`: passed, thresholds satisfied after `npm run coverage:check`.
- `npm run test:all`: passed, 27 React test files / 142 tests, 161 core tests, 426 gameplay tests.
- `npm run lint`: passed.
- `npm run format:check`: passed.
- `npm run typecheck`: passed.
- `npm run typecheck:react-shell`: passed.
- `npm run build:ts`: passed.
- `npm run release:check`: passed for 0.1.025.
- `npm run test:e2e:smoke`: blocked locally because Playwright Chromium is not installed; `npx playwright install chromium` was blocked first by default cache ACL, then by network EACCES when using a workspace-local browser path.

## Remote checks
- Quality: success
- Coverage: success
- E2E Smoke: success
- Release Gate: success
- CodeQL Advanced / Analyze: success
- Vercel PR Deployment Panel: success
- Vercel status: success

## Rischi residui
- No saved-game, API, module, persistence, or runtime behavior changes.
- Local E2E remains environment-blocked, but the GitHub E2E Smoke check is green.