### PR TITLE
🛡️ Sentinel: Hardened authored module schemas with maximum string lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.033 - 2026-05-20
+
+- Hardened authored module schemas by enforcing maximum string lengths on name, description, ID, and version fields to mitigate Denial of Service (DoS) risks.
+
 ## 0.1.032 - 2026-05-19
 
 - Hardened password hashing and verification by migrating to asynchronous non-blocking crypto operations.

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -1192,9 +1192,9 @@ export const authoredModuleValidationSchema = objectSchema({
 export type AuthoredModuleValidation = z.infer<typeof authoredModuleValidationSchema>;
 
 export const authoredVictoryObjectiveBaseSchema = objectSchema({
-  id: z.string(),
-  title: z.string(),
-  description: z.string(),
+  id: z.string().max(64),
+  title: z.string().max(128),
+  description: z.string().max(512),
   enabled: z.boolean(),
   type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
 });
@@ -1227,17 +1227,17 @@ export const authoredVictoryObjectiveSchema = z.discriminatedUnion("type", [
 export type AuthoredVictoryObjective = z.infer<typeof authoredVictoryObjectiveSchema>;
 
 export const authoredVictoryModuleContentSchema = objectSchema({
-  mapId: z.string(),
+  mapId: z.string().max(64),
   objectives: z.array(authoredVictoryObjectiveSchema)
 });
 
 export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
 
 export const authoredModuleInputSchema = objectSchema({
-  id: z.string().trim().min(1),
-  name: z.string(),
-  description: z.string(),
-  version: z.string(),
+  id: z.string().trim().min(1).max(64),
+  name: z.string().max(128),
+  description: z.string().max(512),
+  version: z.string().max(32),
   moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
   content: authoredVictoryModuleContentSchema
 });

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -1191,9 +1191,9 @@ export const authoredModuleValidationSchema = objectSchema({
 export type AuthoredModuleValidation = z.infer<typeof authoredModuleValidationSchema>;
 
 export const authoredVictoryObjectiveBaseSchema = objectSchema({
-  id: z.string(),
-  title: z.string(),
-  description: z.string(),
+  id: z.string().max(64),
+  title: z.string().max(128),
+  description: z.string().max(512),
   enabled: z.boolean(),
   type: z.enum(AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES)
 });
@@ -1226,17 +1226,17 @@ export const authoredVictoryObjectiveSchema = z.discriminatedUnion("type", [
 export type AuthoredVictoryObjective = z.infer<typeof authoredVictoryObjectiveSchema>;
 
 export const authoredVictoryModuleContentSchema = objectSchema({
-  mapId: z.string(),
+  mapId: z.string().max(64),
   objectives: z.array(authoredVictoryObjectiveSchema)
 });
 
 export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
 
 export const authoredModuleInputSchema = objectSchema({
-  id: z.string().trim().min(1),
-  name: z.string(),
-  description: z.string(),
-  version: z.string(),
+  id: z.string().trim().min(1).max(64),
+  name: z.string().max(128),
+  description: z.string().max(512),
+  version: z.string().max(32),
   moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
   content: authoredVictoryModuleContentSchema
 });

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.032";
+export const appVersion = "0.1.033";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Authored module schemas (authoredModuleInputSchema, authoredVictoryModuleContentSchema, and authoredVictoryObjectiveBaseSchema) lacked maximum length constraints on string fields like id, name, description, and version.
🎯 Impact: An attacker could send excessively large payloads to these schemas, potentially causing Denial of Service (DoS) through resource exhaustion or storage issues.
🔧 Fix: Added `.max()` constraints using Zod in `shared/runtime-validation.cts`.
- id, mapId: max 64 characters.
- name, title: max 128 characters.
- description: max 512 characters.
- version: max 32 characters.
✅ Verification: Created a temporary test case that verified these fields reject overly long strings. Ran `npm run test:all` and verified all 443 gameplay tests pass.

---
*PR created automatically by Jules for task [12274020457519882086](https://jules.google.com/task/12274020457519882086) started by @andreame-code*