### PR TITLE
🛡️ Sentinel: Implement rate limiting for AI join requests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Security hardening that relies on standard Node.js HTTP response methods like `res.removeHeader` can cause runtime errors in test suites where response objects are mocked without full API parity.
 **Learning:** When applying security headers at the global server level, defensive checks for method existence (e.g., `typeof res.removeHeader === 'function'`) ensure that security logic doesn't break gameplay or regression tests that use lightweight mocks. Additionally, HSTS must be applied conditionally (only over secure connections or in test environments) to align with RFC 6797 and maintain local development accessibility.
 **Prevention:** Always wrap non-standard or late-added response methods in defensive type checks and ensure HSTS application logic respects the connection's security state.
+
+## 2026-05-19 - Rate Limiting for AI Join Requests
+**Vulnerability:** The `/api/ai/join` endpoint lacked rate limiting, allowing authenticated users to rapidly fill game lobbies with AI players, potentially leading to resource exhaustion or disruptive behavior.
+**Learning:** Security enhancements like rate limiting must be applied to all endpoints that perform resource-intensive or state-mutating operations, especially those easily automatable. When testing rate limits, environmental constraints (like lobby capacity) must be considered to ensure the rate limit is hit before other logical limits (e.g., lobby full).
+**Prevention:** Audit all mutation-heavy endpoints for missing throttling. Ensure integration tests for rate limiting account for other application-level constraints that might trigger earlier failure paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.033 - 2026-05-19
+
+- Implemented rate limiting for AI player join requests to mitigate lobby-filling automation and resource exhaustion.
+
 ## 0.1.032 - 2026-05-19
 
 - Hardened password hashing and verification by migrating to asynchronous non-blocking crypto operations.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "login" | "register";
+type AuthThrottleScope = "account" | "ai_join" | "login" | "register";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -48,6 +48,12 @@ type SnapshotForUser = (
   user: AuthContext["user"]
 ) => unknown;
 type Authorize = (action: string, context: Record<string, unknown>) => void;
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordFailure(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordSuccess(key: Record<string, unknown>): void;
+};
 type GetGame = (gameId: string | null) => Promise<any>;
 type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
@@ -60,6 +66,8 @@ const {
   startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
 
 async function handleAiJoinRoute(
@@ -77,7 +85,8 @@ async function handleAiJoinRoute(
   broadcastGame: BroadcastGame,
   snapshotForState: SnapshotForState,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
@@ -95,6 +104,28 @@ async function handleAiJoinRoute(
     sendLocalizedError as SendLocalizedError
   );
   if (!parsedBody) {
+    return;
+  }
+
+  const throttleKey = createAuthThrottleKey("ai_join", req, authContext.user.username);
+  const throttleDecision = authAttemptThrottle?.check(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+    sendLocalizedError(
+      res,
+      429,
+      {
+        error: "Troppi tentativi di aggiunta AI. Riprova più tardi.",
+        errorKey: "auth.throttle.tooManyAttempts",
+        errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        code: "AUTH_RATE_LIMITED"
+      },
+      "Troppi tentativi di aggiunta AI. Riprova più tardi.",
+      "auth.throttle.tooManyAttempts",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+      "AUTH_RATE_LIMITED",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+    );
     return;
   }
 
@@ -128,6 +159,7 @@ async function handleAiJoinRoute(
     return;
   }
 
+  authAttemptThrottle?.recordAttempt(throttleKey);
   await persistGameContext(gameContext);
   broadcastGame(gameContext);
   sendJson(res, result.rejoined ? 200 : 201, {

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1600,7 +1600,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForState,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7252,6 +7252,48 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
   });
 });
 
+register("API ai join applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const ownerSession = await createAuthenticatedSession(baseUrl, uniqueName("throttle_ai"));
+
+    // Default limit is 5 attempts per user/IP
+    for (let i = 0; i < 5; i++) {
+      const created = await fetch(baseUrl + "/api/games", {
+        method: "POST",
+        headers: authHeaders(ownerSession.sessionToken),
+        body: JSON.stringify({ name: `Match ${i}` })
+      });
+      assert.equal(created.status, 201);
+      const gameId = (await readJson(created)).game.id;
+
+      const res = await fetch(`${baseUrl}/api/ai/join`, {
+        method: "POST",
+        headers: authHeaders(ownerSession.sessionToken),
+        body: JSON.stringify({ name: `AI ${i}`, gameId })
+      });
+      assert.equal(res.status, 201);
+    }
+
+    const createdLast = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: authHeaders(ownerSession.sessionToken),
+      body: JSON.stringify({ name: "Final Match" })
+    });
+    assert.equal(createdLast.status, 201);
+    const lastGameId = (await readJson(createdLast)).game.id;
+
+    const limitedRes = await fetch(`${baseUrl}/api/ai/join`, {
+      method: "POST",
+      headers: authHeaders(ownerSession.sessionToken),
+      body: JSON.stringify({ name: "AI Limited", gameId: lastGameId })
+    });
+    assert.equal(limitedRes.status, 429);
+    assert.equal(limitedRes.headers.get("retry-after"), "60");
+    const payload: any = await limitedRes.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 async function run() {
   let failures = 0;
   for (const test of tests) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.032";
+export const appVersion = "0.1.033";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
### 🛡️ Sentinel: [MEDIUM] Rate Limiting for AI Join Requests

**🚨 Severity:** MEDIUM

**💡 Vulnerability:** The `/api/ai/join` endpoint lacked rate limiting, allowing authenticated users to programmatically fill game lobbies with AI players at a high frequency.

**🎯 Impact:** This could lead to resource exhaustion on the server, disruptive lobby-filling behavior, and potential Denial of Service (DoS) if exploited at scale.

**🔧 Fix:** Implemented rate limiting for the AI join endpoint using the existing `AuthAttemptThrottle` mechanism. A new `ai_join` scope was added, enforcing a default limit of 5 attempts per user/IP combination.

**✅ Verification:**
- Added a new regression test in `scripts/run-tests.cts` that verifies the 429 status code and `AUTH_RATE_LIMITED` error after exceeding the attempt limit.
- Verified that all 162 core integration tests and 443 gameplay regression tests pass.
- Incremented `appVersion` and updated `CHANGELOG.md` to reflect the security enhancement.

---
*PR created automatically by Jules for task [356688708335211685](https://jules.google.com/task/356688708335211685) started by @andreame-code*