### PR TITLE
Split React shell entry bundle and enforce performance budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ NetRisk uses the application version from `shared/version-manifest.cts` as the r
 ## 0.1.057 - 2026-08-05
 
 - Split the direct landing and authenticated React shell entries and deferred the optional Sentry integration until after the initial render.
-- Moved landing and gameplay styles into route-owned CSS chunks, reducing initial landing and lobby transfers without changing their behavior.
+- Moved landing styles into a route-owned CSS chunk and kept shared game-shell styles behind the lazy authenticated shell boundary, reducing initial transfers without changing route layouts.
 - Added documented, route-aware initial JavaScript/CSS budgets that fail the production build and CI with a clear regression report.
 
 ## 0.1.056 - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.057 - 2026-08-05
+
+- Split the direct landing and authenticated React shell entries and deferred the optional Sentry integration until after the initial render.
+- Moved landing and gameplay styles into route-owned CSS chunks, reducing initial landing and lobby transfers without changing their behavior.
+- Added documented, route-aware initial JavaScript/CSS budgets that fail the production build and CI with a clear regression report.
+
 ## 0.1.056 - 2026-08-05
 
 - Pinned Playwright 1.61.1, Chromium 149.0.7827.55 (revision 1228), Ubuntu 24.04, and the Linux font dependencies used by visual baselines.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ npm run test:all:e2e:split
 - `npm run test:e2e:serial`: explicit single-process Playwright runner
 - `npm run test:e2e:headed`: headed Playwright run for local debugging
 - `npm run test:e2e:update`: intentionally updates Playwright visual baselines after an approved UI change
+- `npm run build:react-shell`: builds the React shell and enforces the documented [landing/lobby initial-transfer budgets](docs/react-shell-performance.md)
 - `npm run test:all`: repository + gameplay tests
 - `npm run test:all:e2e`: repository + gameplay + e2e tests
 - `npm run test:all:e2e:split`: repository + gameplay tests plus split E2E shards

--- a/docs/react-shell-performance.md
+++ b/docs/react-shell-performance.md
@@ -1,0 +1,38 @@
+# React shell initial-transfer budget
+
+The production build measures the JavaScript and CSS required for the first render of the public landing page and lobby. For each route, the measurement includes the entry chunk, the route entry, every static JavaScript import in that closure, and the CSS attached to those chunks. Gzip is calculated per emitted file, matching separate HTTP transfers.
+
+## Baseline and result
+
+The baseline was recorded from `main` at `891f48f67e1553d2ae30a5cab25155505f71b8c2` before the split:
+
+| Route   | Baseline JS raw / gzip | Current JS raw / gzip | Baseline CSS raw / gzip | Current CSS raw / gzip |
+| ------- | ---------------------: | --------------------: | ----------------------: | ---------------------: |
+| Landing |     664.15 / 189.43 kB |    518.32 / 145.84 kB |       345.00 / 52.86 kB |      179.20 / 30.74 kB |
+| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.03 kB |       345.00 / 52.86 kB |      165.42 / 27.48 kB |
+
+The landing and authenticated shell are selected through dynamic entries. Sentry is loaded after the initial render during an idle window (or immediately for the first reportable error), and the 204 kB source gameplay stylesheet is emitted with the gameplay route instead of the entry stylesheet. Landing-specific CSS is emitted only with the landing route.
+
+## Enforced budgets
+
+| Route   | Initial JS gzip | Initial CSS gzip |
+| ------- | --------------: | ---------------: |
+| Landing |          155 kB |            33 kB |
+| Lobby   |          180 kB |            30 kB |
+
+`npm run build:react-shell` and the normal production/CI build print raw and gzip measurements, then fail with a route-specific error if a budget is exceeded. The budget implementation lives in `frontend/react-shell/performance-budget.ts`.
+
+## Largest modules remaining in the entry
+
+The build reports the ten largest rendered module contributions before final minification. At the time of this baseline the largest are:
+
+| Module                           | Rendered contribution |
+| -------------------------------- | --------------------: |
+| `react-dom-client.production.js` |             452.14 kB |
+| Italian locale catalog           |              49.98 kB |
+| English locale catalog           |              47.94 kB |
+| German locale catalog            |              31.54 kB |
+| Spanish locale catalog           |              30.99 kB |
+| `react.production.js`            |              15.10 kB |
+
+React DOM is required to mount every route. The locale catalogs remain shared because the current translation API is synchronous; moving them behind locale-specific async boundaries is a separate architectural change and is intentionally not hidden by the budget.

--- a/docs/react-shell-performance.md
+++ b/docs/react-shell-performance.md
@@ -8,8 +8,8 @@ The baseline was recorded from `main` at `891f48f67e1553d2ae30a5cab25155505f71b8
 
 | Route   | Baseline JS raw / gzip | Current JS raw / gzip | Baseline CSS raw / gzip | Current CSS raw / gzip |
 | ------- | ---------------------: | --------------------: | ----------------------: | ---------------------: |
-| Landing |     664.15 / 189.43 kB |    518.32 / 145.84 kB |       345.00 / 52.86 kB |      179.20 / 30.74 kB |
-| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.03 kB |       345.00 / 52.86 kB |      165.42 / 27.48 kB |
+| Landing |     664.15 / 189.43 kB |    518.48 / 145.85 kB |       345.00 / 52.86 kB |      179.20 / 30.74 kB |
+| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.05 kB |       345.00 / 52.86 kB |      165.42 / 27.48 kB |
 
 The landing and authenticated shell are selected through dynamic entries. Sentry is loaded after the initial render during an idle window (or immediately for the first reportable error), and the 204 kB source gameplay stylesheet is emitted with the gameplay route instead of the entry stylesheet. Landing-specific CSS is emitted only with the landing route.
 

--- a/docs/react-shell-performance.md
+++ b/docs/react-shell-performance.md
@@ -8,17 +8,17 @@ The baseline was recorded from `main` at `891f48f67e1553d2ae30a5cab25155505f71b8
 
 | Route   | Baseline JS raw / gzip | Current JS raw / gzip | Baseline CSS raw / gzip | Current CSS raw / gzip |
 | ------- | ---------------------: | --------------------: | ----------------------: | ---------------------: |
-| Landing |     664.15 / 189.43 kB |    518.48 / 145.85 kB |       345.00 / 52.86 kB |      179.20 / 30.74 kB |
-| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.03 kB |       345.00 / 52.86 kB |      331.98 / 51.08 kB |
+| Landing |     664.15 / 189.43 kB |    518.48 / 145.85 kB |       345.00 / 52.86 kB |      179.20 / 30.05 kB |
+| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.03 kB |       345.00 / 52.86 kB |      345.00 / 52.86 kB |
 
-The landing and authenticated shell are selected through dynamic entries. Sentry is loaded after the initial render during an idle window (or immediately for the first reportable error). Landing-specific CSS is emitted only with the landing route, while `game-layout.css` stays at the lazy authenticated-shell boundary because it also contains the shared lobby, profile, and new-game layouts.
+The landing and authenticated shell are selected through dynamic entries. Sentry is loaded after the initial render during an idle window (or immediately for the first reportable error). The direct landing omits `game-layout.css`; the lazy authenticated-shell CSS entry preserves the established stylesheet order because `game-layout.css` also contains shared lobby, profile, and new-game layouts and the shell can navigate back to the landing without a document reload.
 
 ## Enforced budgets
 
 | Route   | Initial JS gzip | Initial CSS gzip |
 | ------- | --------------: | ---------------: |
 | Landing |          155 kB |            33 kB |
-| Lobby   |          180 kB |            53 kB |
+| Lobby   |          180 kB |            55 kB |
 
 `npm run build:react-shell` and the normal production/CI build print raw and gzip measurements, then fail with a route-specific error if a budget is exceeded. The budget implementation lives in `frontend/react-shell/performance-budget.ts`.
 

--- a/docs/react-shell-performance.md
+++ b/docs/react-shell-performance.md
@@ -9,16 +9,16 @@ The baseline was recorded from `main` at `891f48f67e1553d2ae30a5cab25155505f71b8
 | Route   | Baseline JS raw / gzip | Current JS raw / gzip | Baseline CSS raw / gzip | Current CSS raw / gzip |
 | ------- | ---------------------: | --------------------: | ----------------------: | ---------------------: |
 | Landing |     664.15 / 189.43 kB |    518.48 / 145.85 kB |       345.00 / 52.86 kB |      179.20 / 30.74 kB |
-| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.05 kB |       345.00 / 52.86 kB |      165.42 / 27.48 kB |
+| Lobby   |     693.09 / 197.05 kB |    596.97 / 170.03 kB |       345.00 / 52.86 kB |      331.98 / 51.08 kB |
 
-The landing and authenticated shell are selected through dynamic entries. Sentry is loaded after the initial render during an idle window (or immediately for the first reportable error), and the 204 kB source gameplay stylesheet is emitted with the gameplay route instead of the entry stylesheet. Landing-specific CSS is emitted only with the landing route.
+The landing and authenticated shell are selected through dynamic entries. Sentry is loaded after the initial render during an idle window (or immediately for the first reportable error). Landing-specific CSS is emitted only with the landing route, while `game-layout.css` stays at the lazy authenticated-shell boundary because it also contains the shared lobby, profile, and new-game layouts.
 
 ## Enforced budgets
 
 | Route   | Initial JS gzip | Initial CSS gzip |
 | ------- | --------------: | ---------------: |
 | Landing |          155 kB |            33 kB |
-| Lobby   |          180 kB |            30 kB |
+| Lobby   |          180 kB |            53 kB |
 
 `npm run build:react-shell` and the normal production/CI build print raw and gzip measurements, then fail with a route-specific error if a budget is exceeded. The budget implementation lives in `frontend/react-shell/performance-budget.ts`.
 

--- a/frontend/react-shell/performance-budget.ts
+++ b/frontend/react-shell/performance-budget.ts
@@ -1,0 +1,225 @@
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+import type { Plugin } from "vite";
+
+type RenderedModule = {
+  renderedLength: number;
+};
+
+export type PerformanceBundleChunk = {
+  type: "chunk";
+  fileName: string;
+  code: string;
+  facadeModuleId: string | null;
+  imports: string[];
+  isEntry: boolean;
+  modules: Record<string, RenderedModule>;
+  viteMetadata?: {
+    importedCss?: Set<string>;
+  };
+};
+
+export type PerformanceBundleAsset = {
+  type: "asset";
+  fileName: string;
+  source: string | Uint8Array;
+};
+
+export type PerformanceBundleOutput = PerformanceBundleChunk | PerformanceBundleAsset;
+
+type TransferSize = {
+  rawBytes: number;
+  gzipBytes: number;
+};
+
+export type RoutePerformanceResult = {
+  route: string;
+  js: TransferSize;
+  css: TransferSize;
+  jsFiles: string[];
+  cssFiles: string[];
+};
+
+export type ReactShellPerformanceReport = {
+  routes: RoutePerformanceResult[];
+  largestEntryModules: Array<{
+    module: string;
+    renderedBytes: number;
+  }>;
+};
+
+export const reactShellPerformanceBudgets = Object.freeze({
+  landing: Object.freeze({ jsGzipBytes: 155_000, cssGzipBytes: 33_000 }),
+  lobby: Object.freeze({ jsGzipBytes: 180_000, cssGzipBytes: 30_000 })
+});
+
+const routeEntrySuffixes = Object.freeze({
+  landing: ["/landing-app.tsx"],
+  lobby: ["/App.tsx", "/lobby-route.tsx"]
+});
+
+function byteLength(source: string | Uint8Array): number {
+  return typeof source === "string" ? Buffer.byteLength(source) : source.byteLength;
+}
+
+function gzipLength(source: string | Uint8Array): number {
+  return gzipSync(source).byteLength;
+}
+
+function collectStaticChunkClosure(
+  roots: PerformanceBundleChunk[],
+  chunksByFile: Map<string, PerformanceBundleChunk>
+): PerformanceBundleChunk[] {
+  const collected = new Map<string, PerformanceBundleChunk>();
+
+  function visit(chunk: PerformanceBundleChunk): void {
+    if (collected.has(chunk.fileName)) {
+      return;
+    }
+
+    collected.set(chunk.fileName, chunk);
+    for (const importedFile of chunk.imports) {
+      const importedChunk = chunksByFile.get(importedFile);
+      if (importedChunk) {
+        visit(importedChunk);
+      }
+    }
+  }
+
+  roots.forEach(visit);
+  return [...collected.values()];
+}
+
+function transferSize(sources: Array<string | Uint8Array>): TransferSize {
+  return {
+    rawBytes: sources.reduce((total, source) => total + byteLength(source), 0),
+    gzipBytes: sources.reduce((total, source) => total + gzipLength(source), 0)
+  };
+}
+
+export function analyzeReactShellBundle(
+  outputs: PerformanceBundleOutput[],
+  projectRoot: string
+): ReactShellPerformanceReport {
+  const chunks = outputs.filter(
+    (output): output is PerformanceBundleChunk => output.type === "chunk"
+  );
+  const assets = outputs.filter(
+    (output): output is PerformanceBundleAsset => output.type === "asset"
+  );
+  const chunksByFile = new Map(chunks.map((chunk) => [chunk.fileName, chunk]));
+  const assetsByFile = new Map(assets.map((asset) => [asset.fileName, asset]));
+  const entryChunk = chunks.find((chunk) => chunk.isEntry);
+
+  if (!entryChunk) {
+    throw new Error("React shell performance budget could not find the application entry chunk.");
+  }
+
+  const routes = Object.entries(routeEntrySuffixes).map(([route, moduleSuffixes]) => {
+    const routeRootChunks = moduleSuffixes.map((moduleSuffix) => {
+      const routeChunk = chunks.find((chunk) => chunk.facadeModuleId?.endsWith(moduleSuffix));
+      if (!routeChunk) {
+        throw new Error(
+          `React shell performance budget could not find ${moduleSuffix} for the ${route} route.`
+        );
+      }
+      return routeChunk;
+    });
+
+    const routeChunks = collectStaticChunkClosure([entryChunk, ...routeRootChunks], chunksByFile);
+    const cssFiles = [
+      ...new Set(
+        routeChunks.flatMap((chunk) => [...(chunk.viteMetadata?.importedCss || new Set<string>())])
+      )
+    ].sort();
+    const cssAssets = cssFiles.map((fileName) => {
+      const asset = assetsByFile.get(fileName);
+      if (!asset) {
+        throw new Error(`React shell performance budget could not read CSS asset ${fileName}.`);
+      }
+      return asset.source;
+    });
+
+    return {
+      route,
+      js: transferSize(routeChunks.map((chunk) => chunk.code)),
+      css: transferSize(cssAssets),
+      jsFiles: routeChunks.map((chunk) => chunk.fileName).sort(),
+      cssFiles
+    };
+  });
+
+  const largestEntryModules = Object.entries(entryChunk.modules)
+    .map(([moduleId, details]) => ({
+      module: path.relative(projectRoot, moduleId).replaceAll(path.sep, "/"),
+      renderedBytes: details.renderedLength
+    }))
+    .sort((left, right) => right.renderedBytes - left.renderedBytes)
+    .slice(0, 10);
+
+  return { routes, largestEntryModules };
+}
+
+function formatKilobytes(bytes: number): string {
+  return `${(bytes / 1000).toFixed(2)} kB`;
+}
+
+export function performanceBudgetErrors(report: ReactShellPerformanceReport): string[] {
+  const errors: string[] = [];
+
+  for (const route of report.routes) {
+    const budget =
+      reactShellPerformanceBudgets[route.route as keyof typeof reactShellPerformanceBudgets];
+    if (!budget) {
+      errors.push(`No initial-transfer budget is configured for ${route.route}.`);
+      continue;
+    }
+
+    if (route.js.gzipBytes > budget.jsGzipBytes) {
+      errors.push(
+        `${route.route} initial JS is ${formatKilobytes(route.js.gzipBytes)} gzip; budget is ${formatKilobytes(budget.jsGzipBytes)}.`
+      );
+    }
+    if (route.css.gzipBytes > budget.cssGzipBytes) {
+      errors.push(
+        `${route.route} initial CSS is ${formatKilobytes(route.css.gzipBytes)} gzip; budget is ${formatKilobytes(budget.cssGzipBytes)}.`
+      );
+    }
+  }
+
+  return errors;
+}
+
+export function reactShellPerformanceBudgetPlugin(projectRoot: string): Plugin {
+  return {
+    name: "netrisk-react-shell-performance-budget",
+    apply: "build",
+    enforce: "post",
+    generateBundle(_options, bundle) {
+      const report = analyzeReactShellBundle(
+        Object.values(bundle) as PerformanceBundleOutput[],
+        projectRoot
+      );
+
+      console.log("\nReact shell initial-transfer budget (raw / gzip):");
+      for (const route of report.routes) {
+        const budget =
+          reactShellPerformanceBudgets[route.route as keyof typeof reactShellPerformanceBudgets];
+        console.log(
+          `- ${route.route}: JS ${formatKilobytes(route.js.rawBytes)} / ${formatKilobytes(route.js.gzipBytes)} (budget ${formatKilobytes(budget.jsGzipBytes)} gzip); CSS ${formatKilobytes(route.css.rawBytes)} / ${formatKilobytes(route.css.gzipBytes)} (budget ${formatKilobytes(budget.cssGzipBytes)} gzip)`
+        );
+      }
+
+      console.log("Largest modules remaining in the entry chunk:");
+      for (const module of report.largestEntryModules) {
+        console.log(`- ${module.module}: ${formatKilobytes(module.renderedBytes)} rendered`);
+      }
+
+      const errors = performanceBudgetErrors(report);
+      if (errors.length > 0) {
+        throw new Error(`React shell initial-transfer budget exceeded:\n${errors.join("\n")}`);
+      }
+    }
+  };
+}

--- a/frontend/react-shell/performance-budget.ts
+++ b/frontend/react-shell/performance-budget.ts
@@ -51,7 +51,7 @@ export type ReactShellPerformanceReport = {
 
 export const reactShellPerformanceBudgets = Object.freeze({
   landing: Object.freeze({ jsGzipBytes: 155_000, cssGzipBytes: 33_000 }),
-  lobby: Object.freeze({ jsGzipBytes: 180_000, cssGzipBytes: 53_000 })
+  lobby: Object.freeze({ jsGzipBytes: 180_000, cssGzipBytes: 55_000 })
 });
 
 const routeEntrySuffixes = Object.freeze({

--- a/frontend/react-shell/performance-budget.ts
+++ b/frontend/react-shell/performance-budget.ts
@@ -51,7 +51,7 @@ export type ReactShellPerformanceReport = {
 
 export const reactShellPerformanceBudgets = Object.freeze({
   landing: Object.freeze({ jsGzipBytes: 155_000, cssGzipBytes: 33_000 }),
-  lobby: Object.freeze({ jsGzipBytes: 180_000, cssGzipBytes: 30_000 })
+  lobby: Object.freeze({ jsGzipBytes: 180_000, cssGzipBytes: 53_000 })
 });
 
 const routeEntrySuffixes = Object.freeze({

--- a/frontend/react-shell/src/App.tsx
+++ b/frontend/react-shell/src/App.tsx
@@ -4,6 +4,8 @@ import { AppRoutes } from "@react-shell/routes";
 import { queryClient } from "@react-shell/react-query";
 import { ShellErrorBoundary } from "@react-shell/shell-error-boundary";
 
+import "./game-layout.css";
+
 export function App() {
   return (
     <ShellErrorBoundary>

--- a/frontend/react-shell/src/App.tsx
+++ b/frontend/react-shell/src/App.tsx
@@ -4,7 +4,7 @@ import { AppRoutes } from "@react-shell/routes";
 import { queryClient } from "@react-shell/react-query";
 import { ShellErrorBoundary } from "@react-shell/shell-error-boundary";
 
-import "./game-layout.css";
+import "./shell-app.css";
 
 export function App() {
   return (

--- a/frontend/react-shell/src/__tests__/observability.test.tsx
+++ b/frontend/react-shell/src/__tests__/observability.test.tsx
@@ -80,33 +80,58 @@ describe("react shell observability", () => {
     });
   });
 
-  it("initializes Sentry only for preview and production when the DSN is configured", () => {
+  it("initializes Sentry only for preview and production when the DSN is configured", async () => {
     const config = resolveReactShellObservabilityConfig({
       dsn: "https://public@example.ingest.sentry.io/123",
       environment: "preview",
       release: "sha-preview"
     });
 
-    const resolved = initReactShellObservability(config);
+    const resolved = initReactShellObservability(config, (callback) => callback());
 
     expect(resolved.enabled).toBe(true);
-    expect(sentryMocks.init).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dsn: "https://public@example.ingest.sentry.io/123",
-        environment: "preview",
-        release: "sha-preview",
-        sendDefaultPii: false
-      })
+    await vi.waitFor(() =>
+      expect(sentryMocks.init).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dsn: "https://public@example.ingest.sentry.io/123",
+          environment: "preview",
+          release: "sha-preview",
+          sendDefaultPii: false
+        })
+      )
     );
   });
 
-  it("forwards registered frontend errors to Sentry with request correlation context", () => {
-    initReactShellObservability({
-      enabled: true,
-      dsn: "https://public@example.ingest.sentry.io/123",
-      environment: "production",
-      release: "sha-prod"
-    });
+  it("defers the optional Sentry download until the post-render scheduler runs", async () => {
+    const scheduledCallbacks: Array<() => void> = [];
+    initReactShellObservability(
+      {
+        enabled: true,
+        dsn: "https://public@example.ingest.sentry.io/123",
+        environment: "production",
+        release: "sha-prod"
+      },
+      (callback) => {
+        scheduledCallbacks.push(callback);
+      }
+    );
+
+    expect(sentryMocks.init).not.toHaveBeenCalled();
+    expect(scheduledCallbacks).toHaveLength(1);
+    scheduledCallbacks[0]();
+    await vi.waitFor(() => expect(sentryMocks.init).toHaveBeenCalledOnce());
+  });
+
+  it("forwards registered frontend errors to Sentry with request correlation context", async () => {
+    initReactShellObservability(
+      {
+        enabled: true,
+        dsn: "https://public@example.ingest.sentry.io/123",
+        environment: "production",
+        release: "sha-prod"
+      },
+      (callback) => callback()
+    );
 
     const error = new Error("Unexpected HTTP failure.");
     reportFrontendException(error, {
@@ -119,7 +144,7 @@ describe("react shell observability", () => {
       schemaName: "ProfileResponse"
     });
 
-    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
+    await vi.waitFor(() => expect(sentryMocks.captureException).toHaveBeenCalledWith(error));
     expect(sentryMocks.scope.setTag).toHaveBeenCalledWith("app.request_id", "req-42");
     expect(sentryMocks.scope.setExtra).toHaveBeenCalledWith("statusCode", 500);
     expect(sentryMocks.scope.setExtra).toHaveBeenCalledWith("schemaName", "ProfileResponse");

--- a/frontend/react-shell/src/__tests__/performance-budget.test.ts
+++ b/frontend/react-shell/src/__tests__/performance-budget.test.ts
@@ -39,7 +39,8 @@ describe("React shell performance budget", () => {
       }),
       chunk("assets/app.js", {
         facadeModuleId: "/repo/frontend/react-shell/src/App.tsx",
-        imports: ["assets/vendor.js"]
+        imports: ["assets/vendor.js"],
+        viteMetadata: { importedCss: new Set(["assets/shell.css"]) }
       }),
       chunk("assets/lobby.js", {
         facadeModuleId: "/repo/frontend/react-shell/src/lobby-route.tsx",
@@ -47,7 +48,8 @@ describe("React shell performance budget", () => {
       }),
       chunk("assets/query.js"),
       { type: "asset", fileName: "assets/base.css", source: "base" },
-      { type: "asset", fileName: "assets/landing.css", source: "landing" }
+      { type: "asset", fileName: "assets/landing.css", source: "landing" },
+      { type: "asset", fileName: "assets/shell.css", source: "shell" }
     ];
 
     const report = analyzeReactShellBundle(outputs, "/repo");
@@ -63,6 +65,7 @@ describe("React shell performance budget", () => {
       "assets/query.js",
       "assets/vendor.js"
     ]);
+    expect(lobby?.cssFiles).toEqual(["assets/base.css", "assets/shell.css"]);
     expect(report.largestEntryModules[0]).toEqual({
       module: "src/main.tsx",
       renderedBytes: 20

--- a/frontend/react-shell/src/__tests__/performance-budget.test.ts
+++ b/frontend/react-shell/src/__tests__/performance-budget.test.ts
@@ -1,0 +1,91 @@
+import {
+  analyzeReactShellBundle,
+  performanceBudgetErrors,
+  type PerformanceBundleChunk,
+  type PerformanceBundleOutput
+} from "../../performance-budget";
+
+import { describe, expect, it } from "vitest";
+
+function chunk(
+  fileName: string,
+  options: Partial<PerformanceBundleChunk> = {}
+): PerformanceBundleChunk {
+  return {
+    type: "chunk",
+    fileName,
+    code: fileName,
+    facadeModuleId: null,
+    imports: [],
+    isEntry: false,
+    modules: {},
+    ...options
+  };
+}
+
+describe("React shell performance budget", () => {
+  it("measures the static JS and CSS closure for landing and lobby", () => {
+    const outputs: PerformanceBundleOutput[] = [
+      chunk("assets/index.js", {
+        isEntry: true,
+        imports: ["assets/vendor.js"],
+        modules: { "/repo/src/main.tsx": { renderedLength: 20 } },
+        viteMetadata: { importedCss: new Set(["assets/base.css"]) }
+      }),
+      chunk("assets/vendor.js"),
+      chunk("assets/landing.js", {
+        facadeModuleId: "/repo/frontend/react-shell/src/landing-app.tsx",
+        viteMetadata: { importedCss: new Set(["assets/landing.css"]) }
+      }),
+      chunk("assets/app.js", {
+        facadeModuleId: "/repo/frontend/react-shell/src/App.tsx",
+        imports: ["assets/vendor.js"]
+      }),
+      chunk("assets/lobby.js", {
+        facadeModuleId: "/repo/frontend/react-shell/src/lobby-route.tsx",
+        imports: ["assets/query.js"]
+      }),
+      chunk("assets/query.js"),
+      { type: "asset", fileName: "assets/base.css", source: "base" },
+      { type: "asset", fileName: "assets/landing.css", source: "landing" }
+    ];
+
+    const report = analyzeReactShellBundle(outputs, "/repo");
+    const landing = report.routes.find((route) => route.route === "landing");
+    const lobby = report.routes.find((route) => route.route === "lobby");
+
+    expect(landing?.jsFiles).toEqual(["assets/index.js", "assets/landing.js", "assets/vendor.js"]);
+    expect(landing?.cssFiles).toEqual(["assets/base.css", "assets/landing.css"]);
+    expect(lobby?.jsFiles).toEqual([
+      "assets/app.js",
+      "assets/index.js",
+      "assets/lobby.js",
+      "assets/query.js",
+      "assets/vendor.js"
+    ]);
+    expect(report.largestEntryModules[0]).toEqual({
+      module: "src/main.tsx",
+      renderedBytes: 20
+    });
+  });
+
+  it("returns clear route-specific failures when gzip budgets are exceeded", () => {
+    expect(
+      performanceBudgetErrors({
+        routes: [
+          {
+            route: "landing",
+            js: { rawBytes: 200_000, gzipBytes: 155_001 },
+            css: { rawBytes: 40_000, gzipBytes: 33_001 },
+            jsFiles: [],
+            cssFiles: []
+          }
+        ],
+        largestEntryModules: []
+      })
+    ).toEqual([
+      "landing initial JS is 155.00 kB gzip; budget is 155.00 kB.",
+      "landing initial CSS is 33.00 kB gzip; budget is 33.00 kB."
+    ]);
+  });
+});

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -56,8 +56,6 @@ import {
   type GameDrawerKey
 } from "@react-shell/gameplay-ui-panels";
 
-import "./game-layout.css";
-
 function phaseLabel(phase: string | null | undefined): string {
   if (phase === "active") {
     return t("common.phase.active");

--- a/frontend/react-shell/src/gameplay-route.tsx
+++ b/frontend/react-shell/src/gameplay-route.tsx
@@ -56,6 +56,8 @@ import {
   type GameDrawerKey
 } from "@react-shell/gameplay-ui-panels";
 
+import "./game-layout.css";
+
 function phaseLabel(phase: string | null | undefined): string {
   if (phase === "active") {
     return t("common.phase.active");

--- a/frontend/react-shell/src/landing-app.css
+++ b/frontend/react-shell/src/landing-app.css
@@ -1,0 +1,4 @@
+@import "./styles.css";
+@import "./landing.css";
+@import "./shell-reset.css";
+@import "./theme-tokens.css";

--- a/frontend/react-shell/src/landing-app.tsx
+++ b/frontend/react-shell/src/landing-app.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter } from "react-router-dom";
 
 import { LandingRoute } from "@react-shell/landing-route";
 
+import "./landing-app.css";
+
 export function LandingApp() {
   return (
     <BrowserRouter>

--- a/frontend/react-shell/src/landing-app.tsx
+++ b/frontend/react-shell/src/landing-app.tsx
@@ -1,0 +1,11 @@
+import { BrowserRouter } from "react-router-dom";
+
+import { LandingRoute } from "@react-shell/landing-route";
+
+export function LandingApp() {
+  return (
+    <BrowserRouter>
+      <LandingRoute />
+    </BrowserRouter>
+  );
+}

--- a/frontend/react-shell/src/landing-route.tsx
+++ b/frontend/react-shell/src/landing-route.tsx
@@ -10,8 +10,6 @@ import {
   buildRegisterPath
 } from "@react-shell/public-auth-paths";
 
-import "./landing.css";
-
 const landingNavLinks = [
   { href: "#features", labelKey: "landing.nav.features" },
   { href: "#maps", labelKey: "landing.nav.maps" },

--- a/frontend/react-shell/src/landing-route.tsx
+++ b/frontend/react-shell/src/landing-route.tsx
@@ -10,6 +10,8 @@ import {
   buildRegisterPath
 } from "@react-shell/public-auth-paths";
 
+import "./landing.css";
+
 const landingNavLinks = [
   { href: "#features", labelKey: "landing.nav.features" },
   { href: "#maps", labelKey: "landing.nav.maps" },
@@ -156,14 +158,14 @@ export function LandingRoute() {
               </select>
             </label>
             {setupPageAvailable ? (
-              <Link className="ld-btn-ghost" to="/setup">
+              <Link className="ld-btn-ghost" to="/setup" reloadDocument>
                 Setup
               </Link>
             ) : null}
-            <Link className="ld-btn-ghost" to={buildLobbyPath("canonical")}>
+            <Link className="ld-btn-ghost" to={buildLobbyPath("canonical")} reloadDocument>
               {t("auth.login")}
             </Link>
-            <Link className="ld-btn-primary" to={buildRegisterPath("canonical")}>
+            <Link className="ld-btn-primary" to={buildRegisterPath("canonical")} reloadDocument>
               {t("auth.register")}
             </Link>
           </div>
@@ -202,7 +204,11 @@ export function LandingRoute() {
             </h1>
             <p className="ld-hero-desc">{t("landing.hero.desc")}</p>
             <div className="ld-hero-cta">
-              <Link className="ld-btn-primary ld-btn-lg" to={buildRegisterPath("canonical")}>
+              <Link
+                className="ld-btn-primary ld-btn-lg"
+                to={buildRegisterPath("canonical")}
+                reloadDocument
+              >
                 {t("landing.hero.ctaPrimary")}
               </Link>
               <a className="ld-btn-ghost ld-btn-lg" href="#maps">
@@ -432,10 +438,18 @@ export function LandingRoute() {
             <h2>{t("landing.final.heading")}</h2>
             <p className="ld-final-cta-desc">{t("landing.final.desc")}</p>
             <div className="ld-final-cta-btns">
-              <Link className="ld-btn-primary ld-btn-lg" to={buildRegisterPath("canonical")}>
+              <Link
+                className="ld-btn-primary ld-btn-lg"
+                to={buildRegisterPath("canonical")}
+                reloadDocument
+              >
                 {t("landing.final.ctaPrimary")}
               </Link>
-              <Link className="ld-btn-ghost ld-btn-lg" to={buildLobbyPath("canonical")}>
+              <Link
+                className="ld-btn-ghost ld-btn-lg"
+                to={buildLobbyPath("canonical")}
+                reloadDocument
+              >
                 {t("landing.final.ctaSecondary")}
               </Link>
             </div>
@@ -450,9 +464,15 @@ export function LandingRoute() {
             <span className="ld-brand-name">Frontline Dominion</span>
           </Link>
           <nav className="ld-footer-links" aria-label={t("landing.footer.aria")}>
-            <Link to={buildLobbyPath("canonical")}>{t("nav.lobby")}</Link>
-            <Link to={buildGameIndexPath("canonical")}>{t("landing.footer.game")}</Link>
-            <Link to={buildRegisterPath("canonical")}>{t("auth.register")}</Link>
+            <Link to={buildLobbyPath("canonical")} reloadDocument>
+              {t("nav.lobby")}
+            </Link>
+            <Link to={buildGameIndexPath("canonical")} reloadDocument>
+              {t("landing.footer.game")}
+            </Link>
+            <Link to={buildRegisterPath("canonical")} reloadDocument>
+              {t("auth.register")}
+            </Link>
             <a href="#top">{t("landing.footer.backToTop")}</a>
           </nav>
         </div>

--- a/frontend/react-shell/src/main.tsx
+++ b/frontend/react-shell/src/main.tsx
@@ -8,10 +8,6 @@ import { resolveLocale, setLocale } from "@frontend-i18n";
 import { createReactShellRootOptions } from "@react-shell/observability";
 import { applyStoredRegisteredShellTheme, installShellThemeBridge } from "@react-shell/theme";
 
-import "./styles.css";
-import "./shell-reset.css";
-import "./theme-tokens.css";
-
 const LandingApp = lazy(async () => ({
   default: (await import("@react-shell/landing-app")).LandingApp
 }));

--- a/frontend/react-shell/src/main.tsx
+++ b/frontend/react-shell/src/main.tsx
@@ -1,18 +1,23 @@
 import "./instrument";
 
+import { lazy, Suspense } from "react";
 import ReactDOM from "react-dom/client";
 
 import { resolveLocale, setLocale } from "@frontend-i18n";
 
-import { App } from "@react-shell/App";
 import { createReactShellRootOptions } from "@react-shell/observability";
 import { applyStoredRegisteredShellTheme, installShellThemeBridge } from "@react-shell/theme";
 
 import "./styles.css";
-import "./game-layout.css";
-import "./landing.css";
 import "./shell-reset.css";
 import "./theme-tokens.css";
+
+const LandingApp = lazy(async () => ({
+  default: (await import("@react-shell/landing-app")).LandingApp
+}));
+const ShellApp = lazy(async () => ({
+  default: (await import("@react-shell/App")).App
+}));
 
 setLocale(resolveLocale());
 installShellThemeBridge();
@@ -23,4 +28,18 @@ if (!rootElement) {
   throw new Error("React shell root element not found.");
 }
 
-ReactDOM.createRoot(rootElement, createReactShellRootOptions()).render(<App />);
+const InitialApp = window.location.pathname === "/" ? LandingApp : ShellApp;
+
+ReactDOM.createRoot(rootElement, createReactShellRootOptions()).render(
+  <Suspense
+    fallback={
+      <section className="status-panel status-panel-loading" data-testid="react-shell-loading">
+        <p className="status-label">Loading</p>
+        <h2>Loading NetRisk</h2>
+        <p className="status-copy">Preparing the requested route.</p>
+      </section>
+    }
+  >
+    <InitialApp />
+  </Suspense>
+);

--- a/frontend/react-shell/src/observability.ts
+++ b/frontend/react-shell/src/observability.ts
@@ -1,10 +1,9 @@
-import * as Sentry from "@sentry/react";
-
 import {
   registerFrontendObservabilityReporter,
   reportFrontendException,
   type FrontendObservabilityContext
 } from "@frontend-core/observability.mts";
+import type * as SentryReact from "@sentry/react";
 
 export type ReactShellObservabilityConfig = {
   enabled: boolean;
@@ -18,6 +17,12 @@ type ReactRootErrorInfo = {
 };
 
 let initialized = false;
+let initializationScheduled = false;
+let observabilityGeneration = 0;
+type SentryModule = typeof SentryReact;
+let sentryPromise: Promise<SentryModule> | null = null;
+
+export type ObservabilityScheduler = (callback: () => void) => void;
 
 function firstNonEmpty(...values: unknown[]): string | null {
   for (const value of values) {
@@ -75,7 +80,16 @@ export function resolveReactShellObservabilityConfig(
   };
 }
 
-function applyObservabilityScope(error: Error, context: FrontendObservabilityContext = {}): void {
+function loadSentry(): Promise<SentryModule> {
+  sentryPromise ??= import("@sentry/react");
+  return sentryPromise;
+}
+
+function applyObservabilityScope(
+  Sentry: SentryModule,
+  error: Error,
+  context: FrontendObservabilityContext = {}
+): void {
   Sentry.withScope((scope) => {
     scope.setLevel("error");
     scope.setTag("app.area", context.area || "react-shell");
@@ -116,29 +130,61 @@ function applyObservabilityScope(error: Error, context: FrontendObservabilityCon
   });
 }
 
+function initializeSentry(config: ReactShellObservabilityConfig): Promise<SentryModule> {
+  return loadSentry().then((Sentry) => {
+    if (!initialized) {
+      Sentry.init({
+        dsn: config.dsn || undefined,
+        environment: config.environment,
+        release: config.release,
+        sendDefaultPii: false
+      });
+      initialized = true;
+    }
+    return Sentry;
+  });
+}
+
+function scheduleAfterInitialRender(callback: () => void): void {
+  const targetWindow = window as Window & {
+    requestIdleCallback?: (idleCallback: () => void, options?: { timeout: number }) => number;
+  };
+
+  if (typeof targetWindow.requestIdleCallback === "function") {
+    targetWindow.requestIdleCallback(callback, { timeout: 3_000 });
+    return;
+  }
+
+  window.setTimeout(callback, 1_500);
+}
+
 export function initReactShellObservability(
-  config: ReactShellObservabilityConfig = resolveReactShellObservabilityConfig()
+  config: ReactShellObservabilityConfig = resolveReactShellObservabilityConfig(),
+  schedule: ObservabilityScheduler = scheduleAfterInitialRender
 ): ReactShellObservabilityConfig {
   registerFrontendObservabilityReporter((error, context) => {
     if (!config.enabled) {
       return;
     }
 
-    applyObservabilityScope(toError(error), context);
+    void initializeSentry(config)
+      .then((Sentry) => applyObservabilityScope(Sentry, toError(error), context))
+      .catch(() => {});
   });
 
-  if (!config.enabled || initialized) {
+  if (!config.enabled || initialized || initializationScheduled) {
     return config;
   }
 
-  Sentry.init({
-    dsn: config.dsn || undefined,
-    environment: config.environment,
-    release: config.release,
-    sendDefaultPii: false
+  initializationScheduled = true;
+  const generation = observabilityGeneration;
+  schedule(() => {
+    if (generation !== observabilityGeneration) {
+      return;
+    }
+    initializationScheduled = false;
+    void initializeSentry(config).catch(() => {});
   });
-
-  initialized = true;
   return config;
 }
 
@@ -177,6 +223,9 @@ export function createReactShellRootOptions(): {
 }
 
 export function resetReactShellObservabilityForTests(): void {
+  observabilityGeneration += 1;
   initialized = false;
+  initializationScheduled = false;
+  sentryPromise = null;
   registerFrontendObservabilityReporter(null);
 }

--- a/frontend/react-shell/src/routes.tsx
+++ b/frontend/react-shell/src/routes.tsx
@@ -11,7 +11,6 @@ import {
 } from "react-router-dom";
 import { AppShellLayout } from "@react-shell/app-shell-layout";
 import { useAuth, AuthProvider } from "@react-shell/auth";
-import { LandingRoute } from "@react-shell/landing-route";
 import { LoadingAnimation } from "@react-shell/loading-animation";
 import {
   buildBootstrapPath,
@@ -26,6 +25,9 @@ import { t } from "@frontend-i18n";
 
 const RegisterRoute = lazy(async () => ({
   default: (await import("@react-shell/register-route")).RegisterRoute
+}));
+const LandingRoute = lazy(async () => ({
+  default: (await import("@react-shell/landing-route")).LandingRoute
 }));
 const SetupRoute = lazy(async () => ({
   default: (await import("@react-shell/setup-route")).SetupRoute
@@ -274,7 +276,18 @@ export function AppRoutes() {
     <BrowserRouter>
       <AuthProvider>
         <Routes>
-          <Route path="/" element={<LandingRoute />} />
+          <Route
+            path="/"
+            element={
+              <Suspense
+                fallback={
+                  <LoadingPanel title="Loading NetRisk" copy="Preparing the public landing page." />
+                }
+              >
+                <LandingRoute />
+              </Suspense>
+            }
+          />
           <Route path="/react" element={<BootstrapRoute />} />
           <Route element={<ShellLayout />}>
             <Route path="/login" element={<LoginPage />} />

--- a/frontend/react-shell/src/shell-app.css
+++ b/frontend/react-shell/src/shell-app.css
@@ -1,0 +1,5 @@
+@import "./styles.css";
+@import "./game-layout.css";
+@import "./landing.css";
+@import "./shell-reset.css";
+@import "./theme-tokens.css";

--- a/frontend/react-shell/vite.config.ts
+++ b/frontend/react-shell/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { reactShellPerformanceBudgetPlugin } from "./performance-budget";
 
 const reactShellRoot = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(reactShellRoot, "..", "..");
@@ -69,7 +70,7 @@ if (shouldValidateDeployEnv && reactShellObservabilityEnabled && !hasSentryUploa
 }
 
 const shouldUploadSentryArtifacts = reactShellObservabilityEnabled && hasSentryUploadCredentials;
-const reactShellPlugins = [react()];
+const reactShellPlugins = [react(), reactShellPerformanceBudgetPlugin(projectRoot)];
 if (shouldUploadSentryArtifacts) {
   reactShellPlugins.push(
     sentryVitePlugin({

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.056";
+export const appVersion = "0.1.057";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;


### PR DESCRIPTION
## Summary

- split the public landing app from the authenticated shell and defer landing-only CSS
- preserve the established shell stylesheet cascade in a lazy shell-specific CSS entry
- lazy-load Sentry after initial render while preserving immediate first-error reporting
- measure the complete static JS/CSS closure for landing and lobby during every production build
- enforce documented gzip budgets and report the ten largest remaining entry modules
- preserve landing-to-shell navigation with full-document handoff

Closes #357

## Measurements

| Route | Baseline JS raw / gzip | Current JS raw / gzip | Baseline CSS raw / gzip | Current CSS raw / gzip | Budget JS / CSS gzip |
| --- | ---: | ---: | ---: | ---: | ---: |
| Landing | 664.15 / 189.43 kB | 518.48 / 145.85 kB | 345.00 / 52.86 kB | 179.20 / 30.05 kB | 155 / 33 kB |
| Lobby | 693.09 / 197.05 kB | 596.97 / 170.03 kB | 345.00 / 52.86 kB | 345.00 / 52.86 kB | 180 / 55 kB |

## Local verification

- `npm run typecheck:react-shell`
- `npm run lint`
- `npm run format:check`
- `npm run test:all` — 156 React, 167 backend, 491 gameplay tests passed
- `npm run release:check` — release gate passed for 0.1.057
- `npm run build:react-shell` — both route budgets passed

Visual CI correctly rejected two intermediate CSS ownership/cascade implementations. Head `ccfdb92` now emits separate landing and shell CSS entries: the shell entry reproduces the original 345.00 kB cascade in the original order, while the direct landing excludes `game-layout.css`. No snapshots were changed. Merge remains gated on the fresh pinned GitHub E2E smoke and visual jobs.