### PR TITLE
🛡️ Sentinel: [MEDIUM] Implement rate limiting on AI join endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.033 - 2026-05-25
+
+- Implemented rate limiting on the AI join endpoint to mitigate automated lobby-filling and resource exhaustion.
+
 ## 0.1.032 - 2026-05-19
 
 - Hardened password hashing and verification by migrating to asynchronous non-blocking crypto operations.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "login" | "register";
+type AuthThrottleScope = "account" | "login" | "register" | "ai_join";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -52,6 +52,10 @@ type GetGame = (gameId: string | null) => Promise<any>;
 type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+};
 
 const {
   aiJoinRequestSchema,
@@ -61,6 +65,8 @@ const {
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
 const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 
 async function handleAiJoinRoute(
   req: unknown,
@@ -77,7 +83,8 @@ async function handleAiJoinRoute(
   broadcastGame: BroadcastGame,
   snapshotForState: SnapshotForState,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
@@ -95,6 +102,28 @@ async function handleAiJoinRoute(
     sendLocalizedError as SendLocalizedError
   );
   if (!parsedBody) {
+    return;
+  }
+
+  const throttleKey = createAuthThrottleKey("ai_join", req, authContext.user.username);
+  const throttleDecision = authAttemptThrottle?.check(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+    sendLocalizedError(
+      res,
+      429,
+      {
+        error: "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+        errorKey: "auth.throttle.tooManyAttempts",
+        errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        code: "AUTH_RATE_LIMITED"
+      },
+      "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+      "auth.throttle.tooManyAttempts",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+      "AUTH_RATE_LIMITED",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+    );
     return;
   }
 
@@ -117,6 +146,7 @@ async function handleAiJoinRoute(
   const gameContext = await loadGameContext(gameId);
   const result = addPlayer(gameContext.state, parsedBody.name, { isAi: true });
   if (!result.ok) {
+    authAttemptThrottle?.recordAttempt(throttleKey);
     sendLocalizedError(
       res,
       400,
@@ -128,6 +158,7 @@ async function handleAiJoinRoute(
     return;
   }
 
+  authAttemptThrottle?.recordAttempt(throttleKey);
   await persistGameContext(gameContext);
   broadcastGame(gameContext);
   sendJson(res, result.rejoined ? 200 : 201, {

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1600,7 +1600,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForState,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7252,6 +7252,41 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
   });
 });
 
+register("API AI join applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const owner = await createAuthenticatedSession(baseUrl, uniqueName("ai_throttle"));
+    const created = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ name: "AI Throttle Match" })
+    });
+    assert.equal(created.status, 201);
+    const createdPayload: any = await readJson(created);
+
+    // Default maxAttempts is 5.
+    // However, the test environment may have more than 2 slots.
+    // If the lobby gets full, it returns 400 instead of 201.
+    for (let i = 0; i < 5; i++) {
+      const res = await fetch(baseUrl + "/api/ai/join", {
+        method: "POST",
+        headers: authHeaders(owner.sessionToken),
+        body: JSON.stringify({ name: `CPU ${i}`, gameId: createdPayload.game.id })
+      });
+      assert.ok(res.status === 201 || res.status === 400);
+    }
+
+    const limitedRes = await fetch(baseUrl + "/api/ai/join", {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ name: "CPU Limited", gameId: createdPayload.game.id })
+    });
+    assert.equal(limitedRes.status, 429);
+    assert.equal(limitedRes.headers.get("retry-after"), "60");
+    const payload: any = await limitedRes.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 async function run() {
   let failures = 0;
   for (const test of tests) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.032";
+export const appVersion = "0.1.033";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The AI join endpoint (/api/ai/join) lacked rate limiting, allowing authenticated users to automate AI player injection and potentially exhaust server resources or fill game lobbies maliciously.
🎯 Impact: Automated lobby-filling can disrupt gameplay for human players and lead to resource exhaustion (DoS) on the backend.
🔧 Fix: Integrated the existing `AuthAttemptThrottle` mechanism into the `handleAiJoinRoute`. A new `ai_join` scope was added to the throttle utility, and the route now enforces a limit (default 5 attempts per window) before proceeding with game logic.
✅ Verification: Added a dedicated regression test in `scripts/run-tests.cts` that verifies the endpoint returns HTTP 429 after 5 successful or failed attempts from the same user. Ran the full test suite (162 tests passed).

---
*PR created automatically by Jules for task [12256551436208474785](https://jules.google.com/task/12256551436208474785) started by @andreame-code*