### PR TITLE
Add Retry-After to auth throttling responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.029 - 2026-05-19
+
+- Added Retry-After headers to rate-limited authentication and account settings responses.
+
 ## 0.1.028 - 2026-05-19
 
 - Fixed signed-out game deep links so auth-required game reads offer login and registration paths back to the requested game.

--- a/backend/http-response.cts
+++ b/backend/http-response.cts
@@ -27,15 +27,25 @@ type ObservedResponse = HttpTypes.ServerResponse & {
   setHeader?: (name: string, value: string) => void;
 };
 
-function setResponseHeader(res: ObservedResponse, name: string, value: string): void {
-  if (typeof res.setHeader === "function") {
-    res.setHeader(name, value);
+export function setResponseHeader(res: unknown, name: string, value: string): void {
+  if (!res || typeof res !== "object") {
     return;
   }
 
-  if (res.headers && typeof res.headers === "object") {
-    res.headers[name] = value;
+  const observedResponse = res as ObservedResponse;
+  if (typeof observedResponse.setHeader === "function") {
+    observedResponse.setHeader(name, value);
+    return;
   }
+
+  if (observedResponse.headers && typeof observedResponse.headers === "object") {
+    observedResponse.headers[name] = value;
+  }
+}
+
+export function setRetryAfterHeader(res: unknown, retryAfterSeconds: number): void {
+  const delaySeconds = Math.max(0, Math.ceil(Number(retryAfterSeconds) || 0));
+  setResponseHeader(res, "Retry-After", String(delaySeconds));
 }
 
 export function setResponseRequestContext(

--- a/backend/routes/account.cts
+++ b/backend/routes/account.cts
@@ -13,6 +13,7 @@ const {
   themePreferenceResponseSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 
 type RequireAuthFn = (
   req: HttpTypes.IncomingMessage,
@@ -200,6 +201,7 @@ export async function handleAccountSettingsRoute(
   const throttleKey = createAuthThrottleKey("account", deps.req, authContext.user.username);
   const throttleDecision = deps.authAttemptThrottle?.check(throttleKey);
   if (throttleDecision && !throttleDecision.allowed) {
+    setRetryAfterHeader(deps.res, throttleDecision.retryAfterSeconds);
     deps.sendLocalizedError(
       deps.res,
       429,

--- a/backend/routes/password-auth.cts
+++ b/backend/routes/password-auth.cts
@@ -42,12 +42,14 @@ const {
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
 const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 
 function sendTooManyAuthAttempts(
   res: unknown,
   sendLocalizedError: SendLocalizedError,
   retryAfterSeconds: number
 ): void {
+  setRetryAfterHeader(res, retryAfterSeconds);
   sendLocalizedError(
     res,
     429,

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7246,6 +7246,7 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
       body: JSON.stringify({ username: uniqueName("throttle_reg_limited"), password })
     });
     assert.equal(limitedRes.status, 429);
+    assert.equal(limitedRes.headers.get("retry-after"), "60");
     const payload: any = await limitedRes.json();
     assert.equal(payload.code, "AUTH_RATE_LIMITED");
   });

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.028";
+export const appVersion = "0.1.029";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/account-validation-routes.test.cts
+++ b/tests/gameplay/regression/account-validation-routes.test.cts
@@ -349,6 +349,7 @@ register(
 
 register("handleLoginRoute rate limits repeated password failures before auth work", async () => {
   const statuses: number[] = [];
+  const retryAfterHeaders: string[] = [];
   const throttle = createAuthAttemptThrottle({
     maxAttempts: 2,
     maxIpAttempts: 20,
@@ -364,7 +365,13 @@ register("handleLoginRoute rate limits repeated password failures before auth wo
           "x-forwarded-for": "203.0.113.7"
         }
       },
-      {},
+      {
+        setHeader(name: string, value: string) {
+          if (name === "Retry-After") {
+            retryAfterHeaders.push(value);
+          }
+        }
+      },
       { username: "Commander", password: "wrongpass" },
       {
         async loginWithPassword() {
@@ -393,6 +400,7 @@ register("handleLoginRoute rate limits repeated password failures before auth wo
   await attemptLogin();
 
   assert.deepEqual(statuses, [401, 401, 429]);
+  assert.deepEqual(retryAfterHeaders, ["60"]);
   assert.equal(loginCalls, 2);
 });
 
@@ -422,6 +430,7 @@ register(
 
 register("handleAccountSettingsRoute rate limits repeated current password failures", async () => {
   const statuses: number[] = [];
+  const retryAfterHeaders: string[] = [];
   const throttle = createAuthAttemptThrottle({
     maxAttempts: 2,
     maxIpAttempts: 20,
@@ -437,6 +446,13 @@ register("handleAccountSettingsRoute rate limits repeated current password failu
         req: {
           headers: {
             "x-forwarded-for": "203.0.113.9"
+          }
+        },
+        res: {
+          setHeader(name: string, value: string) {
+            if (name === "Retry-After") {
+              retryAfterHeaders.push(value);
+            }
           }
         },
         authAttemptThrottle: throttle,
@@ -468,6 +484,7 @@ register("handleAccountSettingsRoute rate limits repeated current password failu
   await attemptAccountUpdate();
 
   assert.deepEqual(statuses, [401, 401, 429]);
+  assert.deepEqual(retryAfterHeaders, ["60"]);
   assert.equal(accountUpdateCalls, 2);
 });
 


### PR DESCRIPTION
## Summary
- Add a shared response helper for setting headers safely on real and mocked responses.
- Send `Retry-After` on rate-limited registration/login and account settings responses.
- Add route-level and HTTP integration regressions for the new header.
- Bump release metadata to `0.1.029`.

## Extracted from
- Supersedes the useful remaining `Retry-After` portion of #282 without reintroducing the already-merged security-header changes from #295.

## Validation
- `npm run test:gameplay -- tests/gameplay/regression/account-validation-routes.test.cts`
- `npm run test`
- `npm run release:check`
- `git diff --check`

## Risks
- Transport-only behavior: response headers change for 429 auth/account throttling responses; JSON payloads and throttle rules are unchanged.
- No saved-game, module, engine, persistence, or frontend behavior changes.