### PR TITLE
🛡️ Sentinel: [MEDIUM] Implement rate limiting for AI join endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.033 - 2026-05-26
+
+- Implemented rate limiting on the AI join endpoint to prevent automated lobby-filling and resource exhaustion by authenticated users.
+
 ## 0.1.032 - 2026-05-19
 
 - Hardened password hashing and verification by migrating to asynchronous non-blocking crypto operations.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "login" | "register";
+type AuthThrottleScope = "account" | "login" | "register" | "ai_join";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -52,6 +52,10 @@ type GetGame = (gameId: string | null) => Promise<any>;
 type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+};
 
 const {
   aiJoinRequestSchema,
@@ -60,6 +64,8 @@ const {
   startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
 
 async function handleAiJoinRoute(
@@ -77,10 +83,33 @@ async function handleAiJoinRoute(
   broadcastGame: BroadcastGame,
   snapshotForState: SnapshotForState,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
+    return;
+  }
+
+  const throttleKey = createAuthThrottleKey("ai_join", req, authContext.user.username);
+  const throttleDecision = authAttemptThrottle?.recordAttempt(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+    sendLocalizedError(
+      res,
+      429,
+      {
+        error: "Troppi tentativi di aggiunta AI. Riprova più tardi.",
+        errorKey: "auth.throttle.tooManyAttempts",
+        errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        code: "AUTH_RATE_LIMITED"
+      },
+      "Troppi tentativi di aggiunta AI. Riprova più tardi.",
+      "auth.throttle.tooManyAttempts",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+      "AUTH_RATE_LIMITED",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+    );
     return;
   }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1600,7 +1600,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForState,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7252,6 +7252,41 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
   });
 });
 
+register("API ai join applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const session = await createAuthenticatedSession(baseUrl, uniqueName("throttle_ai"));
+    const created = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: authHeaders(session.sessionToken),
+      body: JSON.stringify({ name: "AI Throttle Match" })
+    });
+    assert.equal(created.status, 201);
+    const createdPayload: any = await created.json();
+
+    // Default max attempts is 5.
+    // The 5th attempt will be blocked because recordAttempt increments and checks the limit.
+    for (let i = 0; i < 4; i++) {
+      const res = await fetch(`${baseUrl}/api/ai/join`, {
+        method: "POST",
+        headers: authHeaders(session.sessionToken),
+        body: JSON.stringify({ name: `Bot ${i}`, gameId: createdPayload.game.id })
+      });
+      // Both 201 (Joined) or 400 (Lobby full) are acceptable as attempts are recorded before capacity check.
+      assert.ok(res.status === 201 || res.status === 400);
+    }
+
+    const limitedRes = await fetch(`${baseUrl}/api/ai/join`, {
+      method: "POST",
+      headers: authHeaders(session.sessionToken),
+      body: JSON.stringify({ name: "Limited Bot", gameId: createdPayload.game.id })
+    });
+    assert.equal(limitedRes.status, 429);
+    assert.equal(limitedRes.headers.get("retry-after"), "60");
+    const payload: any = await limitedRes.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 async function run() {
   let failures = 0;
   for (const test of tests) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.032";
+export const appVersion = "0.1.033";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/ai/join` endpoint lacked rate limiting, allowing authenticated users to automate lobby-filling and potentially exhaust server resources.
🎯 Impact: An attacker could flood game lobbies with AI bots, leading to resource exhaustion or disruptive behavior for other players.
🔧 Fix: Integrated the `AuthAttemptThrottle` into the `handleAiJoinRoute` using a dedicated `ai_join` scope. The endpoint now returns an HTTP 429 status code and `Retry-After` header when the limit (default: 5 attempts) is exceeded.
✅ Verification: Added a dedicated integration test in `scripts/run-tests.cts` that verifies the 429 response and `Retry-After` header after multiple join attempts. Confirmed all tests pass with `npm test`.

---
*PR created automatically by Jules for task [3847245142220117147](https://jules.google.com/task/3847245142220117147) started by @andreame-code*