### PR TITLE
Add authored map editor and runtime maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.052 - 2026-08-05
+
+- Added map authoring to the admin Content Studio with persisted drafts, structured territory and continent editing, live validation, and publish/disable lifecycle controls.
+- Integrated published authored maps into runtime game options and game creation while preserving existing victory-objective modules and blocking unsafe map disable operations when referenced.
+- Added regression coverage for map topology validation, API persistence, UI authoring, runtime catalog exposure, and game creation.
+
 ## 0.1.051 - 2026-08-05
 
 - Hardened sensitive game state transitions (starting a game and trading cards) with rate limiting to mitigate spam and automated abuse.

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -1253,10 +1253,8 @@ function createAdminConsole(options: AdminConsoleOptions) {
 
   async function authoredModuleDisableGuard(moduleId: string): Promise<void> {
     const config = await loadConfigRecord();
-    if (config.defaults.victoryRuleSetId === moduleId) {
-      throw new Error(
-        `Victory objective module "${moduleId}" is still referenced by admin defaults.`
-      );
+    if (config.defaults.victoryRuleSetId === moduleId || config.defaults.mapId === moduleId) {
+      throw new Error(`Authored module "${moduleId}" is still referenced by admin defaults.`);
     }
 
     const rawGames = asArray(await maybeResolve(options.gameSessions.datastore.listGames()));
@@ -1266,13 +1264,15 @@ function createAdminConsole(options: AdminConsoleOptions) {
       }
 
       const gameConfig = ensureGameConfig(game?.state || {});
-      return asNonEmptyString(gameConfig.victoryRuleSetId) === moduleId;
+      return (
+        asNonEmptyString(gameConfig.victoryRuleSetId) === moduleId ||
+        asNonEmptyString(gameConfig.mapId) === moduleId ||
+        asNonEmptyString(game?.state?.mapId) === moduleId
+      );
     });
 
     if (activeReference) {
-      throw new Error(
-        `Victory objective module "${moduleId}" is still referenced by an active game.`
-      );
+      throw new Error(`Authored module "${moduleId}" is still referenced by an active game.`);
     }
   }
 

--- a/backend/authored-modules.cts
+++ b/backend/authored-modules.cts
@@ -3,10 +3,12 @@ const {
   authoredModuleSchema
 } = require("../shared/runtime-validation.cjs");
 const { registeredMaps } = require("../shared/maps/index.cjs");
+const { buildContinentDefinition, buildMapDefinition } = require("../shared/typed-map-data.cjs");
 const { listVictoryRuleSets } = require("../shared/victory-rule-sets.cjs");
 
 import type {
   AuthoredMapOption,
+  AuthoredMapModuleRuntime,
   AuthoredModule,
   AuthoredModuleInput,
   AuthoredModulePreview,
@@ -105,6 +107,9 @@ const builtInVictoryRuleSetIds = new Set(
     .map((entry: { id?: unknown }) => normalizeString(entry?.id))
     .filter(isNonEmptyString)
 );
+const builtInMapIds = new Set(
+  registeredMaps.map((entry: SupportedMap) => normalizeString(entry?.id)).filter(isNonEmptyString)
+);
 
 function buildMapOption(map: SupportedMap): AuthoredMapOption {
   const territories = Array.isArray(map?.territories) ? map.territories : [];
@@ -166,6 +171,12 @@ function objectiveSummary(objective: AuthoredVictoryObjective, map: SupportedMap
 }
 
 function moduleSummaryText(moduleEntry: AuthoredModule, map: SupportedMap | null): string {
+  if (moduleEntry.moduleType === "map") {
+    const territoryCount = moduleEntry.content.territories.length;
+    const continentCount = moduleEntry.content.continents.length;
+    return `${moduleEntry.name || moduleEntry.id || "Custom map"}: ${territoryCount} territories across ${continentCount} continents.`;
+  }
+
   const enabledObjectives = (moduleEntry.content.objectives || []).filter(
     (objective) => objective.enabled
   );
@@ -184,11 +195,53 @@ function buildPreview(
   moduleEntry: AuthoredModule,
   map: SupportedMap | null
 ): AuthoredModulePreview {
+  if (moduleEntry.moduleType === "map") {
+    const detailSummaries = [
+      `${moduleEntry.content.territories.length} territories`,
+      `${moduleEntry.content.continents.length} continents`,
+      `${moduleEntry.content.territories.reduce((total, territory) => total + territory.neighbors.length, 0) / 2} borders`
+    ];
+    return {
+      summary: moduleSummaryText(moduleEntry, map),
+      objectiveSummaries: [],
+      detailSummaries
+    };
+  }
+
   return {
     summary: moduleSummaryText(moduleEntry, map),
     objectiveSummaries: (moduleEntry.content.objectives || []).map((objective) =>
       objectiveSummary(objective as AuthoredVictoryObjective, map)
-    )
+    ),
+    detailSummaries: []
+  };
+}
+
+function buildAuthoredSupportedMap(moduleEntry: AuthoredModule): SupportedMap {
+  if (moduleEntry.moduleType !== "map") {
+    throw new Error(`Authored module "${moduleEntry.id}" is not a map module.`);
+  }
+
+  const source = `authored:${moduleEntry.id}`;
+  const mapDefinition = buildMapDefinition(source, moduleEntry.content.territories);
+  const continentDefinition = buildContinentDefinition(source, moduleEntry.content.continents, {
+    validTerritoryIds: mapDefinition.territories
+      .map((entry: { territory: { id?: string | null } }) => entry.territory.id)
+      .filter((territoryId: unknown): territoryId is string => isNonEmptyString(territoryId))
+  });
+
+  return {
+    id: moduleEntry.id,
+    name: moduleEntry.name,
+    territories: mapDefinition.territories.map(
+      (entry: { territory: SupportedMap["territories"][number] }) => entry.territory
+    ),
+    positions: mapDefinition.positions,
+    continents: continentDefinition.continents,
+    mapDefinition: {
+      ...mapDefinition,
+      continents: continentDefinition.continents
+    }
   };
 }
 
@@ -196,6 +249,25 @@ function buildRuntime(
   moduleEntry: AuthoredModule,
   map: SupportedMap | null
 ): AuthoredModuleRuntime {
+  if (moduleEntry.moduleType === "map") {
+    const runtime: AuthoredMapModuleRuntime = {
+      id: moduleEntry.id,
+      name: moduleEntry.name,
+      description: moduleEntry.description,
+      version: moduleEntry.version,
+      moduleType: "map",
+      kind: "authored-map",
+      map: {
+        id: moduleEntry.id,
+        name: moduleEntry.name,
+        territoryRecords: clone(moduleEntry.content.territories),
+        continentRecords: clone(moduleEntry.content.continents)
+      },
+      preview: buildPreview(moduleEntry, map)
+    };
+    return runtime;
+  }
+
   const mapOption = map ? buildMapOption(map) : null;
 
   return {
@@ -256,6 +328,257 @@ function buildRuntime(
   };
 }
 
+function validateModuleMetadata(
+  moduleEntry: AuthoredModule,
+  errors: AuthoredModuleValidationIssue[]
+): void {
+  const moduleId = normalizeString(moduleEntry.id);
+  if (!moduleId) {
+    errors.push(issue("required-id", "id", "Module id is required."));
+  } else if (!ID_PATTERN.test(moduleId)) {
+    errors.push(
+      issue(
+        "invalid-id",
+        "id",
+        "Use letters, numbers, dashes, underscores, or dots for the module id."
+      )
+    );
+  } else if (
+    (moduleEntry.moduleType === "victory-objectives" && builtInVictoryRuleSetIds.has(moduleId)) ||
+    (moduleEntry.moduleType === "map" && builtInMapIds.has(moduleId))
+  ) {
+    errors.push(
+      issue(
+        "reserved-module-id",
+        "id",
+        `Module id "${moduleId}" is already used by built-in content.`
+      )
+    );
+  }
+
+  if (!normalizeString(moduleEntry.name)) {
+    errors.push(issue("required-name", "name", "Module name is required."));
+  }
+
+  if (!normalizeString(moduleEntry.description)) {
+    errors.push(issue("required-description", "description", "Module description is required."));
+  }
+
+  if (!normalizeString(moduleEntry.version)) {
+    errors.push(issue("required-version", "version", "Module version is required."));
+  }
+}
+
+function validateAuthoredMap(
+  moduleEntry: Extract<AuthoredModule, { moduleType: "map" }>,
+  errors: AuthoredModuleValidationIssue[]
+): SupportedMap | null {
+  const territories = moduleEntry.content.territories;
+  const continents = moduleEntry.content.continents;
+  const territoryIds = new Set<string>();
+  const continentIds = new Set<string>();
+
+  if (territories.length < 2) {
+    errors.push(
+      issue("required-territories", "content.territories", "Add at least two territories.")
+    );
+  }
+  if (!continents.length) {
+    errors.push(issue("required-continents", "content.continents", "Add at least one continent."));
+  }
+
+  territories.forEach((territory, index) => {
+    const basePath = `content.territories.${index}`;
+    const territoryId = normalizeString(territory.id);
+    if (!territoryId) {
+      errors.push(issue("required-territory-id", `${basePath}.id`, "Territory id is required."));
+    } else if (!ID_PATTERN.test(territoryId)) {
+      errors.push(
+        issue("invalid-territory-id", `${basePath}.id`, "Territory id has invalid characters.")
+      );
+    } else if (territoryIds.has(territoryId)) {
+      errors.push(
+        issue(
+          "duplicate-territory-id",
+          `${basePath}.id`,
+          `Territory id "${territoryId}" is already used.`
+        )
+      );
+    } else {
+      territoryIds.add(territoryId);
+    }
+
+    if (!normalizeString(territory.name)) {
+      errors.push(
+        issue("required-territory-name", `${basePath}.name`, "Territory name is required.")
+      );
+    }
+    if (!normalizeString(territory.continentId)) {
+      errors.push(
+        issue(
+          "required-territory-continent",
+          `${basePath}.continentId`,
+          "Assign the territory to a continent."
+        )
+      );
+    }
+    if (!Number.isFinite(territory.x) || territory.x < 0 || territory.x > 1) {
+      errors.push(issue("invalid-territory-x", `${basePath}.x`, "X must be between 0 and 1."));
+    }
+    if (!Number.isFinite(territory.y) || territory.y < 0 || territory.y > 1) {
+      errors.push(issue("invalid-territory-y", `${basePath}.y`, "Y must be between 0 and 1."));
+    }
+    if (!territory.neighbors.length) {
+      errors.push(
+        issue(
+          "required-neighbor",
+          `${basePath}.neighbors`,
+          "Add at least one neighboring territory."
+        )
+      );
+    }
+  });
+
+  continents.forEach((continent, index) => {
+    const basePath = `content.continents.${index}`;
+    const continentId = normalizeString(continent.id);
+    if (!continentId) {
+      errors.push(issue("required-continent-id", `${basePath}.id`, "Continent id is required."));
+    } else if (!ID_PATTERN.test(continentId)) {
+      errors.push(
+        issue("invalid-continent-id", `${basePath}.id`, "Continent id has invalid characters.")
+      );
+    } else if (continentIds.has(continentId)) {
+      errors.push(
+        issue(
+          "duplicate-continent-id",
+          `${basePath}.id`,
+          `Continent id "${continentId}" is already used.`
+        )
+      );
+    } else {
+      continentIds.add(continentId);
+    }
+
+    if (!normalizeString(continent.name)) {
+      errors.push(
+        issue("required-continent-name", `${basePath}.name`, "Continent name is required.")
+      );
+    }
+    if (!Number.isInteger(continent.bonus) || continent.bonus < 0) {
+      errors.push(
+        issue(
+          "invalid-continent-bonus",
+          `${basePath}.bonus`,
+          "Continent bonus must be a non-negative whole number."
+        )
+      );
+    }
+    if (!continent.territoryIds.length) {
+      errors.push(
+        issue(
+          "required-continent-territories",
+          `${basePath}.territoryIds`,
+          "Assign at least one territory to the continent."
+        )
+      );
+    }
+  });
+
+  territories.forEach((territory, index) => {
+    const continentId = normalizeString(territory.continentId);
+    if (continentId && !continentIds.has(continentId)) {
+      errors.push(
+        issue(
+          "unknown-territory-continent",
+          `content.territories.${index}.continentId`,
+          `Continent "${continentId}" does not exist.`
+        )
+      );
+    }
+
+    const owners = continents.filter((continent) => continent.territoryIds.includes(territory.id));
+    if (owners.length !== 1 || owners[0]?.id !== continentId) {
+      errors.push(
+        issue(
+          "inconsistent-continent-membership",
+          `content.territories.${index}.continentId`,
+          `Territory "${territory.id || index + 1}" must appear exactly once in its assigned continent.`
+        )
+      );
+    }
+  });
+
+  continents.forEach((continent, continentIndex) => {
+    const seenTerritories = new Set<string>();
+    continent.territoryIds.forEach((territoryId, territoryIndex) => {
+      const normalizedTerritoryId = normalizeString(territoryId);
+      const path = `content.continents.${continentIndex}.territoryIds.${territoryIndex}`;
+      if (!territoryIds.has(normalizedTerritoryId)) {
+        errors.push(
+          issue(
+            "unknown-continent-territory",
+            path,
+            `Territory "${normalizedTerritoryId}" does not exist.`
+          )
+        );
+      } else if (seenTerritories.has(normalizedTerritoryId)) {
+        errors.push(
+          issue(
+            "duplicate-continent-territory",
+            path,
+            `Territory "${normalizedTerritoryId}" is listed more than once.`
+          )
+        );
+      }
+      seenTerritories.add(normalizedTerritoryId);
+    });
+  });
+
+  if (errors.length) {
+    return null;
+  }
+
+  try {
+    const map = buildAuthoredSupportedMap(moduleEntry);
+    const visited = new Set<string>();
+    const queue = [map.territories[0]?.id].filter(isNonEmptyString);
+    while (queue.length) {
+      const territoryId = queue.shift() as string;
+      if (visited.has(territoryId)) {
+        continue;
+      }
+      visited.add(territoryId);
+      const territory = map.territories.find((entry) => entry.id === territoryId);
+      (territory?.neighbors || []).forEach((neighborId) => {
+        if (!visited.has(neighborId)) {
+          queue.push(neighborId);
+        }
+      });
+    }
+    if (visited.size !== map.territories.length) {
+      errors.push(
+        issue(
+          "disconnected-map",
+          "content.territories",
+          "All territories must form one connected map."
+        )
+      );
+      return null;
+    }
+    return map;
+  } catch (error: unknown) {
+    errors.push(
+      issue(
+        "invalid-map-graph",
+        "content.territories",
+        error instanceof Error ? error.message : String(error)
+      )
+    );
+    return null;
+  }
+}
+
 function validateModule(
   moduleEntry: AuthoredModule,
   mapCatalog: MapCatalog
@@ -269,10 +592,25 @@ function validateModule(
 } {
   const errors: AuthoredModuleValidationIssue[] = [];
   const warnings: AuthoredModuleValidationIssue[] = [];
-  const moduleId = normalizeString(moduleEntry.id);
-  const name = normalizeString(moduleEntry.name);
-  const description = normalizeString(moduleEntry.description);
-  const version = normalizeString(moduleEntry.version);
+  validateModuleMetadata(moduleEntry, errors);
+
+  if (moduleEntry.moduleType === "map") {
+    const authoredMap = validateAuthoredMap(moduleEntry, errors);
+    const mapOption = authoredMap ? buildMapOption(authoredMap) : null;
+    return {
+      validation: {
+        valid: errors.length === 0,
+        errors,
+        warnings
+      },
+      preview: buildPreview(moduleEntry, authoredMap),
+      runtime: buildRuntime(moduleEntry, authoredMap),
+      map: mapOption,
+      objectiveCount: 0,
+      enabledObjectiveCount: 0
+    };
+  }
+
   const mapId = normalizeString(moduleEntry.content?.mapId);
   const map = mapId ? mapCatalog.resolveMap(mapId) : null;
   const mapOption = map ? buildMapOption(map) : null;
@@ -282,38 +620,6 @@ function validateModule(
   const enabledObjectiveCount = objectives.filter((objective) => objective?.enabled).length;
   const seenObjectiveIds = new Set<string>();
   const validContinentIds = new Set((mapOption?.continents || []).map((continent) => continent.id));
-
-  if (!moduleId) {
-    errors.push(issue("required-id", "id", "Module id is required."));
-  } else if (!ID_PATTERN.test(moduleId)) {
-    errors.push(
-      issue(
-        "invalid-id",
-        "id",
-        "Use letters, numbers, dashes, underscores, or dots for the module id."
-      )
-    );
-  } else if (builtInVictoryRuleSetIds.has(moduleId)) {
-    errors.push(
-      issue(
-        "reserved-module-id",
-        "id",
-        `Module id "${moduleId}" is already used by a built-in victory rule set.`
-      )
-    );
-  }
-
-  if (!name) {
-    errors.push(issue("required-name", "name", "Module name is required."));
-  }
-
-  if (!description) {
-    errors.push(issue("required-description", "description", "Module description is required."));
-  }
-
-  if (!version) {
-    errors.push(issue("required-version", "version", "Module version is required."));
-  }
 
   if (!mapId) {
     errors.push(
@@ -506,7 +812,11 @@ function toSummaryPayload(
         }
       : null,
     objectiveCount: detail.objectiveCount,
-    enabledObjectiveCount: detail.enabledObjectiveCount
+    enabledObjectiveCount: detail.enabledObjectiveCount,
+    territoryCount:
+      moduleEntry.moduleType === "map" ? moduleEntry.content.territories.length : undefined,
+    continentCount:
+      moduleEntry.moduleType === "map" ? moduleEntry.content.continents.length : undefined
   };
 }
 
@@ -523,6 +833,38 @@ function sortModules(modules: AuthoredModule[]): AuthoredModule[] {
 
 function createAuthoredModulesService(options: AuthoredModulesOptions) {
   let mapCatalog = defaultMapCatalog();
+
+  function effectiveMapCatalog(modules: AuthoredModule[]): MapCatalog {
+    const authoredMaps = modules
+      .filter(
+        (entry): entry is Extract<AuthoredModule, { moduleType: "map" }> =>
+          entry.moduleType === "map" && entry.status === "published"
+      )
+      .map((entry) => {
+        const validation = validateModule(entry, mapCatalog);
+        if (!validation.validation.valid) {
+          return null;
+        }
+        try {
+          return buildAuthoredSupportedMap(entry);
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is SupportedMap => Boolean(entry));
+    const authoredById = new Map(authoredMaps.map((entry) => [entry.id, entry]));
+
+    return {
+      listMaps() {
+        const externalMaps = mapCatalog.listMaps().filter((entry) => !authoredById.has(entry.id));
+        return [...externalMaps, ...authoredMaps].map(clone);
+      },
+      resolveMap(mapId: string) {
+        const authoredMap = authoredById.get(mapId);
+        return authoredMap ? clone(authoredMap) : mapCatalog.resolveMap(mapId);
+      }
+    };
+  }
 
   async function readModules(): Promise<AuthoredModule[]> {
     if (typeof options.datastore.getAppState !== "function") {
@@ -556,16 +898,6 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
     );
   }
 
-  async function getModuleOrThrow(moduleId: string): Promise<AuthoredModule> {
-    const modules = await readModules();
-    const match = modules.find((entry) => entry.id === moduleId) || null;
-    if (!match) {
-      throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
-    }
-
-    return match;
-  }
-
   function parseInput(input: unknown): AuthoredModuleInput {
     const parsed = adminAuthoredModuleUpsertRequestSchema.safeParse(input);
     if (!parsed.success) {
@@ -577,13 +909,14 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
 
   async function validateDraft(input: unknown): Promise<AdminAuthoredModuleValidateResponse> {
     const parsed = parseInput(input);
+    const modules = await readModules();
     const moduleEntry: AuthoredModule = {
       ...parsed,
       status: "draft",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
-    const detail = toDetailPayload(moduleEntry, mapCatalog);
+    const detail = toDetailPayload(moduleEntry, effectiveMapCatalog(modules));
 
     return {
       validation: detail.validation,
@@ -620,7 +953,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
     }
 
     await writeModules(modules);
-    return toDetailPayload(nextEntry, mapCatalog);
+    return toDetailPayload(nextEntry, effectiveMapCatalog(modules));
   }
 
   async function publishModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
@@ -630,7 +963,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
       throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
     }
 
-    const detail = toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    const detail = toDetailPayload(modules[index] as AuthoredModule, effectiveMapCatalog(modules));
     if (!detail.validation.valid) {
       throw createServiceError(
         "This module still has validation errors and cannot be published.",
@@ -645,7 +978,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
       updatedAt: new Date().toISOString()
     };
     await writeModules(modules);
-    return toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    return toDetailPayload(modules[index] as AuthoredModule, effectiveMapCatalog(modules));
   }
 
   async function disableModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
@@ -661,7 +994,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
       updatedAt: new Date().toISOString()
     };
     await writeModules(modules);
-    return toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    return toDetailPayload(modules[index] as AuthoredModule, effectiveMapCatalog(modules));
   }
 
   async function enableModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
@@ -671,7 +1004,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
       throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
     }
 
-    const detail = toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    const detail = toDetailPayload(modules[index] as AuthoredModule, effectiveMapCatalog(modules));
     if (!detail.validation.valid) {
       throw createServiceError(
         "This module no longer validates cleanly and cannot be enabled.",
@@ -686,7 +1019,7 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
       updatedAt: new Date().toISOString()
     };
     await writeModules(modules);
-    return toDetailPayload(modules[index] as AuthoredModule, mapCatalog);
+    return toDetailPayload(modules[index] as AuthoredModule, effectiveMapCatalog(modules));
   }
 
   return {
@@ -702,9 +1035,11 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
       };
     },
     async listEditorOptions(): Promise<AdminAuthoredModuleEditorOptionsResponse> {
+      const modules = await readModules();
+      const catalog = effectiveMapCatalog(modules);
       return {
-        moduleTypes: ["victory-objectives"],
-        maps: mapCatalog
+        moduleTypes: ["victory-objectives", "map"],
+        maps: catalog
           .listMaps()
           .map((entry) => buildMapOption(entry))
           .sort((left, right) => left.name.localeCompare(right.name))
@@ -712,10 +1047,16 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
     },
     async listModules(): Promise<AuthoredModuleSummary[]> {
       const modules = await readModules();
-      return modules.map((moduleEntry) => toSummaryPayload(moduleEntry, mapCatalog));
+      const catalog = effectiveMapCatalog(modules);
+      return modules.map((moduleEntry) => toSummaryPayload(moduleEntry, catalog));
     },
     async getModule(moduleId: string): Promise<AdminAuthoredModuleDetailResponse> {
-      return toDetailPayload(await getModuleOrThrow(moduleId), mapCatalog);
+      const modules = await readModules();
+      const moduleEntry = modules.find((entry) => entry.id === moduleId);
+      if (!moduleEntry) {
+        throw createServiceError(`Authored module "${moduleId}" was not found.`, 404);
+      }
+      return toDetailPayload(moduleEntry, effectiveMapCatalog(modules));
     },
     async validateDraft(input: unknown) {
       return validateDraft(input);
@@ -734,11 +1075,17 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
     },
     async listPublishedVictoryRuleSets() {
       const modules = await readModules();
+      const catalog = effectiveMapCatalog(modules);
       return modules
-        .filter((moduleEntry) => moduleEntry.status === "published")
+        .filter(
+          (
+            moduleEntry
+          ): moduleEntry is Extract<AuthoredModule, { moduleType: "victory-objectives" }> =>
+            moduleEntry.status === "published" && moduleEntry.moduleType === "victory-objectives"
+        )
         .map((moduleEntry) => ({
           moduleEntry,
-          detail: toDetailPayload(moduleEntry, mapCatalog)
+          detail: toDetailPayload(moduleEntry, catalog)
         }))
         .filter((entry) => entry.detail.validation.valid)
         .map(({ moduleEntry, detail }) => ({
@@ -758,14 +1105,38 @@ function createAuthoredModulesService(options: AuthoredModulesOptions) {
     ): Promise<AuthoredModuleRuntime | null> {
       const modules = await readModules();
       const moduleEntry = modules.find(
-        (entry) => entry.id === moduleId && entry.status === "published"
+        (entry) =>
+          entry.id === moduleId &&
+          entry.status === "published" &&
+          entry.moduleType === "victory-objectives"
       );
       if (!moduleEntry) {
         return null;
       }
 
-      const detail = toDetailPayload(moduleEntry, mapCatalog);
+      const detail = toDetailPayload(moduleEntry, effectiveMapCatalog(modules));
       return detail.validation.valid ? detail.runtime : null;
+    },
+    async listPublishedMaps() {
+      const modules = await readModules();
+      return modules
+        .filter(
+          (entry): entry is Extract<AuthoredModule, { moduleType: "map" }> =>
+            entry.moduleType === "map" && entry.status === "published"
+        )
+        .map((moduleEntry) => ({
+          moduleEntry,
+          detail: validateModule(moduleEntry, mapCatalog)
+        }))
+        .filter((entry) => entry.detail.validation.valid)
+        .map(({ moduleEntry }) => ({
+          id: moduleEntry.id,
+          name: moduleEntry.name,
+          description: moduleEntry.description,
+          source: "authored" as const,
+          moduleType: moduleEntry.moduleType,
+          map: buildAuthoredSupportedMap(moduleEntry)
+        }));
     },
     async isModuleStored(moduleId: string): Promise<boolean> {
       const modules = await readModules();

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -107,6 +107,7 @@ type ModuleRuntimeOptions = {
     listPublishedVictoryRuleSets?: () =>
       | AuthoredPublishedVictoryRuleSet[]
       | Promise<AuthoredPublishedVictoryRuleSet[]>;
+    listPublishedMaps?: () => AuthoredPublishedMap[] | Promise<AuthoredPublishedMap[]>;
   };
 };
 
@@ -153,6 +154,15 @@ type AuthoredPublishedVictoryRuleSet = {
   objectiveCount?: number;
   moduleType?: string | null;
   runtime: AuthoredVictoryModuleRuntime;
+};
+
+type AuthoredPublishedMap = {
+  id: string;
+  name: string;
+  description: string;
+  source: "authored";
+  moduleType: "map";
+  map: SupportedMap;
 };
 
 const MODULE_CATALOG_STATE_KEY = "moduleCatalogState";
@@ -1010,7 +1020,8 @@ function buildResolvedModuleCatalog(
   runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[],
   runtimeCardRuleSetEntries: RuntimeModuleCardRuleSetEntry[],
   runtimeSiteThemeEntries: RuntimeModuleSiteThemeEntry[],
-  authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = []
+  authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = [],
+  authoredMaps: AuthoredPublishedMap[] = []
 ): NetRiskResolvedModuleCatalog {
   const clonedModules = modules.map(cloneInstalledModule);
   const {
@@ -1046,6 +1057,11 @@ function buildResolvedModuleCatalog(
       new Set([...(content.victoryRuleSetIds || []), ...authoredVictoryRuleSetIds])
     );
   }
+  if (authoredMaps.length) {
+    content.mapIds = Array.from(
+      new Set([...(content.mapIds || []), ...authoredMaps.map((entry) => entry.id)])
+    );
+  }
 
   return {
     modules: clonedModules,
@@ -1057,7 +1073,8 @@ function buildResolvedModuleCatalog(
     maps: filterMapsByAllowedIds(
       [
         ...listCoreBaseMapSummaries().map(cloneMapSummary),
-        ...enabledRuntimeMapEntries.map((entry) => summarizeMap(entry.map)).map(cloneMapSummary)
+        ...enabledRuntimeMapEntries.map((entry) => summarizeMap(entry.map)).map(cloneMapSummary),
+        ...authoredMaps.map((entry) => summarizeMap(entry.map)).map(cloneMapSummary)
       ],
       content.mapIds
     ),
@@ -1155,7 +1172,8 @@ function buildModuleOptions(
   runtimeDiceRuleSetEntries: RuntimeModuleDiceRuleSetEntry[],
   runtimeCardRuleSetEntries: RuntimeModuleCardRuleSetEntry[],
   runtimeSiteThemeEntries: RuntimeModuleSiteThemeEntry[],
-  authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = []
+  authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = [],
+  authoredMaps: AuthoredPublishedMap[] = []
 ): ModuleOptionsSnapshot {
   const resolvedCatalog = buildResolvedModuleCatalog(
     modules,
@@ -1165,7 +1183,8 @@ function buildModuleOptions(
     runtimeDiceRuleSetEntries,
     runtimeCardRuleSetEntries,
     runtimeSiteThemeEntries,
-    authoredVictoryRuleSets
+    authoredVictoryRuleSets,
+    authoredMaps
   );
 
   return {
@@ -1305,6 +1324,7 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
   let runtimeSiteThemeErrorsByModuleId = new Map<string, string[]>();
   let authoredVictoryRuleSets: AuthoredPublishedVictoryRuleSet[] = [];
   let authoredVictoryRuleSetRuntimesById = new Map<string, AuthoredVictoryModuleRuntime>();
+  let authoredMapsById = new Map<string, AuthoredPublishedMap>();
 
   function registerServerModuleMaps(
     moduleId: string,
@@ -2258,7 +2278,7 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
 
   async function getModuleOptions() {
     const modules = await ensureCatalog();
-    await refreshAuthoredVictoryRuleSets();
+    await refreshAuthoredContent();
     return buildModuleOptions(
       modules,
       listEnabledRuntimeMaps(modules),
@@ -2267,27 +2287,52 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       listEnabledRuntimeDiceRuleSets(modules),
       listEnabledRuntimeCardRuleSets(modules),
       listEnabledRuntimeSiteThemes(modules),
-      authoredVictoryRuleSets
+      authoredVictoryRuleSets,
+      Array.from(authoredMapsById.values())
     );
   }
 
-  async function refreshAuthoredVictoryRuleSets() {
+  async function refreshAuthoredContent() {
     if (typeof options.authoredModules?.listPublishedVictoryRuleSets !== "function") {
       authoredVictoryRuleSets = [];
       authoredVictoryRuleSetRuntimesById = new Map();
+    } else {
+      const published = await options.authoredModules.listPublishedVictoryRuleSets();
+      authoredVictoryRuleSets = Array.isArray(published)
+        ? published.map((entry) => ({
+            ...entry,
+            runtime: cloneAuthoredVictoryRuntime(entry.runtime)
+          }))
+        : [];
+      authoredVictoryRuleSetRuntimesById = new Map(
+        authoredVictoryRuleSets.map((entry) => [
+          entry.id,
+          cloneAuthoredVictoryRuntime(entry.runtime)
+        ])
+      );
+    }
+
+    if (typeof options.authoredModules?.listPublishedMaps !== "function") {
+      authoredMapsById = new Map();
       return;
     }
 
-    const published = await options.authoredModules.listPublishedVictoryRuleSets();
-    authoredVictoryRuleSets = Array.isArray(published)
-      ? published.map((entry) => ({
-          ...entry,
-          runtime: cloneAuthoredVictoryRuntime(entry.runtime)
-        }))
-      : [];
-    authoredVictoryRuleSetRuntimesById = new Map(
-      authoredVictoryRuleSets.map((entry) => [entry.id, cloneAuthoredVictoryRuntime(entry.runtime)])
-    );
+    const publishedMaps = await options.authoredModules.listPublishedMaps();
+    const nextMaps = new Map<string, AuthoredPublishedMap>();
+    (Array.isArray(publishedMaps) ? publishedMaps : []).forEach((entry) => {
+      if (
+        findCoreBaseSupportedMap(entry.id) ||
+        runtimeMapsById.has(entry.id) ||
+        nextMaps.has(entry.id)
+      ) {
+        return;
+      }
+      nextMaps.set(entry.id, {
+        ...entry,
+        map: cloneSupportedMap(entry.map)
+      });
+    });
+    authoredMapsById = nextMaps;
   }
 
   return {
@@ -2314,8 +2359,11 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
           return Boolean(ownerModule?.enabled && ownerModule.compatible);
         })
         .map((runtimeEntry) => cloneSupportedMap(runtimeEntry.map));
+      const authoredMaps = Array.from(authoredMapsById.values()).map((entry) =>
+        cloneSupportedMap(entry.map)
+      );
 
-      return [...builtInMaps, ...runtimeMaps];
+      return [...builtInMaps, ...runtimeMaps, ...authoredMaps];
     },
     findSupportedMap(mapId: string): SupportedMap | null {
       const builtInMap = findCoreBaseSupportedMap(mapId);
@@ -2324,18 +2372,17 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       }
 
       const runtimeEntry = runtimeMapsById.get(mapId);
-      if (!runtimeEntry) {
-        return null;
+      if (runtimeEntry) {
+        const ownerModule = cachedModules.find(
+          (moduleEntry) => moduleEntry.id === runtimeEntry.moduleId
+        );
+        if (ownerModule?.enabled && ownerModule.compatible) {
+          return cloneSupportedMap(runtimeEntry.map);
+        }
       }
 
-      const ownerModule = cachedModules.find(
-        (moduleEntry) => moduleEntry.id === runtimeEntry.moduleId
-      );
-      if (!ownerModule || !ownerModule.enabled || !ownerModule.compatible) {
-        return null;
-      }
-
-      return cloneSupportedMap(runtimeEntry.map);
+      const authoredMap = authoredMapsById.get(mapId);
+      return authoredMap ? cloneSupportedMap(authoredMap.map) : null;
     },
     findContentPack(contentPackId: string): ContentPackSummary | null {
       const builtInContentPack = findBuiltInContentPack(contentPackId);
@@ -2767,6 +2814,11 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
             ...(selectedContent.victoryRuleSetIds || []),
             ...authoredVictoryRuleSets.map((entry) => entry.id)
           ])
+        );
+      }
+      if (authoredMapsById.size) {
+        selectedContent.mapIds = Array.from(
+          new Set([...(selectedContent.mapIds || []), ...authoredMapsById.keys()])
         );
       }
       const availableContentProfiles = new Set(

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -16,7 +16,7 @@ The NetRisk administrator area lives at `/admin`, with `/react/admin` kept as th
 - `Games`: searchable list of games/lobbies, issue summary, player/config inspection, raw state view, close/terminate/repair actions
 - `Configurations`: global admin defaults, enabled modules, profiles, runtime defaults, and maintenance thresholds
 - `Runtime / Modules`: module catalog management through the existing module admin tooling
-- `Content Studio`: constrained authoring for gameplay modules; currently supports `victory-objectives`
+- `Content Studio`: constrained authoring for gameplay modules; supports validated maps and `victory-objectives`
 - `Maintenance`: validation report and guarded cleanup/repair actions
 - `System Health`: diagnostics view for module references, game snapshots, stale lobbies, and maintenance findings
 - `Audit Log`: persistent log of admin mutations with actor, action, target, and result
@@ -50,7 +50,8 @@ Notes:
 ## Safety notes
 
 - module disable now refuses when the module is still referenced by admin defaults
-- Content Studio modules are schema-validated server-side before publish/enable and never execute arbitrary uploaded code
+- Content Studio maps and objective modules are schema-validated server-side before publish/enable and never execute arbitrary uploaded code
+- authored maps cannot be disabled while referenced by active games or admin defaults
 - game repair preserves runtime-resolved IDs while synchronizing stale top-level snapshot fields
 - cleanup and destructive actions are audit logged on both success and failure paths where applicable
 
@@ -58,7 +59,7 @@ Notes:
 
 - `frontend/react-shell/src/__tests__/admin-route.integration.test.tsx` verifies admin route gating, non-admin navigation hiding, and overview-shell loading in the React shell
 - `tests/gameplay/regression/admin-console-routes.test.cts` verifies admin API protection for anonymous and non-admin callers, role mutation, destructive confirmation enforcement, failure audit logging, maintenance actions, and admin-default runtime preservation
-- `tests/gameplay/regression/admin-content-studio-routes.test.cts` verifies authored module route protection, validation, publish/enable/disable behavior, and runtime integration
+- `tests/gameplay/regression/admin-content-studio-routes.test.cts` verifies authored module route protection, map/objective validation, publish/enable/disable behavior, runtime integration, and authored-map game creation
 - `tests/gameplay/regression/vercel-routing-config.test.cts` verifies `/admin` and `/react/admin` continue to route correctly through the deployed rewrite layer
 
 Notable backend regressions covered today:

--- a/docs/content-studio-victory-objectives.md
+++ b/docs/content-studio-victory-objectives.md
@@ -1,13 +1,14 @@
-# Content Studio Victory Objectives
+# Content Studio Authored Gameplay
 
-This document describes the first authored gameplay-module flow shipped through the admin console.
+This document describes the authored gameplay-module flows shipped through the admin console.
 
 ## Scope
 
-The new `Content Studio` admin area is the first constrained authoring surface for gameplay modules.
-In this phase it supports one module type:
+The `Content Studio` admin area is a constrained authoring surface for gameplay modules. It
+supports two module types:
 
 - `victory-objectives`
+- `map`
 
 The system is intentionally schema-driven. Admins can author validated objective modules without
 editing source files, but they cannot execute arbitrary code or upload scripts.
@@ -20,7 +21,7 @@ Victory objective modules move through three states:
 - `published`: validated and available in runtime victory-rule catalogs
 - `disabled`: previously published content that is hidden from runtime selection
 
-The admin UI supports:
+The admin UI supports both module types through the same lifecycle:
 
 - listing existing authored modules
 - starting a new draft
@@ -29,6 +30,9 @@ The admin UI supports:
 - publishing a valid draft
 - disabling or re-enabling a published module
 - inspecting the generated runtime JSON
+
+Map drafts additionally provide structured editors for territories, normalized coordinates,
+bidirectional neighbor links, continents, membership, and reinforcement bonuses.
 
 The section is available from the admin console at `/admin/content-studio` and `/react/admin/content-studio`.
 
@@ -51,7 +55,7 @@ The authored module shape includes:
 - `updatedAt`
 - `content`
 
-For `victory-objectives`, `content` currently contains:
+For `victory-objectives`, `content` contains:
 
 - `mapId`
 - `objectives[]`
@@ -60,6 +64,14 @@ Supported objective types in this phase:
 
 - `control-continents`
 - `control-territory-count`
+
+For `map`, `content` contains:
+
+- `territories[]` with stable ids, names, continent assignment, normalized `x`/`y` coordinates,
+  and neighbor ids
+- `continents[]` with stable ids, names, whole-number reinforcement bonuses, and territory ids
+
+The authored map module id is also its runtime map id.
 
 ## Persistence
 
@@ -89,17 +101,41 @@ Current rules include:
 - at least one objective
 - at least one enabled objective before publish
 
+Map validation additionally requires:
+
+- at least two territories and one continent
+- unique, portable ids for territories and continents
+- coordinates between `0` and `1`
+- known, non-duplicated, bidirectional neighbor links
+- a single connected map graph
+- exactly one consistent continent assignment per territory
+- non-negative whole-number continent bonuses
+
 Drafts may remain invalid. Publishing and enabling require a clean validation result.
 
 ## Runtime integration
 
-Published authored victory modules are merged into the runtime catalog by `backend/module-runtime.cts`.
+Published authored victory modules and maps are merged into the runtime catalog by
+`backend/module-runtime.cts`.
 
 That means they now appear in:
 
 - `GET /api/game/options`
 - admin default selection flows
 - runtime victory-rule catalogs used during game creation
+
+Published maps additionally appear in the map catalog used by `GET /api/game/options`, admin
+defaults, new-game setup, and the game engine. Their validated territory graph, positions,
+continents, and bonuses are used directly when a game is created.
+
+## Pluggable rules and bonuses
+
+Authored maps use the same runtime contribution model as installed NetRisk modules rather than a
+parallel rules engine. Map continent bonuses are stored in the authored map definition. Broader
+custom gameplay rules remain data-driven module contributions, including dice and card rule sets,
+reinforcement adjustments, combat/fortify limits, scenario territory bonuses, victory rules, and
+setup profiles. The Content Studio can add more constrained editors for those contribution types
+without allowing uploaded scripts or arbitrary code execution.
 
 When a game is created with an authored victory module:
 
@@ -146,6 +182,7 @@ The authoring screen owns:
 - live validation
 - player-facing preview
 - generated runtime JSON
+- structured map territory and continent editors
 
 Regression coverage lives in:
 

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -562,8 +562,13 @@ function createContentStudioOptionsResponse(): AdminAuthoredModuleEditorOptionsR
   };
 }
 
+type VictoryObjectivesAuthoredModule = Extract<
+  AdminAuthoredModuleDetailResponse["module"],
+  { moduleType: "victory-objectives" }
+>;
+
 function createAuthoredModuleDetail(
-  overrides: Partial<AdminAuthoredModuleDetailResponse["module"]> = {}
+  overrides: Partial<VictoryObjectivesAuthoredModule> = {}
 ): AdminAuthoredModuleDetailResponse {
   return {
     module: {
@@ -665,7 +670,7 @@ function createAuthoredValidationResponse(): AdminAuthoredModuleValidateResponse
 }
 
 function createAuthoredMutationResponse(
-  overrides: Partial<AdminAuthoredModuleDetailResponse["module"]> = {}
+  overrides: Partial<VictoryObjectivesAuthoredModule> = {}
 ): AdminAuthoredModuleMutationResponse {
   const detail = createAuthoredModuleDetail(overrides);
 

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -536,7 +536,7 @@ function createMaintenanceReport(): AdminMaintenanceReport {
 
 function createContentStudioOptionsResponse(): AdminAuthoredModuleEditorOptionsResponse {
   return {
-    moduleTypes: ["victory-objectives"],
+    moduleTypes: ["victory-objectives", "map"],
     maps: [
       {
         id: "classic-mini",
@@ -977,7 +977,7 @@ describe("Admin route integration", () => {
   it("loads the content studio editor, shows preview data, and saves a draft", async () => {
     const { user } = renderReactShell("/react/admin/content-studio");
 
-    expect(await screen.findByText("Author victory objective modules")).toBeInTheDocument();
+    expect(await screen.findByText("Author maps and gameplay modules")).toBeInTheDocument();
     expect(await screen.findByText("North America and Asia")).toBeInTheDocument();
     expect(
       await screen.findByText("Win condition: Control North America and Asia simultaneously.")
@@ -1049,7 +1049,7 @@ describe("Admin route integration", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const { user } = renderReactShell("/react/admin/content-studio");
 
-    expect(await screen.findByText("Author victory objective modules")).toBeInTheDocument();
+    expect(await screen.findByText("Author maps and gameplay modules")).toBeInTheDocument();
     expect(await screen.findByDisplayValue("objective-1")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Remove objective" }));
@@ -1081,7 +1081,7 @@ describe("Admin route integration", () => {
   it("starts a new draft with a generated module id and saves it", async () => {
     const { user } = renderReactShell("/react/admin/content-studio");
 
-    expect(await screen.findByText("Author victory objective modules")).toBeInTheDocument();
+    expect(await screen.findByText("Author maps and gameplay modules")).toBeInTheDocument();
 
     validateAdminAuthoredModuleMock.mockClear();
     createAdminAuthoredModuleMock.mockClear();
@@ -1097,7 +1097,7 @@ describe("Admin route integration", () => {
         })
       );
 
-    await user.click(screen.getByRole("button", { name: "New draft" }));
+    await user.click(screen.getByRole("button", { name: "New objective draft" }));
 
     const moduleIdField = (await screen.findByDisplayValue(
       "victory.new-draft"
@@ -1126,7 +1126,7 @@ describe("Admin route integration", () => {
       );
     });
 
-    await user.click(screen.getByRole("button", { name: "New draft" }));
+    await user.click(screen.getByRole("button", { name: "New objective draft" }));
 
     const nextModuleIdField = (await screen.findByDisplayValue(
       "victory.new-draft-2"
@@ -1141,6 +1141,54 @@ describe("Admin route integration", () => {
         expect.objectContaining({
           id: "victory.new-draft-2",
           moduleType: "victory-objectives"
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it("starts, validates, and saves an authored map draft from the UI", async () => {
+    const { user } = renderReactShell("/react/admin/content-studio");
+
+    expect(await screen.findByText("Author maps and gameplay modules")).toBeInTheDocument();
+    validateAdminAuthoredModuleMock.mockClear();
+    createAdminAuthoredModuleMock.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "New map draft" }));
+
+    expect(await screen.findByDisplayValue("map.new-draft")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add territory" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add continent" })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("territory-1")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(validateAdminAuthoredModuleMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "map.new-draft",
+          moduleType: "map",
+          content: expect.objectContaining({
+            territories: expect.arrayContaining([
+              expect.objectContaining({
+                id: "territory-1",
+                neighbors: ["territory-2", "territory-4"]
+              })
+            ]),
+            continents: expect.arrayContaining([
+              expect.objectContaining({ id: "continent-1", bonus: 2 })
+            ])
+          })
+        }),
+        expect.anything()
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save draft" }));
+
+    await waitFor(() => {
+      expect(createAdminAuthoredModuleMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "map.new-draft",
+          moduleType: "map"
         }),
         expect.anything()
       );

--- a/frontend/react-shell/src/admin-content-studio.tsx
+++ b/frontend/react-shell/src/admin-content-studio.tsx
@@ -5,7 +5,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   AdminAuthoredModuleDetailResponse,
   AdminAuthoredModuleUpsertRequest,
+  AuthoredMapContinent,
   AuthoredMapOption,
+  AuthoredMapTerritory,
   AuthoredVictoryObjective
 } from "@frontend-generated/shared-runtime-validation.mts";
 
@@ -52,6 +54,8 @@ type EditorDraft = AdminAuthoredModuleUpsertRequest & {
   createdAt?: string;
   updatedAt?: string;
 };
+type VictoryEditorDraft = Extract<EditorDraft, { moduleType: "victory-objectives" }>;
+type MapEditorDraft = Extract<EditorDraft, { moduleType: "map" }>;
 
 const NEW_MODULE_KEY = "__content-studio-new__";
 
@@ -142,8 +146,11 @@ function createObjective(
   };
 }
 
-function createDefaultModuleId(existingModuleIds: string[]): string {
-  const baseId = "victory.new-draft";
+function createDefaultModuleId(
+  existingModuleIds: string[],
+  moduleType: EditorDraft["moduleType"]
+): string {
+  const baseId = moduleType === "map" ? "map.new-draft" : "victory.new-draft";
   if (!existingModuleIds.includes(baseId)) {
     return baseId;
   }
@@ -175,12 +182,12 @@ function reservedModuleIds(
   return [...ids];
 }
 
-function createEmptyDraft(
+function createEmptyVictoryDraft(
   mapOption: AuthoredMapOption | null,
   existingModuleIds: string[] = []
-): EditorDraft {
+): VictoryEditorDraft {
   return {
-    id: createDefaultModuleId(existingModuleIds),
+    id: createDefaultModuleId(existingModuleIds, "victory-objectives"),
     name: "",
     description: "",
     version: "1.0.0",
@@ -192,18 +199,90 @@ function createEmptyDraft(
   };
 }
 
+function createEmptyMapDraft(existingModuleIds: string[] = []): MapEditorDraft {
+  return {
+    id: createDefaultModuleId(existingModuleIds, "map"),
+    name: "",
+    description: "",
+    version: "1.0.0",
+    moduleType: "map",
+    content: {
+      territories: [
+        {
+          id: "territory-1",
+          name: "Territory 1",
+          continentId: "continent-1",
+          x: 0.2,
+          y: 0.2,
+          neighbors: ["territory-2", "territory-4"]
+        },
+        {
+          id: "territory-2",
+          name: "Territory 2",
+          continentId: "continent-1",
+          x: 0.8,
+          y: 0.2,
+          neighbors: ["territory-1", "territory-3"]
+        },
+        {
+          id: "territory-3",
+          name: "Territory 3",
+          continentId: "continent-1",
+          x: 0.8,
+          y: 0.8,
+          neighbors: ["territory-2", "territory-4"]
+        },
+        {
+          id: "territory-4",
+          name: "Territory 4",
+          continentId: "continent-1",
+          x: 0.2,
+          y: 0.8,
+          neighbors: ["territory-1", "territory-3"]
+        }
+      ],
+      continents: [
+        {
+          id: "continent-1",
+          name: "Continent 1",
+          bonus: 2,
+          territoryIds: ["territory-1", "territory-2", "territory-3", "territory-4"]
+        }
+      ]
+    }
+  };
+}
+
 function toUpsertRequest(draft: EditorDraft): AdminAuthoredModuleUpsertRequest {
+  if (draft.moduleType === "map") {
+    return {
+      id: draft.id,
+      name: draft.name,
+      description: draft.description,
+      version: draft.version,
+      moduleType: "map",
+      content: clone(draft.content)
+    };
+  }
+
   return {
     id: draft.id,
     name: draft.name,
     description: draft.description,
     version: draft.version,
-    moduleType: draft.moduleType,
+    moduleType: "victory-objectives",
     content: {
       mapId: draft.content.mapId,
       objectives: draft.content.objectives.map((objective) => clone(objective))
     }
   };
+}
+
+function splitIds(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 function currentInspection(
@@ -297,7 +376,10 @@ function PreviewPanel({ inspection }: { inspection: ContentStudioInspection | nu
       </div>
       <p className="content-studio-summary">{inspection?.preview.summary || "No preview yet."}</p>
       <ul className="content-studio-preview-list">
-        {(inspection?.preview.objectiveSummaries || []).map((entry, index) => (
+        {(inspection?.preview.detailSummaries?.length
+          ? inspection.preview.detailSummaries
+          : inspection?.preview.objectiveSummaries || []
+        ).map((entry, index) => (
           <li key={`${entry}-${index}`}>{entry}</li>
         ))}
       </ul>
@@ -368,7 +450,7 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
       return;
     }
 
-    const nextDraft = createEmptyDraft(firstMap(optionsQuery.data), draftReservedModuleIds);
+    const nextDraft = createEmptyVictoryDraft(firstMap(optionsQuery.data), draftReservedModuleIds);
     setDraft(nextDraft);
     setInspection(null);
     setActiveObjectiveId(nextDraft.content.objectives[0]?.id || null);
@@ -385,11 +467,15 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
       preview: detailQuery.data.preview,
       runtime: detailQuery.data.runtime
     });
-    setActiveObjectiveId(detailQuery.data.module.content.objectives[0]?.id || null);
+    setActiveObjectiveId(
+      detailQuery.data.module.moduleType === "victory-objectives"
+        ? detailQuery.data.module.content.objectives[0]?.id || null
+        : null
+    );
   }, [detailQuery.data, selectedModuleId]);
 
   useEffect(() => {
-    if (!draft?.content.objectives.length) {
+    if (!draft || draft.moduleType !== "victory-objectives" || !draft.content.objectives.length) {
       setActiveObjectiveId(null);
       return;
     }
@@ -429,7 +515,11 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
         preview: payload.preview,
         runtime: payload.runtime
       });
-      setActiveObjectiveId(payload.module.content.objectives[0]?.id || null);
+      setActiveObjectiveId(
+        payload.module.moduleType === "victory-objectives"
+          ? payload.module.content.objectives[0]?.id || null
+          : null
+      );
       listMutationKeys.forEach((queryKey) => {
         void queryClient.invalidateQueries({ queryKey });
       });
@@ -501,12 +591,19 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
     return () => window.clearTimeout(timeoutId);
   }, [deferredDraft, detailQuery.data?.module.status, isNewDraft]);
 
-  function startNewDraft() {
-    const nextDraft = createEmptyDraft(firstMap(optionsQuery.data), draftReservedModuleIds);
+  function startNewDraft(moduleType: EditorDraft["moduleType"]) {
+    const nextDraft =
+      moduleType === "map"
+        ? createEmptyMapDraft(draftReservedModuleIds)
+        : createEmptyVictoryDraft(firstMap(optionsQuery.data), draftReservedModuleIds);
     setSelectedEditorKey(NEW_MODULE_KEY);
     setDraft(nextDraft);
     setInspection(null);
-    setActiveObjectiveId(nextDraft.content.objectives[0]?.id || null);
+    setActiveObjectiveId(
+      nextDraft.moduleType === "victory-objectives"
+        ? nextDraft.content.objectives[0]?.id || null
+        : null
+    );
   }
 
   function updateDraft(nextDraft: EditorDraft) {
@@ -528,7 +625,7 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
     objectiveId: string,
     transform: (objective: AuthoredVictoryObjective) => AuthoredVictoryObjective
   ) {
-    if (!draft) {
+    if (!draft || draft.moduleType !== "victory-objectives") {
       return;
     }
 
@@ -544,7 +641,7 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
   }
 
   function addObjective(type: AuthoredVictoryObjective["type"]) {
-    if (!draft) {
+    if (!draft || draft.moduleType !== "victory-objectives") {
       return;
     }
 
@@ -560,7 +657,7 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
   }
 
   function removeObjective(objectiveId: string) {
-    if (!draft) {
+    if (!draft || draft.moduleType !== "victory-objectives") {
       return;
     }
 
@@ -582,6 +679,182 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
       }
     });
     setActiveObjectiveId(nextObjectives[0]?.id || null);
+  }
+
+  function updateMapTerritory(
+    index: number,
+    transform: (territory: AuthoredMapTerritory) => AuthoredMapTerritory
+  ) {
+    if (!draft || draft.moduleType !== "map") {
+      return;
+    }
+
+    const previous = draft.content.territories[index];
+    if (!previous) {
+      return;
+    }
+    const nextTerritory = transform(previous);
+    const nextTerritories = draft.content.territories.map((territory, territoryIndex) => {
+      if (territoryIndex === index) {
+        return nextTerritory;
+      }
+      return previous.id !== nextTerritory.id
+        ? {
+            ...territory,
+            neighbors: territory.neighbors.map((neighborId) =>
+              neighborId === previous.id ? nextTerritory.id : neighborId
+            )
+          }
+        : territory;
+    });
+    const nextContinents = draft.content.continents.map((continent) => ({
+      ...continent,
+      territoryIds: nextTerritories
+        .filter((territory) => territory.continentId === continent.id)
+        .map((territory) => territory.id)
+    }));
+
+    updateDraft({
+      ...draft,
+      content: {
+        territories: nextTerritories,
+        continents: nextContinents
+      }
+    });
+  }
+
+  function addMapTerritory() {
+    if (!draft || draft.moduleType !== "map") {
+      return;
+    }
+    let index = draft.content.territories.length + 1;
+    while (draft.content.territories.some((entry) => entry.id === `territory-${index}`)) {
+      index += 1;
+    }
+    const continentId = draft.content.continents[0]?.id || null;
+    const nextTerritory: AuthoredMapTerritory = {
+      id: `territory-${index}`,
+      name: `Territory ${index}`,
+      continentId,
+      x: 0.5,
+      y: 0.5,
+      neighbors: []
+    };
+    const nextTerritories = [...draft.content.territories, nextTerritory];
+    updateDraft({
+      ...draft,
+      content: {
+        territories: nextTerritories,
+        continents: draft.content.continents.map((continent) => ({
+          ...continent,
+          territoryIds: nextTerritories
+            .filter((territory) => territory.continentId === continent.id)
+            .map((territory) => territory.id)
+        }))
+      }
+    });
+  }
+
+  function removeMapTerritory(index: number) {
+    if (!draft || draft.moduleType !== "map") {
+      return;
+    }
+    const target = draft.content.territories[index];
+    if (!target || !window.confirm(`Remove territory "${target.name || target.id}"?`)) {
+      return;
+    }
+    const nextTerritories = draft.content.territories
+      .filter((_, territoryIndex) => territoryIndex !== index)
+      .map((territory) => ({
+        ...territory,
+        neighbors: territory.neighbors.filter((neighborId) => neighborId !== target.id)
+      }));
+    updateDraft({
+      ...draft,
+      content: {
+        territories: nextTerritories,
+        continents: draft.content.continents.map((continent) => ({
+          ...continent,
+          territoryIds: nextTerritories
+            .filter((territory) => territory.continentId === continent.id)
+            .map((territory) => territory.id)
+        }))
+      }
+    });
+  }
+
+  function updateMapContinent(
+    index: number,
+    transform: (continent: AuthoredMapContinent) => AuthoredMapContinent
+  ) {
+    if (!draft || draft.moduleType !== "map") {
+      return;
+    }
+    const previous = draft.content.continents[index];
+    if (!previous) {
+      return;
+    }
+    const nextContinent = transform(previous);
+    const nextTerritories = draft.content.territories.map((territory) => ({
+      ...territory,
+      continentId: territory.continentId === previous.id ? nextContinent.id : territory.continentId
+    }));
+    const nextContinents = draft.content.continents.map((continent, continentIndex) => ({
+      ...(continentIndex === index ? nextContinent : continent),
+      territoryIds: nextTerritories
+        .filter(
+          (territory) =>
+            territory.continentId === (continentIndex === index ? nextContinent.id : continent.id)
+        )
+        .map((territory) => territory.id)
+    }));
+    updateDraft({
+      ...draft,
+      content: {
+        territories: nextTerritories,
+        continents: nextContinents
+      }
+    });
+  }
+
+  function addMapContinent() {
+    if (!draft || draft.moduleType !== "map") {
+      return;
+    }
+    let index = draft.content.continents.length + 1;
+    while (draft.content.continents.some((entry) => entry.id === `continent-${index}`)) {
+      index += 1;
+    }
+    updateDraft({
+      ...draft,
+      content: {
+        ...draft.content,
+        continents: [
+          ...draft.content.continents,
+          { id: `continent-${index}`, name: `Continent ${index}`, bonus: 0, territoryIds: [] }
+        ]
+      }
+    });
+  }
+
+  function removeMapContinent(index: number) {
+    if (!draft || draft.moduleType !== "map") {
+      return;
+    }
+    const target = draft.content.continents[index];
+    if (!target || !window.confirm(`Remove continent "${target.name || target.id}"?`)) {
+      return;
+    }
+    updateDraft({
+      ...draft,
+      content: {
+        territories: draft.content.territories.map((territory) => ({
+          ...territory,
+          continentId: territory.continentId === target.id ? null : territory.continentId
+        })),
+        continents: draft.content.continents.filter((_, continentIndex) => continentIndex !== index)
+      }
+    });
   }
 
   function handleSaveDraft() {
@@ -624,9 +897,13 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
   }
 
   const selectedMap =
-    optionsQuery.data?.maps.find((entry) => entry.id === draft?.content.mapId) || null;
+    draft?.moduleType === "victory-objectives"
+      ? optionsQuery.data?.maps.find((entry) => entry.id === draft.content.mapId) || null
+      : null;
   const activeObjective =
-    draft?.content.objectives.find((objective) => objective.id === activeObjectiveId) || null;
+    draft?.moduleType === "victory-objectives"
+      ? draft.content.objectives.find((objective) => objective.id === activeObjectiveId) || null
+      : null;
   const latestInspection = currentInspection(detailQuery.data, inspection);
   const modules = authoredModules;
   const isEditableDraft = Boolean(
@@ -676,10 +953,10 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
             <span>Content Studio</span>
           </div>
           <p className="status-label">Content Studio</p>
-          <h1>Author victory objective modules</h1>
+          <h1>Author maps and gameplay modules</h1>
           <p className="status-copy">
-            Create validated, publishable objective packs without editing source files. Published
-            modules flow into the runtime victory-rule catalog and are stored for engine use.
+            Create validated maps and objective packs without editing source files. Published
+            modules flow into the runtime catalog and are stored for engine use.
           </p>
         </div>
         <div className="admin-hero-side">
@@ -691,12 +968,19 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
             <div className="admin-toolbar-summary">
               <span className="chip">Maps {optionsQuery.data?.maps.length || 0}</span>
               <span className="chip">Modules {modules.length}</span>
-              <span className="chip">Type victory-objectives</span>
+              <span className="chip">Types {optionsQuery.data?.moduleTypes.length || 0}</span>
             </div>
           </section>
           <div className="hero-actions admin-hero-actions">
-            <button type="button" className="refresh-button" onClick={startNewDraft}>
-              New draft
+            <button
+              type="button"
+              className="refresh-button"
+              onClick={() => startNewDraft("victory-objectives")}
+            >
+              New objective draft
+            </button>
+            <button type="button" className="ghost-action" onClick={() => startNewDraft("map")}>
+              New map draft
             </button>
           </div>
         </div>
@@ -713,7 +997,11 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
             <span className={`chip ${validationTone(latestInspection?.validation.valid)}`}>
               {latestInspection?.validation.valid ? "Valid" : "Validation pending"}
             </span>
-            <span className="chip">Objectives {draft?.content.objectives.length || 0}</span>
+            <span className="chip">
+              {draft?.moduleType === "map"
+                ? `Territories ${draft.content.territories.length}`
+                : `Objectives ${draft?.content.objectives.length || 0}`}
+            </span>
             <span className="chip">
               Updated {formatTimestamp((detailQuery.data?.module || null)?.updatedAt)}
             </span>
@@ -814,7 +1102,11 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
                     <span className={`badge ${validationTone(moduleEntry.validation.valid)}`}>
                       {moduleEntry.validation.valid ? "valid" : "draft"}
                     </span>
-                    <span className="badge">{moduleEntry.enabledObjectiveCount} enabled</span>
+                    <span className="badge">
+                      {moduleEntry.moduleType === "map"
+                        ? `${moduleEntry.territoryCount || 0} territories`
+                        : `${moduleEntry.enabledObjectiveCount} enabled`}
+                    </span>
                   </div>
                 </button>
               ))
@@ -823,7 +1115,7 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
                 <p className="status-label">Content Studio</p>
                 <h2>No authored modules yet</h2>
                 <p className="status-copy">
-                  Start with a draft victory-objective module and publish it when validation is
+                  Start with a map or victory-objective draft and publish it when validation is
                   clean.
                 </p>
               </section>
@@ -894,29 +1186,37 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
                         disabled={!isEditableDraft}
                       />
                     </label>
-                    <label className="shell-field admin-field">
-                      <span>Target map</span>
-                      <select
-                        value={draft.content.mapId}
-                        onChange={(event) =>
-                          updateDraft({
-                            ...draft,
-                            content: {
-                              ...draft.content,
-                              mapId: event.target.value
-                            }
-                          })
-                        }
-                        disabled={!isEditableDraft}
-                      >
-                        <option value="">Select a map</option>
-                        {optionsQuery.data?.maps.map((entry) => (
-                          <option key={entry.id} value={entry.id}>
-                            {entry.name}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
+                    {draft.moduleType === "victory-objectives" ? (
+                      <label className="shell-field admin-field">
+                        <span>Target map</span>
+                        <select
+                          value={draft.content.mapId}
+                          onChange={(event) =>
+                            updateDraft({
+                              ...draft,
+                              content: {
+                                ...draft.content,
+                                mapId: event.target.value
+                              }
+                            })
+                          }
+                          disabled={!isEditableDraft}
+                        >
+                          <option value="">Select a map</option>
+                          {optionsQuery.data?.maps.map((entry) => (
+                            <option key={entry.id} value={entry.id}>
+                              {entry.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    ) : (
+                      <label className="shell-field admin-field">
+                        <span>Module type</span>
+                        <input value="Map" disabled />
+                        <small>The module id becomes the runtime map id.</small>
+                      </label>
+                    )}
                     <label className="shell-field admin-field admin-card-span">
                       <span>Description</span>
                       <textarea
@@ -928,254 +1228,492 @@ export function AdminContentStudioSection({ frameContext }: { frameContext: Admi
                     </label>
                   </div>
                   <div className="content-studio-map-meta">
-                    <span className="chip">{selectedMap?.name || "No map selected"}</span>
-                    <span className="chip">Territories {selectedMap?.territoryCount || 0}</span>
-                    <span className="chip">Continents {selectedMap?.continentCount || 0}</span>
+                    <span className="chip">
+                      {draft.moduleType === "map"
+                        ? draft.name || "Unnamed map"
+                        : selectedMap?.name || "No map selected"}
+                    </span>
+                    <span className="chip">
+                      Territories{" "}
+                      {draft.moduleType === "map"
+                        ? draft.content.territories.length
+                        : selectedMap?.territoryCount || 0}
+                    </span>
+                    <span className="chip">
+                      Continents{" "}
+                      {draft.moduleType === "map"
+                        ? draft.content.continents.length
+                        : selectedMap?.continentCount || 0}
+                    </span>
                   </div>
                 </section>
 
-                <section className="card-panel content-studio-form-panel">
-                  <div className="card-header">
-                    <div>
-                      <p className="status-label">Objectives</p>
-                      <h2>Victory conditions</h2>
-                    </div>
-                    <div className="admin-inline-actions">
-                      <button
-                        type="button"
-                        className="ghost-action"
-                        onClick={() => addObjective("control-continents")}
-                        disabled={!isEditableDraft}
-                      >
-                        Add continent objective
-                      </button>
-                      <button
-                        type="button"
-                        className="ghost-action"
-                        onClick={() => addObjective("control-territory-count")}
-                        disabled={!isEditableDraft}
-                      >
-                        Add territory objective
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className="content-studio-objective-layout">
-                    <div className="content-studio-objective-list">
-                      {draft.content.objectives.map((objective, index) => (
-                        <button
-                          key={objective.id}
-                          type="button"
-                          className={`admin-list-button${
-                            activeObjectiveId === objective.id ? " is-selected" : ""
-                          }`}
-                          onClick={() => setActiveObjectiveId(objective.id)}
-                        >
-                          <div className="admin-list-copy">
-                            <strong>{objective.title || `Objective ${index + 1}`}</strong>
-                            <span>
-                              {objective.description || "No player-facing description yet."}
-                            </span>
-                            <span className="admin-item-meta">
-                              {objective.id || "missing-id"} · {objectiveTypeLabel(objective.type)}
-                            </span>
-                          </div>
-                          <div className="content-studio-list-meta">
-                            <span className={`badge ${objective.enabled ? "success" : "muted"}`}>
-                              {objective.enabled ? "Enabled" : "Off"}
-                            </span>
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-
-                    {activeObjective ? (
-                      <div className="content-studio-objective-editor">
-                        <div className="admin-form-grid admin-form-grid-2">
-                          <label className="shell-field admin-field">
-                            <span>Objective id</span>
-                            <input
-                              value={activeObjective.id}
-                              onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) => ({
-                                  ...objective,
-                                  id: event.target.value
-                                }))
-                              }
-                              disabled={!isEditableDraft}
-                            />
-                          </label>
-                          <label className="shell-field admin-field">
-                            <span>Objective type</span>
-                            <select
-                              value={activeObjective.type}
-                              onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) => {
-                                  const baseObjective = {
-                                    id: objective.id,
-                                    title: objective.title,
-                                    description: objective.description,
-                                    enabled: objective.enabled
-                                  };
-
-                                  return event.target.value === "control-territory-count"
-                                    ? {
-                                        ...baseObjective,
-                                        type: "control-territory-count",
-                                        territoryCount:
-                                          objective.type === "control-territory-count"
-                                            ? objective.territoryCount
-                                            : 24
-                                      }
-                                    : {
-                                        ...baseObjective,
-                                        type: "control-continents",
-                                        continentIds:
-                                          objective.type === "control-continents"
-                                            ? objective.continentIds
-                                            : []
-                                      };
-                                })
-                              }
-                              disabled={!isEditableDraft}
-                            >
-                              <option value="control-continents">
-                                Control specific continents
-                              </option>
-                              <option value="control-territory-count">
-                                Control minimum territory count
-                              </option>
-                            </select>
-                          </label>
-                          <label className="shell-field admin-field">
-                            <span>Title</span>
-                            <input
-                              value={activeObjective.title}
-                              onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) => ({
-                                  ...objective,
-                                  title: event.target.value
-                                }))
-                              }
-                              disabled={!isEditableDraft}
-                            />
-                          </label>
-                          <label className="shell-field admin-field">
-                            <span>Enabled</span>
-                            <select
-                              value={activeObjective.enabled ? "true" : "false"}
-                              onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) => ({
-                                  ...objective,
-                                  enabled: event.target.value === "true"
-                                }))
-                              }
-                              disabled={!isEditableDraft}
-                            >
-                              <option value="true">Enabled</option>
-                              <option value="false">Disabled</option>
-                            </select>
-                          </label>
-                          <label className="shell-field admin-field admin-card-span">
-                            <span>Player-facing description</span>
-                            <textarea
-                              rows={3}
-                              value={activeObjective.description}
-                              onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) => ({
-                                  ...objective,
-                                  description: event.target.value
-                                }))
-                              }
-                              disabled={!isEditableDraft}
-                            />
-                          </label>
-                        </div>
-
-                        {activeObjective.type === "control-continents" ? (
-                          <div className="content-studio-chip-group">
-                            <p className="admin-item-meta">
-                              Select one or more continents from the active map.
-                            </p>
-                            <div className="content-studio-chip-row">
-                              {(selectedMap?.continents || []).map((continent) => {
-                                const selected = activeObjective.continentIds.includes(
-                                  continent.id
-                                );
-                                return (
-                                  <button
-                                    key={continent.id}
-                                    type="button"
-                                    className={`content-studio-chip${selected ? " is-selected" : ""}`}
-                                    onClick={() =>
-                                      updateObjective(activeObjective.id, (objective) => {
-                                        if (objective.type !== "control-continents") {
-                                          return objective;
-                                        }
-
-                                        return {
-                                          ...objective,
-                                          continentIds: selected
-                                            ? objective.continentIds.filter(
-                                                (entry) => entry !== continent.id
-                                              )
-                                            : [...objective.continentIds, continent.id]
-                                        };
-                                      })
-                                    }
-                                    disabled={!isEditableDraft}
-                                  >
-                                    <strong>{continent.name}</strong>
-                                    <span>
-                                      {continent.territoryCount} territories · bonus{" "}
-                                      {continent.bonus}
-                                    </span>
-                                  </button>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        ) : (
-                          <label className="shell-field admin-field">
-                            <span>Minimum territory count</span>
-                            <input
-                              type="number"
-                              min={1}
-                              max={selectedMap?.territoryCount || 42}
-                              value={String(activeObjective.territoryCount)}
-                              onChange={(event) =>
-                                updateObjective(activeObjective.id, (objective) =>
-                                  objective.type !== "control-territory-count"
-                                    ? objective
-                                    : {
-                                        ...objective,
-                                        territoryCount: Number(event.target.value || "0")
-                                      }
-                                )
-                              }
-                              disabled={!isEditableDraft}
-                            />
-                            <small>
-                              Must be between 1 and {selectedMap?.territoryCount || "the map limit"}
-                              .
-                            </small>
-                          </label>
-                        )}
-
-                        <div className="admin-inline-actions">
-                          <button
-                            type="button"
-                            className="ghost-action"
-                            onClick={() => removeObjective(activeObjective.id)}
-                            disabled={!isEditableDraft}
-                          >
-                            Remove objective
-                          </button>
-                        </div>
+                {draft.moduleType === "victory-objectives" ? (
+                  <section className="card-panel content-studio-form-panel">
+                    <div className="card-header">
+                      <div>
+                        <p className="status-label">Objectives</p>
+                        <h2>Victory conditions</h2>
                       </div>
-                    ) : null}
-                  </div>
-                </section>
+                      <div className="admin-inline-actions">
+                        <button
+                          type="button"
+                          className="ghost-action"
+                          onClick={() => addObjective("control-continents")}
+                          disabled={!isEditableDraft}
+                        >
+                          Add continent objective
+                        </button>
+                        <button
+                          type="button"
+                          className="ghost-action"
+                          onClick={() => addObjective("control-territory-count")}
+                          disabled={!isEditableDraft}
+                        >
+                          Add territory objective
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="content-studio-objective-layout">
+                      <div className="content-studio-objective-list">
+                        {draft.content.objectives.map((objective, index) => (
+                          <button
+                            key={objective.id}
+                            type="button"
+                            className={`admin-list-button${
+                              activeObjectiveId === objective.id ? " is-selected" : ""
+                            }`}
+                            onClick={() => setActiveObjectiveId(objective.id)}
+                          >
+                            <div className="admin-list-copy">
+                              <strong>{objective.title || `Objective ${index + 1}`}</strong>
+                              <span>
+                                {objective.description || "No player-facing description yet."}
+                              </span>
+                              <span className="admin-item-meta">
+                                {objective.id || "missing-id"} ·{" "}
+                                {objectiveTypeLabel(objective.type)}
+                              </span>
+                            </div>
+                            <div className="content-studio-list-meta">
+                              <span className={`badge ${objective.enabled ? "success" : "muted"}`}>
+                                {objective.enabled ? "Enabled" : "Off"}
+                              </span>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+
+                      {activeObjective ? (
+                        <div className="content-studio-objective-editor">
+                          <div className="admin-form-grid admin-form-grid-2">
+                            <label className="shell-field admin-field">
+                              <span>Objective id</span>
+                              <input
+                                value={activeObjective.id}
+                                onChange={(event) =>
+                                  updateObjective(activeObjective.id, (objective) => ({
+                                    ...objective,
+                                    id: event.target.value
+                                  }))
+                                }
+                                disabled={!isEditableDraft}
+                              />
+                            </label>
+                            <label className="shell-field admin-field">
+                              <span>Objective type</span>
+                              <select
+                                value={activeObjective.type}
+                                onChange={(event) =>
+                                  updateObjective(activeObjective.id, (objective) => {
+                                    const baseObjective = {
+                                      id: objective.id,
+                                      title: objective.title,
+                                      description: objective.description,
+                                      enabled: objective.enabled
+                                    };
+
+                                    return event.target.value === "control-territory-count"
+                                      ? {
+                                          ...baseObjective,
+                                          type: "control-territory-count",
+                                          territoryCount:
+                                            objective.type === "control-territory-count"
+                                              ? objective.territoryCount
+                                              : 24
+                                        }
+                                      : {
+                                          ...baseObjective,
+                                          type: "control-continents",
+                                          continentIds:
+                                            objective.type === "control-continents"
+                                              ? objective.continentIds
+                                              : []
+                                        };
+                                  })
+                                }
+                                disabled={!isEditableDraft}
+                              >
+                                <option value="control-continents">
+                                  Control specific continents
+                                </option>
+                                <option value="control-territory-count">
+                                  Control minimum territory count
+                                </option>
+                              </select>
+                            </label>
+                            <label className="shell-field admin-field">
+                              <span>Title</span>
+                              <input
+                                value={activeObjective.title}
+                                onChange={(event) =>
+                                  updateObjective(activeObjective.id, (objective) => ({
+                                    ...objective,
+                                    title: event.target.value
+                                  }))
+                                }
+                                disabled={!isEditableDraft}
+                              />
+                            </label>
+                            <label className="shell-field admin-field">
+                              <span>Enabled</span>
+                              <select
+                                value={activeObjective.enabled ? "true" : "false"}
+                                onChange={(event) =>
+                                  updateObjective(activeObjective.id, (objective) => ({
+                                    ...objective,
+                                    enabled: event.target.value === "true"
+                                  }))
+                                }
+                                disabled={!isEditableDraft}
+                              >
+                                <option value="true">Enabled</option>
+                                <option value="false">Disabled</option>
+                              </select>
+                            </label>
+                            <label className="shell-field admin-field admin-card-span">
+                              <span>Player-facing description</span>
+                              <textarea
+                                rows={3}
+                                value={activeObjective.description}
+                                onChange={(event) =>
+                                  updateObjective(activeObjective.id, (objective) => ({
+                                    ...objective,
+                                    description: event.target.value
+                                  }))
+                                }
+                                disabled={!isEditableDraft}
+                              />
+                            </label>
+                          </div>
+
+                          {activeObjective.type === "control-continents" ? (
+                            <div className="content-studio-chip-group">
+                              <p className="admin-item-meta">
+                                Select one or more continents from the active map.
+                              </p>
+                              <div className="content-studio-chip-row">
+                                {(selectedMap?.continents || []).map((continent) => {
+                                  const selected = activeObjective.continentIds.includes(
+                                    continent.id
+                                  );
+                                  return (
+                                    <button
+                                      key={continent.id}
+                                      type="button"
+                                      className={`content-studio-chip${selected ? " is-selected" : ""}`}
+                                      onClick={() =>
+                                        updateObjective(activeObjective.id, (objective) => {
+                                          if (objective.type !== "control-continents") {
+                                            return objective;
+                                          }
+
+                                          return {
+                                            ...objective,
+                                            continentIds: selected
+                                              ? objective.continentIds.filter(
+                                                  (entry) => entry !== continent.id
+                                                )
+                                              : [...objective.continentIds, continent.id]
+                                          };
+                                        })
+                                      }
+                                      disabled={!isEditableDraft}
+                                    >
+                                      <strong>{continent.name}</strong>
+                                      <span>
+                                        {continent.territoryCount} territories · bonus{" "}
+                                        {continent.bonus}
+                                      </span>
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          ) : (
+                            <label className="shell-field admin-field">
+                              <span>Minimum territory count</span>
+                              <input
+                                type="number"
+                                min={1}
+                                max={selectedMap?.territoryCount || 42}
+                                value={String(activeObjective.territoryCount)}
+                                onChange={(event) =>
+                                  updateObjective(activeObjective.id, (objective) =>
+                                    objective.type !== "control-territory-count"
+                                      ? objective
+                                      : {
+                                          ...objective,
+                                          territoryCount: Number(event.target.value || "0")
+                                        }
+                                  )
+                                }
+                                disabled={!isEditableDraft}
+                              />
+                              <small>
+                                Must be between 1 and{" "}
+                                {selectedMap?.territoryCount || "the map limit"}.
+                              </small>
+                            </label>
+                          )}
+
+                          <div className="admin-inline-actions">
+                            <button
+                              type="button"
+                              className="ghost-action"
+                              onClick={() => removeObjective(activeObjective.id)}
+                              disabled={!isEditableDraft}
+                            >
+                              Remove objective
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  </section>
+                ) : null}
+
+                {draft.moduleType === "map" ? (
+                  <>
+                    <section className="card-panel content-studio-form-panel">
+                      <div className="card-header">
+                        <div>
+                          <p className="status-label">Map topology</p>
+                          <h2>Territories</h2>
+                        </div>
+                        <button
+                          type="button"
+                          className="ghost-action"
+                          onClick={addMapTerritory}
+                          disabled={!isEditableDraft}
+                        >
+                          Add territory
+                        </button>
+                      </div>
+                      <p className="admin-item-meta">
+                        Coordinates use values from 0 to 1. Neighbor links must be bidirectional;
+                        validation blocks disconnected or inconsistent maps.
+                      </p>
+                      <div className="content-studio-objective-list">
+                        {draft.content.territories.map((territory, index) => (
+                          <div
+                            key={`${territory.id}-${index}`}
+                            className="content-studio-objective-editor"
+                          >
+                            <div className="admin-form-grid admin-form-grid-2">
+                              <label className="shell-field admin-field">
+                                <span>Territory id</span>
+                                <input
+                                  value={territory.id}
+                                  onChange={(event) =>
+                                    updateMapTerritory(index, (entry) => ({
+                                      ...entry,
+                                      id: event.target.value
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Name</span>
+                                <input
+                                  value={territory.name}
+                                  onChange={(event) =>
+                                    updateMapTerritory(index, (entry) => ({
+                                      ...entry,
+                                      name: event.target.value
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Continent</span>
+                                <select
+                                  value={territory.continentId || ""}
+                                  onChange={(event) =>
+                                    updateMapTerritory(index, (entry) => ({
+                                      ...entry,
+                                      continentId: event.target.value || null
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                >
+                                  <option value="">Select a continent</option>
+                                  {draft.content.continents.map((continent) => (
+                                    <option key={continent.id} value={continent.id}>
+                                      {continent.name || continent.id}
+                                    </option>
+                                  ))}
+                                </select>
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Neighbors</span>
+                                <input
+                                  value={territory.neighbors.join(", ")}
+                                  onChange={(event) =>
+                                    updateMapTerritory(index, (entry) => ({
+                                      ...entry,
+                                      neighbors: splitIds(event.target.value)
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                                <small>Comma-separated territory ids.</small>
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>X position</span>
+                                <input
+                                  type="number"
+                                  min={0}
+                                  max={1}
+                                  step={0.01}
+                                  value={territory.x}
+                                  onChange={(event) =>
+                                    updateMapTerritory(index, (entry) => ({
+                                      ...entry,
+                                      x: Number(event.target.value)
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Y position</span>
+                                <input
+                                  type="number"
+                                  min={0}
+                                  max={1}
+                                  step={0.01}
+                                  value={territory.y}
+                                  onChange={(event) =>
+                                    updateMapTerritory(index, (entry) => ({
+                                      ...entry,
+                                      y: Number(event.target.value)
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                            </div>
+                            <button
+                              type="button"
+                              className="ghost-action"
+                              onClick={() => removeMapTerritory(index)}
+                              disabled={!isEditableDraft}
+                            >
+                              Remove territory
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </section>
+
+                    <section className="card-panel content-studio-form-panel">
+                      <div className="card-header">
+                        <div>
+                          <p className="status-label">Map rules</p>
+                          <h2>Continents and bonuses</h2>
+                        </div>
+                        <button
+                          type="button"
+                          className="ghost-action"
+                          onClick={addMapContinent}
+                          disabled={!isEditableDraft}
+                        >
+                          Add continent
+                        </button>
+                      </div>
+                      <div className="content-studio-objective-list">
+                        {draft.content.continents.map((continent, index) => (
+                          <div
+                            key={`${continent.id}-${index}`}
+                            className="content-studio-objective-editor"
+                          >
+                            <div className="admin-form-grid admin-form-grid-2">
+                              <label className="shell-field admin-field">
+                                <span>Continent id</span>
+                                <input
+                                  value={continent.id}
+                                  onChange={(event) =>
+                                    updateMapContinent(index, (entry) => ({
+                                      ...entry,
+                                      id: event.target.value
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Name</span>
+                                <input
+                                  value={continent.name}
+                                  onChange={(event) =>
+                                    updateMapContinent(index, (entry) => ({
+                                      ...entry,
+                                      name: event.target.value
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Reinforcement bonus</span>
+                                <input
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={continent.bonus}
+                                  onChange={(event) =>
+                                    updateMapContinent(index, (entry) => ({
+                                      ...entry,
+                                      bonus: Number(event.target.value)
+                                    }))
+                                  }
+                                  disabled={!isEditableDraft}
+                                />
+                              </label>
+                              <label className="shell-field admin-field">
+                                <span>Territories</span>
+                                <input value={continent.territoryIds.join(", ")} disabled />
+                                <small>Derived from the territory assignments above.</small>
+                              </label>
+                            </div>
+                            <button
+                              type="button"
+                              className="ghost-action"
+                              onClick={() => removeMapContinent(index)}
+                              disabled={!isEditableDraft}
+                            >
+                              Remove continent
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </section>
+                  </>
+                ) : null}
 
                 {!isEditableDraft && selectedModuleId ? (
                   <section className="status-panel">

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -22,7 +22,7 @@ export const NETRISK_UI_SLOT_ID_VALUES = [
   "top-nav-bar"
 ] as const;
 const AUTHORED_MODULE_STATUS_VALUES = ["draft", "published", "disabled"] as const;
-const AUTHORED_MODULE_TYPE_VALUES = ["victory-objectives"] as const;
+const AUTHORED_MODULE_TYPE_VALUES = ["victory-objectives", "map"] as const;
 const AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES = [
   "control-continents",
   "control-territory-count"
@@ -37,7 +37,13 @@ const AUTHORED_MODULE_REQUEST_LIMITS = Object.freeze({
   objectiveId: 64,
   objectiveTitle: 255,
   objectiveDescription: 1024,
-  continentId: 64
+  continentId: 64,
+  territoryId: 64,
+  territoryName: 128,
+  continentName: 128,
+  mapTerritories: 250,
+  mapContinents: 50,
+  mapNeighbors: 50
 });
 
 type IssuePathSegment = string | number;
@@ -1269,14 +1275,56 @@ export const authoredVictoryModuleContentSchema = objectSchema({
 
 export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
 
-export const authoredModuleInputSchema = objectSchema({
+export const authoredMapTerritorySchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  continentId: z.string().nullable(),
+  x: z.number(),
+  y: z.number(),
+  neighbors: z.array(z.string())
+});
+
+export type AuthoredMapTerritory = z.infer<typeof authoredMapTerritorySchema>;
+
+export const authoredMapContinentSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  bonus: z.number(),
+  territoryIds: z.array(z.string())
+});
+
+export type AuthoredMapContinent = z.infer<typeof authoredMapContinentSchema>;
+
+export const authoredMapModuleContentSchema = objectSchema({
+  territories: z.array(authoredMapTerritorySchema),
+  continents: z.array(authoredMapContinentSchema)
+});
+
+export type AuthoredMapModuleContent = z.infer<typeof authoredMapModuleContentSchema>;
+
+const authoredModuleInputBaseShape = {
   id: z.string().trim().min(1),
   name: z.string(),
   description: z.string(),
-  version: z.string(),
-  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  version: z.string()
+};
+
+export const authoredVictoryModuleInputSchema = objectSchema({
+  ...authoredModuleInputBaseShape,
+  moduleType: z.literal("victory-objectives"),
   content: authoredVictoryModuleContentSchema
 });
+
+export const authoredMapModuleInputSchema = objectSchema({
+  ...authoredModuleInputBaseShape,
+  moduleType: z.literal("map"),
+  content: authoredMapModuleContentSchema
+});
+
+export const authoredModuleInputSchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleInputSchema,
+  authoredMapModuleInputSchema
+]);
 
 export type AuthoredModuleInput = z.infer<typeof authoredModuleInputSchema>;
 
@@ -1310,17 +1358,58 @@ const authoredVictoryModuleContentRequestSchema = objectSchema({
   objectives: z.array(authoredVictoryObjectiveRequestSchema).max(50)
 });
 
-export const authoredModuleSchema = authoredModuleInputSchema.extend({
+const authoredMapTerritoryRequestSchema = objectSchema({
+  id: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryId),
+  name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryName),
+  continentId: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentId).nullable(),
+  x: z.number(),
+  y: z.number(),
+  neighbors: z
+    .array(z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryId))
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapNeighbors)
+});
+
+const authoredMapContinentRequestSchema = objectSchema({
+  id: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentId),
+  name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentName),
+  bonus: z.number(),
+  territoryIds: z
+    .array(z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryId))
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapTerritories)
+});
+
+const authoredMapModuleContentRequestSchema = objectSchema({
+  territories: z
+    .array(authoredMapTerritoryRequestSchema)
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapTerritories),
+  continents: z
+    .array(authoredMapContinentRequestSchema)
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapContinents)
+});
+
+const authoredModuleStatusShape = {
   status: z.enum(AUTHORED_MODULE_STATUS_VALUES),
   createdAt: z.string().min(1),
   updatedAt: z.string().min(1)
-});
+};
+
+export const authoredVictoryModuleSchema =
+  authoredVictoryModuleInputSchema.extend(authoredModuleStatusShape);
+
+export const authoredMapModuleSchema =
+  authoredMapModuleInputSchema.extend(authoredModuleStatusShape);
+
+export const authoredModuleSchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleSchema,
+  authoredMapModuleSchema
+]);
 
 export type AuthoredModule = z.infer<typeof authoredModuleSchema>;
 
 export const authoredModulePreviewSchema = objectSchema({
   summary: z.string(),
-  objectiveSummaries: z.array(z.string())
+  objectiveSummaries: z.array(z.string()),
+  detailSummaries: z.array(z.string()).optional()
 });
 
 export type AuthoredModulePreview = z.infer<typeof authoredModulePreviewSchema>;
@@ -1374,7 +1463,28 @@ export const authoredVictoryModuleRuntimeSchema = objectSchema({
 
 export type AuthoredVictoryModuleRuntime = z.infer<typeof authoredVictoryModuleRuntimeSchema>;
 
-export const authoredModuleRuntimeSchema = authoredVictoryModuleRuntimeSchema;
+export const authoredMapModuleRuntimeSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  moduleType: z.literal("map"),
+  kind: z.literal("authored-map"),
+  map: objectSchema({
+    id: z.string(),
+    name: z.string(),
+    territoryRecords: z.array(authoredMapTerritorySchema),
+    continentRecords: z.array(authoredMapContinentSchema)
+  }),
+  preview: authoredModulePreviewSchema
+});
+
+export type AuthoredMapModuleRuntime = z.infer<typeof authoredMapModuleRuntimeSchema>;
+
+export const authoredModuleRuntimeSchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleRuntimeSchema,
+  authoredMapModuleRuntimeSchema
+]);
 
 export type AuthoredModuleRuntime = z.infer<typeof authoredModuleRuntimeSchema>;
 
@@ -1397,13 +1507,20 @@ export const authoredMapOptionSchema = objectSchema({
 
 export type AuthoredMapOption = z.infer<typeof authoredMapOptionSchema>;
 
-export const authoredModuleSummarySchema = authoredModuleSchema.extend({
+const authoredModuleSummaryShape = {
   validation: authoredModuleValidationSchema,
   preview: authoredModulePreviewSchema,
   map: authoredMapOptionSchema.omit({ continents: true }).nullable().optional(),
   objectiveCount: z.number().int(),
-  enabledObjectiveCount: z.number().int()
-});
+  enabledObjectiveCount: z.number().int(),
+  territoryCount: z.number().int().nonnegative().optional(),
+  continentCount: z.number().int().nonnegative().optional()
+};
+
+export const authoredModuleSummarySchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleSchema.extend(authoredModuleSummaryShape),
+  authoredMapModuleSchema.extend(authoredModuleSummaryShape)
+]);
 
 export type AuthoredModuleSummary = z.infer<typeof authoredModuleSummarySchema>;
 
@@ -1614,14 +1731,29 @@ export type AdminAuthoredModuleDetailResponse = z.infer<
   typeof adminAuthoredModuleDetailResponseSchema
 >;
 
-export const adminAuthoredModuleUpsertRequestSchema = objectSchema({
+const adminAuthoredModuleUpsertBaseShape = {
   id: z.string().trim().min(1).max(AUTHORED_MODULE_REQUEST_LIMITS.moduleId),
   name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleName),
   description: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleDescription),
-  version: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleVersion),
-  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  version: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleVersion)
+};
+
+export const adminAuthoredVictoryModuleUpsertRequestSchema = objectSchema({
+  ...adminAuthoredModuleUpsertBaseShape,
+  moduleType: z.literal("victory-objectives"),
   content: authoredVictoryModuleContentRequestSchema
 });
+
+export const adminAuthoredMapModuleUpsertRequestSchema = objectSchema({
+  ...adminAuthoredModuleUpsertBaseShape,
+  moduleType: z.literal("map"),
+  content: authoredMapModuleContentRequestSchema
+});
+
+export const adminAuthoredModuleUpsertRequestSchema = z.discriminatedUnion("moduleType", [
+  adminAuthoredVictoryModuleUpsertRequestSchema,
+  adminAuthoredMapModuleUpsertRequestSchema
+]);
 
 export type AdminAuthoredModuleUpsertRequest = z.infer<
   typeof adminAuthoredModuleUpsertRequestSchema

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -235,7 +235,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "module-runtime",
     name: "Module Runtime",
     kind: "platform",
-    version: "1.1.0",
+    version: "1.1.1",
     description:
       "Filesystem module discovery, validation, enablement, and resolved catalog output.",
     ownerPaths: [
@@ -250,9 +250,9 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "authored-victory-objectives",
     name: "Authored Victory Objectives",
     kind: "admin",
-    version: "1.0.1",
+    version: "1.1.0",
     description:
-      "Content Studio authored victory objective drafts, validation, and runtime output.",
+      "Content Studio authored map and victory objective drafts, validation, and runtime output.",
     ownerPaths: [
       "backend/authored-modules.cts",
       "backend/routes/admin-content-studio.cts",

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -263,7 +263,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "admin-console",
     name: "Admin Console",
     kind: "admin",
-    version: "1.0.0",
+    version: "1.0.1",
     description: "Admin routes and operational admin workflows.",
     ownerPaths: ["backend/routes/admin.cts", "docs/admin-console.md", "docs/admin-console-plan.md"]
   },

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -21,7 +21,7 @@ export const NETRISK_UI_SLOT_ID_VALUES = [
   "top-nav-bar"
 ] as const;
 const AUTHORED_MODULE_STATUS_VALUES = ["draft", "published", "disabled"] as const;
-const AUTHORED_MODULE_TYPE_VALUES = ["victory-objectives"] as const;
+const AUTHORED_MODULE_TYPE_VALUES = ["victory-objectives", "map"] as const;
 const AUTHORED_VICTORY_OBJECTIVE_TYPE_VALUES = [
   "control-continents",
   "control-territory-count"
@@ -36,7 +36,13 @@ const AUTHORED_MODULE_REQUEST_LIMITS = Object.freeze({
   objectiveId: 64,
   objectiveTitle: 255,
   objectiveDescription: 1024,
-  continentId: 64
+  continentId: 64,
+  territoryId: 64,
+  territoryName: 128,
+  continentName: 128,
+  mapTerritories: 250,
+  mapContinents: 50,
+  mapNeighbors: 50
 });
 
 type IssuePathSegment = string | number;
@@ -1268,14 +1274,56 @@ export const authoredVictoryModuleContentSchema = objectSchema({
 
 export type AuthoredVictoryModuleContent = z.infer<typeof authoredVictoryModuleContentSchema>;
 
-export const authoredModuleInputSchema = objectSchema({
+export const authoredMapTerritorySchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  continentId: z.string().nullable(),
+  x: z.number(),
+  y: z.number(),
+  neighbors: z.array(z.string())
+});
+
+export type AuthoredMapTerritory = z.infer<typeof authoredMapTerritorySchema>;
+
+export const authoredMapContinentSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  bonus: z.number(),
+  territoryIds: z.array(z.string())
+});
+
+export type AuthoredMapContinent = z.infer<typeof authoredMapContinentSchema>;
+
+export const authoredMapModuleContentSchema = objectSchema({
+  territories: z.array(authoredMapTerritorySchema),
+  continents: z.array(authoredMapContinentSchema)
+});
+
+export type AuthoredMapModuleContent = z.infer<typeof authoredMapModuleContentSchema>;
+
+const authoredModuleInputBaseShape = {
   id: z.string().trim().min(1),
   name: z.string(),
   description: z.string(),
-  version: z.string(),
-  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  version: z.string()
+};
+
+export const authoredVictoryModuleInputSchema = objectSchema({
+  ...authoredModuleInputBaseShape,
+  moduleType: z.literal("victory-objectives"),
   content: authoredVictoryModuleContentSchema
 });
+
+export const authoredMapModuleInputSchema = objectSchema({
+  ...authoredModuleInputBaseShape,
+  moduleType: z.literal("map"),
+  content: authoredMapModuleContentSchema
+});
+
+export const authoredModuleInputSchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleInputSchema,
+  authoredMapModuleInputSchema
+]);
 
 export type AuthoredModuleInput = z.infer<typeof authoredModuleInputSchema>;
 
@@ -1309,17 +1357,58 @@ const authoredVictoryModuleContentRequestSchema = objectSchema({
   objectives: z.array(authoredVictoryObjectiveRequestSchema).max(50)
 });
 
-export const authoredModuleSchema = authoredModuleInputSchema.extend({
+const authoredMapTerritoryRequestSchema = objectSchema({
+  id: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryId),
+  name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryName),
+  continentId: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentId).nullable(),
+  x: z.number(),
+  y: z.number(),
+  neighbors: z
+    .array(z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryId))
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapNeighbors)
+});
+
+const authoredMapContinentRequestSchema = objectSchema({
+  id: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentId),
+  name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.continentName),
+  bonus: z.number(),
+  territoryIds: z
+    .array(z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.territoryId))
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapTerritories)
+});
+
+const authoredMapModuleContentRequestSchema = objectSchema({
+  territories: z
+    .array(authoredMapTerritoryRequestSchema)
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapTerritories),
+  continents: z
+    .array(authoredMapContinentRequestSchema)
+    .max(AUTHORED_MODULE_REQUEST_LIMITS.mapContinents)
+});
+
+const authoredModuleStatusShape = {
   status: z.enum(AUTHORED_MODULE_STATUS_VALUES),
   createdAt: z.string().min(1),
   updatedAt: z.string().min(1)
-});
+};
+
+export const authoredVictoryModuleSchema =
+  authoredVictoryModuleInputSchema.extend(authoredModuleStatusShape);
+
+export const authoredMapModuleSchema =
+  authoredMapModuleInputSchema.extend(authoredModuleStatusShape);
+
+export const authoredModuleSchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleSchema,
+  authoredMapModuleSchema
+]);
 
 export type AuthoredModule = z.infer<typeof authoredModuleSchema>;
 
 export const authoredModulePreviewSchema = objectSchema({
   summary: z.string(),
-  objectiveSummaries: z.array(z.string())
+  objectiveSummaries: z.array(z.string()),
+  detailSummaries: z.array(z.string()).optional()
 });
 
 export type AuthoredModulePreview = z.infer<typeof authoredModulePreviewSchema>;
@@ -1373,7 +1462,28 @@ export const authoredVictoryModuleRuntimeSchema = objectSchema({
 
 export type AuthoredVictoryModuleRuntime = z.infer<typeof authoredVictoryModuleRuntimeSchema>;
 
-export const authoredModuleRuntimeSchema = authoredVictoryModuleRuntimeSchema;
+export const authoredMapModuleRuntimeSchema = objectSchema({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  moduleType: z.literal("map"),
+  kind: z.literal("authored-map"),
+  map: objectSchema({
+    id: z.string(),
+    name: z.string(),
+    territoryRecords: z.array(authoredMapTerritorySchema),
+    continentRecords: z.array(authoredMapContinentSchema)
+  }),
+  preview: authoredModulePreviewSchema
+});
+
+export type AuthoredMapModuleRuntime = z.infer<typeof authoredMapModuleRuntimeSchema>;
+
+export const authoredModuleRuntimeSchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleRuntimeSchema,
+  authoredMapModuleRuntimeSchema
+]);
 
 export type AuthoredModuleRuntime = z.infer<typeof authoredModuleRuntimeSchema>;
 
@@ -1396,13 +1506,20 @@ export const authoredMapOptionSchema = objectSchema({
 
 export type AuthoredMapOption = z.infer<typeof authoredMapOptionSchema>;
 
-export const authoredModuleSummarySchema = authoredModuleSchema.extend({
+const authoredModuleSummaryShape = {
   validation: authoredModuleValidationSchema,
   preview: authoredModulePreviewSchema,
   map: authoredMapOptionSchema.omit({ continents: true }).nullable().optional(),
   objectiveCount: z.number().int(),
-  enabledObjectiveCount: z.number().int()
-});
+  enabledObjectiveCount: z.number().int(),
+  territoryCount: z.number().int().nonnegative().optional(),
+  continentCount: z.number().int().nonnegative().optional()
+};
+
+export const authoredModuleSummarySchema = z.discriminatedUnion("moduleType", [
+  authoredVictoryModuleSchema.extend(authoredModuleSummaryShape),
+  authoredMapModuleSchema.extend(authoredModuleSummaryShape)
+]);
 
 export type AuthoredModuleSummary = z.infer<typeof authoredModuleSummarySchema>;
 
@@ -1613,14 +1730,29 @@ export type AdminAuthoredModuleDetailResponse = z.infer<
   typeof adminAuthoredModuleDetailResponseSchema
 >;
 
-export const adminAuthoredModuleUpsertRequestSchema = objectSchema({
+const adminAuthoredModuleUpsertBaseShape = {
   id: z.string().trim().min(1).max(AUTHORED_MODULE_REQUEST_LIMITS.moduleId),
   name: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleName),
   description: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleDescription),
-  version: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleVersion),
-  moduleType: z.enum(AUTHORED_MODULE_TYPE_VALUES),
+  version: z.string().max(AUTHORED_MODULE_REQUEST_LIMITS.moduleVersion)
+};
+
+export const adminAuthoredVictoryModuleUpsertRequestSchema = objectSchema({
+  ...adminAuthoredModuleUpsertBaseShape,
+  moduleType: z.literal("victory-objectives"),
   content: authoredVictoryModuleContentRequestSchema
 });
+
+export const adminAuthoredMapModuleUpsertRequestSchema = objectSchema({
+  ...adminAuthoredModuleUpsertBaseShape,
+  moduleType: z.literal("map"),
+  content: authoredMapModuleContentRequestSchema
+});
+
+export const adminAuthoredModuleUpsertRequestSchema = z.discriminatedUnion("moduleType", [
+  adminAuthoredVictoryModuleUpsertRequestSchema,
+  adminAuthoredMapModuleUpsertRequestSchema
+]);
 
 export type AdminAuthoredModuleUpsertRequest = z.infer<
   typeof adminAuthoredModuleUpsertRequestSchema

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.051";
+export const appVersion = "0.1.052";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/admin-content-studio-routes.test.cts
+++ b/tests/gameplay/regression/admin-content-studio-routes.test.cts
@@ -161,6 +161,44 @@ function createVictoryDraft(
   };
 }
 
+function createMapDraft() {
+  return {
+    id: "map.route-training",
+    name: "Route Training",
+    description: "A compact map authored through the admin API.",
+    version: "1.0.0",
+    moduleType: "map",
+    content: {
+      territories: [
+        {
+          id: "alpha",
+          name: "Alpha",
+          continentId: "arena",
+          x: 0.2,
+          y: 0.5,
+          neighbors: ["bravo"]
+        },
+        {
+          id: "bravo",
+          name: "Bravo",
+          continentId: "arena",
+          x: 0.8,
+          y: 0.5,
+          neighbors: ["alpha"]
+        }
+      ],
+      continents: [
+        {
+          id: "arena",
+          name: "Arena",
+          bonus: 1,
+          territoryIds: ["alpha", "bravo"]
+        }
+      ]
+    }
+  };
+}
+
 register("content studio routes expose CRUD, validation, and enable toggles", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
     const draft = createVictoryDraft();
@@ -303,6 +341,77 @@ register("content studio routes expose CRUD, validation, and enable toggles", as
       reenabledOptionsResponse.payload.victoryRuleSets.some(
         (entry: { id?: string }) => entry.id === draft.id
       ),
+      true
+    );
+  });
+});
+
+register("content studio publishes authored maps into runtime game options", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const draft = createMapDraft();
+    const createResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/content-studio/modules",
+      draft,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createResponse.statusCode, 201);
+    assert.equal(createResponse.payload.validation.valid, true);
+    assert.equal(createResponse.payload.runtime.kind, "authored-map");
+
+    const publishResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/publish`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(publishResponse.statusCode, 200);
+
+    const optionsResponse = await callApp(app, "GET", "/api/game/options");
+    assert.equal(optionsResponse.statusCode, 200);
+    assert.equal(
+      optionsResponse.payload.maps.some((entry: { id?: string }) => entry.id === draft.id),
+      true
+    );
+    assert.equal(app.moduleRuntime.findSupportedMap(draft.id)?.territories.length, 2);
+
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Authored Map Match",
+        mapId: draft.id,
+        totalPlayers: 2,
+        players: [{ type: "human" }, { type: "human" }]
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createGameResponse.statusCode, 201);
+    assert.equal(createGameResponse.payload.state.gameConfig.mapId, draft.id);
+    assert.equal(createGameResponse.payload.state.map.length, 2);
+
+    const disableInUseResponse = await callApp(
+      app,
+      "POST",
+      `/api/admin/content-studio/modules/${encodeURIComponent(draft.id)}/disable`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(disableInUseResponse.statusCode, 400);
+    assert.match(String(disableInUseResponse.payload.error || ""), /active game/i);
+
+    const studioOptions = await callApp(
+      app,
+      "GET",
+      "/api/admin/content-studio/options",
+      undefined,
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(
+      studioOptions.payload.maps.some((entry: { id?: string }) => entry.id === draft.id),
       true
     );
   });

--- a/tests/gameplay/regression/admin-route-validation.test.cts
+++ b/tests/gameplay/regression/admin-route-validation.test.cts
@@ -376,7 +376,11 @@ register(
     await handleAdminContentStudioValidateRoute(
       {},
       {},
-      { id: "", content: { mapId: 7, objectives: "invalid" } },
+      {
+        id: "",
+        moduleType: "victory-objectives",
+        content: { mapId: 7, objectives: "invalid" }
+      },
       async () => createAuthContext(),
       () => undefined,
       {

--- a/tests/gameplay/regression/authored-modules.test.cts
+++ b/tests/gameplay/regression/authored-modules.test.cts
@@ -62,6 +62,61 @@ function createVictoryDraft(
   };
 }
 
+function createMapDraft(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    territories: any[];
+    continents: any[];
+  }> = {}
+) {
+  return {
+    id: overrides.id || "map.training-ground",
+    name: overrides.name || "Training Ground",
+    description: overrides.description || "A compact authored map for fast matches.",
+    version: overrides.version || "1.0.0",
+    moduleType: "map",
+    content: {
+      territories: overrides.territories || [
+        {
+          id: "north",
+          name: "North",
+          continentId: "training",
+          x: 0.5,
+          y: 0.15,
+          neighbors: ["east", "west"]
+        },
+        {
+          id: "east",
+          name: "East",
+          continentId: "training",
+          x: 0.85,
+          y: 0.75,
+          neighbors: ["north", "west"]
+        },
+        {
+          id: "west",
+          name: "West",
+          continentId: "training",
+          x: 0.15,
+          y: 0.75,
+          neighbors: ["north", "east"]
+        }
+      ],
+      continents: overrides.continents || [
+        {
+          id: "training",
+          name: "Training Grounds",
+          bonus: 2,
+          territoryIds: ["north", "east", "west"]
+        }
+      ]
+    }
+  };
+}
+
 function toStoredModule(
   input: ReturnType<typeof createVictoryDraft>,
   overrides: Record<string, unknown> = {}
@@ -107,7 +162,7 @@ register("authored modules service filters stored modules and exposes editor opt
   const service = createAuthoredModulesService({ datastore });
 
   const options = await service.listEditorOptions();
-  assert.deepEqual(options.moduleTypes, ["victory-objectives"]);
+  assert.deepEqual(options.moduleTypes, ["victory-objectives", "map"]);
   assert.equal(
     options.maps.some((entry: { id?: string }) => entry.id === "world-classic"),
     true
@@ -244,6 +299,79 @@ register(
     );
   }
 );
+
+register("authored modules service validates and publishes runtime maps", async () => {
+  const datastore = createMemoryDatastore();
+  const service = createAuthoredModulesService({ datastore });
+
+  const reservedId = await service.validateDraft(createMapDraft({ id: "world-classic" }));
+  assert.equal(reservedId.validation.valid, false);
+  assert.equal(
+    reservedId.validation.errors.some(
+      (entry: { code?: string }) => entry.code === "reserved-module-id"
+    ),
+    true
+  );
+
+  const invalidAdjacency = createMapDraft({ id: "map.invalid-adjacency" });
+  invalidAdjacency.content.territories[0].neighbors = ["east"];
+  const invalid = await service.validateDraft(invalidAdjacency);
+  assert.equal(invalid.validation.valid, false);
+  assert.equal(
+    invalid.validation.errors.some(
+      (entry: { code?: string }) => entry.code === "invalid-map-graph"
+    ),
+    true
+  );
+
+  const draft = createMapDraft();
+  const validated = await service.validateDraft(draft);
+  assert.equal(validated.validation.valid, true);
+  assert.equal(validated.runtime.moduleType, "map");
+  assert.equal(validated.runtime.map.territoryRecords.length, 3);
+
+  await service.saveDraft(draft);
+  const published = await service.publishModule(draft.id);
+  assert.equal(published.module.status, "published");
+  assert.equal(published.preview.detailSummaries.includes("3 territories"), true);
+
+  const maps = await service.listPublishedMaps();
+  assert.equal(maps.length, 1);
+  assert.equal(maps[0].map.id, draft.id);
+  assert.equal(maps[0].map.territories.length, 3);
+  assert.equal(maps[0].map.continents[0].bonus, 2);
+
+  const options = await service.listEditorOptions();
+  assert.equal(
+    options.maps.some((entry: { id: string }) => entry.id === draft.id),
+    true
+  );
+
+  const objectiveForAuthoredMap = await service.validateDraft(
+    createVictoryDraft({
+      id: "victory.training",
+      mapId: draft.id,
+      objectives: [
+        {
+          id: "hold-training",
+          title: "Hold the training grounds",
+          description: "Control the training continent.",
+          enabled: true,
+          type: "control-continents",
+          continentIds: ["training"]
+        }
+      ]
+    })
+  );
+  assert.equal(objectiveForAuthoredMap.validation.valid, true);
+
+  await service.disableModule(draft.id);
+  const optionsAfterDisable = await service.listEditorOptions();
+  assert.equal(
+    optionsAfterDisable.maps.some((entry: { id: string }) => entry.id === draft.id),
+    false
+  );
+});
 
 register("authored modules service blocks published edits and invalid re-enabling", async () => {
   const datastore = createMemoryDatastore();


### PR DESCRIPTION
## Summary

- add a structured map editor to the admin Content Studio
- persist and validate authored map drafts with the existing publish/disable lifecycle
- validate coordinates, bidirectional adjacency, graph connectivity, continent membership, and bonuses
- expose published authored maps through runtime options and real game creation
- prevent disabling authored maps that are referenced by active games or admin defaults
- document how authored maps reuse the existing pluggable rules and bonuses model

## Impact

Admins can create, edit, save, load, publish, disable, and use custom maps without editing source files or uploading executable code. Existing authored victory-objective modules remain compatible.

## Validation

- `npm run test:all` — 151 React tests, 166 integration tests, 478 gameplay tests
- `npm run lint`
- `npm run format:check`
- `npm run release:check` — passed for 0.1.052
- remote branch tree verified identical to the tested local tree

Closes #61