### PR TITLE
Rate limit AI join requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.042 - 2026-06-05
+
+- Added rate limiting for AI lobby join requests to reduce automated lobby filling and resource exhaustion.
+
 ## 0.1.041 - 2026-06-05
 
 - Added focused victory objective assignment coverage and made generated validation sync skip unchanged files.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "login" | "register";
+type AuthThrottleScope = "account" | "ai_join" | "login" | "register";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -52,6 +52,10 @@ type GetGame = (gameId: string | null) => Promise<any>;
 type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+};
 
 const {
   aiJoinRequestSchema,
@@ -66,6 +70,8 @@ const {
   readExpectedVersionOrSendError,
   sendVersionConflict
 } = require("./game-mutation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 
 async function handleAiJoinRoute(
   req: unknown,
@@ -82,7 +88,8 @@ async function handleAiJoinRoute(
   broadcastGame: BroadcastGame,
   snapshotForState: SnapshotForState,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
@@ -101,6 +108,36 @@ async function handleAiJoinRoute(
   );
   if (!parsedBody) {
     return;
+  }
+
+  if (authAttemptThrottle) {
+    const throttleKey = createAuthThrottleKey(
+      "ai_join",
+      req,
+      authContext.user.id || authContext.user.username
+    );
+    const throttleDecision = authAttemptThrottle.check(throttleKey);
+    if (!throttleDecision.allowed) {
+      setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+      sendLocalizedError(
+        res,
+        429,
+        {
+          error: "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+          errorKey: "auth.throttle.tooManyAttempts",
+          errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+          code: "AUTH_RATE_LIMITED"
+        },
+        "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+        "auth.throttle.tooManyAttempts",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        "AUTH_RATE_LIMITED",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+      );
+      return;
+    }
+
+    authAttemptThrottle.recordAttempt(throttleKey);
   }
 
   const gameId = parsedBody.gameId;

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1605,7 +1605,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForState,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7227,6 +7227,40 @@ register("API register + login + join completa il flusso di accesso", async () =
   });
 });
 
+register("API AI join applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const owner = await createAuthenticatedSession(baseUrl, uniqueName("ai_limit_host"));
+    const created = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ name: "AI Limit Match" })
+    });
+    assert.equal(created.status, 201);
+    const createdPayload: any = await created.json();
+    const gameId = createdPayload.game.id;
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await fetch(`${baseUrl}/api/ai/join`, {
+        method: "POST",
+        headers: authHeaders(owner.sessionToken),
+        body: JSON.stringify({ gameId, name: `CPU ${index}` })
+      });
+
+      assert.ok(response.status === 201 || response.status === 400);
+    }
+
+    const limitedResponse = await fetch(`${baseUrl}/api/ai/join`, {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ gameId, name: "CPU Limited" })
+    });
+    assert.equal(limitedResponse.status, 429);
+    assert.equal(limitedResponse.headers.get("retry-after"), "60");
+    const payload: any = await limitedResponse.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 register("API registration applica il rate limiting dopo troppi tentativi", async () => {
   await withServer(async (baseUrl) => {
     const password = TEST_PASSWORD;

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.1",
+    version: "1.0.2",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.041";
+export const appVersion = "0.1.042";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary
- add an `ai_join` auth throttle scope and apply it to `/api/ai/join` after auth and request validation
- return `429`, `Retry-After`, and `AUTH_RATE_LIMITED` before loading or mutating the game when the AI join budget is exhausted
- bump app version to `0.1.042` and `setup-flow` to `1.0.2`

## Validation
- `npm run build:ts`
- `npm run release:check`
- `npm run check:module-versioning`
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-tests.cjs` (162 tests passed)
- `npm exec --yes --package node@22 -- node .tsbuild/scripts/run-gameplay-tests.cjs` (455 gameplay tests passed)
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Notes
- Rebased manually onto current `main`.
- This intentionally excludes authored-module metadata length constraints from #304 because that PR has a compatibility/data-loss review concern for existing saved modules.