### PR TITLE
Make Vercel deployment registration resilient

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Note skipped Vercel env parity check
         if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.vercel_auth.outcome != 'success' }}
         run: |
+          echo "::warning title=Vercel environment audit skipped::VERCEL_TOKEN is missing or invalid; production environment parity was not verified."
           echo "Skipping Vercel env parity check because VERCEL_TOKEN is missing or invalid for this run." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Vercel env parity check

--- a/.github/workflows/vercel-github-deployment.yml
+++ b/.github/workflows/vercel-github-deployment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Create GitHub deployment for Vercel preview
+      - name: Create GitHub deployment for Vercel status
         uses: actions/github-script@v9
         env:
           VERCEL_ORG_ID: team_KZLHaqyM8HI03cxJQzg1e9Wz
@@ -48,11 +48,6 @@ jobs:
 
             if (!deploymentKey) {
               core.setFailed(`Unable to parse Vercel deployment id from ${statusUrl}.`);
-              return;
-            }
-
-            if (!process.env.VERCEL_TOKEN) {
-              core.setFailed("VERCEL_TOKEN is required to resolve the Vercel deployment URL.");
               return;
             }
 
@@ -92,6 +87,13 @@ jobs:
             }
 
             async function fetchVercelDeployment() {
+              if (!process.env.VERCEL_TOKEN) {
+                core.warning(
+                  "VERCEL_TOKEN is unavailable; registering the Vercel dashboard URL instead."
+                );
+                return null;
+              }
+
               const failures = [];
 
               for (const lookupUrl of uniqueDeploymentLookupUrls()) {
@@ -111,26 +113,38 @@ jobs:
                 core.info(`Vercel deployment lookup failed at ${lookupUrl}: ${response.status}`);
               }
 
-              core.setFailed(
-                `Unable to fetch Vercel deployment ${deploymentKey}: ${failures.join(" | ")}`
+              core.warning(
+                `Unable to resolve Vercel deployment ${deploymentKey}; ` +
+                  `registering the dashboard URL instead. ${failures.join(" | ")}`
               );
               return null;
             }
 
             const vercelDeployment = await fetchVercelDeployment();
+            const deploymentUrl = vercelDeployment?.url
+              ? `https://${vercelDeployment.url}`
+              : statusUrl;
+            const defaultBranch = String(context.payload.repository?.default_branch || "main");
+            const statusBranches = Array.isArray(status.branches) ? status.branches : [];
+            let statusIsForDefaultBranch = statusBranches.some(
+              (branch) => String(branch?.name || "") === defaultBranch
+            );
 
-            if (!vercelDeployment) {
-              return;
+            if (!statusIsForDefaultBranch) {
+              const defaultBranchResponse = await github.rest.repos.getBranch({
+                owner,
+                repo,
+                branch: defaultBranch,
+              });
+              statusIsForDefaultBranch =
+                String(defaultBranchResponse.data.commit?.sha || "") === sha;
             }
 
-            const deploymentUrl = vercelDeployment.url ? `https://${vercelDeployment.url}` : "";
-
-            if (!deploymentUrl) {
-              core.setFailed(`Vercel deployment ${deploymentKey} did not include a URL.`);
-              return;
-            }
-
-            const environment = vercelDeployment.target === "production" ? "Production" : "Preview";
+            const environment =
+              vercelDeployment?.target === "production" ||
+              (!vercelDeployment && statusIsForDefaultBranch)
+                ? "Production"
+                : "Preview";
             const deployments = await github.paginate(github.rest.repos.listDeployments, {
               owner,
               repo,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.054 - 2026-08-05
+
+- Made Vercel-to-GitHub deployment registration resilient to missing, expired, or unauthorized API tokens by falling back to the successful Vercel status URL.
+- Preserved Production versus Preview classification during token-free deployment registration.
+- Added a visible GitHub Actions warning when Vercel environment parity cannot be audited, plus regression coverage for both workflows.
+
 ## 0.1.053 - 2026-08-05
 
 - Added selectable easy, medium, and hard difficulty for each AI player, with legacy AI slots defaulting to medium.

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.053";
+export const appVersion = "0.1.054";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/vercel-routing-config.test.cts
+++ b/tests/gameplay/regression/vercel-routing-config.test.cts
@@ -25,6 +25,10 @@ function loadVercelConfig(): VercelConfig {
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
 }
 
+function loadWorkflow(name: string): string {
+  return fs.readFileSync(path.join(process.cwd(), ".github", "workflows", name), "utf8");
+}
+
 function hasRewriteRule(rewrites: RewriteRule[], source: string, destination: string): boolean {
   return rewrites.some((entry) => entry.source === source && entry.destination === destination);
 }
@@ -133,4 +137,49 @@ register("vercel preview rewrites React shell deep links to the shell entry docu
       value: "(?<gameId>.+)"
     }
   ]);
+});
+
+register("vercel deployment registration survives an unavailable API token", () => {
+  const workflow = loadWorkflow("vercel-github-deployment.yml");
+
+  assert.match(
+    workflow,
+    /VERCEL_TOKEN is unavailable; registering the Vercel dashboard URL instead\./,
+    "Expected the deployment workflow to document its token-free fallback."
+  );
+  assert.match(
+    workflow,
+    /const deploymentUrl = vercelDeployment\?\.url[\s\S]*?: statusUrl;/,
+    "Expected the dashboard status URL to be registered when the Vercel API is unavailable."
+  );
+  assert.match(
+    workflow,
+    /statusIsForDefaultBranch[\s\S]*?\? "Production"[\s\S]*?: "Preview";/,
+    "Expected token-free deployment registration to preserve production classification."
+  );
+  assert.match(
+    workflow,
+    /github\.rest\.repos\.getBranch\([\s\S]*?branch: defaultBranch/,
+    "Expected production classification to fall back to the current default-branch SHA."
+  );
+  assert.doesNotMatch(
+    workflow,
+    /VERCEL_TOKEN is required to resolve the Vercel deployment URL/,
+    "The deployment status workflow must not fail only because its optional lookup token expired."
+  );
+});
+
+register("quality workflow exposes skipped Vercel environment audits", () => {
+  const workflow = loadWorkflow("quality.yml");
+
+  assert.match(
+    workflow,
+    /::warning title=Vercel environment audit skipped::/,
+    "Expected an invalid Vercel token to create a visible GitHub Actions warning."
+  );
+  assert.match(
+    workflow,
+    /production environment parity was not verified/,
+    "Expected the warning to state which production check did not run."
+  );
 });


### PR DESCRIPTION
## Root cause
The Vercel deployment itself completed successfully, but the custom `Vercel GitHub Deployment` workflow failed while resolving the deployment URL because `VERCEL_TOKEN` returned `403 Forbidden` with `invalidToken: true`. The Quality workflow also skipped environment parity after the same authentication failure.

## Fix
- fall back to the successful Vercel status/dashboard URL when the optional API lookup token is unavailable or unauthorized
- preserve Production versus Preview classification from the status webhook and current default-branch SHA
- expose skipped Vercel environment audits as visible GitHub Actions warnings
- add regression coverage and bump the app version to 0.1.054

## Validation
- `npm run test:all` — 151 React, 167 integration, 487 gameplay tests
- `npm run typecheck:react-shell`
- `npm run lint`
- `npm run format:check`
- `npm run release:check`
- `NETRISK_MODULE_VERSION_BASE_REF=origin/main npm run check:module-versioning`
- `git diff --check`

## Compatibility
No runtime API, persistence, save-game, or module compatibility changes.