### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting for game creation and joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.047 - 2026-06-05
+
+- Added rate limiting for game creation and joining requests to mitigate automated lobby creation and spam.
+
 ## 0.1.046 - 2026-06-05
 
 - Added Linux Playwright visual baselines and stabilized E2E card trade and attack dice assertions for local CI-style runs.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,6 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "ai_join" | "login" | "register";
+type AuthThrottleScope = "account" | "ai_join" | "game_create" | "game_join" | "login" | "register";
 
 type AuthThrottleBucket = {
   attempts: number;
@@ -8,16 +8,23 @@ type AuthThrottleBucket = {
   lockedUntil: number;
 };
 
-type AuthThrottleKey = {
+export type AuthThrottleKey = {
   scope: AuthThrottleScope;
   ip: string;
   username: string;
 };
 
-type AuthThrottleDecision = {
+export type AuthThrottleDecision = {
   allowed: boolean;
   retryAfterSeconds: number;
 };
+
+export interface AuthAttemptThrottle {
+  check(key: AuthThrottleKey): AuthThrottleDecision;
+  recordAttempt(key: AuthThrottleKey): AuthThrottleDecision;
+  recordFailure(key: AuthThrottleKey): AuthThrottleDecision;
+  recordSuccess(key: AuthThrottleKey): void;
+}
 
 type AuthAttemptThrottleOptions = {
   cleanupIntervalMs?: number;
@@ -109,7 +116,7 @@ function createAuthThrottleKey(
   };
 }
 
-function createAuthAttemptThrottle(options: AuthAttemptThrottleOptions = {}) {
+function createAuthAttemptThrottle(options: AuthAttemptThrottleOptions = {}): AuthAttemptThrottle {
   const buckets = new Map<string, AuthThrottleBucket>();
   const maxAttempts = options.maxAttempts || DEFAULT_MAX_ATTEMPTS;
   const maxIpAttempts = options.maxIpAttempts || DEFAULT_MAX_IP_ATTEMPTS;

--- a/backend/routes/account.cts
+++ b/backend/routes/account.cts
@@ -41,11 +41,7 @@ interface AccountRouteDeps {
       theme: string
     ): Promise<{ preferences?: { theme?: string | null } } | null>;
   };
-  authAttemptThrottle?: {
-    check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-    recordFailure(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-    recordSuccess(key: Record<string, unknown>): void;
-  };
+  authAttemptThrottle?: import("../auth-attempt-throttle.cts").AuthAttemptThrottle;
   playerProfiles: {
     getPlayerProfile(username: string): Promise<Record<string, unknown>> | Record<string, unknown>;
   };

--- a/backend/routes/game-management.cts
+++ b/backend/routes/game-management.cts
@@ -47,6 +47,7 @@ type SnapshotForUser = (
 ) => unknown;
 type ResumeAiTurnsForRead = (gameContext: any) => Promise<any>;
 type ResolvePlayerForUser = (state: any, user: unknown) => any;
+type AuthAttemptThrottle = import("../auth-attempt-throttle.cts").AuthAttemptThrottle;
 
 const {
   createGameRequestSchema,
@@ -55,6 +56,8 @@ const {
   gameMutationResponseSchema
 } = require("../../shared/runtime-validation.cjs");
 const { parseRequestOrSendError, sendValidatedJson } = require("../route-validation.cjs");
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 
 async function handleCreateGameRoute(
   req: unknown,
@@ -70,7 +73,8 @@ async function handleCreateGameRoute(
   broadcastGame: BroadcastGame,
   snapshot: Snapshot,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
@@ -87,7 +91,36 @@ async function handleCreateGameRoute(
     return;
   }
 
+  const throttleKey = authAttemptThrottle
+    ? createAuthThrottleKey("game_create", req, authContext.user.username)
+    : null;
+  if (authAttemptThrottle && throttleKey) {
+    const throttleDecision = authAttemptThrottle.check(throttleKey);
+    if (!throttleDecision.allowed) {
+      setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+      sendLocalizedError(
+        res,
+        429,
+        {
+          error: "Troppi tentativi di creazione partita. Riprova piu tardi.",
+          errorKey: "auth.throttle.tooManyAttempts",
+          errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+          code: "AUTH_RATE_LIMITED"
+        },
+        "Troppi tentativi di creazione partita. Riprova piu tardi.",
+        "auth.throttle.tooManyAttempts",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        "AUTH_RATE_LIMITED",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+      );
+      return;
+    }
+  }
+
   try {
+    if (authAttemptThrottle && throttleKey) {
+      authAttemptThrottle.recordAttempt(throttleKey);
+    }
     const policy = authorize("game:create", { user: authContext.user });
     const configured = await createConfiguredInitialState(parsedBody);
     const creatorJoin = addPlayer(configured.state, authContext.user.username, {

--- a/backend/routes/game-management.cts
+++ b/backend/routes/game-management.cts
@@ -102,12 +102,12 @@ async function handleCreateGameRoute(
         res,
         429,
         {
-          error: "Troppi tentativi di creazione partita. Riprova piu tardi.",
+          error: "Troppi tentativi di creazione partita. Riprova più tardi.",
           errorKey: "auth.throttle.tooManyAttempts",
           errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
           code: "AUTH_RATE_LIMITED"
         },
-        "Troppi tentativi di creazione partita. Riprova piu tardi.",
+        "Troppi tentativi di creazione partita. Riprova più tardi.",
         "auth.throttle.tooManyAttempts",
         { retryAfterSeconds: throttleDecision.retryAfterSeconds },
         "AUTH_RATE_LIMITED",

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -52,10 +52,7 @@ type GetGame = (gameId: string | null) => Promise<any>;
 type GetPlayer = (state: any, playerId: string) => any;
 type PlayerBelongsToUser = (player: any, user: AuthContext["user"]) => boolean;
 type StartGame = (state: any) => any;
-type AuthAttemptThrottle = {
-  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-};
+type AuthAttemptThrottle = import("../auth-attempt-throttle.cts").AuthAttemptThrottle;
 
 const {
   aiJoinRequestSchema,
@@ -198,7 +195,8 @@ async function handleJoinRoute(
   snapshotForState: SnapshotForState,
   publicUser: (user: unknown) => unknown,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
@@ -226,6 +224,33 @@ async function handleJoinRoute(
   );
   if (!parsedBody) {
     return;
+  }
+
+  const throttleKey = authAttemptThrottle
+    ? createAuthThrottleKey("game_join", req, authContext.user.username)
+    : null;
+  if (authAttemptThrottle && throttleKey) {
+    const throttleDecision = authAttemptThrottle.check(throttleKey);
+    if (!throttleDecision.allowed) {
+      setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+      sendLocalizedError(
+        res,
+        429,
+        {
+          error: "Troppi tentativi di partecipazione partita. Riprova piu tardi.",
+          errorKey: "auth.throttle.tooManyAttempts",
+          errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+          code: "AUTH_RATE_LIMITED"
+        },
+        "Troppi tentativi di partecipazione partita. Riprova piu tardi.",
+        "auth.throttle.tooManyAttempts",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        "AUTH_RATE_LIMITED",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+      );
+      return;
+    }
+    authAttemptThrottle.recordAttempt(throttleKey);
   }
 
   const gameContext = await loadGameContext(parsedBody.gameId);

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -237,12 +237,12 @@ async function handleJoinRoute(
         res,
         429,
         {
-          error: "Troppi tentativi di partecipazione partita. Riprova piu tardi.",
+          error: "Troppi tentativi di partecipazione partita. Riprova più tardi.",
           errorKey: "auth.throttle.tooManyAttempts",
           errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
           code: "AUTH_RATE_LIMITED"
         },
-        "Troppi tentativi di partecipazione partita. Riprova piu tardi.",
+        "Troppi tentativi di partecipazione partita. Riprova più tardi.",
         "auth.throttle.tooManyAttempts",
         { retryAfterSeconds: throttleDecision.retryAfterSeconds },
         "AUTH_RATE_LIMITED",

--- a/backend/routes/password-auth.cts
+++ b/backend/routes/password-auth.cts
@@ -29,12 +29,7 @@ type AuthStore = {
 type ExtractSessionToken = (req: unknown, body?: Record<string, unknown>) => string | null;
 type BuildSessionCookie = (req: unknown, sessionToken: string) => string;
 type ClearSessionCookie = (req: unknown) => string;
-type AuthAttemptThrottle = {
-  check(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-  recordAttempt(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-  recordFailure(key: Record<string, unknown>): { allowed: boolean; retryAfterSeconds: number };
-  recordSuccess(key: Record<string, unknown>): void;
-};
+type AuthAttemptThrottle = import("../auth-attempt-throttle.cts").AuthAttemptThrottle;
 const {
   loginRequestSchema,
   loginResponseSchema,

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1431,7 +1431,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshot,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }
@@ -1627,7 +1628,8 @@ function createApp(options: CreateAppOptions = {}) {
         snapshotForState,
         auth.publicUser,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -7286,6 +7286,65 @@ register("API registration applica il rate limiting dopo troppi tentativi", asyn
   });
 });
 
+register("API game creation applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const session = await createAuthenticatedSession(baseUrl, uniqueName("create_limit"));
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await fetch(`${baseUrl}/api/games`, {
+        method: "POST",
+        headers: authHeaders(session.sessionToken),
+        body: JSON.stringify({ name: `Game ${index}` })
+      });
+      assert.equal(response.status, 201);
+    }
+
+    const limitedResponse = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: authHeaders(session.sessionToken),
+      body: JSON.stringify({ name: "Game Limited" })
+    });
+    assert.equal(limitedResponse.status, 429);
+    assert.equal(limitedResponse.headers.get("retry-after"), "60");
+    const payload: any = await limitedResponse.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
+register("API game join applica il rate limiting dopo troppi tentativi", async () => {
+  await withServer(async (baseUrl) => {
+    const owner = await createAuthenticatedSession(baseUrl, uniqueName("join_limit_host"));
+    const opponent = await createAuthenticatedSession(baseUrl, uniqueName("join_limit_opp"));
+
+    const created = await fetch(`${baseUrl}/api/games`, {
+      method: "POST",
+      headers: authHeaders(owner.sessionToken),
+      body: JSON.stringify({ name: "Join Limit Match" })
+    });
+    const { game } = (await created.json()) as { game: { id: string } };
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await fetch(`${baseUrl}/api/join`, {
+        method: "POST",
+        headers: authHeaders(opponent.sessionToken),
+        body: JSON.stringify({ gameId: game.id })
+      });
+      // 201 on first join, 200 on rejoin
+      assert.ok(response.status === 201 || response.status === 200);
+    }
+
+    const limitedResponse = await fetch(`${baseUrl}/api/join`, {
+      method: "POST",
+      headers: authHeaders(opponent.sessionToken),
+      body: JSON.stringify({ gameId: game.id })
+    });
+    assert.equal(limitedResponse.status, 429);
+    assert.equal(limitedResponse.headers.get("retry-after"), "60");
+    const payload: any = await limitedResponse.json();
+    assert.equal(payload.code, "AUTH_RATE_LIMITED");
+  });
+});
+
 async function run() {
   let failures = 0;
   for (const test of tests) {

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -222,10 +222,11 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.2",
+    version: "1.0.3",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",
+      "backend/routes/game-management.cts",
       "backend/routes/game-setup.cts",
       "backend/routes/setup.cts"
     ]

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.046";
+export const appVersion = "0.1.047";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The game creation and joining endpoints were not rate-limited, allowing for automated lobby spam and potential resource exhaustion DoS attacks.
🎯 Impact: An attacker could programmatically create thousands of game lobbies or repeatedly join/leave games, cluttering the UI for legitimate users and putting unnecessary load on the datastore and server.
🔧 Fix: Implemented rate limiting using the existing `AuthAttemptThrottle` system for the `/api/games` (POST) and `/api/join` endpoints. Centralized the `AuthAttemptThrottle` interface and unified its usage across the codebase.
✅ Verification: Added new integration tests in `scripts/run-tests.cts` that verify the 429 status code and `Retry-After` header after exceeding the attempt limit for both creation and joining. Ran `npm test` and all 164 tests passed.

---
*PR created automatically by Jules for task [13985728257285607875](https://jules.google.com/task/13985728257285607875) started by @andreame-code*