### PR TITLE
🛡️ Sentinel: MEDIUM improvement - Add rate limiting to game start and trade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.050 - 2025-06-07
+
+- Added rate limiting for game-starting and card-trading endpoints to mitigate automation and spam.
+- Hardened the `game_start` and `game_trade` scopes with standard attempt-based lockout policies via `AuthAttemptThrottle`.
+
 ## 0.1.049 - 2026-06-06
 
 - Hardened API request parsing by enforcing strict `Content-Type: application/json` for mutation requests (POST, PUT, PATCH).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
-## 0.1.050 - 2025-06-07
+## 0.1.050 - 2026-06-22
 
 - Added rate limiting for game-starting and card-trading endpoints to mitigate automation and spam.
 - Hardened the `game_start` and `game_trade` scopes with standard attempt-based lockout policies via `AuthAttemptThrottle`.

--- a/backend/auth-attempt-throttle.cts
+++ b/backend/auth-attempt-throttle.cts
@@ -1,6 +1,14 @@
 type HeaderValue = string | string[] | undefined;
 
-type AuthThrottleScope = "account" | "ai_join" | "game_create" | "game_join" | "login" | "register";
+type AuthThrottleScope =
+  | "account"
+  | "ai_join"
+  | "game_create"
+  | "game_join"
+  | "game_start"
+  | "game_trade"
+  | "login"
+  | "register";
 
 type AuthThrottleBucket = {
   attempts: number;

--- a/backend/routes/game-cards.cts
+++ b/backend/routes/game-cards.cts
@@ -51,6 +51,10 @@ type SnapshotForUser = (
   gameName: string | null,
   user: unknown
 ) => unknown;
+type AuthAttemptThrottle = import("../auth-attempt-throttle.cts").AuthAttemptThrottle;
+
+const { createAuthThrottleKey } = require("../auth-attempt-throttle.cjs");
+const { setRetryAfterHeader } = require("../http-response.cjs");
 
 async function handleCardsTradeRoute(
   req: unknown,
@@ -67,11 +71,42 @@ async function handleCardsTradeRoute(
   broadcastGame: BroadcastGame,
   snapshotForUser: SnapshotForUser,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
     return;
+  }
+
+  if (authAttemptThrottle) {
+    const throttleKey = createAuthThrottleKey(
+      "game_trade",
+      req,
+      authContext.user.id || authContext.user.username
+    );
+    const throttleDecision = authAttemptThrottle.check(throttleKey);
+    if (!throttleDecision.allowed) {
+      setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+      sendLocalizedError(
+        res,
+        429,
+        {
+          error: "Troppi tentativi di scambio carte. Riprova piu tardi.",
+          errorKey: "auth.throttle.tooManyAttempts",
+          errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+          code: "AUTH_RATE_LIMITED"
+        },
+        "Troppi tentativi di scambio carte. Riprova piu tardi.",
+        "auth.throttle.tooManyAttempts",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        "AUTH_RATE_LIMITED",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+      );
+      return;
+    }
+
+    authAttemptThrottle.recordAttempt(throttleKey);
   }
 
   const preflightExpectedVersion = readExpectedVersionOrSendError(

--- a/backend/routes/game-setup.cts
+++ b/backend/routes/game-setup.cts
@@ -307,11 +307,42 @@ async function handleStartRoute(
   broadcastGame: BroadcastGame,
   snapshotForUser: SnapshotForUser,
   sendJson: SendJson,
-  sendLocalizedError: SendLocalizedError
+  sendLocalizedError: SendLocalizedError,
+  authAttemptThrottle?: AuthAttemptThrottle
 ): Promise<void> {
   const authContext = await requireAuth(req, res, body);
   if (!authContext) {
     return;
+  }
+
+  if (authAttemptThrottle) {
+    const throttleKey = createAuthThrottleKey(
+      "game_start",
+      req,
+      authContext.user.id || authContext.user.username
+    );
+    const throttleDecision = authAttemptThrottle.check(throttleKey);
+    if (!throttleDecision.allowed) {
+      setRetryAfterHeader(res, throttleDecision.retryAfterSeconds);
+      sendLocalizedError(
+        res,
+        429,
+        {
+          error: "Troppi tentativi di avvio partita. Riprova piu tardi.",
+          errorKey: "auth.throttle.tooManyAttempts",
+          errorParams: { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+          code: "AUTH_RATE_LIMITED"
+        },
+        "Troppi tentativi di avvio partita. Riprova piu tardi.",
+        "auth.throttle.tooManyAttempts",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds },
+        "AUTH_RATE_LIMITED",
+        { retryAfterSeconds: throttleDecision.retryAfterSeconds }
+      );
+      return;
+    }
+
+    authAttemptThrottle.recordAttempt(throttleKey);
   }
 
   const resolvedBody = {

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -1669,7 +1669,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForUser,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }
@@ -1693,7 +1694,8 @@ function createApp(options: CreateAppOptions = {}) {
         broadcastGame,
         snapshotForUser,
         sendJson,
-        sendLocalizedError
+        sendLocalizedError,
+        authAttemptThrottle
       );
       return;
     }

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -160,7 +160,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "card-rule-sets",
     name: "Card Rule Sets",
     kind: "rule-family",
-    version: "1.1.0",
+    version: "1.1.1",
     description: "Card deck, trade-in, and route-facing card rule-set behavior.",
     ownerPaths: ["shared/cards.cts", "backend/routes/game-cards.cts"]
   },
@@ -222,7 +222,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "setup-flow",
     name: "Setup Flow",
     kind: "gameplay",
-    version: "1.0.3",
+    version: "1.0.4",
     description: "New-game setup, setup defaults, profiles, and setup route behavior.",
     ownerPaths: [
       "backend/engine/game-setup.cts",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.049";
+export const appVersion = "0.1.050";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing rate limiting on sensitive game actions (`/api/start` and `/api/cards/trade`).
🎯 Impact: These endpoints were susceptible to automated abuse or spam, allowing a user to repeatedly attempt to start games or trade cards without any per-user or per-IP throttling.
🔧 Fix: Integrated the existing `AuthAttemptThrottle` mechanism into `handleStartRoute` and `handleCardsTradeRoute`. Added specific scopes for these actions to ensure standard attempt-based lockout policies are applied.
✅ Verification: Verified the implementation by running the full test suite (`npm run test:all`), which includes 476 gameplay tests and core integration tests. All tests passed, ensuring no regressions in the game logic or existing rate-limiting behavior.

---
*PR created automatically by Jules for task [12770793346905947770](https://jules.google.com/task/12770793346905947770) started by @andreame-code*