### PR TITLE
Make Playwright visual tests reproducible

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   e2e-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -30,7 +30,7 @@ jobs:
         run: npm run build:ts
 
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        run: npm run e2e:visual:install
 
       - name: Ensure E2E data directory exists
         run: mkdir -p data
@@ -43,6 +43,38 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: playwright-smoke-artifacts
+          path: |
+            playwright-report
+            test-results
+
+  e2e-visual:
+    runs-on: ubuntu-24.04
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      options: --ipc=host
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify and run visual regression suite
+        run: npm run test:e2e:visual
+
+      - name: Upload visual regression artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-visual-artifacts
+          if-no-files-found: warn
+          retention-days: 14
           path: |
             playwright-report
             test-results

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Trust the container checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.056 - 2026-08-05
+
+- Pinned Playwright 1.61.1, Chromium 149.0.7827.55 (revision 1228), Ubuntu 24.04, and the Linux font dependencies used by visual baselines.
+- Added a visual-test environment preflight that reports and rejects browser, operating-system, or font drift before snapshot assertions run.
+- Added a reproducible visual-regression CI/container workflow while retaining Playwright expected, actual, and diff artifacts on failures.
+
 ## 0.1.055 - 2026-08-05
 
 - Replaced unauthenticated lobby open/join requests with explicit login links that preserve the selected game destination.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ npm test
 npm run test:gameplay
 npm run test:e2e
 npm run test:e2e:smoke
+npm run test:e2e:visual
+npm run e2e:visual:install
+npm run e2e:visual:preflight
 npm run test:e2e:split
 npm run test:e2e:parallel
 npm run test:e2e:serial
@@ -285,6 +288,9 @@ npm run test:all:e2e:split
 - `npm run test:gameplay`: game engine validation
 - `npm run test:e2e`: Playwright tests for user flows
 - `npm run test:e2e:smoke`: fast Playwright smoke coverage
+- `npm run test:e2e:visual`: runs screenshot assertions after enforcing the pinned browser, OS, and font environment documented in [docs/visual-regression.md](docs/visual-regression.md)
+- `npm run e2e:visual:install`: installs the exact Chromium build and Linux dependencies selected by the pinned Playwright version
+- `npm run e2e:visual:preflight`: reports and validates the rendering environment without running snapshots
 - `npm run test:e2e:split` / `npm run test:e2e:parallel`: isolated Playwright shard runners
 - `npm run test:e2e:serial`: explicit single-process Playwright runner
 - `npm run test:e2e:headed`: headed Playwright run for local debugging

--- a/docs/visual-regression.md
+++ b/docs/visual-regression.md
@@ -1,0 +1,37 @@
+# Visual regression environment
+
+Linux screenshot baselines are generated and compared only in the following rendering environment:
+
+- `@playwright/test` 1.61.1;
+- Chromium `149.0.7827.55`, Playwright revision `1228`;
+- Ubuntu 24.04 (`noble`);
+- Playwright container `mcr.microsoft.com/playwright:v1.61.1-noble`;
+- the Playwright Ubuntu font dependencies `fonts-freefont-ttf`, `fonts-ipafont-gothic`, `fonts-liberation`, `fonts-noto-color-emoji`, `fonts-tlwg-loma-otf`, `fonts-unifont`, `fonts-wqy-zenhei`, `libfontconfig1`, and `libfreetype6`.
+
+The expected Latin fallback families are Liberation Sans, Liberation Serif, and Liberation Mono. Noto Color Emoji is required for emoji rendering. Proprietary first-choice fonts referenced by the application (`Arial`, `Georgia`, `Helvetica Neue`, `Inter`, `Segoe UI`, and `Trebuchet MS`) must not be installed in the Linux snapshot environment because they change text metrics and rasterization.
+
+## Supported commands
+
+On an Ubuntu 24.04 host, bootstrap and run the visual suite with:
+
+```bash
+npm ci
+npm run e2e:visual:install
+npm run e2e:visual:preflight
+npm run test:e2e:visual
+```
+
+The reproducible local workflow uses the exact CI image:
+
+```bash
+docker run --rm --init --ipc=host \
+  -v "$PWD:/work" -w /work \
+  mcr.microsoft.com/playwright:v1.61.1-noble \
+  bash -lc "npm ci && npm run test:e2e:visual"
+```
+
+The preflight launches Chromium before the application server starts, reports the detected versions and executable, verifies the Linux release and font stack, and exits with a bootstrap hint if anything differs. A compatible-looking system Chromium is intentionally rejected.
+
+GitHub Actions runs the same visual command in the pinned container. Playwright keeps failed test output in `test-results`; the workflow uploads that directory and `playwright-report` so expected, actual, and diff images remain available for diagnosis.
+
+Only run `npm run test:e2e:update` after an approved UI change and in the supported environment. Never update baselines merely to silence an unexplained browser or font mismatch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "1.61.1",
         "@sentry/vite-plugin": "^5.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "test:e2e:parallel": "npm run build:ts && node .tsbuild/scripts/run-e2e-default.cjs",
     "test:e2e:serial": "npm run build:ts && node .tsbuild/scripts/run-e2e.cjs",
     "test:e2e:smoke": "npm run build:ts && node .tsbuild/scripts/run-e2e.cjs e2e/smoke",
+    "test:e2e:visual": "npm run build:ts && node .tsbuild/scripts/run-e2e.cjs e2e/00-visual",
+    "e2e:visual:install": "npx playwright install --with-deps chromium",
+    "e2e:visual:preflight": "npm run build:ts && node .tsbuild/scripts/check-playwright-visual-env.cjs",
     "test:e2e:update": "npm run build:ts && node .tsbuild/scripts/run-e2e.cjs --update-snapshots",
     "test:gameplay": "npm run build:ts && node .tsbuild/scripts/run-gameplay-tests.cjs",
     "test:all": "npm run build:ts && npm run test:react && node .tsbuild/scripts/run-tests.cjs && node .tsbuild/scripts/run-gameplay-tests.cjs",
@@ -47,7 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "1.61.1",
     "@sentry/vite-plugin": "^5.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,8 @@ const includeHtmlReport = process.env.CI || process.env.PLAYWRIGHT_HTML_REPORT =
 
 export default defineConfig({
   testDir: "./e2e",
+  outputDir: "test-results",
+  preserveOutput: "failures-only",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: 0,
@@ -25,18 +27,20 @@ export default defineConfig({
     video: process.env.CI ? "retain-on-failure" : "off",
     viewport: { width: 1440, height: 960 }
   },
-  webServer: skipWebServer ? undefined : {
-    command: "node .tsbuild/scripts/start-e2e.cjs",
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-    env: {
-      ...process.env,
-      PORT: String(e2ePort),
-      E2E_PORT: String(e2ePort),
-      E2E_BASE_URL: baseURL
-    }
-  },
+  webServer: skipWebServer
+    ? undefined
+    : {
+        command: "node .tsbuild/scripts/start-e2e.cjs",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+        env: {
+          ...process.env,
+          PORT: String(e2ePort),
+          E2E_PORT: String(e2ePort),
+          E2E_BASE_URL: baseURL
+        }
+      },
   projects: [
     {
       name: "chromium",

--- a/scripts/check-playwright-visual-env.cts
+++ b/scripts/check-playwright-visual-env.cts
@@ -1,0 +1,143 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  supportedVisualEnvironment,
+  validateVisualEnvironment,
+  type VisualEnvironmentSnapshot
+} from "./playwright-visual-environment.cjs";
+
+type BrowserRegistryEntry = {
+  name?: string;
+  revision?: string;
+  browserVersion?: string;
+};
+
+function readOsRelease(): Record<string, string> {
+  if (process.platform !== "linux") {
+    return {};
+  }
+
+  return Object.fromEntries(
+    readFileSync("/etc/os-release", "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.match(/^([A-Z_]+)=(.*)$/))
+      .filter((match): match is RegExpMatchArray => Boolean(match))
+      .map((match) => [match[1].toLowerCase(), match[2].replace(/^['"]|['"]$/g, "")])
+  );
+}
+
+function installedFontPackages(): Record<string, boolean> {
+  if (process.platform !== "linux") {
+    return {};
+  }
+
+  return Object.fromEntries(
+    supportedVisualEnvironment.linux.fontPackages.map((packageName) => {
+      try {
+        const status = execFileSync("dpkg-query", ["-W", "-f=${db:Status-Abbrev}", packageName], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"]
+        }).trim();
+        return [packageName, status === "ii"];
+      } catch (_error) {
+        return [packageName, false];
+      }
+    })
+  );
+}
+
+function installedFontFamilies(): string[] {
+  if (process.platform !== "linux") {
+    return [];
+  }
+
+  const output = execFileSync("fc-list", ["--format=%{family}\n"], { encoding: "utf8" });
+  return Array.from(
+    new Set(
+      output
+        .split(/\r?\n/)
+        .flatMap((line) => line.split(","))
+        .map((family) => family.trim())
+        .filter(Boolean)
+    )
+  ).sort();
+}
+
+function browserRegistryEntry(): BrowserRegistryEntry {
+  const corePackagePath = require.resolve("playwright-core/package.json");
+  const registry = JSON.parse(
+    readFileSync(join(dirname(corePackagePath), "browsers.json"), "utf8")
+  ) as { browsers?: BrowserRegistryEntry[] };
+  return (
+    registry.browsers?.find((entry) => entry.name === supportedVisualEnvironment.browserName) || {}
+  );
+}
+
+export async function inspectVisualEnvironment(): Promise<VisualEnvironmentSnapshot> {
+  const { chromium } = require("@playwright/test");
+  const packagePath = require.resolve("@playwright/test/package.json");
+  const playwrightPackage = JSON.parse(readFileSync(packagePath, "utf8")) as {
+    version?: string;
+  };
+  const registryEntry = browserRegistryEntry();
+  const osRelease = readOsRelease();
+  let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+
+  try {
+    browser = await chromium.launch({ headless: true });
+    return {
+      platform: process.platform,
+      playwrightVersion: playwrightPackage.version || "unknown",
+      browserVersion: browser.version(),
+      browserRevision: registryEntry.revision || "unknown",
+      browserExecutablePath: chromium.executablePath(),
+      osId: osRelease.id,
+      osVersionId: osRelease.version_id,
+      fontPackages: installedFontPackages(),
+      fontFamilies: installedFontFamilies()
+    };
+  } finally {
+    await browser?.close();
+  }
+}
+
+export async function runVisualEnvironmentPreflight(): Promise<void> {
+  let snapshot: VisualEnvironmentSnapshot;
+  try {
+    snapshot = await inspectVisualEnvironment();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Visual-test browser preflight failed before snapshots started. Run \`npm run e2e:visual:install\` or use ${supportedVisualEnvironment.linux.containerImage}.\n${detail}`,
+      { cause: error }
+    );
+  }
+
+  console.log("Visual regression environment preflight:");
+  console.log(`- Playwright: ${snapshot.playwrightVersion}`);
+  console.log(`- Chromium: ${snapshot.browserVersion} (revision ${snapshot.browserRevision})`);
+  console.log(`- Executable: ${snapshot.browserExecutablePath}`);
+  if (snapshot.platform === "linux") {
+    console.log(`- Linux: ${snapshot.osId} ${snapshot.osVersionId}`);
+    console.log(
+      `- Required font packages: ${supportedVisualEnvironment.linux.fontPackages.join(", ")}`
+    );
+  }
+
+  const errors = validateVisualEnvironment(snapshot);
+  if (errors.length > 0) {
+    throw new Error(
+      `Unsupported visual regression environment:\n${errors.map((error) => `- ${error}`).join("\n")}\nUse the documented container command before generating or comparing Linux baselines.`
+    );
+  }
+
+  console.log("Visual regression environment is supported.");
+}
+
+if (require.main === module) {
+  void runVisualEnvironmentPreflight().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/playwright-visual-environment.cts
+++ b/scripts/playwright-visual-environment.cts
@@ -1,0 +1,105 @@
+export type VisualEnvironmentSnapshot = {
+  platform: NodeJS.Platform;
+  playwrightVersion: string;
+  browserVersion: string;
+  browserRevision: string;
+  browserExecutablePath: string;
+  osId?: string;
+  osVersionId?: string;
+  fontPackages?: Record<string, boolean>;
+  fontFamilies?: string[];
+};
+
+export const supportedVisualEnvironment = Object.freeze({
+  playwrightVersion: "1.61.1",
+  browserName: "chromium",
+  browserVersion: "149.0.7827.55",
+  browserRevision: "1228",
+  linux: Object.freeze({
+    osId: "ubuntu",
+    osVersionId: "24.04",
+    containerImage: "mcr.microsoft.com/playwright:v1.61.1-noble",
+    fontPackages: Object.freeze([
+      "fonts-freefont-ttf",
+      "fonts-ipafont-gothic",
+      "fonts-liberation",
+      "fonts-noto-color-emoji",
+      "fonts-tlwg-loma-otf",
+      "fonts-unifont",
+      "fonts-wqy-zenhei",
+      "libfontconfig1",
+      "libfreetype6"
+    ]),
+    requiredFontFamilies: Object.freeze([
+      "Liberation Mono",
+      "Liberation Sans",
+      "Liberation Serif",
+      "Noto Color Emoji"
+    ]),
+    forbiddenFontFamilies: Object.freeze([
+      "Arial",
+      "Georgia",
+      "Helvetica Neue",
+      "Inter",
+      "Segoe UI",
+      "Trebuchet MS"
+    ])
+  })
+});
+
+export function validateVisualEnvironment(snapshot: VisualEnvironmentSnapshot): string[] {
+  const errors: string[] = [];
+
+  if (snapshot.playwrightVersion !== supportedVisualEnvironment.playwrightVersion) {
+    errors.push(
+      `Playwright ${snapshot.playwrightVersion} is unsupported; expected ${supportedVisualEnvironment.playwrightVersion}.`
+    );
+  }
+
+  if (snapshot.browserVersion !== supportedVisualEnvironment.browserVersion) {
+    errors.push(
+      `Chromium ${snapshot.browserVersion} is unsupported; expected ${supportedVisualEnvironment.browserVersion}.`
+    );
+  }
+
+  if (snapshot.browserRevision !== supportedVisualEnvironment.browserRevision) {
+    errors.push(
+      `Chromium revision ${snapshot.browserRevision} is unsupported; expected ${supportedVisualEnvironment.browserRevision}.`
+    );
+  }
+
+  if (snapshot.platform !== "linux") {
+    return errors;
+  }
+
+  const linux = supportedVisualEnvironment.linux;
+  if (snapshot.osId !== linux.osId || snapshot.osVersionId !== linux.osVersionId) {
+    errors.push(
+      `Linux visual snapshots require ${linux.osId} ${linux.osVersionId}; found ${snapshot.osId || "unknown"} ${snapshot.osVersionId || "unknown"}.`
+    );
+  }
+
+  const fontPackages = snapshot.fontPackages || {};
+  for (const packageName of linux.fontPackages) {
+    if (!fontPackages[packageName]) {
+      errors.push(`Required visual-test font package is missing: ${packageName}.`);
+    }
+  }
+
+  const fontFamilies = new Set(snapshot.fontFamilies || []);
+  for (const family of linux.requiredFontFamilies) {
+    if (!fontFamilies.has(family)) {
+      errors.push(`Required visual-test font family is missing: ${family}.`);
+    }
+  }
+
+  for (const family of linux.forbiddenFontFamilies) {
+    if (fontFamilies.has(family)) {
+      errors.push(
+        `Unsupported host font ${family} is installed and can change screenshot rasterization.`
+      );
+    }
+  }
+
+  return errors;
+}

--- a/scripts/playwright-visual-environment.cts
+++ b/scripts/playwright-visual-environment.cts
@@ -47,18 +47,114 @@ export const supportedVisualEnvironment = Object.freeze({
   })
 });
 
-export function requiresVisualEnvironmentPreflight(args: string[]): boolean {
-  const explicitE2ePaths = args
-    .map((arg) => arg.replace(/^\.\//, ""))
-    .filter((arg) => arg === "e2e" || arg.startsWith("e2e/"));
+const playwrightOptionsWithRequiredValues = new Set([
+  "--browser",
+  "-c",
+  "--config",
+  "-g",
+  "--grep",
+  "-G",
+  "--grep-invert",
+  "--global-timeout",
+  "-j",
+  "--workers",
+  "--last-failed-file",
+  "--max-failures",
+  "--output",
+  "--project",
+  "--repeat-each",
+  "--reporter",
+  "--retries",
+  "--run-agents",
+  "--shard",
+  "--test-list",
+  "--test-list-invert",
+  "--timeout",
+  "--trace",
+  "--tsconfig",
+  "--ui-host",
+  "--ui-port",
+  "--update-source-method"
+]);
 
-  if (explicitE2ePaths.length === 0) {
+const playwrightOptionsWithOptionalValues = new Set([
+  "--debug",
+  "--only-changed",
+  "-u",
+  "--update-snapshots"
+]);
+
+const playwrightBooleanOptions = new Set([
+  "--fail-on-flaky-tests",
+  "--forbid-only",
+  "--fully-parallel",
+  "--headed",
+  "--ignore-snapshots",
+  "--last-failed",
+  "--list",
+  "--no-deps",
+  "--pass-with-no-tests",
+  "--quiet",
+  "--ui",
+  "-x"
+]);
+
+function getLiteralTestFilters(args: string[]): string[] | null {
+  const filters: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") {
+      filters.push(...args.slice(index + 1));
+      break;
+    }
+
+    if (!arg.startsWith("-")) {
+      filters.push(arg);
+      continue;
+    }
+
+    const optionName = arg.split("=", 1)[0];
+    if (arg.includes("=")) {
+      if (
+        !playwrightOptionsWithRequiredValues.has(optionName) &&
+        !playwrightOptionsWithOptionalValues.has(optionName)
+      ) {
+        return null;
+      }
+      continue;
+    }
+
+    if (playwrightOptionsWithRequiredValues.has(optionName)) {
+      if (index + 1 >= args.length) {
+        return null;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (playwrightOptionsWithOptionalValues.has(optionName)) {
+      return null;
+    }
+
+    if (!playwrightBooleanOptions.has(optionName)) {
+      return null;
+    }
+  }
+
+  return filters;
+}
+
+export function requiresVisualEnvironmentPreflight(args: string[]): boolean {
+  const filters = getLiteralTestFilters(args);
+  if (!filters || filters.length === 0) {
     return true;
   }
 
-  return explicitE2ePaths.some(
-    (arg) => arg === "e2e/00-visual" || arg.startsWith("e2e/00-visual/")
-  );
+  return !filters.every((filter) => {
+    const normalized = filter.replace(/^\.\//, "");
+    return /^e2e\/(?!00-visual(?:\/|$))[A-Za-z0-9._/-]+$/.test(normalized);
+  });
 }
 
 export function validateVisualEnvironment(snapshot: VisualEnvironmentSnapshot): string[] {
@@ -83,6 +179,9 @@ export function validateVisualEnvironment(snapshot: VisualEnvironmentSnapshot): 
   }
 
   if (snapshot.platform !== "linux") {
+    errors.push(
+      `Visual snapshots require Linux ${supportedVisualEnvironment.linux.osId} ${supportedVisualEnvironment.linux.osVersionId}; found ${snapshot.platform}.`
+    );
     return errors;
   }
 

--- a/scripts/playwright-visual-environment.cts
+++ b/scripts/playwright-visual-environment.cts
@@ -47,6 +47,20 @@ export const supportedVisualEnvironment = Object.freeze({
   })
 });
 
+export function requiresVisualEnvironmentPreflight(args: string[]): boolean {
+  const explicitE2ePaths = args
+    .map((arg) => arg.replace(/^\.\//, ""))
+    .filter((arg) => arg === "e2e" || arg.startsWith("e2e/"));
+
+  if (explicitE2ePaths.length === 0) {
+    return true;
+  }
+
+  return explicitE2ePaths.some(
+    (arg) => arg === "e2e/00-visual" || arg.startsWith("e2e/00-visual/")
+  );
+}
+
 export function validateVisualEnvironment(snapshot: VisualEnvironmentSnapshot): string[] {
   const errors: string[] = [];
 

--- a/scripts/run-e2e.cts
+++ b/scripts/run-e2e.cts
@@ -15,6 +15,14 @@ interface ExitResult {
   signal: NodeJS.Signals | null;
 }
 
+function includesVisualSnapshots(args: string[]): boolean {
+  const positionalArgs = args.filter((arg) => !arg.startsWith("-"));
+  return (
+    positionalArgs.length === 0 ||
+    positionalArgs.some((arg) => arg === "e2e/00-visual" || arg.startsWith("e2e/00-visual/"))
+  );
+}
+
 function canBind(port: number): Promise<boolean> {
   return new Promise((resolve: (value: boolean) => void) => {
     const server = net.createServer();
@@ -151,6 +159,12 @@ async function main(): Promise<void> {
       process.env.NETRISK_AUTH_THROTTLE_MAX_IP_ATTEMPTS || "1000",
     PLAYWRIGHT_SKIP_WEBSERVER: "true"
   };
+  if (includesVisualSnapshots(args)) {
+    const { runVisualEnvironmentPreflight } = require("./check-playwright-visual-env.cjs") as {
+      runVisualEnvironmentPreflight: () => Promise<void>;
+    };
+    await runVisualEnvironmentPreflight();
+  }
   await cleanupStaleE2eDatabases(dataDir);
   await cleanupSqliteFiles(dbFile);
   const serverChild = spawn(

--- a/scripts/run-e2e.cts
+++ b/scripts/run-e2e.cts
@@ -15,14 +15,6 @@ interface ExitResult {
   signal: NodeJS.Signals | null;
 }
 
-function includesVisualSnapshots(args: string[]): boolean {
-  const positionalArgs = args.filter((arg) => !arg.startsWith("-"));
-  return (
-    positionalArgs.length === 0 ||
-    positionalArgs.some((arg) => arg === "e2e/00-visual" || arg.startsWith("e2e/00-visual/"))
-  );
-}
-
 function canBind(port: number): Promise<boolean> {
   return new Promise((resolve: (value: boolean) => void) => {
     const server = net.createServer();
@@ -159,7 +151,10 @@ async function main(): Promise<void> {
       process.env.NETRISK_AUTH_THROTTLE_MAX_IP_ATTEMPTS || "1000",
     PLAYWRIGHT_SKIP_WEBSERVER: "true"
   };
-  if (includesVisualSnapshots(args)) {
+  const { requiresVisualEnvironmentPreflight } = require("./playwright-visual-environment.cjs") as {
+    requiresVisualEnvironmentPreflight: (runnerArgs: string[]) => boolean;
+  };
+  if (requiresVisualEnvironmentPreflight(args)) {
     const { runVisualEnvironmentPreflight } = require("./check-playwright-visual-env.cjs") as {
       runVisualEnvironmentPreflight: () => Promise<void>;
     };

--- a/scripts/run-e2e.cts
+++ b/scripts/run-e2e.cts
@@ -165,6 +165,7 @@ async function main(): Promise<void> {
     };
     await runVisualEnvironmentPreflight();
   }
+  await fs.promises.mkdir(dataDir, { recursive: true });
   await cleanupStaleE2eDatabases(dataDir);
   await cleanupSqliteFiles(dbFile);
   const serverChild = spawn(

--- a/scripts/run-gameplay-tests.cts
+++ b/scripts/run-gameplay-tests.cts
@@ -73,6 +73,7 @@ const gameplayTestModules = [
   "../tests/gameplay/regression/sync-shared-runtime-validation-frontend.test.cjs",
   "../tests/gameplay/regression/check-no-js-sources.test.cjs",
   "../tests/gameplay/regression/vercel-routing-config.test.cjs",
+  "../tests/gameplay/regression/playwright-visual-environment.test.cjs",
   "../tests/gameplay/regression/account-validation-routes.test.cjs",
   "../tests/gameplay/regression/setup-service.test.cjs",
   "../tests/gameplay/regression/attack-route-guard.test.cjs",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.055";
+export const appVersion = "0.1.056";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/tests/gameplay/regression/playwright-visual-environment.test.cts
+++ b/tests/gameplay/regression/playwright-visual-environment.test.cts
@@ -53,4 +53,19 @@ register("visual preflight cannot be bypassed by grep or snapshot-update selecto
   );
   assert.equal(requiresVisualEnvironmentPreflight(["e2e/smoke", "--grep", "app loads"]), false);
   assert.equal(requiresVisualEnvironmentPreflight(["./e2e/00-visual/main-screen.spec.ts"]), true);
+  assert.equal(requiresVisualEnvironmentPreflight(["--output", "e2e/tmp"]), true);
+  assert.equal(requiresVisualEnvironmentPreflight(["e2e/(00-visual|profile)"]), true);
+  assert.equal(requiresVisualEnvironmentPreflight(["--update-snapshots", "e2e/smoke"]), true);
+  assert.equal(
+    requiresVisualEnvironmentPreflight(["--update-snapshots=changed", "e2e/smoke"]),
+    false
+  );
+  assert.equal(requiresVisualEnvironmentPreflight(["--unknown", "e2e/smoke"]), true);
+});
+
+register("visual environment rejects unsupported non-Linux hosts", () => {
+  for (const platform of ["darwin", "win32"]) {
+    const errors = validateVisualEnvironment(supportedSnapshot({ platform }));
+    assert.ok(errors.some((error: string) => error.includes(`found ${platform}`)));
+  }
 });

--- a/tests/gameplay/regression/playwright-visual-environment.test.cts
+++ b/tests/gameplay/regression/playwright-visual-environment.test.cts
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const {
+  requiresVisualEnvironmentPreflight,
   supportedVisualEnvironment,
   validateVisualEnvironment
 } = require("../../../scripts/playwright-visual-environment.cjs");
@@ -41,4 +42,15 @@ register("visual environment rejects browser, OS, and font drift before snapshot
   assert.ok(errors.some((error: string) => error.includes("font package is missing")));
   assert.ok(errors.some((error: string) => error.includes("font family is missing")));
   assert.ok(errors.some((error: string) => error.includes("Unsupported host font Arial")));
+});
+
+register("visual preflight cannot be bypassed by grep or snapshot-update selectors", () => {
+  assert.equal(requiresVisualEnvironmentPreflight([]), true);
+  assert.equal(requiresVisualEnvironmentPreflight(["--grep", "battlefield layout"]), true);
+  assert.equal(
+    requiresVisualEnvironmentPreflight(["--update-snapshots", "--grep", "battlefield layout"]),
+    true
+  );
+  assert.equal(requiresVisualEnvironmentPreflight(["e2e/smoke", "--grep", "app loads"]), false);
+  assert.equal(requiresVisualEnvironmentPreflight(["./e2e/00-visual/main-screen.spec.ts"]), true);
 });

--- a/tests/gameplay/regression/playwright-visual-environment.test.cts
+++ b/tests/gameplay/regression/playwright-visual-environment.test.cts
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const {
+  supportedVisualEnvironment,
+  validateVisualEnvironment
+} = require("../../../scripts/playwright-visual-environment.cjs");
+
+declare function register(name: string, fn: () => void | Promise<void>): void;
+
+function supportedSnapshot(overrides: Record<string, unknown> = {}) {
+  const linux = supportedVisualEnvironment.linux;
+  return {
+    platform: "linux",
+    playwrightVersion: supportedVisualEnvironment.playwrightVersion,
+    browserVersion: supportedVisualEnvironment.browserVersion,
+    browserRevision: supportedVisualEnvironment.browserRevision,
+    browserExecutablePath: "/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell",
+    osId: linux.osId,
+    osVersionId: linux.osVersionId,
+    fontPackages: Object.fromEntries(linux.fontPackages.map((name: string) => [name, true])),
+    fontFamilies: [...linux.requiredFontFamilies],
+    ...overrides
+  };
+}
+
+register("visual environment accepts the pinned browser and Linux font stack", () => {
+  assert.deepEqual(validateVisualEnvironment(supportedSnapshot()), []);
+});
+
+register("visual environment rejects browser, OS, and font drift before snapshots", () => {
+  const errors = validateVisualEnvironment(
+    supportedSnapshot({
+      browserVersion: "149.0.7827.0",
+      osVersionId: "22.04",
+      fontPackages: {},
+      fontFamilies: ["Arial"]
+    })
+  );
+
+  assert.ok(errors.some((error: string) => error.includes("149.0.7827.0")));
+  assert.ok(errors.some((error: string) => error.includes("ubuntu 24.04")));
+  assert.ok(errors.some((error: string) => error.includes("font package is missing")));
+  assert.ok(errors.some((error: string) => error.includes("font family is missing")));
+  assert.ok(errors.some((error: string) => error.includes("Unsupported host font Arial")));
+});


### PR DESCRIPTION
## Summary

- pin Playwright 1.61.1 and Chromium 149.0.7827.55 (revision 1228)
- enforce Ubuntu 24.04 plus the documented Playwright Linux font stack before snapshots run
- add supported bootstrap, preflight, visual-suite, and pinned-container commands
- run visual regression in GitHub Actions inside `mcr.microsoft.com/playwright:v1.61.1-noble`
- retain Playwright expected/actual/diff output and HTML reports on failures
- keep all existing visual baselines unchanged

Closes #359

## Local validation

- `npm run build:ts`
- `npm run lint`
- `npm run format:check`
- `npm run test:all` — 153 React, 167 backend, 489 gameplay passed
- `npm run release:check` — release gate passed for 0.1.056
- unsupported-host preflight — rejected before server startup with the documented bootstrap hint

## Required PR validation

The new `e2e-visual` job must pass in the pinned Playwright container before merge. This is the supported rendering environment that is unavailable in the current Debian workspace.