### PR TITLE
🛡️ Sentinel: Harden authored module metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.043 - 2026-06-05
+
+- Added bounded admin authored-module request validation while preserving legacy authored-module storage compatibility.
+
 ## 0.1.042 - 2026-06-05
 
 - Added rate limiting for AI lobby join requests to reduce automated lobby filling and resource exhaustion.

--- a/backend/authored-modules.cts
+++ b/backend/authored-modules.cts
@@ -1,5 +1,5 @@
 const {
-  authoredModuleInputSchema,
+  adminAuthoredModuleUpsertRequestSchema,
   authoredModuleSchema
 } = require("../shared/runtime-validation.cjs");
 const { registeredMaps } = require("../shared/maps/index.cjs");
@@ -567,7 +567,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
   }
 
   function parseInput(input: unknown): AuthoredModuleInput {
-    const parsed = authoredModuleInputSchema.safeParse(input);
+    const parsed = adminAuthoredModuleUpsertRequestSchema.safeParse(input);
     if (!parsed.success) {
       throw createServiceError("Authored module payload is not valid.", 400);
     }

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -28,6 +28,17 @@ const AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES = [
   "control-territory-count"
 ] as const;
 const AUTHORED_MODULE_VALIDATION_SEVERITY_VALUES = ["warning", "error"] as const;
+const AUTHORED_MODULE_REQUEST_LIMITS = Object.freeze({
+  moduleId: 64,
+  moduleName: 128,
+  moduleDescription: 1024,
+  moduleVersion: 32,
+  mapId: 64,
+  objectiveId: 64,
+  objectiveTitle: 255,
+  objectiveDescription: 1024,
+  continentId: 64
+});
 
 type IssuePathSegment = string | number;
 
@@ -1269,6 +1280,36 @@ export const authoredModuleInputSchema = objectSchema({
 
 export type AuthoredModuleInput = z.infer<typeof authoredModuleInputSchema>;
 
+const authoredVictoryObjectiveRequestBaseSchema = objectSchema({
+  id: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.objectiveId),
+  title: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.objectiveTitle),
+  description: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.objectiveDescription),
+  enabled: z.boolean(),
+  type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
+});
+
+const authoredVictoryControlContinentsObjectiveRequestSchema =
+  authoredVictoryObjectiveRequestBaseSchema.extend({
+    type: z.literal("control-continents"),
+    continentIds: z.array(z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentId))
+  });
+
+const authoredVictoryTerritoryCountObjectiveRequestSchema =
+  authoredVictoryObjectiveRequestBaseSchema.extend({
+    type: z.literal("control-territory-count"),
+    territoryCount: z.number().int().nullable().optional()
+  });
+
+const authoredVictoryObjectiveRequestSchema = z.discriminatedUnion("type", [
+  authoredVictoryControlContinentsObjectiveRequestSchema,
+  authoredVictoryTerritoryCountObjectiveRequestSchema
+]);
+
+const authoredVictoryModuleContentRequestSchema = objectSchema({
+  mapId: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.mapId),
+  objectives: z.array(authoredVictoryObjectiveRequestSchema)
+});
+
 export const authoredModuleSchema = authoredModuleInputSchema.extend({
   status: z.enum(AUTHORED_MODULE_STATUS_VALUES),
   createdAt: z.string().min(1),
@@ -1573,7 +1614,14 @@ export type AdminAuthoredModuleDetailResponse = z.infer<
   typeof adminAuthoredModuleDetailResponseSchema
 >;
 
-export const adminAuthoredModuleUpsertRequestSchema = authoredModuleInputSchema;
+export const adminAuthoredModuleUpsertRequestSchema = objectSchema({
+  id: z.string().trim().min(1).max(AUTHORED_MODULE_REQUEST_LIMITS.moduleId),
+  name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleName),
+  description: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleDescription),
+  version: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleVersion),
+  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  content: authoredVictoryModuleContentRequestSchema
+});
 
 export type AdminAuthoredModuleUpsertRequest = z.infer<
   typeof adminAuthoredModuleUpsertRequestSchema

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -249,7 +249,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "authored-victory-objectives",
     name: "Authored Victory Objectives",
     kind: "admin",
-    version: "1.0.0",
+    version: "1.0.1",
     description:
       "Content Studio authored victory objective drafts, validation, and runtime output.",
     ownerPaths: [

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -27,6 +27,17 @@ const AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES = [
   "control-territory-count"
 ] as const;
 const AUTHORED_MODULE_VALIDATION_SEVERITY_VALUES = ["warning", "error"] as const;
+const AUTHORED_MODULE_REQUEST_LIMITS = Object.freeze({
+  moduleId: 64,
+  moduleName: 128,
+  moduleDescription: 1024,
+  moduleVersion: 32,
+  mapId: 64,
+  objectiveId: 64,
+  objectiveTitle: 255,
+  objectiveDescription: 1024,
+  continentId: 64
+});
 
 type IssuePathSegment = string | number;
 
@@ -1268,6 +1279,36 @@ export const authoredModuleInputSchema = objectSchema({
 
 export type AuthoredModuleInput = z.infer<typeof authoredModuleInputSchema>;
 
+const authoredVictoryObjectiveRequestBaseSchema = objectSchema({
+  id: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.objectiveId),
+  title: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.objectiveTitle),
+  description: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.objectiveDescription),
+  enabled: z.boolean(),
+  type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
+});
+
+const authoredVictoryControlContinentsObjectiveRequestSchema =
+  authoredVictoryObjectiveRequestBaseSchema.extend({
+    type: z.literal("control-continents"),
+    continentIds: z.array(z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentId))
+  });
+
+const authoredVictoryTerritoryCountObjectiveRequestSchema =
+  authoredVictoryObjectiveRequestBaseSchema.extend({
+    type: z.literal("control-territory-count"),
+    territoryCount: z.number().int().nullable().optional()
+  });
+
+const authoredVictoryObjectiveRequestSchema = z.discriminatedUnion("type", [
+  authoredVictoryControlContinentsObjectiveRequestSchema,
+  authoredVictoryTerritoryCountObjectiveRequestSchema
+]);
+
+const authoredVictoryModuleContentRequestSchema = objectSchema({
+  mapId: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.mapId),
+  objectives: z.array(authoredVictoryObjectiveRequestSchema)
+});
+
 export const authoredModuleSchema = authoredModuleInputSchema.extend({
   status: z.enum(AUTHORED_MODULE_STATUS_VALUES),
   createdAt: z.string().min(1),
@@ -1572,7 +1613,14 @@ export type AdminAuthoredModuleDetailResponse = z.infer<
   typeof adminAuthoredModuleDetailResponseSchema
 >;
 
-export const adminAuthoredModuleUpsertRequestSchema = authoredModuleInputSchema;
+export const adminAuthoredModuleUpsertRequestSchema = objectSchema({
+  id: z.string().trim().min(1).max(AUTHORED_MODULE_REQUEST_LIMITS.moduleId),
+  name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleName),
+  description: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleDescription),
+  version: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleVersion),
+  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  content: authoredVictoryModuleContentRequestSchema
+});
 
 export type AdminAuthoredModuleUpsertRequest = z.infer<
   typeof adminAuthoredModuleUpsertRequestSchema

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.042";
+export const appVersion = "0.1.043";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/authored-modules.test.cts
+++ b/tests/gameplay/regression/authored-modules.test.cts
@@ -176,6 +176,48 @@ register(
     assert.equal(invalidCodes.includes("invalid-continent-id"), true);
     assert.equal(invalidCodes.includes("invalid-territory-count"), true);
 
+    const incompleteDraft = createVictoryDraft({ id: "victory.incomplete-draft" });
+    incompleteDraft.name = "";
+    incompleteDraft.description = "";
+    incompleteDraft.version = "";
+    incompleteDraft.content.mapId = "";
+    incompleteDraft.content.objectives = [
+      {
+        id: "",
+        title: "",
+        description: "",
+        enabled: true,
+        type: "control-continents",
+        continentIds: ["north_america"]
+      }
+    ];
+    const incompleteValidation = await service.validateDraft(incompleteDraft);
+    const incompleteCodes = incompleteValidation.validation.errors.map(
+      (entry: { code: string }) => entry.code
+    );
+    assert.equal(incompleteCodes.includes("required-name"), true);
+    assert.equal(incompleteCodes.includes("required-description"), true);
+    assert.equal(incompleteCodes.includes("required-version"), true);
+    assert.equal(incompleteCodes.includes("required-map"), true);
+    assert.equal(incompleteCodes.includes("required-objective-id"), true);
+    assert.equal(incompleteCodes.includes("required-objective-title"), true);
+    assert.equal(incompleteCodes.includes("required-objective-description"), true);
+
+    await assert.rejects(
+      () =>
+        service.saveDraft(
+          createVictoryDraft({
+            id: "victory.oversized-description",
+            description: "d".repeat(1025)
+          })
+        ),
+      (error: any) => {
+        assert.equal(error.statusCode, 400);
+        assert.match(error.message, /payload is not valid/i);
+        return true;
+      }
+    );
+
     const savedDraft = await service.saveDraft(createVictoryDraft({ id: "victory.lifecycle" }));
     assert.equal(savedDraft.module.status, "draft");
 

--- a/tests/gameplay/shared/runtime-validation.test.cts
+++ b/tests/gameplay/shared/runtime-validation.test.cts
@@ -2,6 +2,8 @@ const assert = require("node:assert/strict");
 const {
   accountSettingsRequestSchema,
   accountSettingsResponseSchema,
+  adminAuthoredModuleUpsertRequestSchema,
+  authoredModuleSchema,
   authSessionResponseSchema,
   formatValidationPath,
   gameIdRequestSchema,
@@ -307,3 +309,114 @@ register("shared runtime validation rejects passwords exceeding 128 characters",
   });
   assert.equal(invalidRegister.success, false);
 });
+
+register(
+  "shared runtime validation bounds authored module requests without invalidating legacy storage",
+  () => {
+    const baseRequest = {
+      id: "victory.request-limits",
+      name: "Request Limits",
+      description: "Valid authored module metadata.",
+      version: "1.0.0",
+      moduleType: "victory-objectives",
+      content: {
+        mapId: "world-classic",
+        objectives: [
+          {
+            id: "hold-north-america",
+            title: "Hold North America",
+            description: "Control North America.",
+            enabled: true,
+            type: "control-continents",
+            continentIds: ["north_america"]
+          }
+        ]
+      }
+    };
+
+    const incompleteDraft = {
+      ...baseRequest,
+      name: "",
+      description: "",
+      version: "",
+      content: {
+        mapId: "",
+        objectives: [
+          {
+            ...baseRequest.content.objectives[0],
+            id: "",
+            title: "",
+            description: "",
+            continentIds: [""]
+          }
+        ]
+      }
+    };
+
+    assert.equal(adminAuthoredModuleUpsertRequestSchema.safeParse(incompleteDraft).success, true);
+
+    const oversizedRequests = [
+      { ...baseRequest, id: "a".repeat(65) },
+      { ...baseRequest, name: "n".repeat(129) },
+      { ...baseRequest, description: "d".repeat(1025) },
+      { ...baseRequest, version: "v".repeat(33) },
+      { ...baseRequest, content: { ...baseRequest.content, mapId: "m".repeat(65) } },
+      {
+        ...baseRequest,
+        content: {
+          ...baseRequest.content,
+          objectives: [{ ...baseRequest.content.objectives[0], id: "o".repeat(65) }]
+        }
+      },
+      {
+        ...baseRequest,
+        content: {
+          ...baseRequest.content,
+          objectives: [{ ...baseRequest.content.objectives[0], title: "t".repeat(256) }]
+        }
+      },
+      {
+        ...baseRequest,
+        content: {
+          ...baseRequest.content,
+          objectives: [{ ...baseRequest.content.objectives[0], description: "d".repeat(1025) }]
+        }
+      },
+      {
+        ...baseRequest,
+        content: {
+          ...baseRequest.content,
+          objectives: [{ ...baseRequest.content.objectives[0], continentIds: ["c".repeat(65)] }]
+        }
+      }
+    ];
+
+    oversizedRequests.forEach((request) => {
+      assert.equal(adminAuthoredModuleUpsertRequestSchema.safeParse(request).success, false);
+    });
+
+    const legacyStoredModule = {
+      ...baseRequest,
+      name: "n".repeat(129),
+      description: "d".repeat(1025),
+      version: "v".repeat(33),
+      content: {
+        mapId: "m".repeat(65),
+        objectives: [
+          {
+            ...baseRequest.content.objectives[0],
+            id: "o".repeat(65),
+            title: "t".repeat(256),
+            description: "d".repeat(1025),
+            continentIds: ["c".repeat(65)]
+          }
+        ]
+      },
+      status: "draft",
+      createdAt: "2026-06-05T10:00:00.000Z",
+      updatedAt: "2026-06-05T10:00:00.000Z"
+    };
+
+    assert.equal(authoredModuleSchema.safeParse(legacyStoredModule).success, true);
+  }
+);


### PR DESCRIPTION
## Summary

- Adds bounded admin authored-module request validation for metadata and objective strings.
- Keeps the stored authored-module schema compatible with existing legacy modules, so oversized legacy metadata is still readable instead of being silently filtered out.
- Keeps incomplete drafts structurally valid so Content Studio can continue returning publish-gate validation issues such as `required-name`.
- Bumps the app release to `0.1.043` and `authored-victory-objectives` to `1.0.1`.

## Validation

Local validation run before updating this PR:

- `npm run build:ts` - passed
- `npm run test:all:e2e` - started; `build:ts` and `test:react` passed, then the Node 20 runner stopped on missing `node:sqlite`
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-tests.cjs` - passed, 162 tests
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-gameplay-tests.cjs` - passed, 456 tests
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-e2e.cjs` - attempted, blocked because local Chromium cannot start: missing system library `libnspr4.so`
- `npm run release:check` - passed
- `npm run check:module-versioning` - passed after the module bump, 1 touched module
- `npm run lint` - passed
- `npm run format:check` - passed
- `git diff --check` - passed

Merge is intentionally held until GitHub CI runs the complete suite in an environment with the native Playwright dependencies available.