### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to AI join endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.033 - 2026-05-19
+
+- Implemented rate limiting on the AI join endpoint to prevent automated lobby-filling and resource exhaustion.
+
 ## 0.1.032 - 2026-05-19
 
 - Hardened password hashing and verification by migrating to asynchronous non-blocking crypto operations.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "login" | "register";
+type AuthThrottleScope = "account" | "login" | "register" | "ai_join";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -53,6 +53,11 @@ type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
 
+type AuthAttemptThrottle = {
+  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
+};
+
 const {
   aiJoinRequestSchema,
   gameIdRequestSchema,
@@ -60,6 +65,8 @@ const {
   startGameRequestSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 const { persistBroadcastAndSendMutation, sendVersionConflict } = require("./game-mutation.cjs");
 
 async function handleAiJoinRoute(
@@ -77,10 +84,33 @@ async function handleAiJoinRoute(
   broadcastGame: BroadcastGame,
   snapshotForState: SnapshotForState,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
+    return;
+  }
+
+  const throttleKey = createAuthThrottleKey("ai_join", req, authContext.user.username);
+  const throttleDecision = authAttemptThrottle?.recordAttempt(throttleKey);
+  if (throttleDecision && !throttleDecision.allowed) {
+    setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+    sendLocalizedError(
+      res,
+      429,
+      {
+        error: "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+        errorKey: "auth.throttle.tooManyAttempts",
+        errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        code: "AUTH_RATE_LIMITED"
+      },
+      "Troppi tentativi di aggiunta AI. Riprova piu tardi.",
+      "auth.throttle.tooManyAttempts",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+      "AUTH_RATE_LIMITED",
+      { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+    );
     return;
   }
 

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1600,7 +1600,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForState,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7252,6 +7252,42 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
   });
 });
 
+register("API ai join applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const owner = await createAuthenticatedSession(baseUrl, uniqueName("ai_limiter"));
+
+    const created = await fetch(baseUrl + "/api/games", {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ name: "AI Limit Match", totalPlayers: 4 })
+    });
+    assert.equal(created.status, 201);
+
+    // Default limit is 5 attempts. The first 4 should pass (201 Created or 400 Lobby full).
+    // Note: AI join recordings happen before the lobby capacity check in the handler.
+    for (let i = 0; i < 4; i++) {
+      const res = await fetch(baseUrl + "/api/ai/join", {
+        method: "POST",
+        headers: authHeaders(owner.sessionToken),
+        body: JSON.stringify({ name: `CPU ${i}` })
+      });
+      // Accept either 201 (Joined) or 400 (Lobby full) as both are valid pre-throttle responses.
+      assert.ok(res.status === 201 || res.status === 400);
+    }
+
+    const limitedRes = await fetch(baseUrl + "/api/ai/join", {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ name: "CPU Limited" })
+    });
+
+    assert.equal(limitedRes.status, 429);
+    assert.equal(limitedRes.headers.get("retry-after"), "60");
+    const payload: any = await readJson(limitedRes);
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 async function run() {
   let failures = 0;
   for (const test of tests) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.032";
+export const appVersion = "0.1.033";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The AI join endpoint was not rate-limited, allowing authenticated users to programmatically fill game lobbies with AI players.
🎯 Impact: Potential resource exhaustion and disruption of game matchmaking by automated lobby-filling.
🔧 Fix: Integrated the existing `AuthAttemptThrottle` into the AI join route with a dedicated `ai_join` scope.
✅ Verification: Added a regression test in `scripts/run-tests.cts` that verifies a 429 status code is returned after 5 attempts. All existing tests passed.

---
*PR created automatically by Jules for task [10334255114154397635](https://jules.google.com/task/10334255114154397635) started by @andreame-code*