### PR TITLE
[codex] Improve branch coverage for shared helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.030 - 2026-05-19
+
+- Added branch-focused coverage for shared content pack/message helpers and local environment file loading.
+
 ## 0.1.029 - 2026-05-19
 
 - Added Retry-After headers to rate-limited authentication and account settings responses.

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -25,6 +25,7 @@ const gameplayTestModules = [
   "../tests/gameplay/shared/continent-loader.test.cjs",
   "../tests/gameplay/shared/extensions.test.cjs",
   "../tests/gameplay/shared/core-base-catalog.test.cjs",
+  "../tests/gameplay/shared/content-packs-and-messages.test.cjs",
   "../tests/gameplay/shared/version-registry.test.cjs",
   "../tests/gameplay/shared/module-versions.test.cjs",
   "../tests/gameplay/shared/runtime-validation.test.cjs",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.029";
+export const appVersion = "0.1.030";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -5,6 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const { createSupabaseDatastore } = require("../../../backend/datastore-supabase.cjs");
+const { loadLocalEnv } = require("../../../backend/load-local-env.cjs");
 const { checkSupabaseConnection } = require("../../../scripts/check-supabase-connection.cjs");
 const { getSupabaseSchemaSql } = require("../../../supabase/schema.cjs");
 
@@ -287,6 +288,82 @@ register("sync public assets removes stale removed UI artifacts", () => {
     });
     assert.equal(fs.readFileSync(path.join(publicDir, "assets", "favicon.svg"), "utf8"), "<svg />");
   } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+register("loadLocalEnv parses local env files without overriding existing values", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netrisk-local-env-"));
+  const originalCwd = process.cwd();
+  const trackedEnvKeys = [
+    "E2E",
+    "TEST",
+    "NODE_ENV",
+    "NETRISK_PROJECT_ROOT",
+    "NETRISK_QUOTED_VALUE",
+    "NETRISK_SINGLE_QUOTED_VALUE",
+    "NETRISK_PLAIN_VALUE",
+    "NETRISK_LOCAL_ONLY_VALUE",
+    "NETRISK_EXISTING_VALUE",
+    "NETRISK_EMPTY_VALUE",
+    "NETRISK_SKIPPED_VALUE"
+  ];
+  const originalEnv = Object.fromEntries(trackedEnvKeys.map((key) => [key, process.env[key]]));
+
+  fs.writeFileSync(
+    path.join(tempRoot, ".env"),
+    [
+      "# ignored comment",
+      'NETRISK_QUOTED_VALUE="quoted value"',
+      "NETRISK_SINGLE_QUOTED_VALUE='single quoted value'",
+      "NETRISK_PLAIN_VALUE= plain value ",
+      "NETRISK_EXISTING_VALUE=from-file",
+      "NETRISK_EMPTY_VALUE=",
+      "MALFORMED_WITHOUT_SEPARATOR",
+      "=missing-key"
+    ].join("\n")
+  );
+  fs.writeFileSync(
+    path.join(tempRoot, ".env.local"),
+    ["NETRISK_LOCAL_ONLY_VALUE=from-local", "NETRISK_QUOTED_VALUE=from-local"].join("\n")
+  );
+
+  try {
+    delete process.env.E2E;
+    delete process.env.TEST;
+    delete process.env.NODE_ENV;
+    process.env.NETRISK_PROJECT_ROOT = tempRoot;
+    process.env.NETRISK_EXISTING_VALUE = "from-process";
+    process.chdir(tempRoot);
+
+    loadLocalEnv();
+
+    assert.equal(process.env.NETRISK_QUOTED_VALUE, "quoted value");
+    assert.equal(process.env.NETRISK_SINGLE_QUOTED_VALUE, "single quoted value");
+    assert.equal(process.env.NETRISK_PLAIN_VALUE, "plain value");
+    assert.equal(process.env.NETRISK_LOCAL_ONLY_VALUE, "from-local");
+    assert.equal(process.env.NETRISK_EXISTING_VALUE, "from-process");
+    assert.equal(process.env.NETRISK_EMPTY_VALUE, "");
+    assert.equal(process.env.MALFORMED_WITHOUT_SEPARATOR, undefined);
+
+    delete process.env.NETRISK_SKIPPED_VALUE;
+    process.env.TEST = "true";
+    fs.writeFileSync(path.join(tempRoot, ".env"), "NETRISK_SKIPPED_VALUE=should-not-load\n");
+
+    loadLocalEnv();
+
+    assert.equal(process.env.NETRISK_SKIPPED_VALUE, undefined);
+  } finally {
+    process.chdir(originalCwd);
+    trackedEnvKeys.forEach((key) => {
+      if (typeof originalEnv[key] === "undefined") {
+        delete process.env[key];
+        return;
+      }
+
+      process.env[key] = originalEnv[key];
+    });
+    delete process.env.MALFORMED_WITHOUT_SEPARATOR;
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });

--- a/tests/gameplay/shared/content-packs-and-messages.test.cts
+++ b/tests/gameplay/shared/content-packs-and-messages.test.cts
@@ -1,0 +1,103 @@
+const assert = require("node:assert/strict");
+
+const {
+  DEFAULT_CONTENT_PACK_ID,
+  findContentPack,
+  getContentPack,
+  listContentPacks
+} = require("../../../shared/content/content-packs/index.cjs");
+const {
+  createActionFailure,
+  createDomainFailure,
+  createLocalizedError,
+  createLogEntry,
+  createValidationFailure
+} = require("../../../shared/messages.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+register("content packs expose summaries, defaults and localized missing errors", () => {
+  const summaries = listContentPacks();
+  const defaultPack = getContentPack();
+  const explicitDefaultPack = getContentPack(DEFAULT_CONTENT_PACK_ID);
+
+  assert.equal(defaultPack.id, DEFAULT_CONTENT_PACK_ID);
+  assert.equal(explicitDefaultPack.id, DEFAULT_CONTENT_PACK_ID);
+  assert.equal(findContentPack("missing-content-pack"), null);
+  assert.equal(
+    summaries.some(
+      (pack: {
+        id: string;
+        defaultSiteThemeId: string;
+        defaultMapId: string;
+        defaultDiceRuleSetId: string;
+        defaultCardRuleSetId: string;
+        defaultVictoryRuleSetId: string;
+        defaultPieceSetId: string;
+      }) =>
+        pack.id === DEFAULT_CONTENT_PACK_ID &&
+        pack.defaultSiteThemeId === defaultPack.defaultSiteThemeId &&
+        pack.defaultMapId === defaultPack.defaultMapId &&
+        pack.defaultDiceRuleSetId === defaultPack.defaultDiceRuleSetId &&
+        pack.defaultCardRuleSetId === defaultPack.defaultCardRuleSetId &&
+        pack.defaultVictoryRuleSetId === defaultPack.defaultVictoryRuleSetId &&
+        pack.defaultPieceSetId === defaultPack.defaultPieceSetId
+    ),
+    true
+  );
+
+  assert.throws(
+    () => getContentPack("missing-content-pack"),
+    (error: unknown) => {
+      assert.equal(error instanceof Error, true);
+      const localized = error as Error & {
+        messageKey?: string | null;
+        messageParams?: { contentPackId?: string };
+      };
+      assert.equal(localized.message, "Unsupported content pack.");
+      assert.equal(localized.messageKey, "contentPack.unsupported");
+      assert.equal(localized.messageParams?.contentPackId, "missing-content-pack");
+      return true;
+    }
+  );
+});
+
+register("message helpers normalize metadata and preserve error codes", () => {
+  const codedError = createLocalizedError("Denied.", "auth.denied", { role: "admin" }, "DENIED");
+  const defaultedError = createLocalizedError("Plain.", "");
+  const actionFailure = createActionFailure("Cannot attack.", null);
+  const domainFailure = createDomainFailure("Invalid move.", "move.invalid", { from: "aurora" });
+  const validationFailure = createValidationFailure("Bad input.", null);
+  const logEntry = createLogEntry("Turn started.", "", undefined);
+
+  assert.equal(codedError.message, "Denied.");
+  assert.equal(codedError.messageKey, "auth.denied");
+  assert.deepEqual(codedError.messageParams, { role: "admin" });
+  assert.equal(codedError.code, "DENIED");
+  assert.equal(defaultedError.messageKey, null);
+  assert.deepEqual(defaultedError.messageParams, {});
+  assert.equal(Object.prototype.hasOwnProperty.call(defaultedError, "code"), false);
+  assert.deepEqual(actionFailure, {
+    ok: false,
+    message: "Cannot attack.",
+    messageKey: null,
+    messageParams: {}
+  });
+  assert.deepEqual(domainFailure, {
+    ok: false,
+    error: "Invalid move.",
+    errorKey: "move.invalid",
+    errorParams: { from: "aurora" }
+  });
+  assert.deepEqual(validationFailure, {
+    ok: false,
+    reason: "Bad input.",
+    reasonKey: null,
+    reasonParams: {}
+  });
+  assert.deepEqual(logEntry, {
+    message: "Turn started.",
+    messageKey: null,
+    messageParams: {}
+  });
+});


### PR DESCRIPTION
## Obiettivo

Aumentare la coverage in modo utile, con focus su branch coverage ed edge case osservabili, senza modificare il comportamento applicativo.

## Aree toccate

- Shared content pack registry: default lookup, summaries, missing-pack localized error.
- Shared message helpers: metadata fallback and error-code preservation.
- Backend local env loader: `.env` / `.env.local` parsing, quote stripping, malformed-line handling, existing-env precedence, test-mode skip.
- Gameplay test runner registration for the new shared test module.
- Release metadata bump to `0.1.030`, required by the repository Release Gate for every merge to `main`.

## Coverage

Before baseline:
- Statements: 89.79%
- Branches: 78.75%
- Functions: 79.00%
- Lines: 89.79%

After:
- Statements: 89.99%
- Branches: 78.79%
- Functions: 79.32%
- Lines: 89.99%

## Fix minimi

No runtime fixes. Added the required app version/changelog bump after Release Gate reported that `appVersion` must increase for every merge to `main`.

## Validazione locale

- `npm run coverage`
- `npm run coverage:check`
- `npm run build:ts`
- `npm run test:gameplay`
- `npm run test:react`
- `npm run test:e2e:smoke`
- `npm run typecheck`
- `npm run typecheck:frontend`
- `npm run typecheck:react-shell`
- `npm run lint`
- `npm run format:check`
- `npm run release:check`

## Rischi residui

Low. Runtime behavior, persistence format, API contract, and module compatibility are unchanged.