### PR TITLE
🛡️ Sentinel: implement rate limiting for AI join endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Security hardening that relies on standard Node.js HTTP response methods like `res.removeHeader` can cause runtime errors in test suites where response objects are mocked without full API parity.
 **Learning:** When applying security headers at the global server level, defensive checks for method existence (e.g., `typeof res.removeHeader === 'function'`) ensure that security logic doesn't break gameplay or regression tests that use lightweight mocks. Additionally, HSTS must be applied conditionally (only over secure connections or in test environments) to align with RFC 6797 and maintain local development accessibility.
 **Prevention:** Always wrap non-standard or late-added response methods in defensive type checks and ensure HSTS application logic respects the connection's security state.
+
+## 2026-06-04 - Rate Limiting for Automated Mutation Endpoints
+**Vulnerability:** The AI join endpoint (/api/ai/join) was authenticated but lacked rate limiting, making it susceptible to automated lobby-filling and resource exhaustion by authenticated users.
+**Learning:** Even internal-facing or "helper" mutation endpoints must implement rate limiting to prevent abuse from compromised accounts or buggy client implementations. Reusing the existing AuthAttemptThrottle with dedicated scopes provides a consistent protection layer across the API boundary.
+**Prevention:** Audit all state-mutating endpoints and ensure they are covered by the application's throttling infrastructure with appropriate scopes and limits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.033 - 2026-06-04
+
+- Implemented rate limiting for the AI join endpoint to mitigate automated lobby-filling and resource exhaustion.
+
 ## 0.1.032 - 2026-05-19
 
 - Hardened password hashing and verification by migrating to asynchronous non-blocking crypto operations.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "login" | "register";
+type AuthThrottleScope = "account" | "login" | "register" | "ai_join";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -53,6 +53,13 @@ type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
 
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordFailure(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordSuccess(key: Record<string, unknown>): void;
+};
+
 const {
   aiJoinRequestSchema,
   gameIdRequestSchema,
@@ -60,6 +67,8 @@ const {
   startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
 
 async function handleAiJoinRoute(
@@ -77,10 +86,33 @@ async function handleAiJoinRoute(
   broadcastGame: BroadcastGame,
   snapshotForState: SnapshotForState,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
+    return;
+  }
+
+  const throttleKey = createAuthThrottleKey("ai_join", req, authContext.user.username);
+  const throttleDecision = authAttemptThrottle?.recordAttempt(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+    sendLocalizedError(
+      res,
+      429,
+      {
+        error: "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+        errorKey: "auth.throttle.tooManyAttempts",
+        errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        code: "AUTH_RATE_LIMITED"
+      },
+      "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+      "auth.throttle.tooManyAttempts",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+      "AUTH_RATE_LIMITED",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+    );
     return;
   }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1600,7 +1600,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForState,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7252,6 +7252,46 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
   });
 });
 
+register("API /api/ai/join applica il rate limiting dopo 5 tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const session = await createAuthenticatedSession(baseUrl, uniqueName("ai_rate_limit"));
+    const ownerHeaders = authHeaders(session.sessionToken);
+
+    // Initial game creation
+    const created = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: ownerHeaders,
+      body: JSON.stringify({ name: "AI Rate Limit Match" })
+    });
+    assert.equal(created.status, 201);
+    const createdPayload: any = await readJson(created);
+
+    // Record 4 attempts (limit is 5)
+    // We don't care if they succeed or fail (e.g. lobby full), just that they are recorded.
+    for (let i = 1; i <= 4; i++) {
+      const res = await fetch(baseUrl + "/api/ai/join", {
+        method: "POST",
+        headers: ownerHeaders,
+        body: JSON.stringify({ name: `AI ${i}`, gameId: createdPayload.game.id })
+      });
+      // status will be 201 (Joined) or 400 (Lobby full) depending on capacity
+      assert.ok([201, 400].includes(res.status));
+    }
+
+    // 5th attempt should be rate limited
+    const limitedRes = await fetch(baseUrl + "/api/ai/join", {
+      method: "POST",
+      headers: ownerHeaders,
+      body: JSON.stringify({ name: "AI 5", gameId: createdPayload.game.id })
+    });
+
+    assert.equal(limitedRes.status, 429);
+    assert.equal(limitedRes.headers.get("retry-after"), "60");
+    const payload: any = await limitedRes.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 async function run() {
   let failures = 0;
   for (const test of tests) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.032";
+export const appVersion = "0.1.033";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
### 🛡️ Sentinel: Security Enhancement - AI Join Rate Limiting

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The `/api/ai/join` endpoint was authenticated but lacked rate limiting, allowing authenticated users to flood lobbies with AI bots, potentially causing resource exhaustion or disrupting game setup flows.
**🎯 Impact:** Automated abuse could lead to lobby exhaustion or service degradation for other users.
**🔧 Fix:** Integrated the existing `AuthAttemptThrottle` infrastructure into the `handleAiJoinRoute`. The endpoint now enforces a rate limit (default 5 attempts per window) and returns a `429 Too Many Requests` response with a `Retry-After` header when the limit is exceeded.
**✅ Verification:** 
- Added a dedicated regression test in `scripts/run-tests.cts` that verifies the 5th consecutive attempt is blocked with a 429 status code.
- Ran the full test suite (`npm run test:all`), which passed successfully (162 integration tests, 443 gameplay tests).
- Verified TypeScript compilation with `npm run build:ts`.
- Adheres to CI requirements for version increments and changelog updates.

---
*PR created automatically by Jules for task [5009731755204781026](https://jules.google.com/task/5009731755204781026) started by @andreame-code*