### PR TITLE
Safely repair orphaned game module references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NetRisk uses the application version from `shared/version-manifest.cts` as the r
 - Added a guarded admin preview and repair flow for finished games with orphaned runtime module and profile references while preserving valid gameplay state and selections.
 - Added explicit game-ID confirmation, fail-closed validation, and success/failure audit evidence for configuration repairs.
 - Prevented development-only demo, test, and fixture module IDs from being enabled or persisted in Vercel preview and production deployments.
+- Advanced the central API compatibility version to 1.1.0 for the additive required admin repair-preview response fields.
 
 ## 0.1.058 - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NetRisk uses the application version from `shared/version-manifest.cts` as the r
 - Added explicit game-ID confirmation, fail-closed validation, and success/failure audit evidence for configuration repairs.
 - Prevented development-only demo, test, and fixture module IDs from being enabled or persisted in Vercel preview and production deployments.
 - Advanced the central API compatibility version to 1.1.0 for the additive required admin repair-preview response fields.
+- Added atomic app-state compare-and-set persistence so concurrent Vercel instances cannot overwrite newer admin configuration or module catalog changes during cleanup migrations.
+- Recorded minor functional versions for the changed module runtime, public-state contract, and datastore concurrency surface.
 
 ## 0.1.058 - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.059 - 2026-08-06
+
+- Added a guarded admin preview and repair flow for finished games with orphaned runtime module and profile references while preserving valid gameplay state and selections.
+- Added explicit game-ID confirmation, fail-closed validation, and success/failure audit evidence for configuration repairs.
+- Prevented development-only demo, test, and fixture module IDs from being enabled or persisted in Vercel preview and production deployments.
+
 ## 0.1.058 - 2026-08-05
 
 - Localized login and registration metadata and content across Italian, English, German, and Spanish on canonical and React alias routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NetRisk uses the application version from `shared/version-manifest.cts` as the r
 - Added explicit game-ID confirmation, fail-closed validation, and success/failure audit evidence for configuration repairs.
 - Prevented development-only demo, test, and fixture module IDs from being enabled or persisted in Vercel preview and production deployments.
 - Advanced the central API compatibility version to 1.1.0 for the additive required admin repair-preview response fields.
-- Added atomic app-state compare-and-set persistence so concurrent Vercel instances cannot overwrite newer admin configuration or module catalog changes during cleanup migrations.
+- Added atomic app-state compare-and-set persistence and advanced the datastore schema to version 2 so concurrent Vercel instances cannot overwrite newer admin configuration or module catalog changes during cleanup migrations.
 - Recorded minor functional versions for the changed module runtime, public-state contract, and datastore concurrency surface.
 
 ## 0.1.058 - 2026-08-05

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -5,6 +5,10 @@ const {
   findVisualTheme,
   migrateGameStateExtensions
 } = require("../shared/extensions.cjs");
+const {
+  isDevelopmentOnlyModuleId,
+  isPersistentVercelEnvironment
+} = require("./module-runtime.cjs");
 
 type PublicUser = {
   id: string;
@@ -414,7 +418,7 @@ const REPAIR_PROFILE_FIELDS = Object.freeze([
 ]);
 
 function valuesEqual(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function pushRepairChange(
@@ -438,6 +442,114 @@ function pushRepairChange(
 
 function profileBelongsToModule(profileId: string, moduleId: string): boolean {
   return profileId === moduleId || profileId.startsWith(`${moduleId}.`);
+}
+
+function repairChangeCoversPath(changes: AdminGameRepairChange[], path: string): boolean {
+  return changes.some(
+    (change) =>
+      change.path === path ||
+      path.startsWith(`${change.path}.`) ||
+      path.startsWith(`${change.path}[`)
+  );
+}
+
+function appendUnreportedRepairChanges(
+  before: unknown,
+  after: unknown,
+  path: string,
+  changes: AdminGameRepairChange[]
+): void {
+  if (valuesEqual(before, after) || repairChangeCoversPath(changes, path)) {
+    return;
+  }
+
+  const beforeRecord = asRecord(before);
+  const afterRecord = asRecord(after);
+  if (beforeRecord && afterRecord && !Array.isArray(before) && !Array.isArray(after)) {
+    const keys = Array.from(new Set([...Object.keys(beforeRecord), ...Object.keys(afterRecord)]));
+    keys.forEach((key) =>
+      appendUnreportedRepairChanges(
+        beforeRecord[key],
+        afterRecord[key],
+        path ? `${path}.${key}` : key,
+        changes
+      )
+    );
+    return;
+  }
+
+  if (path) {
+    pushRepairChange(
+      changes,
+      path,
+      before,
+      after,
+      "Normalize legacy persisted state before applying the module repair."
+    );
+  }
+}
+
+function profileCatalogById(value: unknown): Map<string, string | null> | null {
+  const entries = asRecordArray(value);
+  if (!entries) {
+    return null;
+  }
+
+  return new Map(
+    entries
+      .map((entry) => {
+        const id = asNonEmptyString(entry.id);
+        return id ? ([id, asNonEmptyString(entry.moduleId)] as const) : null;
+      })
+      .filter((entry): entry is readonly [string, string | null] => Boolean(entry))
+  );
+}
+
+function findUnavailableCatalogOwner(
+  selectionId: string,
+  orphanedModuleIds: string[],
+  catalog: Map<string, string | null> | null
+): string | null {
+  if (catalog?.has(selectionId)) {
+    const explicitOwner = catalog.get(selectionId) || null;
+    return explicitOwner && orphanedModuleIds.includes(explicitOwner) ? explicitOwner : null;
+  }
+
+  return (
+    orphanedModuleIds.find((moduleId) => profileBelongsToModule(selectionId, moduleId)) || null
+  );
+}
+
+function migratePersistedDevelopmentModuleDefaults(input: Record<string, unknown>): {
+  defaults: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!isPersistentVercelEnvironment()) {
+    return { defaults: input, changed: false };
+  }
+
+  const defaults = safeClone(input);
+  const activeModuleIds = asArray(defaults.activeModuleIds as string[] | undefined).filter(
+    (moduleId): moduleId is string => typeof moduleId === "string" && moduleId.trim().length > 0
+  );
+  const removedModuleIds = activeModuleIds.filter((moduleId) =>
+    isDevelopmentOnlyModuleId(moduleId)
+  );
+  let changed = removedModuleIds.length > 0;
+  if (changed) {
+    defaults.activeModuleIds = activeModuleIds.filter(
+      (moduleId) => !removedModuleIds.includes(moduleId)
+    );
+  }
+  [...REPAIR_PROFILE_FIELDS, "gamePresetId"].forEach((field) => {
+    const selectionId = asNonEmptyString(defaults[field]);
+    if (selectionId && isDevelopmentOnlyModuleId(selectionId)) {
+      defaults[field] = null;
+      changed = true;
+    }
+  });
+
+  return { defaults, changed };
 }
 
 async function maybeResolve<T>(value: Promise<T> | T): Promise<T> {
@@ -518,37 +630,10 @@ function createAdminConsole(options: AdminConsoleOptions) {
       );
     }
 
-    const profileCatalogByField = new Map<string, Set<string> | null>([
-      [
-        "contentProfileId",
-        asRecordArray(moduleOptions?.contentProfiles)
-          ? new Set(
-              asRecordArray(moduleOptions?.contentProfiles)
-                ?.map((entry) => asNonEmptyString(entry.id))
-                .filter((value): value is string => Boolean(value)) || []
-            )
-          : null
-      ],
-      [
-        "gameplayProfileId",
-        asRecordArray(moduleOptions?.gameplayProfiles)
-          ? new Set(
-              asRecordArray(moduleOptions?.gameplayProfiles)
-                ?.map((entry) => asNonEmptyString(entry.id))
-                .filter((value): value is string => Boolean(value)) || []
-            )
-          : null
-      ],
-      [
-        "uiProfileId",
-        asRecordArray(moduleOptions?.uiProfiles)
-          ? new Set(
-              asRecordArray(moduleOptions?.uiProfiles)
-                ?.map((entry) => asNonEmptyString(entry.id))
-                .filter((value): value is string => Boolean(value)) || []
-            )
-          : null
-      ]
+    const profileCatalogByField = new Map<string, Map<string, string | null> | null>([
+      ["contentProfileId", profileCatalogById(moduleOptions?.contentProfiles)],
+      ["gameplayProfileId", profileCatalogById(moduleOptions?.gameplayProfiles)],
+      ["uiProfileId", profileCatalogById(moduleOptions?.uiProfiles)]
     ]);
     const relatedProfileIds: string[] = [];
 
@@ -558,10 +643,12 @@ function createAdminConsole(options: AdminConsoleOptions) {
         return;
       }
 
-      const owningOrphan = orphanedModuleIds.find((moduleId) =>
-        profileBelongsToModule(profileId, moduleId)
-      );
       const availableProfiles = profileCatalogByField.get(field) || null;
+      const owningOrphan = findUnavailableCatalogOwner(
+        profileId,
+        orphanedModuleIds,
+        availableProfiles
+      );
       if (owningOrphan) {
         relatedProfileIds.push(profileId);
         nextConfig[field] = null;
@@ -583,8 +670,9 @@ function createAdminConsole(options: AdminConsoleOptions) {
     });
 
     const gamePresetId = asNonEmptyString(originalConfig.gamePresetId);
+    const gamePresetCatalog = profileCatalogById(moduleOptions?.gamePresets);
     const presetOwner = gamePresetId
-      ? orphanedModuleIds.find((moduleId) => profileBelongsToModule(gamePresetId, moduleId))
+      ? findUnavailableCatalogOwner(gamePresetId, orphanedModuleIds, gamePresetCatalog)
       : null;
     if (gamePresetId && presetOwner) {
       nextConfig.gamePresetId = null;
@@ -636,6 +724,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
         `Synchronize the persisted root value with gameConfig.${field}.`
       );
     });
+    appendUnreportedRepairChanges(originalState, nextState, "", changes);
 
     return {
       status: blockers.length ? "blocked" : changes.length ? "safe" : "not-needed",
@@ -731,11 +820,20 @@ function createAdminConsole(options: AdminConsoleOptions) {
 
   async function loadConfigRecord(): Promise<AdminConfigRecord> {
     const source = await readConfigSource();
-    const defaults = await resolveAdminDefaults(
+    const rawDefaults =
       source.defaults && typeof source.defaults === "object"
         ? (source.defaults as Record<string, unknown>)
-        : {}
-    );
+        : {};
+    const defaultsMigration = migratePersistedDevelopmentModuleDefaults(rawDefaults);
+    const defaults = await resolveAdminDefaults(defaultsMigration.defaults);
+    if (defaultsMigration.changed) {
+      await maybeResolve(
+        options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, {
+          ...source,
+          defaults: safeClone(defaults)
+        })
+      );
+    }
     const updatedBySource =
       source.updatedBy && typeof source.updatedBy === "object"
         ? (source.updatedBy as StoredUser | PublicUser)

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -444,12 +444,9 @@ function profileBelongsToModule(profileId: string, moduleId: string): boolean {
   return profileId === moduleId || profileId.startsWith(`${moduleId}.`);
 }
 
-function repairChangeCoversPath(changes: AdminGameRepairChange[], path: string): boolean {
-  return changes.some(
-    (change) =>
-      change.path === path ||
-      path.startsWith(`${change.path}.`) ||
-      path.startsWith(`${change.path}[`)
+function repairChangeAncestor(changes: AdminGameRepairChange[], path: string) {
+  return changes.find(
+    (change) => path.startsWith(`${change.path}.`) || path.startsWith(`${change.path}[`)
   );
 }
 
@@ -459,7 +456,19 @@ function appendUnreportedRepairChanges(
   path: string,
   changes: AdminGameRepairChange[]
 ): void {
-  if (valuesEqual(before, after) || repairChangeCoversPath(changes, path)) {
+  if (valuesEqual(before, after)) {
+    return;
+  }
+
+  const existingChange = changes.find((change) => change.path === path);
+  if (existingChange) {
+    if (!valuesEqual(existingChange.after, after)) {
+      existingChange.after = safeClone(after);
+    }
+    return;
+  }
+
+  if (repairChangeAncestor(changes, path)) {
     return;
   }
 

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -119,6 +119,37 @@ type AdminIssue = {
   actionId?: string | null;
 };
 
+type AdminGameRepairChange = {
+  path: string;
+  before: unknown;
+  after: unknown;
+  reason: string;
+};
+
+type AdminGameRepairPreview = {
+  status: "safe" | "blocked" | "not-needed";
+  orphanedModuleIds: string[];
+  relatedProfileIds: string[];
+  changes: AdminGameRepairChange[];
+  blockers: string[];
+  preservedFields: string[];
+};
+
+type AdminGameRepairPlan = AdminGameRepairPreview & {
+  nextState: GameState;
+};
+
+function toAdminGameRepairPreview(plan: AdminGameRepairPlan): AdminGameRepairPreview {
+  return {
+    status: plan.status,
+    orphanedModuleIds: plan.orphanedModuleIds,
+    relatedProfileIds: plan.relatedProfileIds,
+    changes: plan.changes,
+    blockers: plan.blockers,
+    preservedFields: plan.preservedFields
+  };
+}
+
 type AdminConsoleOptions = {
   datastore: {
     listUsers(): Promise<StoredUser[]> | StoredUser[];
@@ -358,6 +389,57 @@ function normalizeGameStateForRepair(state: GameState): GameState {
   return state;
 }
 
+const REPAIR_PRESERVED_FIELDS = Object.freeze([
+  "players",
+  "territories",
+  "hands and cards",
+  "turn and phase state",
+  "winner and version metadata",
+  "resolved map, rules, theme, and piece selections"
+]);
+
+const REPAIR_ROOT_CONFIG_FIELDS = Object.freeze([
+  "contentPackId",
+  "diceRuleSetId",
+  "victoryRuleSetId",
+  "pieceSetId",
+  "mapId",
+  "mapName"
+]);
+
+const REPAIR_PROFILE_FIELDS = Object.freeze([
+  "contentProfileId",
+  "gameplayProfileId",
+  "uiProfileId"
+]);
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function pushRepairChange(
+  changes: AdminGameRepairChange[],
+  path: string,
+  before: unknown,
+  after: unknown,
+  reason: string
+) {
+  if (valuesEqual(before, after)) {
+    return;
+  }
+
+  changes.push({
+    path,
+    before: safeClone(before),
+    after: safeClone(after),
+    reason
+  });
+}
+
+function profileBelongsToModule(profileId: string, moduleId: string): boolean {
+  return profileId === moduleId || profileId.startsWith(`${moduleId}.`);
+}
+
 async function maybeResolve<T>(value: Promise<T> | T): Promise<T> {
   return value;
 }
@@ -379,6 +461,191 @@ function createAdminConsole(options: AdminConsoleOptions) {
     }
 
     return asRecord(await maybeResolve(options.moduleRuntime.getModuleOptions()));
+  }
+
+  async function buildGameRepairPlan(state: GameState): Promise<AdminGameRepairPlan> {
+    const originalState = safeClone(state);
+    const nextState = safeClone(state);
+    const originalConfig = ensureGameConfig(originalState);
+    const nextConfig = ensureGameConfig(nextState);
+    const changes: AdminGameRepairChange[] = [];
+    const blockers: string[] = [];
+    const [installedModules, moduleOptions] = await Promise.all([
+      options.moduleRuntime.listInstalledModules(),
+      ensureRuntimeCatalogReady()
+    ]);
+    const installedById = new Map(installedModules.map((entry) => [String(entry.id || ""), entry]));
+    const activeModules = asArray(
+      originalConfig.activeModules as Array<{ id?: string; version?: string }> | null
+    )
+      .map((entry) => ({
+        id: asNonEmptyString(entry?.id),
+        version: asNonEmptyString(entry?.version)
+      }))
+      .filter((entry): entry is { id: string; version: string | null } => Boolean(entry.id));
+    const orphanedModuleIds = activeModules
+      .filter((reference) => {
+        const installed = installedById.get(reference.id);
+        return !installed || installed.enabled === false || installed.compatible === false;
+      })
+      .map((reference) => reference.id);
+    const orphanedModuleIdSet = new Set(orphanedModuleIds);
+
+    if (orphanedModuleIdSet.has("core.base")) {
+      blockers.push("The core.base module is unavailable; automatic repair cannot continue.");
+    }
+
+    if (orphanedModuleIds.length && nextState.phase !== "finished") {
+      blockers.push(
+        "Automatic orphan repair is limited to finished games so live gameplay semantics cannot change."
+      );
+    }
+
+    const retainedModules = activeModules
+      .filter((reference) => !orphanedModuleIdSet.has(reference.id))
+      .map((reference) => ({
+        id: reference.id,
+        ...(reference.version ? { version: reference.version } : {})
+      }));
+    if (orphanedModuleIds.length) {
+      nextConfig.activeModules = retainedModules;
+      pushRepairChange(
+        changes,
+        "gameConfig.activeModules",
+        originalConfig.activeModules,
+        retainedModules,
+        `Remove unavailable module reference${orphanedModuleIds.length === 1 ? "" : "s"}: ${orphanedModuleIds.join(", ")}.`
+      );
+    }
+
+    const profileCatalogByField = new Map<string, Set<string> | null>([
+      [
+        "contentProfileId",
+        asRecordArray(moduleOptions?.contentProfiles)
+          ? new Set(
+              asRecordArray(moduleOptions?.contentProfiles)
+                ?.map((entry) => asNonEmptyString(entry.id))
+                .filter((value): value is string => Boolean(value)) || []
+            )
+          : null
+      ],
+      [
+        "gameplayProfileId",
+        asRecordArray(moduleOptions?.gameplayProfiles)
+          ? new Set(
+              asRecordArray(moduleOptions?.gameplayProfiles)
+                ?.map((entry) => asNonEmptyString(entry.id))
+                .filter((value): value is string => Boolean(value)) || []
+            )
+          : null
+      ],
+      [
+        "uiProfileId",
+        asRecordArray(moduleOptions?.uiProfiles)
+          ? new Set(
+              asRecordArray(moduleOptions?.uiProfiles)
+                ?.map((entry) => asNonEmptyString(entry.id))
+                .filter((value): value is string => Boolean(value)) || []
+            )
+          : null
+      ]
+    ]);
+    const relatedProfileIds: string[] = [];
+
+    REPAIR_PROFILE_FIELDS.forEach((field) => {
+      const profileId = asNonEmptyString(originalConfig[field]);
+      if (!profileId) {
+        return;
+      }
+
+      const owningOrphan = orphanedModuleIds.find((moduleId) =>
+        profileBelongsToModule(profileId, moduleId)
+      );
+      const availableProfiles = profileCatalogByField.get(field) || null;
+      if (owningOrphan) {
+        relatedProfileIds.push(profileId);
+        nextConfig[field] = null;
+        pushRepairChange(
+          changes,
+          `gameConfig.${field}`,
+          profileId,
+          null,
+          `Clear profile owned by unavailable module ${owningOrphan}.`
+        );
+        return;
+      }
+
+      if (orphanedModuleIds.length && availableProfiles && !availableProfiles.has(profileId)) {
+        blockers.push(
+          `${field} "${profileId}" is unresolved and is not owned by an identified orphaned module.`
+        );
+      }
+    });
+
+    const gamePresetId = asNonEmptyString(originalConfig.gamePresetId);
+    const presetOwner = gamePresetId
+      ? orphanedModuleIds.find((moduleId) => profileBelongsToModule(gamePresetId, moduleId))
+      : null;
+    if (gamePresetId && presetOwner) {
+      nextConfig.gamePresetId = null;
+      pushRepairChange(
+        changes,
+        "gameConfig.gamePresetId",
+        gamePresetId,
+        null,
+        `Clear preset owned by unavailable module ${presetOwner}.`
+      );
+    } else if (gamePresetId && orphanedModuleIds.length) {
+      const resolvedPreset = await options.moduleRuntime.resolveGamePreset({ gamePresetId });
+      if (!resolvedPreset) {
+        blockers.push(`gamePresetId "${gamePresetId}" cannot be resolved safely.`);
+      }
+    }
+
+    if (orphanedModuleIds.length && !blockers.length) {
+      try {
+        await options.moduleRuntime.resolveGameSelection({
+          activeModuleIds: retainedModules
+            .map((entry) => entry.id)
+            .filter((moduleId) => moduleId !== "core.base"),
+          contentProfileId: asNonEmptyString(nextConfig.contentProfileId),
+          gameplayProfileId: asNonEmptyString(nextConfig.gameplayProfileId),
+          uiProfileId: asNonEmptyString(nextConfig.uiProfileId),
+          contentPackId: asNonEmptyString(nextConfig.contentPackId),
+          pieceSetId: asNonEmptyString(nextConfig.pieceSetId),
+          mapId: asNonEmptyString(nextConfig.mapId),
+          diceRuleSetId: asNonEmptyString(nextConfig.diceRuleSetId),
+          victoryRuleSetId: asNonEmptyString(nextConfig.victoryRuleSetId),
+          themeId: asNonEmptyString(nextConfig.themeId),
+          pieceSkinId: asNonEmptyString(nextConfig.pieceSkinId)
+        });
+      } catch (error: unknown) {
+        blockers.push(
+          `The remaining runtime selections cannot be resolved: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+
+    normalizeGameStateForRepair(nextState);
+    REPAIR_ROOT_CONFIG_FIELDS.forEach((field) => {
+      pushRepairChange(
+        changes,
+        field,
+        originalState[field],
+        nextState[field],
+        `Synchronize the persisted root value with gameConfig.${field}.`
+      );
+    });
+
+    return {
+      status: blockers.length ? "blocked" : changes.length ? "safe" : "not-needed",
+      orphanedModuleIds,
+      relatedProfileIds,
+      changes,
+      blockers,
+      preservedFields: [...REPAIR_PRESERVED_FIELDS],
+      nextState
+    };
   }
 
   async function resolveAdminDefaults(input: Record<string, unknown> = {}) {
@@ -601,11 +868,20 @@ function createAdminConsole(options: AdminConsoleOptions) {
 
     activeModules.forEach((moduleRef) => {
       const moduleEntry = installedById.get(moduleRef.id);
+      const relatedProfiles = REPAIR_PROFILE_FIELDS.flatMap((field) => {
+        const profileId = asNonEmptyString(config[field]);
+        return profileId && profileBelongsToModule(profileId, moduleRef.id)
+          ? [`${field}="${profileId}"`]
+          : [];
+      });
+      const relatedCopy = relatedProfiles.length
+        ? ` Profili collegati: ${relatedProfiles.join(", ")}.`
+        : "";
       if (!moduleEntry) {
         issues.push({
           code: "orphaned-module-reference",
           severity: "error",
-          message: `La partita riferisce il modulo mancante "${moduleRef.id}".`,
+          message: `La partita riferisce il modulo mancante "${moduleRef.id}".${relatedCopy}`,
           gameId: summary.id
         });
         return;
@@ -615,7 +891,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
         issues.push({
           code: "disabled-module-reference",
           severity: "error",
-          message: `La partita dipende dal modulo non disponibile "${moduleRef.id}".`,
+          message: `La partita dipende dal modulo non disponibile "${moduleRef.id}".${relatedCopy}`,
           gameId: summary.id
         });
       }
@@ -970,11 +1246,13 @@ function createAdminConsole(options: AdminConsoleOptions) {
       },
       config.maintenance.staleLobbyDays
     );
+    const repairPreview = toAdminGameRepairPreview(await buildGameRepairPlan(record.state));
 
     return {
       game: summary,
       players: buildPlayerSummaries(record.state),
-      rawState: safeClone(record.state)
+      rawState: safeClone(record.state),
+      repairPreview
     };
   }
 
@@ -997,9 +1275,10 @@ function createAdminConsole(options: AdminConsoleOptions) {
       throw new Error(`Partita "${input.gameId}" non trovata.`);
     }
 
-    const nextState = safeClone(gameContext.state);
+    let nextState = safeClone(gameContext.state);
     const beforeState = JSON.stringify(nextState);
     const now = new Date().toISOString();
+    let appliedRepairPreview: AdminGameRepairPreview | null = null;
 
     if (input.action === "close-lobby") {
       requireConfirmation(input.gameId, input.confirmation);
@@ -1014,7 +1293,16 @@ function createAdminConsole(options: AdminConsoleOptions) {
       }
       nextState.phase = "finished";
     } else {
-      normalizeGameStateForRepair(nextState);
+      requireConfirmation(input.gameId, input.confirmation);
+      const repairPlan = await buildGameRepairPlan(nextState);
+      if (repairPlan.status === "blocked") {
+        throw new Error(`Riparazione bloccata: ${repairPlan.blockers.join(" ")}`);
+      }
+      if (repairPlan.status === "not-needed") {
+        throw new Error("La partita non richiede alcuna riparazione sicura.");
+      }
+      nextState = repairPlan.nextState;
+      appliedRepairPreview = toAdminGameRepairPreview(repairPlan);
     }
 
     nextState.adminMeta = {
@@ -1049,13 +1337,21 @@ function createAdminConsole(options: AdminConsoleOptions) {
       targetLabel: detail.game.name,
       result: "success",
       details: {
-        changed
+        changed,
+        ...(appliedRepairPreview
+          ? {
+              orphanedModuleIds: appliedRepairPreview.orphanedModuleIds,
+              relatedProfileIds: appliedRepairPreview.relatedProfileIds,
+              changes: appliedRepairPreview.changes
+            }
+          : {})
       }
     });
 
     return {
       ok: true,
       ...detail,
+      ...(appliedRepairPreview ? { repairPreview: appliedRepairPreview } : {}),
       audit
     };
   }

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -698,12 +698,6 @@ function createAdminConsole(options: AdminConsoleOptions) {
       blockers.push("The core.base module is unavailable; automatic repair cannot continue.");
     }
 
-    if (orphanedModuleIds.length && nextState.phase !== "finished") {
-      blockers.push(
-        "Automatic orphan repair is limited to finished games so live gameplay semantics cannot change."
-      );
-    }
-
     const retainedModules = activeModules
       .filter((reference) => !orphanedModuleIdSet.has(reference.id))
       .map((reference) => ({
@@ -842,6 +836,11 @@ function createAdminConsole(options: AdminConsoleOptions) {
       );
     });
     appendUnreportedRepairChanges(originalState, nextState, "", changes);
+    if (changes.length && originalState.phase !== "finished") {
+      blockers.push(
+        "Automatic configuration repair is limited to finished games so live gameplay semantics cannot change."
+      );
+    }
 
     return {
       status: blockers.length ? "blocked" : changes.length ? "safe" : "not-needed",

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -568,6 +568,19 @@ function installedSelectionOwners(
   return ownersByField;
 }
 
+function mergeSelectionOwnerCatalogs(
+  ...catalogs: Array<Map<string, string | null> | Map<string, string> | null | undefined>
+): Map<string, string | null> | null {
+  const availableCatalogs = catalogs.filter(
+    (catalog): catalog is Map<string, string | null> | Map<string, string> => Boolean(catalog)
+  );
+  if (!availableCatalogs.length) {
+    return null;
+  }
+
+  return new Map(availableCatalogs.flatMap((catalog) => Array.from(catalog.entries())));
+}
+
 function migratePersistedDevelopmentModuleDefaults(
   input: Record<string, unknown>,
   installedModules: Array<Record<string, unknown>>
@@ -628,6 +641,17 @@ function asRecordArray(value: unknown): Array<Record<string, unknown>> | null {
 }
 
 function createAdminConsole(options: AdminConsoleOptions) {
+  let configMutationQueue: Promise<void> = Promise.resolve();
+
+  function withConfigMutationLock<T>(operation: () => Promise<T>): Promise<T> {
+    const next = configMutationQueue.then(operation, operation);
+    configMutationQueue = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  }
+
   async function ensureRuntimeCatalogReady(): Promise<Record<string, unknown> | null> {
     if (typeof options.moduleRuntime.getModuleOptions !== "function") {
       return null;
@@ -648,6 +672,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
       ensureRuntimeCatalogReady()
     ]);
     const installedById = new Map(installedModules.map((entry) => [String(entry.id || ""), entry]));
+    const installedOwnersByField = installedSelectionOwners(installedModules);
     const activeModules = asArray(
       originalConfig.activeModules as Array<{ id?: string; version?: string }> | null
     )
@@ -691,7 +716,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
       );
     }
 
-    const profileCatalogByField = new Map<string, Map<string, string | null> | null>([
+    const availableProfileCatalogByField = new Map<string, Map<string, string | null> | null>([
       ["contentProfileId", profileCatalogById(moduleOptions?.contentProfiles)],
       ["gameplayProfileId", profileCatalogById(moduleOptions?.gameplayProfiles)],
       ["uiProfileId", profileCatalogById(moduleOptions?.uiProfiles)]
@@ -704,11 +729,15 @@ function createAdminConsole(options: AdminConsoleOptions) {
         return;
       }
 
-      const availableProfiles = profileCatalogByField.get(field) || null;
+      const availableProfiles = availableProfileCatalogByField.get(field) || null;
+      const ownershipCatalog = mergeSelectionOwnerCatalogs(
+        installedOwnersByField.get(field),
+        availableProfiles
+      );
       const owningOrphan = findUnavailableCatalogOwner(
         profileId,
         orphanedModuleIds,
-        availableProfiles
+        ownershipCatalog
       );
       if (owningOrphan) {
         relatedProfileIds.push(profileId);
@@ -733,7 +762,11 @@ function createAdminConsole(options: AdminConsoleOptions) {
     const gamePresetId = asNonEmptyString(originalConfig.gamePresetId);
     const gamePresetCatalog = profileCatalogById(moduleOptions?.gamePresets);
     const presetOwner = gamePresetId
-      ? findUnavailableCatalogOwner(gamePresetId, orphanedModuleIds, gamePresetCatalog)
+      ? findUnavailableCatalogOwner(
+          gamePresetId,
+          orphanedModuleIds,
+          mergeSelectionOwnerCatalogs(installedOwnersByField.get("gamePresetId"), gamePresetCatalog)
+        )
       : null;
     if (gamePresetId && presetOwner) {
       nextConfig.gamePresetId = null;
@@ -781,7 +814,19 @@ function createAdminConsole(options: AdminConsoleOptions) {
       }
     }
 
+    const resolvedCatalog = asRecord(moduleOptions?.resolvedCatalog) || moduleOptions;
+    const retainedRuntimeThemeId = asNonEmptyString(nextConfig.themeId);
+    const retainedRuntimeThemeIsAvailable = Boolean(
+      retainedRuntimeThemeId &&
+      asRecordArray(resolvedCatalog?.themes)?.some(
+        (theme) => asNonEmptyString(theme.id) === retainedRuntimeThemeId
+      )
+    );
+
     normalizeGameStateForRepair(nextState);
+    if (retainedRuntimeThemeId && retainedRuntimeThemeIsAvailable) {
+      ensureGameConfig(nextState).themeId = retainedRuntimeThemeId;
+    }
     REPAIR_ROOT_CONFIG_FIELDS.forEach((field) => {
       pushRepairChange(
         changes,
@@ -886,7 +931,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
   }
 
   async function loadConfigRecord(): Promise<AdminConfigRecord> {
-    const source = await readConfigSource();
+    let source = await readConfigSource();
     const rawDefaults =
       source.defaults && typeof source.defaults === "object"
         ? (source.defaults as Record<string, unknown>)
@@ -896,14 +941,42 @@ function createAdminConsole(options: AdminConsoleOptions) {
       rawDefaults,
       installedModules
     );
-    const defaults = await resolveAdminDefaults(defaultsMigration.defaults);
+    let defaults: Record<string, unknown>;
     if (defaultsMigration.changed) {
-      await maybeResolve(
-        options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, {
-          ...source,
-          defaults: safeClone(defaults)
-        })
-      );
+      const migrationResult = await withConfigMutationLock(async () => {
+        const latestSource = await readConfigSource();
+        const latestRawDefaults =
+          latestSource.defaults && typeof latestSource.defaults === "object"
+            ? (latestSource.defaults as Record<string, unknown>)
+            : {};
+        const latestMigration = migratePersistedDevelopmentModuleDefaults(
+          latestRawDefaults,
+          installedModules
+        );
+        const latestResolvedDefaults = await resolveAdminDefaults(latestMigration.defaults);
+        if (!latestMigration.changed) {
+          return { source: latestSource, defaults: latestResolvedDefaults };
+        }
+
+        const mergedDefaults: Record<string, unknown> = safeClone(latestRawDefaults);
+        const migratedDefaults = latestMigration.defaults as unknown as Record<string, unknown>;
+        const resolvedDefaults = latestResolvedDefaults as unknown as Record<string, unknown>;
+        ["activeModuleIds", ...REPAIR_PROFILE_FIELDS, "gamePresetId"].forEach((field) => {
+          if (!valuesEqual(latestRawDefaults[field], migratedDefaults[field])) {
+            mergedDefaults[field] = safeClone(resolvedDefaults[field]);
+          }
+        });
+        const persistedSource = {
+          ...latestSource,
+          defaults: mergedDefaults
+        };
+        await maybeResolve(options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, persistedSource));
+        return { source: persistedSource, defaults: latestResolvedDefaults };
+      });
+      source = migrationResult.source;
+      defaults = migrationResult.defaults;
+    } else {
+      defaults = await resolveAdminDefaults(defaultsMigration.defaults);
     }
     const updatedBySource =
       source.updatedBy && typeof source.updatedBy === "object"
@@ -919,13 +992,15 @@ function createAdminConsole(options: AdminConsoleOptions) {
   }
 
   async function saveConfigRecord(record: AdminConfigRecord): Promise<AdminConfigRecord> {
-    await maybeResolve(
-      options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, {
-        defaults: safeClone(record.defaults),
-        maintenance: safeClone(record.maintenance),
-        updatedAt: record.updatedAt,
-        updatedBy: record.updatedBy
-      })
+    await withConfigMutationLock(() =>
+      maybeResolve(
+        options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, {
+          defaults: safeClone(record.defaults),
+          maintenance: safeClone(record.maintenance),
+          updatedAt: record.updatedAt,
+          updatedBy: record.updatedBy
+        })
+      )
     );
 
     return loadConfigRecord();

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -456,11 +456,15 @@ function appendUnreportedRepairChanges(
   path: string,
   changes: AdminGameRepairChange[]
 ): void {
+  const existingChangeIndex = changes.findIndex((change) => change.path === path);
   if (valuesEqual(before, after)) {
+    if (existingChangeIndex >= 0) {
+      changes.splice(existingChangeIndex, 1);
+    }
     return;
   }
 
-  const existingChange = changes.find((change) => change.path === path);
+  const existingChange = existingChangeIndex >= 0 ? changes[existingChangeIndex] : undefined;
   if (existingChange) {
     if (!valuesEqual(existingChange.after, after)) {
       existingChange.after = safeClone(after);
@@ -529,7 +533,45 @@ function findUnavailableCatalogOwner(
   );
 }
 
-function migratePersistedDevelopmentModuleDefaults(input: Record<string, unknown>): {
+function installedSelectionOwners(
+  installedModules: Array<Record<string, unknown>>
+): Map<string, Map<string, string>> {
+  const ownersByField = new Map<string, Map<string, string>>(
+    [...REPAIR_PROFILE_FIELDS, "gamePresetId"].map((field) => [field, new Map()])
+  );
+
+  installedModules.forEach((moduleEntry) => {
+    const moduleId = asNonEmptyString(moduleEntry.id);
+    const clientManifest = asRecord(moduleEntry.clientManifest);
+    if (!moduleId || !clientManifest) {
+      return;
+    }
+
+    const profiles = asRecord(clientManifest.profiles);
+    const entriesByField: Record<string, Array<Record<string, unknown>>> = {
+      contentProfileId: asRecordArray(profiles?.content) || [],
+      gameplayProfileId: asRecordArray(profiles?.gameplay) || [],
+      uiProfileId: asRecordArray(profiles?.ui) || [],
+      gamePresetId: asRecordArray(clientManifest.gamePresets) || []
+    };
+
+    Object.entries(entriesByField).forEach(([field, entries]) => {
+      entries.forEach((entry) => {
+        const selectionId = asNonEmptyString(entry.id);
+        if (selectionId) {
+          ownersByField.get(field)?.set(selectionId, asNonEmptyString(entry.moduleId) || moduleId);
+        }
+      });
+    });
+  });
+
+  return ownersByField;
+}
+
+function migratePersistedDevelopmentModuleDefaults(
+  input: Record<string, unknown>,
+  installedModules: Array<Record<string, unknown>>
+): {
   defaults: Record<string, unknown>;
   changed: boolean;
 } {
@@ -550,9 +592,19 @@ function migratePersistedDevelopmentModuleDefaults(input: Record<string, unknown
       (moduleId) => !removedModuleIds.includes(moduleId)
     );
   }
+  const ownersByField = installedSelectionOwners(installedModules);
+  const developmentModuleIds = new Set(
+    installedModules
+      .map((moduleEntry) => asNonEmptyString(moduleEntry.id))
+      .filter(
+        (moduleId): moduleId is string =>
+          Boolean(moduleId) && isDevelopmentOnlyModuleId(moduleId as string)
+      )
+  );
   [...REPAIR_PROFILE_FIELDS, "gamePresetId"].forEach((field) => {
     const selectionId = asNonEmptyString(defaults[field]);
-    if (selectionId && isDevelopmentOnlyModuleId(selectionId)) {
+    const ownerId = selectionId ? ownersByField.get(field)?.get(selectionId) : null;
+    if (ownerId && developmentModuleIds.has(ownerId)) {
       defaults[field] = null;
       changed = true;
     }
@@ -693,9 +745,15 @@ function createAdminConsole(options: AdminConsoleOptions) {
         `Clear preset owned by unavailable module ${presetOwner}.`
       );
     } else if (gamePresetId && orphanedModuleIds.length) {
-      const resolvedPreset = await options.moduleRuntime.resolveGamePreset({ gamePresetId });
-      if (!resolvedPreset) {
-        blockers.push(`gamePresetId "${gamePresetId}" cannot be resolved safely.`);
+      try {
+        const resolvedPreset = await options.moduleRuntime.resolveGamePreset({ gamePresetId });
+        if (!resolvedPreset) {
+          blockers.push(`gamePresetId "${gamePresetId}" cannot be resolved safely.`);
+        }
+      } catch (error: unknown) {
+        blockers.push(
+          `gamePresetId "${gamePresetId}" cannot be resolved safely: ${error instanceof Error ? error.message : String(error)}`
+        );
       }
     }
 
@@ -833,7 +891,11 @@ function createAdminConsole(options: AdminConsoleOptions) {
       source.defaults && typeof source.defaults === "object"
         ? (source.defaults as Record<string, unknown>)
         : {};
-    const defaultsMigration = migratePersistedDevelopmentModuleDefaults(rawDefaults);
+    const installedModules = await options.moduleRuntime.listInstalledModules();
+    const defaultsMigration = migratePersistedDevelopmentModuleDefaults(
+      rawDefaults,
+      installedModules
+    );
     const defaults = await resolveAdminDefaults(defaultsMigration.defaults);
     if (defaultsMigration.changed) {
       await maybeResolve(

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -162,6 +162,11 @@ type AdminConsoleOptions = {
     deleteSessionsForUser?(userId: string): Promise<void> | void;
     getAppState(key: string): Promise<unknown> | unknown;
     setAppState(key: string, value: unknown): Promise<unknown> | unknown;
+    compareAndSetAppState?(
+      key: string,
+      expectedValue: unknown,
+      nextValue: unknown
+    ): Promise<boolean> | boolean;
   };
   auth: {
     publicUser(user: StoredUser | null | undefined): PublicUser | null;
@@ -925,9 +930,37 @@ function createAdminConsole(options: AdminConsoleOptions) {
     };
   }
 
-  async function readConfigSource(): Promise<Record<string, unknown>> {
+  async function readConfigSourceSnapshot(): Promise<{
+    expectedValue: unknown;
+    source: Record<string, unknown>;
+  }> {
     const raw = await maybeResolve(options.datastore.getAppState(ADMIN_CONFIG_STATE_KEY));
-    return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+    return {
+      expectedValue: raw,
+      source: raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+    };
+  }
+
+  async function readConfigSource(): Promise<Record<string, unknown>> {
+    return (await readConfigSourceSnapshot()).source;
+  }
+
+  async function compareAndSetConfigSource(
+    expectedValue: unknown,
+    nextSource: Record<string, unknown>
+  ): Promise<boolean> {
+    if (typeof options.datastore.compareAndSetAppState === "function") {
+      return Boolean(
+        await maybeResolve(
+          options.datastore.compareAndSetAppState(ADMIN_CONFIG_STATE_KEY, expectedValue, nextSource)
+        )
+      );
+    }
+    if (isPersistentVercelEnvironment()) {
+      throw new Error("Atomic app-state updates are required in persistent Vercel environments.");
+    }
+    await maybeResolve(options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, nextSource));
+    return true;
   }
 
   async function loadConfigRecord(): Promise<AdminConfigRecord> {
@@ -944,34 +977,39 @@ function createAdminConsole(options: AdminConsoleOptions) {
     let defaults: Record<string, unknown>;
     if (defaultsMigration.changed) {
       const migrationResult = await withConfigMutationLock(async () => {
-        const latestSource = await readConfigSource();
-        const latestRawDefaults =
-          latestSource.defaults && typeof latestSource.defaults === "object"
-            ? (latestSource.defaults as Record<string, unknown>)
-            : {};
-        const latestMigration = migratePersistedDevelopmentModuleDefaults(
-          latestRawDefaults,
-          installedModules
-        );
-        const latestResolvedDefaults = await resolveAdminDefaults(latestMigration.defaults);
-        if (!latestMigration.changed) {
-          return { source: latestSource, defaults: latestResolvedDefaults };
-        }
-
-        const mergedDefaults: Record<string, unknown> = safeClone(latestRawDefaults);
-        const migratedDefaults = latestMigration.defaults as unknown as Record<string, unknown>;
-        const resolvedDefaults = latestResolvedDefaults as unknown as Record<string, unknown>;
-        ["activeModuleIds", ...REPAIR_PROFILE_FIELDS, "gamePresetId"].forEach((field) => {
-          if (!valuesEqual(latestRawDefaults[field], migratedDefaults[field])) {
-            mergedDefaults[field] = safeClone(resolvedDefaults[field]);
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+          const latestSnapshot = await readConfigSourceSnapshot();
+          const latestSource = latestSnapshot.source;
+          const latestRawDefaults =
+            latestSource.defaults && typeof latestSource.defaults === "object"
+              ? (latestSource.defaults as Record<string, unknown>)
+              : {};
+          const latestMigration = migratePersistedDevelopmentModuleDefaults(
+            latestRawDefaults,
+            installedModules
+          );
+          const latestResolvedDefaults = await resolveAdminDefaults(latestMigration.defaults);
+          if (!latestMigration.changed) {
+            return { source: latestSource, defaults: latestResolvedDefaults };
           }
-        });
-        const persistedSource = {
-          ...latestSource,
-          defaults: mergedDefaults
-        };
-        await maybeResolve(options.datastore.setAppState(ADMIN_CONFIG_STATE_KEY, persistedSource));
-        return { source: persistedSource, defaults: latestResolvedDefaults };
+
+          const mergedDefaults: Record<string, unknown> = safeClone(latestRawDefaults);
+          const migratedDefaults = latestMigration.defaults as unknown as Record<string, unknown>;
+          const resolvedDefaults = latestResolvedDefaults as unknown as Record<string, unknown>;
+          ["activeModuleIds", ...REPAIR_PROFILE_FIELDS, "gamePresetId"].forEach((field) => {
+            if (!valuesEqual(latestRawDefaults[field], migratedDefaults[field])) {
+              mergedDefaults[field] = safeClone(resolvedDefaults[field]);
+            }
+          });
+          const persistedSource = {
+            ...latestSource,
+            defaults: mergedDefaults
+          };
+          if (await compareAndSetConfigSource(latestSnapshot.expectedValue, persistedSource)) {
+            return { source: persistedSource, defaults: latestResolvedDefaults };
+          }
+        }
+        throw new Error("Admin configuration changed repeatedly during automatic migration.");
       });
       source = migrationResult.source;
       defaults = migrationResult.defaults;

--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -659,6 +659,18 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
       );
       return datastore.getAppState(key);
     },
+    async compareAndSetAppState(key: string, expectedValue: unknown, nextValue: unknown) {
+      await ensureInitialized();
+      const updated = await request("/rpc/netrisk_compare_and_set_app_state", {
+        method: "POST",
+        body: {
+          app_state_key: String(key || ""),
+          expected_value_json: JSON.stringify(expectedValue ?? null),
+          next_value_json: JSON.stringify(nextValue ?? null)
+        }
+      });
+      return updated === true;
+    },
     async setActiveGameId(gameId: string | null) {
       await ensureInitialized();
       await upsertRows(

--- a/backend/datastore.cts
+++ b/backend/datastore.cts
@@ -277,6 +277,12 @@ function createDatastore(options: DatastoreOptions = {}) {
     ) as Statement<AppStateRow | null>,
     setAppState: db.prepare(
       "INSERT INTO app_state (key, value_json) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json"
+    ) as Statement<unknown>,
+    compareAndSetAppState: db.prepare(
+      "UPDATE app_state SET value_json = ? WHERE key = ? AND value_json = ?"
+    ) as Statement<unknown>,
+    insertAppStateIfMissing: db.prepare(
+      "INSERT INTO app_state (key, value_json) VALUES (?, ?) ON CONFLICT(key) DO NOTHING"
     ) as Statement<unknown>
   };
 
@@ -542,6 +548,28 @@ function createDatastore(options: DatastoreOptions = {}) {
         statements.setAppState.run(String(key || ""), JSON.stringify(value ?? null));
       });
       return datastore.getAppState(key);
+    },
+    compareAndSetAppState(key: string, expectedValue: unknown, nextValue: unknown) {
+      return transaction(() => {
+        const normalizedKey = String(key || "");
+        const expectedJson = JSON.stringify(expectedValue ?? null);
+        const nextJson = JSON.stringify(nextValue ?? null);
+        const updated = statements.compareAndSetAppState.run(
+          nextJson,
+          normalizedKey,
+          expectedJson
+        ) as { changes?: number };
+        if (Number(updated.changes) === 1) {
+          return true;
+        }
+        if (expectedValue == null) {
+          const inserted = statements.insertAppStateIfMissing.run(normalizedKey, nextJson) as {
+            changes?: number;
+          };
+          return Number(inserted.changes) === 1;
+        }
+        return false;
+      });
     },
     setActiveGameId(gameId: string | null) {
       transaction(() => {

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -101,6 +101,11 @@ type ModuleRuntimeOptions = {
   datastore: {
     getAppState?: (key: string) => unknown | Promise<unknown>;
     setAppState?: (key: string, value: unknown) => unknown | Promise<unknown>;
+    compareAndSetAppState?: (
+      key: string,
+      expectedValue: unknown,
+      nextValue: unknown
+    ) => boolean | Promise<boolean>;
     listGames?: () => Array<Record<string, unknown>> | Promise<Array<Record<string, unknown>>>;
   };
   authoredModules?: {
@@ -692,6 +697,14 @@ function normalizeCatalogState(raw: unknown): CatalogState {
     enabledById,
     updatedAt: isNonEmptyString(raw.updatedAt) ? String(raw.updatedAt) : null
   };
+}
+
+function catalogStatesEqual(left: CatalogState | null, right: CatalogState): boolean {
+  return Boolean(
+    left &&
+    left.updatedAt === right.updatedAt &&
+    JSON.stringify(left.enabledById) === JSON.stringify(right.enabledById)
+  );
 }
 
 function safeReadJson(filePath: string): unknown {
@@ -1978,49 +1991,91 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       }));
   }
 
-  async function loadCatalogState(): Promise<CatalogState> {
-    if (!cachedState) {
-      const rawState =
-        typeof options.datastore.getAppState === "function"
-          ? await options.datastore.getAppState(MODULE_CATALOG_STATE_KEY)
-          : null;
-      cachedState = normalizeCatalogState(rawState);
+  async function readCatalogStateSnapshot(): Promise<{ raw: unknown; state: CatalogState }> {
+    const raw =
+      typeof options.datastore.getAppState === "function"
+        ? await options.datastore.getAppState(MODULE_CATALOG_STATE_KEY)
+        : null;
+    return { raw, state: normalizeCatalogState(raw) };
+  }
+
+  function cacheCatalogState(nextState: CatalogState): CatalogState {
+    if (catalogStatesEqual(cachedState, nextState)) {
+      return cachedState as CatalogState;
     }
-    if (isPersistentVercelEnvironment()) {
-      const developmentModuleIds = Object.keys(cachedState.enabledById).filter(
-        (moduleId) =>
-          moduleId !== CORE_MODULE_ID &&
-          isDevelopmentOnlyModuleId(moduleId) &&
-          cachedState?.enabledById[moduleId] !== false
-      );
-      if (developmentModuleIds.length) {
-        const games = await listGames();
-        const safelyDisabledModuleIds = developmentModuleIds.filter(
-          (moduleId) => !activeGameUsesModule(moduleId, games)
-        );
-        if (!safelyDisabledModuleIds.length) {
-          return cachedState;
-        }
-        cachedState = {
-          enabledById: {
-            ...cachedState.enabledById,
-            ...Object.fromEntries(safelyDisabledModuleIds.map((moduleId) => [moduleId, false]))
-          },
-          updatedAt: new Date().toISOString()
-        };
-        if (typeof options.datastore.setAppState === "function") {
-          await options.datastore.setAppState(MODULE_CATALOG_STATE_KEY, cachedState);
-        }
-      }
-    }
+    cachedState = nextState;
     return cachedState;
   }
 
-  async function saveCatalogState(nextState: CatalogState): Promise<void> {
-    cachedState = nextState;
-    if (typeof options.datastore.setAppState === "function") {
-      await options.datastore.setAppState(MODULE_CATALOG_STATE_KEY, nextState);
+  async function updateCatalogState(
+    update: (currentState: CatalogState) => CatalogState | Promise<CatalogState>
+  ): Promise<CatalogState> {
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const snapshot = await readCatalogStateSnapshot();
+      const nextState = await update(snapshot.state);
+      if (catalogStatesEqual(snapshot.state, nextState)) {
+        return cacheCatalogState(snapshot.state);
+      }
+
+      if (typeof options.datastore.compareAndSetAppState === "function") {
+        const updated = await options.datastore.compareAndSetAppState(
+          MODULE_CATALOG_STATE_KEY,
+          snapshot.raw,
+          nextState
+        );
+        if (!updated) {
+          continue;
+        }
+        return cacheCatalogState(nextState);
+      }
+
+      if (isPersistentVercelEnvironment()) {
+        throw new Error("Atomic app-state updates are required in persistent Vercel environments.");
+      }
+      if (typeof options.datastore.setAppState === "function") {
+        await options.datastore.setAppState(MODULE_CATALOG_STATE_KEY, nextState);
+      }
+      return cacheCatalogState(nextState);
     }
+
+    throw new Error("Module catalog changed repeatedly during an atomic update.");
+  }
+
+  async function loadCatalogState(): Promise<CatalogState> {
+    if (!isPersistentVercelEnvironment()) {
+      if (cachedState) {
+        return cachedState;
+      }
+      return cacheCatalogState((await readCatalogStateSnapshot()).state);
+    }
+
+    return updateCatalogState(async (currentState) => {
+      const developmentModuleIds = Object.keys(currentState.enabledById).filter(
+        (moduleId) =>
+          moduleId !== CORE_MODULE_ID &&
+          isDevelopmentOnlyModuleId(moduleId) &&
+          currentState.enabledById[moduleId] !== false
+      );
+      if (!developmentModuleIds.length) {
+        return currentState;
+      }
+
+      const games = await listGames();
+      const safelyDisabledModuleIds = developmentModuleIds.filter(
+        (moduleId) => !activeGameUsesModule(moduleId, games)
+      );
+      if (!safelyDisabledModuleIds.length) {
+        return currentState;
+      }
+
+      return {
+        enabledById: {
+          ...currentState.enabledById,
+          ...Object.fromEntries(safelyDisabledModuleIds.map((moduleId) => [moduleId, false]))
+        },
+        updatedAt: new Date().toISOString()
+      };
+    });
   }
 
   function scanFilesystemModules(enabledById: Record<string, boolean>): NetRiskInstalledModule[] {
@@ -2569,17 +2624,14 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
         );
       }
 
-      const catalogState = await loadCatalogState();
-      const nextState: CatalogState = {
+      await updateCatalogState((catalogState) => ({
         enabledById: {
           ...catalogState.enabledById,
           [moduleId]: true,
           [CORE_MODULE_ID]: true
         },
         updatedAt: new Date().toISOString()
-      };
-
-      await saveCatalogState(nextState);
+      }));
       cachedModules = [];
       return ensureCatalog();
     },
@@ -2599,17 +2651,14 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
         throw new Error(`Module "${moduleId}" is still referenced by an active game.`);
       }
 
-      const catalogState = await loadCatalogState();
-      const nextState: CatalogState = {
+      await updateCatalogState((catalogState) => ({
         enabledById: {
           ...catalogState.enabledById,
           [moduleId]: false,
           [CORE_MODULE_ID]: true
         },
         updatedAt: new Date().toISOString()
-      };
-
-      await saveCatalogState(nextState);
+      }));
       cachedModules = [];
       return ensureCatalog();
     },

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -1979,15 +1979,13 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
   }
 
   async function loadCatalogState(): Promise<CatalogState> {
-    if (cachedState) {
-      return cachedState;
+    if (!cachedState) {
+      const rawState =
+        typeof options.datastore.getAppState === "function"
+          ? await options.datastore.getAppState(MODULE_CATALOG_STATE_KEY)
+          : null;
+      cachedState = normalizeCatalogState(rawState);
     }
-
-    const rawState =
-      typeof options.datastore.getAppState === "function"
-        ? await options.datastore.getAppState(MODULE_CATALOG_STATE_KEY)
-        : null;
-    cachedState = normalizeCatalogState(rawState);
     if (isPersistentVercelEnvironment()) {
       const developmentModuleIds = Object.keys(cachedState.enabledById).filter(
         (moduleId) =>
@@ -2310,6 +2308,13 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
   }
 
   async function ensureCatalog(): Promise<NetRiskInstalledModule[]> {
+    if (cachedModules.length && isPersistentVercelEnvironment()) {
+      const previousCatalogState = cachedState;
+      await loadCatalogState();
+      if (cachedState !== previousCatalogState) {
+        cachedModules = [];
+      }
+    }
     if (cachedModules.length) {
       return cachedModules.map(cloneInstalledModule);
     }

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -1996,10 +1996,17 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
           cachedState?.enabledById[moduleId] !== false
       );
       if (developmentModuleIds.length) {
+        const games = await listGames();
+        const safelyDisabledModuleIds = developmentModuleIds.filter(
+          (moduleId) => !activeGameUsesModule(moduleId, games)
+        );
+        if (!safelyDisabledModuleIds.length) {
+          return cachedState;
+        }
         cachedState = {
           enabledById: {
             ...cachedState.enabledById,
-            ...Object.fromEntries(developmentModuleIds.map((moduleId) => [moduleId, false]))
+            ...Object.fromEntries(safelyDisabledModuleIds.map((moduleId) => [moduleId, false]))
           },
           updatedAt: new Date().toISOString()
         };

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -183,11 +183,15 @@ function isPersistentVercelEnvironment(env: NodeJS.ProcessEnv = process.env): bo
   return vercelEnvironment === "preview" || vercelEnvironment === "production";
 }
 
+function isDevelopmentOnlyModuleId(moduleId: string): boolean {
+  return DEVELOPMENT_ONLY_MODULE_ID.test(moduleId);
+}
+
 function assertPersistentModuleIdAllowed(
   moduleId: string,
   env: NodeJS.ProcessEnv = process.env
 ): void {
-  if (isPersistentVercelEnvironment(env) && DEVELOPMENT_ONLY_MODULE_ID.test(moduleId)) {
+  if (isPersistentVercelEnvironment(env) && isDevelopmentOnlyModuleId(moduleId)) {
     throw new Error(
       `Development-only module "${moduleId}" cannot be enabled or persisted in a Vercel deployment.`
     );
@@ -1984,6 +1988,26 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
         ? await options.datastore.getAppState(MODULE_CATALOG_STATE_KEY)
         : null;
     cachedState = normalizeCatalogState(rawState);
+    if (isPersistentVercelEnvironment()) {
+      const developmentModuleIds = Object.keys(cachedState.enabledById).filter(
+        (moduleId) =>
+          moduleId !== CORE_MODULE_ID &&
+          isDevelopmentOnlyModuleId(moduleId) &&
+          cachedState?.enabledById[moduleId] !== false
+      );
+      if (developmentModuleIds.length) {
+        cachedState = {
+          enabledById: {
+            ...cachedState.enabledById,
+            ...Object.fromEntries(developmentModuleIds.map((moduleId) => [moduleId, false]))
+          },
+          updatedAt: new Date().toISOString()
+        };
+        if (typeof options.datastore.setAppState === "function") {
+          await options.datastore.setAppState(MODULE_CATALOG_STATE_KEY, cachedState);
+        }
+      }
+    }
     return cachedState;
   }
 
@@ -2899,5 +2923,6 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
 module.exports = {
   assertPersistentModuleIdAllowed,
   createModuleRuntime,
+  isDevelopmentOnlyModuleId,
   isPersistentVercelEnvironment
 };

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -166,6 +166,7 @@ type AuthoredPublishedMap = {
 };
 
 const MODULE_CATALOG_STATE_KEY = "moduleCatalogState";
+const DEVELOPMENT_ONLY_MODULE_ID = /^(?:demo|test|fixture)(?:[.-]|$)/i;
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -173,6 +174,24 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPersistentVercelEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  const vercelEnvironment = String(env.VERCEL_ENV || "")
+    .trim()
+    .toLowerCase();
+  return vercelEnvironment === "preview" || vercelEnvironment === "production";
+}
+
+function assertPersistentModuleIdAllowed(
+  moduleId: string,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  if (isPersistentVercelEnvironment(env) && DEVELOPMENT_ONLY_MODULE_ID.test(moduleId)) {
+    throw new Error(
+      `Development-only module "${moduleId}" cannot be enabled or persisted in a Vercel deployment.`
+    );
+  }
 }
 
 function toModuleProfileArray(
@@ -2497,6 +2516,7 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       return enabledReferences(await ensureCatalog());
     },
     async enableModule(moduleId: string) {
+      assertPersistentModuleIdAllowed(moduleId);
       const installedModules = await ensureCatalog();
       const target = installedModules.find((moduleEntry) => moduleEntry.id === moduleId);
       if (!target || !target.manifest) {
@@ -2779,6 +2799,7 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
       const requestedIds = Array.isArray(input.activeModuleIds)
         ? Array.from(new Set(input.activeModuleIds.filter((value) => isNonEmptyString(value))))
         : [];
+      requestedIds.forEach((moduleId) => assertPersistentModuleIdAllowed(moduleId));
       const selectedModuleRefs = requestedIds.map((moduleId) => {
         const match = optionsSnapshot.gameModules.find(
           (moduleEntry) => moduleEntry.id === moduleId
@@ -2876,5 +2897,7 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
 }
 
 module.exports = {
-  createModuleRuntime
+  assertPersistentModuleIdAllowed,
+  createModuleRuntime,
+  isPersistentVercelEnvironment
 };

--- a/backend/module-runtime.cts
+++ b/backend/module-runtime.cts
@@ -2388,15 +2388,21 @@ function createModuleRuntime(options: ModuleRuntimeOptions) {
 
   async function getModuleOptions() {
     const modules = await ensureCatalog();
+    const optionModules = isPersistentVercelEnvironment()
+      ? modules.filter(
+          (moduleEntry) =>
+            moduleEntry.id === CORE_MODULE_ID || !isDevelopmentOnlyModuleId(moduleEntry.id)
+        )
+      : modules;
     await refreshAuthoredContent();
     return buildModuleOptions(
-      modules,
-      listEnabledRuntimeMaps(modules),
-      listEnabledRuntimeContentPacks(modules),
-      listEnabledRuntimePlayerPieceSets(modules),
-      listEnabledRuntimeDiceRuleSets(modules),
-      listEnabledRuntimeCardRuleSets(modules),
-      listEnabledRuntimeSiteThemes(modules),
+      optionModules,
+      listEnabledRuntimeMaps(optionModules),
+      listEnabledRuntimeContentPacks(optionModules),
+      listEnabledRuntimePlayerPieceSets(optionModules),
+      listEnabledRuntimeDiceRuleSets(optionModules),
+      listEnabledRuntimeCardRuleSets(optionModules),
+      listEnabledRuntimeSiteThemes(optionModules),
       authoredVictoryRuleSets,
       Array.from(authoredMapsById.values())
     );

--- a/e2e/smoke/admin-orphan-repair.spec.ts
+++ b/e2e/smoke/admin-orphan-repair.spec.ts
@@ -189,8 +189,10 @@ test("admin safely previews, repairs, and audits a finished orphaned game", asyn
   await expect(page.getByText("Invalid games").locator("..").locator("..")).toContainText("0");
 
   await page.goto("/admin/system-health");
-  await expect(page.getByText("Module references").locator("..")).toContainText("OK");
-  await expect(page.getByText("Game snapshots").locator("..")).toContainText("OK");
+  await expect(page.getByText("Module references", { exact: true }).locator("..")).toContainText(
+    "OK"
+  );
+  await expect(page.getByText("Game snapshots", { exact: true }).locator("..")).toContainText("OK");
 
   await page.goto("/admin/audit");
   await expect(page.getByText("game.repair-game-config")).toBeVisible();

--- a/e2e/smoke/admin-orphan-repair.spec.ts
+++ b/e2e/smoke/admin-orphan-repair.spec.ts
@@ -183,8 +183,10 @@ test("admin safely previews, repairs, and audits a finished orphaned game", asyn
 
   await page.goto("/admin/maintenance");
   await expect(page.getByText("No maintenance issues detected.")).toBeVisible();
-  await expect(page.getByText("Orphaned module refs").locator("..")).toContainText("0");
-  await expect(page.getByText("Invalid games").locator("..")).toContainText("0");
+  await expect(page.getByText("Orphaned module refs").locator("..").locator("..")).toContainText(
+    "0"
+  );
+  await expect(page.getByText("Invalid games").locator("..").locator("..")).toContainText("0");
 
   await page.goto("/admin/system-health");
   await expect(page.getByText("Module references").locator("..")).toContainText("OK");

--- a/e2e/smoke/admin-orphan-repair.spec.ts
+++ b/e2e/smoke/admin-orphan-repair.spec.ts
@@ -1,0 +1,197 @@
+const { test, expect } = require("@playwright/test");
+const { DatabaseSync } = require("node:sqlite");
+
+const {
+  attachSessionCookie,
+  createAuthenticatedSession,
+  resetGame,
+  uniqueUser
+} = require("../support/game-helpers");
+
+function withE2eDatabase(run) {
+  const dbFile = process.env.E2E_DB_FILE;
+  expect(dbFile).toBeTruthy();
+
+  const db = new DatabaseSync(dbFile);
+  try {
+    return run(db);
+  } finally {
+    db.close();
+  }
+}
+
+function promoteUserToAdmin(username) {
+  withE2eDatabase((db) => {
+    const result = db
+      .prepare("UPDATE users SET role = 'admin' WHERE lower(username) = lower(?)")
+      .run(username);
+    expect(result.changes).toBe(1);
+  });
+}
+
+function configureFinishedOrphanGame(gameId) {
+  return withE2eDatabase((db) => {
+    const row = db.prepare("SELECT state_json FROM games WHERE id = ?").get(gameId);
+    expect(row).toBeTruthy();
+
+    const state = JSON.parse(row.state_json);
+    state.phase = "finished";
+    state.turnPhase = "finished";
+    state.gameConfig.activeModules = [
+      { id: "core.base", version: "1.0.0" },
+      { id: "demo.defaults", version: "1.0.0" }
+    ];
+    state.gameConfig.contentProfileId = "demo.defaults.content";
+    state.gameConfig.gameplayProfileId = "demo.defaults.gameplay";
+    state.gameConfig.uiProfileId = "demo.defaults.ui";
+    state.gameConfig.scenarioSetup = {
+      logMessage: "Persisted UAT scenario output",
+      territoryBonuses: [{ territoryId: "aurora", armies: 1 }]
+    };
+
+    const updated = db
+      .prepare("UPDATE games SET state_json = ?, updated_at = ? WHERE id = ?")
+      .run(JSON.stringify(state), new Date().toISOString(), gameId);
+    expect(updated.changes).toBe(1);
+
+    return JSON.parse(
+      JSON.stringify({
+        players: state.players,
+        territories: state.territories,
+        hands: state.hands,
+        turnPhase: state.turnPhase,
+        currentTurnIndex: state.currentTurnIndex,
+        winnerId: state.winnerId,
+        versionInfo: state.versionInfo,
+        scenarioSetup: state.gameConfig.scenarioSetup,
+        mapId: state.gameConfig.mapId,
+        contentPackId: state.gameConfig.contentPackId,
+        ruleSetId: state.gameConfig.ruleSetId,
+        diceRuleSetId: state.gameConfig.diceRuleSetId,
+        victoryRuleSetId: state.gameConfig.victoryRuleSetId,
+        themeId: state.gameConfig.themeId,
+        pieceSetId: state.gameConfig.pieceSetId,
+        pieceSkinId: state.gameConfig.pieceSkinId
+      })
+    );
+  });
+}
+
+async function createGame(page, sessionToken, name) {
+  const response = await page.request.post("/api/games", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` },
+    data: {
+      name,
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    }
+  });
+  await expect(response.ok()).toBeTruthy();
+  return response.json();
+}
+
+function preservedStateSnapshot(state) {
+  return JSON.parse(
+    JSON.stringify({
+      players: state.players,
+      territories: state.territories,
+      hands: state.hands,
+      turnPhase: state.turnPhase,
+      currentTurnIndex: state.currentTurnIndex,
+      winnerId: state.winnerId,
+      versionInfo: state.versionInfo,
+      scenarioSetup: state.gameConfig.scenarioSetup,
+      mapId: state.gameConfig.mapId,
+      contentPackId: state.gameConfig.contentPackId,
+      ruleSetId: state.gameConfig.ruleSetId,
+      diceRuleSetId: state.gameConfig.diceRuleSetId,
+      victoryRuleSetId: state.gameConfig.victoryRuleSetId,
+      themeId: state.gameConfig.themeId,
+      pieceSetId: state.gameConfig.pieceSetId,
+      pieceSkinId: state.gameConfig.pieceSkinId
+    })
+  );
+}
+
+test("admin safely previews, repairs, and audits a finished orphaned game", async ({ page }) => {
+  await resetGame(page);
+
+  const adminUsername = uniqueUser("admin_orphan_uat");
+  const sessionToken = await createAuthenticatedSession(page, adminUsername);
+  promoteUserToAdmin(adminUsername);
+
+  const gameName = uniqueUser("orphan_repair_uat");
+  const createdGame = await createGame(page, sessionToken, gameName);
+  const gameId = createdGame.game.id;
+  const preservedBefore = configureFinishedOrphanGame(gameId);
+
+  await createGame(page, sessionToken, uniqueUser("active_cache_uat"));
+  await attachSessionCookie(page, sessionToken);
+
+  const maintenanceBefore = await page.request.get("/api/admin/maintenance", {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` }
+  });
+  await expect(maintenanceBefore.ok()).toBeTruthy();
+  const maintenanceBeforePayload = await maintenanceBefore.json();
+  expect(maintenanceBeforePayload.summary.orphanedModuleReferences).toBe(1);
+  expect(maintenanceBeforePayload.summary.invalidGames).toBe(1);
+
+  await page.goto("/admin/games");
+  await expect(page.getByTestId("admin-route-page")).toBeVisible();
+  await page.getByPlaceholder("Search games...").fill(gameName);
+  await page.getByRole("button", { name: new RegExp(gameName) }).click();
+
+  const preview = page.getByTestId("admin-game-repair-preview");
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText("safe");
+  await expect(preview).toContainText("Unavailable modules: demo.defaults");
+  await expect(preview).toContainText(
+    "Related profiles: demo.defaults.content, demo.defaults.gameplay, demo.defaults.ui"
+  );
+  await expect(preview).toContainText("gameConfig.activeModules");
+  await expect(preview).toContainText("gameConfig.contentProfileId");
+  await expect(preview).toContainText("gameConfig.gameplayProfileId");
+  await expect(preview).toContainText("gameConfig.uiProfileId");
+  await expect(preview).toContainText("winner and version metadata");
+
+  const repairButton = page.getByRole("button", { name: "Apply safe repair" });
+  await expect(repairButton).toBeEnabled();
+  page.once("dialog", async (dialog) => {
+    expect(dialog.type()).toBe("prompt");
+    expect(dialog.message()).toBe(`Type ${gameId} to confirm repair-game-config.`);
+    await dialog.accept(gameId);
+  });
+  await repairButton.click();
+
+  await expect(page.getByRole("heading", { name: "Game action completed" })).toBeVisible();
+  await expect(repairButton).toBeDisabled();
+
+  const detailsResponse = await page.request.get(`/api/admin/games/${encodeURIComponent(gameId)}`, {
+    headers: { Cookie: `netrisk_session=${encodeURIComponent(sessionToken)}` }
+  });
+  await expect(detailsResponse.ok()).toBeTruthy();
+  const details = await detailsResponse.json();
+  expect(details.repairPreview.status).toBe("not-needed");
+  expect(details.game.issueCount).toBe(0);
+  expect(details.rawState.gameConfig.activeModules).toEqual([
+    { id: "core.base", version: "1.0.0" }
+  ]);
+  expect(details.rawState.gameConfig.contentProfileId).toBeNull();
+  expect(details.rawState.gameConfig.gameplayProfileId).toBeNull();
+  expect(details.rawState.gameConfig.uiProfileId).toBeNull();
+  expect(preservedStateSnapshot(details.rawState)).toEqual(preservedBefore);
+
+  await page.goto("/admin/maintenance");
+  await expect(page.getByText("No maintenance issues detected.")).toBeVisible();
+  await expect(page.getByText("Orphaned module refs").locator("..")).toContainText("0");
+  await expect(page.getByText("Invalid games").locator("..")).toContainText("0");
+
+  await page.goto("/admin/system-health");
+  await expect(page.getByText("Module references").locator("..")).toContainText("OK");
+  await expect(page.getByText("Game snapshots").locator("..")).toContainText("OK");
+
+  await page.goto("/admin/audit");
+  await expect(page.getByText("game.repair-game-config")).toBeVisible();
+  await expect(page.getByText(gameName)).toBeVisible();
+  await expect(page.getByText("success", { exact: true })).toBeVisible();
+});

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -329,6 +329,21 @@ function createGameDetailsResponse(): AdminGameDetailsResponse {
     rawState: {
       phase: "lobby",
       turnIndex: 0
+    },
+    repairPreview: {
+      status: "safe",
+      orphanedModuleIds: ["demo.defaults"],
+      relatedProfileIds: ["demo.defaults.content", "demo.defaults.gameplay", "demo.defaults.ui"],
+      changes: [
+        {
+          path: "gameConfig.activeModules",
+          before: ["core.base", "demo.defaults"],
+          after: ["core.base"],
+          reason: "Remove the unavailable demo.defaults module."
+        }
+      ],
+      blockers: [],
+      preservedFields: ["players", "territories", "turn and phase state"]
     }
   };
 }
@@ -902,6 +917,7 @@ describe("Admin route integration", () => {
       rawState: {
         phase: "finished"
       },
+      repairPreview: createGameDetailsResponse().repairPreview,
       audit: createAuditEntry({
         action: "game.close-lobby",
         targetType: "game",
@@ -933,6 +949,46 @@ describe("Admin route integration", () => {
         {
           gameId: "game-1",
           action: "close-lobby",
+          confirmation: "game-1"
+        },
+        expect.anything()
+      );
+    });
+  });
+
+  it("shows the guarded orphan repair preview and requires the game id before applying it", async () => {
+    listAdminGamesMock.mockResolvedValue(createGamesResponse());
+    const gameDetails = createGameDetailsResponse();
+    getAdminGameDetailsMock.mockResolvedValue(gameDetails);
+    runAdminGameActionMock.mockResolvedValue({
+      ok: true,
+      ...gameDetails,
+      audit: createAuditEntry({
+        action: "game.repair-game-config",
+        targetType: "game",
+        targetId: "game-1",
+        targetLabel: "Border Siege"
+      })
+    });
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("game-1");
+    const { user } = renderReactShell("/react/admin/games");
+
+    const preview = await screen.findByTestId("admin-game-repair-preview");
+    expect(within(preview).getByText(/Unavailable modules: demo.defaults/)).toBeInTheDocument();
+    expect(
+      within(preview).getByText(/demo.defaults.content, demo.defaults.gameplay, demo.defaults.ui/)
+    ).toBeInTheDocument();
+    expect(within(preview).getByText(/gameConfig.activeModules/)).toBeInTheDocument();
+    expect(within(preview).getByText(/Preserved: players, territories/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Apply safe repair" }));
+
+    expect(promptSpy).toHaveBeenCalledWith("Type game-1 to confirm repair-game-config.");
+    await waitFor(() => {
+      expect(runAdminGameActionMock).toHaveBeenCalledWith(
+        {
+          gameId: "game-1",
+          action: "repair-game-config",
           confirmation: "game-1"
         },
         expect.anything()

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -1314,12 +1314,9 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
       return;
     }
 
-    const destructive = action === "close-lobby" || action === "terminate-game";
-    const confirmation = destructive
-      ? window.prompt(`Type ${selectedGameId} to confirm ${action}.`)
-      : null;
+    const confirmation = window.prompt(`Type ${selectedGameId} to confirm ${action}.`);
 
-    if (destructive && !confirmation?.trim()) {
+    if (!confirmation?.trim()) {
       return;
     }
 
@@ -1397,6 +1394,15 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
           </p>
         </section>
       ) : null}
+      {actionMutation.isSuccess ? (
+        <section className="status-panel status-panel-success" role="status">
+          <p className="status-label">Games</p>
+          <h2>Game action completed</h2>
+          <p className="status-copy">
+            The server persisted the guarded action and recorded it in the admin audit log.
+          </p>
+        </section>
+      ) : null}
 
       <div className="grid-shell admin-games-grid">
         <section className="card-panel">
@@ -1460,9 +1466,13 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
                 type="button"
                 className="refresh-button"
                 onClick={() => handleGameAction("repair-game-config")}
-                disabled={!selectedGameId || actionMutation.isPending}
+                disabled={
+                  !selectedGameId ||
+                  actionMutation.isPending ||
+                  detailsQuery.data?.repairPreview.status !== "safe"
+                }
               >
-                Repair config
+                Apply safe repair
               </button>
               <button
                 type="button"
@@ -1578,6 +1588,67 @@ function GamesSection({ frameContext }: { frameContext: AdminFrameContext }) {
                   />
                 </section>
               </div>
+
+              <section
+                className="admin-subpanel"
+                data-testid="admin-game-repair-preview"
+                aria-label="Game repair preview"
+              >
+                <div className="card-header">
+                  <div>
+                    <p className="status-label">Repair preview</p>
+                    <h3>Guarded configuration normalization</h3>
+                  </div>
+                  <span
+                    className={`status-pill ${
+                      detailsQuery.data.repairPreview.status === "safe"
+                        ? "success"
+                        : detailsQuery.data.repairPreview.status === "blocked"
+                          ? "danger"
+                          : "neutral"
+                    }`}
+                  >
+                    {detailsQuery.data.repairPreview.status}
+                  </span>
+                </div>
+
+                {detailsQuery.data.repairPreview.orphanedModuleIds.length ? (
+                  <p className="status-copy">
+                    Unavailable modules:{" "}
+                    {detailsQuery.data.repairPreview.orphanedModuleIds.join(", ")}
+                  </p>
+                ) : null}
+                {detailsQuery.data.repairPreview.relatedProfileIds.length ? (
+                  <p className="status-copy">
+                    Related profiles: {detailsQuery.data.repairPreview.relatedProfileIds.join(", ")}
+                  </p>
+                ) : null}
+
+                {detailsQuery.data.repairPreview.changes.length ? (
+                  <ul className="admin-note-list">
+                    {detailsQuery.data.repairPreview.changes.map((change) => (
+                      <li key={change.path}>
+                        <strong>{change.path}</strong>: {JSON.stringify(change.before)} →{" "}
+                        {JSON.stringify(change.after)}. {change.reason}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="status-copy">No safe configuration changes are required.</p>
+                )}
+
+                {detailsQuery.data.repairPreview.blockers.length ? (
+                  <ul className="admin-note-list">
+                    {detailsQuery.data.repairPreview.blockers.map((blocker) => (
+                      <li key={blocker}>{blocker}</li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                <p className="status-copy">
+                  Preserved: {detailsQuery.data.repairPreview.preservedFields.join(", ")}.
+                </p>
+              </section>
 
               <details className="admin-debug-panel">
                 <summary>Advanced and debug state</summary>

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -1596,6 +1596,26 @@ export const adminGamePlayerSchema = objectSchema({
 
 export type AdminGamePlayer = z.infer<typeof adminGamePlayerSchema>;
 
+export const adminGameRepairChangeSchema = objectSchema({
+  path: z.string().min(1),
+  before: z.unknown(),
+  after: z.unknown(),
+  reason: z.string().min(1)
+});
+
+export type AdminGameRepairChange = z.infer<typeof adminGameRepairChangeSchema>;
+
+export const adminGameRepairPreviewSchema = objectSchema({
+  status: z.enum(["safe", "blocked", "not-needed"]),
+  orphanedModuleIds: z.array(z.string().min(1)),
+  relatedProfileIds: z.array(z.string().min(1)),
+  changes: z.array(adminGameRepairChangeSchema),
+  blockers: z.array(z.string().min(1)),
+  preservedFields: z.array(z.string().min(1))
+});
+
+export type AdminGameRepairPreview = z.infer<typeof adminGameRepairPreviewSchema>;
+
 export const adminOverviewResponseSchema = objectSchema({
   summary: objectSchema({
     totalUsers: z.number().int(),
@@ -1653,7 +1673,8 @@ export type AdminGamesResponse = z.infer<typeof adminGamesResponseSchema>;
 export const adminGameDetailsResponseSchema = objectSchema({
   game: adminGameSummarySchema,
   players: z.array(adminGamePlayerSchema),
-  rawState: z.record(z.string(), z.unknown())
+  rawState: z.record(z.string(), z.unknown()),
+  repairPreview: adminGameRepairPreviewSchema
 });
 
 export type AdminGameDetailsResponse = z.infer<typeof adminGameDetailsResponseSchema>;
@@ -1671,6 +1692,7 @@ export const adminGameActionResponseSchema = objectSchema({
   game: adminGameSummarySchema,
   players: z.array(adminGamePlayerSchema),
   rawState: z.record(z.string(), z.unknown()),
+  repairPreview: adminGameRepairPreviewSchema,
   audit: adminAuditEntrySchema
 });
 

--- a/scripts/check-no-js-sources.cts
+++ b/scripts/check-no-js-sources.cts
@@ -46,6 +46,7 @@ const allowedPathPatterns = [
   /^docs\/assets\/.+\.(png|jpg|jpeg|svg|webp)$/i,
   /^docs\/openapi\.json$/i,
   /^e2e\/.+-snapshots\/.+\.png$/i,
+  /^supabase\/migrations\/[0-9]+_[a-z0-9_]+\.sql$/i,
   /(^|\/)[^/]+\.md$/i
 ];
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -2723,7 +2723,7 @@ register("frontend API client valida sessione, profilo e lobby list al boundary"
       assert.equal(profile.profile.gamesPlayed, 3);
       assert.equal(games.games[0].id, "game-1");
       assert.equal(versionInfo.compatible, true);
-      assert.equal(versionInfo.apiVersion, "1.0.0");
+      assert.equal(versionInfo.apiVersion, "1.1.0");
     }
   );
 

--- a/shared/api-contracts.cts
+++ b/shared/api-contracts.cts
@@ -300,6 +300,22 @@ export interface AdminGamePlayerContract {
   cardCount: number;
 }
 
+export interface AdminGameRepairChangeContract {
+  path: string;
+  before: unknown;
+  after: unknown;
+  reason: string;
+}
+
+export interface AdminGameRepairPreviewContract {
+  status: "safe" | "blocked" | "not-needed";
+  orphanedModuleIds: string[];
+  relatedProfileIds: string[];
+  changes: AdminGameRepairChangeContract[];
+  blockers: string[];
+  preservedFields: string[];
+}
+
 export interface AdminOverviewResponseContract {
   summary: {
     totalUsers: number;
@@ -343,6 +359,7 @@ export interface AdminGameDetailsResponseContract {
   game: AdminGameSummaryContract;
   players: AdminGamePlayerContract[];
   rawState: Record<string, unknown>;
+  repairPreview: AdminGameRepairPreviewContract;
 }
 
 export interface AdminGameActionResponseContract {
@@ -350,6 +367,7 @@ export interface AdminGameActionResponseContract {
   game: AdminGameSummaryContract;
   players: AdminGamePlayerContract[];
   rawState: Record<string, unknown>;
+  repairPreview: AdminGameRepairPreviewContract;
   audit: AdminAuditEntryContract;
 }
 

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -236,7 +236,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "module-runtime",
     name: "Module Runtime",
     kind: "platform",
-    version: "1.1.2",
+    version: "1.2.0",
     description:
       "Filesystem module discovery, validation, enablement, and resolved catalog output.",
     ownerPaths: [
@@ -277,12 +277,13 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "datastore",
     name: "Datastore",
     kind: "platform",
-    version: "1.0.2",
+    version: "1.1.0",
     description:
       "Game/session persistence, app state persistence, backups, and datastore schema use.",
     ownerPaths: [
       "backend/game-session-store.cts",
       "backend/datastore.cts",
+      "backend/datastore-supabase.cts",
       "backend/sqlite-datastore.cts",
       "scripts/backup-datastore.cts",
       "scripts/check-backup.cts",
@@ -293,7 +294,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "public-state",
     name: "Public Game State",
     kind: "platform",
-    version: "1.2.1",
+    version: "1.3.0",
     description: "Public/read API game state contracts, snapshots, and shared game models.",
     ownerPaths: [
       "shared/api-contracts.cts",

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -264,9 +264,14 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "admin-console",
     name: "Admin Console",
     kind: "admin",
-    version: "1.0.1",
+    version: "1.1.0",
     description: "Admin routes and operational admin workflows.",
-    ownerPaths: ["backend/routes/admin.cts", "docs/admin-console.md", "docs/admin-console-plan.md"]
+    ownerPaths: [
+      "backend/admin-console.cts",
+      "backend/routes/admin.cts",
+      "docs/admin-console.md",
+      "docs/admin-console-plan.md"
+    ]
   },
   {
     id: "datastore",

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -236,7 +236,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "module-runtime",
     name: "Module Runtime",
     kind: "platform",
-    version: "1.1.1",
+    version: "1.1.2",
     description:
       "Filesystem module discovery, validation, enablement, and resolved catalog output.",
     ownerPaths: [
@@ -288,7 +288,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "public-state",
     name: "Public Game State",
     kind: "platform",
-    version: "1.2.0",
+    version: "1.2.1",
     description: "Public/read API game state contracts, snapshots, and shared game models.",
     ownerPaths: [
       "shared/api-contracts.cts",

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -1595,6 +1595,26 @@ export const adminGamePlayerSchema = objectSchema({
 
 export type AdminGamePlayer = z.infer<typeof adminGamePlayerSchema>;
 
+export const adminGameRepairChangeSchema = objectSchema({
+  path: z.string().min(1),
+  before: z.unknown(),
+  after: z.unknown(),
+  reason: z.string().min(1)
+});
+
+export type AdminGameRepairChange = z.infer<typeof adminGameRepairChangeSchema>;
+
+export const adminGameRepairPreviewSchema = objectSchema({
+  status: z.enum(["safe", "blocked", "not-needed"]),
+  orphanedModuleIds: z.array(z.string().min(1)),
+  relatedProfileIds: z.array(z.string().min(1)),
+  changes: z.array(adminGameRepairChangeSchema),
+  blockers: z.array(z.string().min(1)),
+  preservedFields: z.array(z.string().min(1))
+});
+
+export type AdminGameRepairPreview = z.infer<typeof adminGameRepairPreviewSchema>;
+
 export const adminOverviewResponseSchema = objectSchema({
   summary: objectSchema({
     totalUsers: z.number().int(),
@@ -1652,7 +1672,8 @@ export type AdminGamesResponse = z.infer<typeof adminGamesResponseSchema>;
 export const adminGameDetailsResponseSchema = objectSchema({
   game: adminGameSummarySchema,
   players: z.array(adminGamePlayerSchema),
-  rawState: z.record(z.string(), z.unknown())
+  rawState: z.record(z.string(), z.unknown()),
+  repairPreview: adminGameRepairPreviewSchema
 });
 
 export type AdminGameDetailsResponse = z.infer<typeof adminGameDetailsResponseSchema>;
@@ -1670,6 +1691,7 @@ export const adminGameActionResponseSchema = objectSchema({
   game: adminGameSummarySchema,
   players: z.array(adminGamePlayerSchema),
   rawState: z.record(z.string(), z.unknown()),
+  repairPreview: adminGameRepairPreviewSchema,
   audit: adminAuditEntrySchema
 });
 

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,7 +1,7 @@
 export const appVersion = "0.1.059";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.1.0";
-export const datastoreSchemaVersion = 1;
+export const datastoreSchemaVersion = 2;
 export const saveGameSchemaVersion = 1;
 export const moduleApiVersion = "1.0.0";
 export const minimumCompatibleSaveGameSchemaVersion = 1;

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,6 +1,6 @@
 export const appVersion = "0.1.059";
 export const engineVersion = "1.0.0";
-export const apiVersion = "1.0.0";
+export const apiVersion = "1.1.0";
 export const datastoreSchemaVersion = 1;
 export const saveGameSchemaVersion = 1;
 export const moduleApiVersion = "1.0.0";

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.058";
+export const appVersion = "0.1.059";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.0.0";
 export const datastoreSchemaVersion = 1;

--- a/supabase/migrations/202608060001_add_atomic_app_state_compare_and_set.sql
+++ b/supabase/migrations/202608060001_add_atomic_app_state_compare_and_set.sql
@@ -1,0 +1,52 @@
+create or replace function public.netrisk_compare_and_set_app_state(
+  app_state_key text,
+  expected_value_json text,
+  next_value_json text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  affected_rows integer;
+begin
+  update public.app_state
+  set value_json = to_jsonb(next_value_json)
+  where key = app_state_key
+    and value_json = to_jsonb(expected_value_json);
+
+  get diagnostics affected_rows = row_count;
+  if affected_rows = 1 then
+    return true;
+  end if;
+
+  if expected_value_json = 'null' then
+    insert into public.app_state (key, value_json)
+    values (app_state_key, to_jsonb(next_value_json))
+    on conflict (key) do nothing;
+
+    get diagnostics affected_rows = row_count;
+    return affected_rows = 1;
+  end if;
+
+  return false;
+end;
+$$;
+
+revoke all on function public.netrisk_compare_and_set_app_state(text, text, text) from public;
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    revoke all on function public.netrisk_compare_and_set_app_state(text, text, text) from authenticated;
+  end if;
+
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    revoke all on function public.netrisk_compare_and_set_app_state(text, text, text) from anon;
+  end if;
+
+  if exists (select 1 from pg_roles where rolname = 'service_role') then
+    grant execute on function public.netrisk_compare_and_set_app_state(text, text, text) to service_role;
+  end if;
+end $$;

--- a/supabase/schema.cts
+++ b/supabase/schema.cts
@@ -36,6 +36,44 @@ create table if not exists public.app_state (
   value_json jsonb not null
 );
 
+create or replace function public.netrisk_compare_and_set_app_state(
+  app_state_key text,
+  expected_value_json text,
+  next_value_json text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  affected_rows integer;
+begin
+  update public.app_state
+  set value_json = to_jsonb(next_value_json)
+  where key = app_state_key
+    and value_json = to_jsonb(expected_value_json);
+
+  get diagnostics affected_rows = row_count;
+  if affected_rows = 1 then
+    return true;
+  end if;
+
+  if expected_value_json = 'null' then
+    insert into public.app_state (key, value_json)
+    values (app_state_key, to_jsonb(next_value_json))
+    on conflict (key) do nothing;
+
+    get diagnostics affected_rows = row_count;
+    return affected_rows = 1;
+  end if;
+
+  return false;
+end;
+$$;
+
+revoke all on function public.netrisk_compare_and_set_app_state(text, text, text) from public;
+
 alter table public.users enable row level security;
 alter table public.sessions enable row level security;
 alter table public.games enable row level security;
@@ -45,10 +83,16 @@ do $$
 begin
   if exists (select 1 from pg_roles where rolname = 'anon') then
     revoke all on table public.users, public.sessions, public.games, public.app_state from anon;
+    revoke all on function public.netrisk_compare_and_set_app_state(text, text, text) from anon;
   end if;
 
   if exists (select 1 from pg_roles where rolname = 'authenticated') then
     revoke all on table public.users, public.sessions, public.games, public.app_state from authenticated;
+    revoke all on function public.netrisk_compare_and_set_app_state(text, text, text) from authenticated;
+  end if;
+
+  if exists (select 1 from pg_roles where rolname = 'service_role') then
+    grant execute on function public.netrisk_compare_and_set_app_state(text, text, text) to service_role;
   end if;
 end $$;
 `.trim() + "\n";

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -823,6 +823,149 @@ register(
   }
 );
 
+register(
+  "persistent deployments migrate enabled development modules and saved admin defaults",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "demo.command-center",
+          manifest: {
+            schemaVersion: 1,
+            id: "demo.command-center",
+            version: "1.0.0",
+            displayName: "Demo Command Center",
+            engineVersion: "1.0.0",
+            kind: "hybrid",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [],
+            entrypoints: {
+              clientManifest: "client-manifest.json"
+            }
+          },
+          clientManifest: {
+            profiles: {
+              content: [{ id: "demo.command-center.content", name: "Demo Content" }],
+              gameplay: [{ id: "demo.command-center.gameplay", name: "Demo Gameplay" }],
+              ui: [{ id: "demo.command-center.ui", name: "Demo UI" }]
+            },
+            gamePresets: [
+              {
+                id: "demo.command-center.command-ops",
+                name: "Command Ops",
+                activeModuleIds: ["demo.command-center"]
+              }
+            ]
+          }
+        }
+      ],
+      async ({ app, adminSessionToken }) => {
+        const originalVercelEnvironment = process.env.VERCEL_ENV;
+        process.env.VERCEL_ENV = "production";
+
+        try {
+          await app.datastore.setAppState("moduleCatalogState", {
+            enabledById: {
+              "core.base": true,
+              "demo.command-center": true
+            },
+            updatedAt: "2026-08-01T00:00:00.000Z"
+          });
+          await app.datastore.setAppState("adminConsoleConfig", {
+            defaults: {
+              activeModuleIds: ["demo.command-center"],
+              gamePresetId: "demo.command-center.command-ops",
+              contentProfileId: "demo.command-center.content",
+              gameplayProfileId: "demo.command-center.gameplay",
+              uiProfileId: "demo.command-center.ui",
+              totalPlayers: 2
+            },
+            maintenance: {
+              staleLobbyDays: 7,
+              auditLogLimit: 120
+            },
+            updatedAt: "2026-08-01T00:00:00.000Z",
+            updatedBy: null
+          });
+
+          const installedModules = await app.moduleRuntime.rescan();
+          const migratedDevelopmentModule = installedModules.find(
+            (entry: any) => entry.id === "demo.command-center"
+          );
+          assert.ok(migratedDevelopmentModule);
+          assert.equal(migratedDevelopmentModule.enabled, false);
+          const catalogState = await app.datastore.getAppState("moduleCatalogState");
+          assert.equal(catalogState.enabledById["demo.command-center"], false);
+
+          const configResponse = await callApp(
+            app,
+            "GET",
+            "/api/admin/config",
+            {},
+            authHeaders(adminSessionToken)
+          );
+          assert.equal(configResponse.statusCode, 200, JSON.stringify(configResponse.payload));
+          assert.deepEqual(configResponse.payload.config.defaults.activeModuleIds, ["core.base"]);
+          assert.equal(configResponse.payload.config.defaults.gamePresetId, null);
+          assert.equal(configResponse.payload.config.defaults.contentProfileId, null);
+          assert.equal(configResponse.payload.config.defaults.gameplayProfileId, null);
+          assert.equal(configResponse.payload.config.defaults.uiProfileId, null);
+
+          const persistedConfig = await app.datastore.getAppState("adminConsoleConfig");
+          assert.deepEqual(persistedConfig.defaults.activeModuleIds, ["core.base"]);
+          assert.equal(persistedConfig.defaults.gamePresetId, null);
+
+          await app.datastore.setAppState("adminConsoleConfig", {
+            ...persistedConfig,
+            defaults: {
+              gamePresetId: "demo.command-center.command-ops",
+              contentProfileId: "demo.command-center.content",
+              totalPlayers: 2
+            }
+          });
+          const presetOnlyConfigResponse = await callApp(
+            app,
+            "GET",
+            "/api/admin/config",
+            {},
+            authHeaders(adminSessionToken)
+          );
+          assert.equal(
+            presetOnlyConfigResponse.statusCode,
+            200,
+            JSON.stringify(presetOnlyConfigResponse.payload)
+          );
+          assert.equal(presetOnlyConfigResponse.payload.config.defaults.gamePresetId, null);
+          assert.equal(presetOnlyConfigResponse.payload.config.defaults.contentProfileId, null);
+
+          const createGameResponse = await callApp(
+            app,
+            "POST",
+            "/api/games",
+            { name: "Migrated production defaults" },
+            authHeaders(adminSessionToken)
+          );
+          assert.equal(
+            createGameResponse.statusCode,
+            201,
+            JSON.stringify(createGameResponse.payload)
+          );
+          assert.deepEqual(createGameResponse.payload.state.gameConfig.activeModules, [
+            { id: "core.base", version: "1.0.0" }
+          ]);
+        } finally {
+          if (typeof originalVercelEnvironment === "undefined") {
+            delete process.env.VERCEL_ENV;
+          } else {
+            process.env.VERCEL_ENV = originalVercelEnvironment;
+          }
+        }
+      }
+    );
+  }
+);
+
 register("public game options ignore stale invalid admin defaults instead of failing", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
     const configResponse = await callApp(
@@ -1243,6 +1386,129 @@ register("admin previews and repairs a finished game with an orphaned runtime mo
   });
 });
 
+register(
+  "admin orphan repair retains a catalog profile whose id only shares an orphan prefix",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "acme.extra",
+          manifest: {
+            schemaVersion: 1,
+            id: "acme.extra",
+            version: "1.0.0",
+            displayName: "Acme Extra",
+            engineVersion: "1.0.0",
+            kind: "hybrid",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [
+              {
+                kind: "gameplay-hook",
+                scope: "game",
+                hook: "setup.profile",
+                description: "Catalog ownership collision fixture"
+              }
+            ],
+            entrypoints: {
+              clientManifest: "client-manifest.json"
+            }
+          },
+          clientManifest: {
+            profiles: {
+              content: [{ id: "acme.extra.standard", name: "Acme Extra Standard" }],
+              gameplay: [],
+              ui: []
+            }
+          }
+        }
+      ],
+      async ({ app, adminSessionToken }) => {
+        const enableResponse = await callApp(
+          app,
+          "POST",
+          "/api/modules/acme.extra/enable",
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(enableResponse.statusCode, 200, JSON.stringify(enableResponse.payload));
+
+        const createGameResponse = await callApp(
+          app,
+          "POST",
+          "/api/games",
+          {
+            name: "Profile ownership collision",
+            activeModuleIds: ["acme.extra"],
+            contentProfileId: "acme.extra.standard",
+            totalPlayers: 2,
+            players: [{ type: "human" }, { type: "ai" }]
+          },
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(
+          createGameResponse.statusCode,
+          201,
+          JSON.stringify(createGameResponse.payload)
+        );
+
+        const gameId = createGameResponse.payload.game.id;
+        const storedGame = await app.datastore.findGameById(gameId);
+        assert.ok(storedGame);
+        storedGame.state.phase = "finished";
+        storedGame.state.turnPhase = "finished";
+        storedGame.state.gameConfig.activeModules = [
+          { id: "core.base", version: "1.0.0" },
+          { id: "acme", version: "1.0.0" },
+          { id: "acme.extra", version: "1.0.0" }
+        ];
+        storedGame.updatedAt = new Date().toISOString();
+        await app.datastore.updateGame(storedGame);
+        await activateSeparateGame(app, adminSessionToken);
+
+        const detailResponse = await callApp(
+          app,
+          "GET",
+          `/api/admin/games/${gameId}`,
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(detailResponse.statusCode, 200, JSON.stringify(detailResponse.payload));
+        assert.equal(detailResponse.payload.repairPreview.status, "safe");
+        assert.deepEqual(detailResponse.payload.repairPreview.orphanedModuleIds, ["acme"]);
+        assert.deepEqual(detailResponse.payload.repairPreview.relatedProfileIds, []);
+        assert.equal(
+          detailResponse.payload.repairPreview.changes.some(
+            (change: any) => change.path === "gameConfig.contentProfileId"
+          ),
+          false
+        );
+
+        const repairResponse = await callApp(
+          app,
+          "POST",
+          "/api/admin/games/action",
+          {
+            gameId,
+            action: "repair-game-config",
+            confirmation: gameId
+          },
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(repairResponse.statusCode, 200, JSON.stringify(repairResponse.payload));
+        assert.equal(
+          repairResponse.payload.rawState.gameConfig.contentProfileId,
+          "acme.extra.standard"
+        );
+        assert.deepEqual(repairResponse.payload.rawState.gameConfig.activeModules, [
+          { id: "core.base", version: "1.0.0" },
+          { id: "acme.extra", version: "1.0.0" }
+        ]);
+      }
+    );
+  }
+);
+
 register("admin orphan repair fails closed for a live game", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
     const createGameResponse = await callApp(
@@ -1585,7 +1851,10 @@ register(
             "p-user": [{ id: "card-1" }],
             "p-admin": []
           },
-          gameConfig: {}
+          gameConfig: {
+            extensionSchemaVersion: 0,
+            activeModules: [{ id: "module.retired", version: "1.0.0" }]
+          }
         }
       },
       {
@@ -1696,7 +1965,7 @@ register(
         mapId: null,
         mapName: null,
         diceRuleSetId: null,
-        activeModules: [],
+        activeModules: [{ id: "module.retired", version: "1.0.0" }],
         gamePresetId: null,
         contentProfileId: null,
         gameplayProfileId: null,
@@ -2021,6 +2290,20 @@ register(
     assert.equal(gameDetail.players[0].territoryCount, 1);
     assert.equal(gameDetail.players[1].cardCount, 1);
 
+    const legacyRepairDetail = await adminConsole.getGameDetails("finished-user-win");
+    assert.equal(legacyRepairDetail.repairPreview.status, "safe");
+    assert.deepEqual(
+      legacyRepairDetail.repairPreview.changes.find(
+        (change: any) => change.path === "gameConfig.extensionSchemaVersion"
+      ),
+      {
+        path: "gameConfig.extensionSchemaVersion",
+        before: 0,
+        after: 1,
+        reason: "Normalize legacy persisted state before applying the module repair."
+      }
+    );
+
     const config = await adminConsole.getConfig();
     assert.equal(config.config.defaults.activeModuleIds[0], "module.safe");
     assert.equal(config.config.updatedBy.username, "admin_commander");
@@ -2028,7 +2311,7 @@ register(
     const maintenanceReport = await adminConsole.getMaintenanceReport();
     assert.equal(maintenanceReport.summary.staleLobbies, 1);
     assert.equal(maintenanceReport.summary.invalidGames >= 2, true);
-    assert.equal(maintenanceReport.summary.orphanedModuleReferences, 2);
+    assert.equal(maintenanceReport.summary.orphanedModuleReferences, 3);
 
     const audit = await adminConsole.listAudit();
     assert.equal(audit.entries.length, 3);

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -1114,6 +1114,20 @@ register(
           );
           const catalogState = await app.datastore.getAppState("moduleCatalogState");
           assert.equal(catalogState.enabledById["demo.live"], true);
+
+          const liveGame = await app.datastore.findGameById("live-development-module");
+          assert.ok(liveGame);
+          liveGame.state.phase = "finished";
+          liveGame.updatedAt = "2026-08-01T01:00:00.000Z";
+          await app.datastore.updateGame(liveGame);
+
+          const cleanedModules = await app.moduleRuntime.listInstalledModules();
+          assert.equal(
+            cleanedModules.find((entry: any) => entry.id === "demo.live")?.enabled,
+            false
+          );
+          const cleanedCatalogState = await app.datastore.getAppState("moduleCatalogState");
+          assert.equal(cleanedCatalogState.enabledById["demo.live"], false);
         } finally {
           if (typeof originalVercelEnvironment === "undefined") {
             delete process.env.VERCEL_ENV;
@@ -1125,6 +1139,96 @@ register(
     );
   }
 );
+
+register("read-time default migration preserves a concurrent newer admin config", async () => {
+  await withModuleAdminApp(
+    [
+      {
+        dir: "demo.concurrent",
+        manifest: {
+          schemaVersion: 1,
+          id: "demo.concurrent",
+          version: "1.0.0",
+          displayName: "Demo Concurrent",
+          engineVersion: "1.0.0",
+          kind: "hybrid",
+          dependencies: [{ id: "core.base", version: "1.x" }],
+          conflicts: [],
+          capabilities: [],
+          entrypoints: { clientManifest: "client-manifest.json" }
+        },
+        clientManifest: {}
+      }
+    ],
+    async ({ app, adminSessionToken }) => {
+      const originalVercelEnvironment = process.env.VERCEL_ENV;
+      process.env.VERCEL_ENV = "production";
+
+      try {
+        await app.datastore.setAppState("moduleCatalogState", {
+          enabledById: { "core.base": true, "demo.concurrent": true },
+          updatedAt: "2026-08-01T00:00:00.000Z"
+        });
+        await app.datastore.setAppState("adminConsoleConfig", {
+          defaults: { activeModuleIds: ["demo.concurrent"], totalPlayers: 2 },
+          maintenance: { staleLobbyDays: 7, auditLogLimit: 120 },
+          updatedAt: "2026-08-01T00:00:00.000Z",
+          updatedBy: null
+        });
+
+        const originalListInstalledModules = app.moduleRuntime.listInstalledModules.bind(
+          app.moduleRuntime
+        );
+        let concurrentUpdateInjected = false;
+        app.moduleRuntime.listInstalledModules = async () => {
+          const installedModules = await originalListInstalledModules();
+          if (!concurrentUpdateInjected) {
+            concurrentUpdateInjected = true;
+            await app.datastore.setAppState("adminConsoleConfig", {
+              defaults: {
+                activeModuleIds: ["demo.concurrent"],
+                totalPlayers: 4,
+                turnTimeoutHours: 72
+              },
+              maintenance: { staleLobbyDays: 31, auditLogLimit: 77 },
+              updatedAt: "2026-08-01T00:30:00.000Z",
+              updatedBy: null
+            });
+          }
+          return installedModules;
+        };
+
+        const response = await callApp(
+          app,
+          "GET",
+          "/api/admin/config",
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(response.statusCode, 200, JSON.stringify(response.payload));
+        assert.equal(response.payload.config.defaults.totalPlayers, 4);
+        assert.equal(response.payload.config.defaults.turnTimeoutHours, 72);
+        assert.deepEqual(response.payload.config.defaults.activeModuleIds, ["core.base"]);
+        assert.equal(response.payload.config.maintenance.staleLobbyDays, 31);
+        assert.equal(response.payload.config.maintenance.auditLogLimit, 77);
+        assert.equal(response.payload.config.updatedAt, "2026-08-01T00:30:00.000Z");
+
+        const persisted = await app.datastore.getAppState("adminConsoleConfig");
+        assert.equal(persisted.defaults.totalPlayers, 4);
+        assert.equal(persisted.defaults.turnTimeoutHours, 72);
+        assert.deepEqual(persisted.defaults.activeModuleIds, ["core.base"]);
+        assert.equal(persisted.maintenance.staleLobbyDays, 31);
+        assert.equal(persisted.updatedAt, "2026-08-01T00:30:00.000Z");
+      } finally {
+        if (typeof originalVercelEnvironment === "undefined") {
+          delete process.env.VERCEL_ENV;
+        } else {
+          process.env.VERCEL_ENV = originalVercelEnvironment;
+        }
+      }
+    }
+  );
+});
 
 register("public game options ignore stale invalid admin defaults instead of failing", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
@@ -1719,6 +1823,227 @@ register(
     );
   }
 );
+
+register(
+  "admin orphan repair reads arbitrary profile and preset ownership from disabled manifests",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "community.retired",
+          manifest: {
+            schemaVersion: 1,
+            id: "community.retired",
+            version: "1.0.0",
+            displayName: "Community Retired",
+            engineVersion: "1.0.0",
+            kind: "hybrid",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [
+              {
+                kind: "gameplay-hook",
+                scope: "game",
+                hook: "setup.profile",
+                description: "Arbitrary profile ownership fixture"
+              }
+            ],
+            entrypoints: { clientManifest: "client-manifest.json" }
+          },
+          clientManifest: {
+            profiles: {
+              content: [{ id: "hardcore", name: "Hardcore" }],
+              gameplay: [],
+              ui: []
+            },
+            gamePresets: [
+              {
+                id: "ironman",
+                name: "Ironman",
+                activeModuleIds: ["community.retired"]
+              }
+            ]
+          }
+        }
+      ],
+      async ({ app, adminSessionToken }) => {
+        const enableResponse = await callApp(
+          app,
+          "POST",
+          "/api/modules/community.retired/enable",
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(enableResponse.statusCode, 200, JSON.stringify(enableResponse.payload));
+
+        const createResponse = await callApp(
+          app,
+          "POST",
+          "/api/games",
+          {
+            name: "Arbitrary Ownership Repair",
+            activeModuleIds: ["community.retired"],
+            gamePresetId: "ironman",
+            contentProfileId: "hardcore",
+            totalPlayers: 2,
+            players: [{ type: "human" }, { type: "ai" }]
+          },
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(createResponse.statusCode, 201, JSON.stringify(createResponse.payload));
+        const gameId = createResponse.payload.game.id;
+        const storedGame = await app.datastore.findGameById(gameId);
+        assert.ok(storedGame);
+        storedGame.state.phase = "finished";
+        storedGame.state.turnPhase = "finished";
+        storedGame.updatedAt = new Date().toISOString();
+        await app.datastore.updateGame(storedGame);
+        await activateSeparateGame(app, adminSessionToken);
+
+        const disableResponse = await callApp(
+          app,
+          "POST",
+          "/api/modules/community.retired/disable",
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(disableResponse.statusCode, 200, JSON.stringify(disableResponse.payload));
+
+        const detailResponse = await callApp(
+          app,
+          "GET",
+          `/api/admin/games/${gameId}`,
+          {},
+          authHeaders(adminSessionToken)
+        );
+        assert.equal(detailResponse.statusCode, 200, JSON.stringify(detailResponse.payload));
+        assert.equal(detailResponse.payload.repairPreview.status, "safe");
+        assert.deepEqual(detailResponse.payload.repairPreview.orphanedModuleIds, [
+          "community.retired"
+        ]);
+        assert.deepEqual(detailResponse.payload.repairPreview.relatedProfileIds, ["hardcore"]);
+        assert.equal(
+          detailResponse.payload.repairPreview.changes.some(
+            (change: any) => change.path === "gameConfig.contentProfileId" && change.after === null
+          ),
+          true
+        );
+        assert.equal(
+          detailResponse.payload.repairPreview.changes.some(
+            (change: any) => change.path === "gameConfig.gamePresetId" && change.after === null
+          ),
+          true
+        );
+      }
+    );
+  }
+);
+
+register("admin orphan repair preserves a valid retained runtime theme", async () => {
+  await withModuleAdminApp(
+    [
+      {
+        dir: "community.themes",
+        manifest: {
+          schemaVersion: 1,
+          id: "community.themes",
+          version: "1.0.0",
+          displayName: "Community Themes",
+          engineVersion: "1.0.0",
+          kind: "hybrid",
+          dependencies: [{ id: "core.base", version: "1.x" }],
+          conflicts: [],
+          capabilities: [
+            { kind: "site-theme", scope: "global", description: "Runtime theme fixture" }
+          ],
+          entrypoints: {
+            clientManifest: "client-manifest.json",
+            server: "server-module.cjs"
+          }
+        },
+        clientManifest: {
+          ui: {
+            themeTokens: ['html[data-theme="demo-aurora"] { --accent: #77ffee; }']
+          }
+        },
+        serverEntryPath: "server-module.cjs",
+        serverEntrySource: `module.exports = {
+  siteThemes: [
+    {
+      id: "demo-aurora",
+      name: "Demo Aurora",
+      description: "Runtime theme supplied by a retained module."
+    }
+  ]
+};`
+      }
+    ],
+    async ({ app, adminSessionToken }) => {
+      const enableResponse = await callApp(
+        app,
+        "POST",
+        "/api/modules/community.themes/enable",
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(enableResponse.statusCode, 200, JSON.stringify(enableResponse.payload));
+
+      const createResponse = await callApp(
+        app,
+        "POST",
+        "/api/games",
+        {
+          name: "Runtime Theme Repair",
+          activeModuleIds: ["community.themes"],
+          themeId: "demo-aurora",
+          totalPlayers: 2,
+          players: [{ type: "human" }, { type: "ai" }]
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(createResponse.statusCode, 201, JSON.stringify(createResponse.payload));
+      const gameId = createResponse.payload.game.id;
+      const storedGame = await app.datastore.findGameById(gameId);
+      assert.ok(storedGame);
+      storedGame.state.phase = "finished";
+      storedGame.state.turnPhase = "finished";
+      storedGame.state.gameConfig.activeModules.push({
+        id: "module.retired",
+        version: "1.0.0"
+      });
+      storedGame.updatedAt = new Date().toISOString();
+      await app.datastore.updateGame(storedGame);
+      await activateSeparateGame(app, adminSessionToken);
+
+      const detailResponse = await callApp(
+        app,
+        "GET",
+        `/api/admin/games/${gameId}`,
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(detailResponse.statusCode, 200, JSON.stringify(detailResponse.payload));
+      assert.equal(detailResponse.payload.repairPreview.status, "safe");
+      assert.equal(detailResponse.payload.rawState.gameConfig.themeId, "demo-aurora");
+      assert.equal(
+        detailResponse.payload.repairPreview.changes.some(
+          (change: any) => change.path === "gameConfig.themeId"
+        ),
+        false
+      );
+
+      const repairResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/games/action",
+        { gameId, action: "repair-game-config", confirmation: gameId },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(repairResponse.statusCode, 200, JSON.stringify(repairResponse.payload));
+      assert.equal(repairResponse.payload.rawState.gameConfig.themeId, "demo-aurora");
+    }
+  );
+});
 
 register("admin orphan repair fails closed for a live game", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -1567,6 +1567,8 @@ register(
         storedGame.state.gameConfig.diceRuleSetId = "demo-barrage";
         storedGame.state.gameConfig.diceRuleSetName = "Demo Barrage";
         storedGame.state.diceRuleSetId = "standard";
+        storedGame.state.phase = "finished";
+        storedGame.state.turnPhase = "finished";
         storedGame.updatedAt = new Date().toISOString();
         await app.datastore.updateGame(storedGame);
         await activateSeparateGame(app, adminSessionToken);
@@ -2156,6 +2158,70 @@ register("admin orphan repair fails closed for a live game", async () => {
     ]);
   });
 });
+
+register(
+  "admin configuration repair blocks legacy normalization on a live core-only game",
+  async () => {
+    await withAdminApp(async ({ app, adminSessionToken }) => {
+      const createGameResponse = await callApp(
+        app,
+        "POST",
+        "/api/games",
+        {
+          name: "Live legacy normalization fixture",
+          totalPlayers: 2,
+          players: [{ type: "human" }, { type: "ai" }]
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(createGameResponse.statusCode, 201, JSON.stringify(createGameResponse.payload));
+      const gameId = createGameResponse.payload.game.id;
+      const storedGame = await app.datastore.findGameById(gameId);
+      assert.ok(storedGame);
+      storedGame.state.phase = "active";
+      storedGame.state.diceRuleSetId = "legacy-stale";
+      storedGame.updatedAt = new Date().toISOString();
+      await app.datastore.updateGame(storedGame);
+      const beforeRepair = await app.datastore.findGameById(gameId);
+      assert.ok(beforeRepair);
+
+      const detailResponse = await callApp(
+        app,
+        "GET",
+        `/api/admin/games/${gameId}`,
+        {},
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(detailResponse.statusCode, 200, JSON.stringify(detailResponse.payload));
+      assert.equal(detailResponse.payload.repairPreview.orphanedModuleIds.length, 0);
+      assert.equal(detailResponse.payload.repairPreview.status, "blocked");
+      assert.equal(
+        detailResponse.payload.repairPreview.changes.some(
+          (change: any) => change.path === "diceRuleSetId"
+        ),
+        true
+      );
+      assert.equal(
+        detailResponse.payload.repairPreview.blockers.some((blocker: string) =>
+          blocker.includes("finished games")
+        ),
+        true
+      );
+
+      const repairResponse = await callApp(
+        app,
+        "POST",
+        "/api/admin/games/action",
+        { gameId, action: "repair-game-config", confirmation: gameId },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(repairResponse.statusCode, 400, JSON.stringify(repairResponse.payload));
+      const afterRepair = await app.datastore.findGameById(gameId);
+      assert.equal(afterRepair?.version, beforeRepair.version);
+      assert.equal(afterRepair?.state.diceRuleSetId, "legacy-stale");
+    });
+  }
+);
 
 register(
   "admin console routes expose operational reads, maintenance validation, termination, and audit history",

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -1074,7 +1074,18 @@ register(
             capabilities: [],
             entrypoints: { clientManifest: "client-manifest.json" }
           },
-          clientManifest: {}
+          clientManifest: {
+            gamePresets: [
+              {
+                id: "demo-live-preset",
+                name: "Demo Live Preset",
+                activeModuleIds: ["demo.live"]
+              }
+            ],
+            profiles: {
+              content: [{ id: "demo-live-content", name: "Demo Live Content" }]
+            }
+          }
         }
       ],
       async ({ app }) => {
@@ -1114,6 +1125,25 @@ register(
           );
           const catalogState = await app.datastore.getAppState("moduleCatalogState");
           assert.equal(catalogState.enabledById["demo.live"], true);
+          const creationOptions = await app.moduleRuntime.getModuleOptions();
+          assert.equal(
+            creationOptions.gameModules.some((entry: any) => entry.id === "demo.live"),
+            false
+          );
+          assert.equal(
+            creationOptions.gamePresets.some((entry: any) => entry.id === "demo-live-preset"),
+            false
+          );
+          assert.equal(
+            creationOptions.contentProfiles.some((entry: any) => entry.id === "demo-live-content"),
+            false
+          );
+          assert.equal(
+            (await app.moduleRuntime.getEnabledModules()).some(
+              (entry: any) => entry.id === "demo.live"
+            ),
+            true
+          );
 
           const liveGame = await app.datastore.findGameById("live-development-module");
           assert.ok(liveGame);

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -966,6 +966,166 @@ register(
   }
 );
 
+register(
+  "persistent default migration uses catalog ownership instead of selection name prefixes",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "community.operations",
+          manifest: {
+            schemaVersion: 1,
+            id: "community.operations",
+            version: "1.0.0",
+            displayName: "Community Operations",
+            engineVersion: "1.0.0",
+            kind: "hybrid",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [],
+            entrypoints: { clientManifest: "client-manifest.json" }
+          },
+          clientManifest: {
+            profiles: {
+              content: [{ id: "demo-mode", name: "Demo Mode" }],
+              gameplay: [{ id: "test-rules", name: "Test Rules" }],
+              ui: [{ id: "fixture-ui", name: "Fixture UI" }]
+            },
+            gamePresets: [
+              {
+                id: "demo-preset",
+                name: "Demo Preset",
+                activeModuleIds: ["community.operations"]
+              }
+            ]
+          }
+        }
+      ],
+      async ({ app, adminSessionToken }) => {
+        const originalVercelEnvironment = process.env.VERCEL_ENV;
+        process.env.VERCEL_ENV = "production";
+
+        try {
+          await app.datastore.setAppState("moduleCatalogState", {
+            enabledById: {
+              "core.base": true,
+              "community.operations": true
+            },
+            updatedAt: "2026-08-01T00:00:00.000Z"
+          });
+          await app.datastore.setAppState("adminConsoleConfig", {
+            defaults: {
+              activeModuleIds: ["community.operations"],
+              gamePresetId: "demo-preset",
+              contentProfileId: "demo-mode",
+              gameplayProfileId: "test-rules",
+              uiProfileId: "fixture-ui",
+              totalPlayers: 2
+            },
+            maintenance: { staleLobbyDays: 7, auditLogLimit: 120 },
+            updatedAt: "2026-08-01T00:00:00.000Z",
+            updatedBy: null
+          });
+
+          const response = await callApp(
+            app,
+            "GET",
+            "/api/admin/config",
+            {},
+            authHeaders(adminSessionToken)
+          );
+          assert.equal(response.statusCode, 200, JSON.stringify(response.payload));
+          assert.deepEqual(response.payload.config.defaults.activeModuleIds, [
+            "core.base",
+            "community.operations"
+          ]);
+          assert.equal(response.payload.config.defaults.gamePresetId, "demo-preset");
+          assert.equal(response.payload.config.defaults.contentProfileId, "demo-mode");
+          assert.equal(response.payload.config.defaults.gameplayProfileId, "test-rules");
+          assert.equal(response.payload.config.defaults.uiProfileId, "fixture-ui");
+        } finally {
+          if (typeof originalVercelEnvironment === "undefined") {
+            delete process.env.VERCEL_ENV;
+          } else {
+            process.env.VERCEL_ENV = originalVercelEnvironment;
+          }
+        }
+      }
+    );
+  }
+);
+
+register(
+  "persistent catalog migration preserves development modules used by live games",
+  async () => {
+    await withModuleAdminApp(
+      [
+        {
+          dir: "demo.live",
+          manifest: {
+            schemaVersion: 1,
+            id: "demo.live",
+            version: "1.0.0",
+            displayName: "Demo Live",
+            engineVersion: "1.0.0",
+            kind: "hybrid",
+            dependencies: [{ id: "core.base", version: "1.x" }],
+            conflicts: [],
+            capabilities: [],
+            entrypoints: { clientManifest: "client-manifest.json" }
+          },
+          clientManifest: {}
+        }
+      ],
+      async ({ app }) => {
+        const originalVercelEnvironment = process.env.VERCEL_ENV;
+        process.env.VERCEL_ENV = "production";
+
+        try {
+          await app.datastore.setAppState("moduleCatalogState", {
+            enabledById: { "core.base": true, "demo.live": true },
+            updatedAt: "2026-08-01T00:00:00.000Z"
+          });
+          await app.datastore.createGame({
+            id: "live-development-module",
+            name: "Live Development Module",
+            version: 1,
+            creatorUserId: null,
+            state: {
+              phase: "lobby",
+              players: [],
+              territories: {},
+              hands: {},
+              gameConfig: {
+                activeModules: [
+                  { id: "core.base", version: "1.0.0" },
+                  { id: "demo.live", version: "1.0.0" }
+                ]
+              }
+            },
+            createdAt: "2026-08-01T00:00:00.000Z",
+            updatedAt: "2026-08-01T00:00:00.000Z"
+          });
+
+          const installedModules = await app.moduleRuntime.rescan();
+          assert.equal(
+            installedModules.find((entry: any) => entry.id === "demo.live")?.enabled,
+            true
+          );
+          const catalogState = await app.datastore.getAppState("moduleCatalogState");
+          assert.equal(catalogState.enabledById["demo.live"], true);
+        } finally {
+          if (typeof originalVercelEnvironment === "undefined") {
+            delete process.env.VERCEL_ENV;
+          } else {
+            process.env.VERCEL_ENV = originalVercelEnvironment;
+          }
+        }
+      }
+    );
+  }
+);
+
 register("public game options ignore stale invalid admin defaults instead of failing", async () => {
   await withAdminApp(async ({ app, adminSessionToken }) => {
     const configResponse = await callApp(
@@ -1015,6 +1175,57 @@ register("public game options ignore stale invalid admin defaults instead of fai
     );
     assert.equal(createGameResponse.statusCode, 201);
     assert.equal(createGameResponse.payload.state.gameConfig.mapId, "world-classic");
+  });
+});
+
+register("admin orphan preview converts preset lookup failures into blockers", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const createResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      { name: "Unknown Preset Orphan" },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createResponse.statusCode, 201, JSON.stringify(createResponse.payload));
+    const gameId = createResponse.payload.game.id;
+    const storedGame = await app.datastore.findGameById(gameId);
+    assert.ok(storedGame);
+    storedGame.state.gameConfig.activeModules = [
+      { id: "core.base", version: "1.0.0" },
+      { id: "demo.missing", version: "1.0.0" }
+    ];
+    storedGame.state.gameConfig.gamePresetId = "unknown-preset";
+    storedGame.updatedAt = new Date().toISOString();
+    await app.datastore.updateGame(storedGame);
+    await activateSeparateGame(app, adminSessionToken);
+
+    const detailResponse = await callApp(
+      app,
+      "GET",
+      `/api/admin/games/${gameId}`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(detailResponse.statusCode, 200, JSON.stringify(detailResponse.payload));
+    assert.equal(detailResponse.payload.repairPreview.status, "blocked");
+    assert.equal(
+      detailResponse.payload.repairPreview.blockers.some((blocker: string) =>
+        blocker.includes('Unknown game preset "unknown-preset"')
+      ),
+      true
+    );
+
+    const closeResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/games/action",
+      { gameId, action: "close-lobby", confirmation: gameId },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(closeResponse.statusCode, 200, JSON.stringify(closeResponse.payload));
+    assert.equal(closeResponse.payload.game.phase, "finished");
+    assert.equal(closeResponse.payload.repairPreview.status, "blocked");
   });
 });
 
@@ -1858,6 +2069,23 @@ register(
         }
       },
       {
+        id: "finished-core-unavailable",
+        name: "Finished Core Unavailable",
+        version: 1,
+        creatorUserId: "admin-1",
+        createdAt: "2026-04-18T10:00:00.000Z",
+        updatedAt: "2026-04-18T12:00:00.000Z",
+        state: {
+          phase: "finished",
+          players: [],
+          territories: {},
+          hands: {},
+          gameConfig: {
+            activeModules: [{ id: "core.base", version: "1.0.0" }]
+          }
+        }
+      },
+      {
         id: "broken-lobby",
         name: "Broken Lobby",
         version: 1,
@@ -1966,6 +2194,26 @@ register(
         mapName: null,
         diceRuleSetId: null,
         activeModules: [{ id: "module.retired", version: "1.0.0" }],
+        gamePresetId: null,
+        contentProfileId: null,
+        gameplayProfileId: null,
+        uiProfileId: null,
+        updatedAt: "2026-04-18T12:00:00.000Z",
+        createdAt: "2026-04-18T10:00:00.000Z"
+      },
+      {
+        id: "finished-core-unavailable",
+        name: "Finished Core Unavailable",
+        version: 1,
+        phase: "finished",
+        playerCount: 0,
+        totalPlayers: null,
+        creatorUserId: "admin-1",
+        contentPackId: null,
+        mapId: null,
+        mapName: null,
+        diceRuleSetId: null,
+        activeModules: [{ id: "core.base", version: "1.0.0" }],
         gamePresetId: null,
         contentProfileId: null,
         gameplayProfileId: null,
@@ -2310,6 +2558,21 @@ register(
       [{ id: "core.base", version: "1.0.0" }]
     );
 
+    const unavailableCoreDetail = await adminConsole.getGameDetails("finished-core-unavailable");
+    assert.equal(unavailableCoreDetail.repairPreview.status, "blocked");
+    assert.equal(
+      unavailableCoreDetail.repairPreview.changes.some(
+        (change: any) => change.path === "gameConfig.activeModules"
+      ),
+      false
+    );
+    assert.equal(
+      unavailableCoreDetail.repairPreview.blockers.some((blocker: string) =>
+        blocker.includes("core.base module is unavailable")
+      ),
+      true
+    );
+
     const config = await adminConsole.getConfig();
     assert.equal(config.config.defaults.activeModuleIds[0], "module.safe");
     assert.equal(config.config.updatedBy.username, "admin_commander");
@@ -2317,7 +2580,7 @@ register(
     const maintenanceReport = await adminConsole.getMaintenanceReport();
     assert.equal(maintenanceReport.summary.staleLobbies, 1);
     assert.equal(maintenanceReport.summary.invalidGames >= 2, true);
-    assert.equal(maintenanceReport.summary.orphanedModuleReferences, 3);
+    assert.equal(maintenanceReport.summary.orphanedModuleReferences, 4);
 
     const audit = await adminConsole.listAudit();
     assert.equal(audit.entries.length, 3);

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -2303,6 +2303,12 @@ register(
         reason: "Normalize legacy persisted state before applying the module repair."
       }
     );
+    assert.deepEqual(
+      legacyRepairDetail.repairPreview.changes.find(
+        (change: any) => change.path === "gameConfig.activeModules"
+      )?.after,
+      [{ id: "core.base", version: "1.0.0" }]
+    );
 
     const config = await adminConsole.getConfig();
     assert.equal(config.config.defaults.activeModuleIds[0], "module.safe");

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -1121,6 +1121,32 @@ register(
           liveGame.updatedAt = "2026-08-01T01:00:00.000Z";
           await app.datastore.updateGame(liveGame);
 
+          const originalCompareAndSetAppState = app.datastore.compareAndSetAppState.bind(
+            app.datastore
+          );
+          let concurrentCatalogUpdateInjected = false;
+          app.datastore.compareAndSetAppState = async (
+            key: string,
+            expectedValue: unknown,
+            nextValue: unknown
+          ) => {
+            if (key === "moduleCatalogState" && !concurrentCatalogUpdateInjected) {
+              concurrentCatalogUpdateInjected = true;
+              const concurrentState = (await app.datastore.getAppState(
+                "moduleCatalogState"
+              )) as any;
+              await app.datastore.setAppState("moduleCatalogState", {
+                ...concurrentState,
+                enabledById: {
+                  ...concurrentState.enabledById,
+                  "community.production": true
+                },
+                updatedAt: "2026-08-01T01:30:00.000Z"
+              });
+            }
+            return originalCompareAndSetAppState(key, expectedValue, nextValue);
+          };
+
           const cleanedModules = await app.moduleRuntime.listInstalledModules();
           assert.equal(
             cleanedModules.find((entry: any) => entry.id === "demo.live")?.enabled,
@@ -1128,6 +1154,7 @@ register(
           );
           const cleanedCatalogState = await app.datastore.getAppState("moduleCatalogState");
           assert.equal(cleanedCatalogState.enabledById["demo.live"], false);
+          assert.equal(cleanedCatalogState.enabledById["community.production"], true);
         } finally {
           if (typeof originalVercelEnvironment === "undefined") {
             delete process.env.VERCEL_ENV;
@@ -1198,6 +1225,31 @@ register("read-time default migration preserves a concurrent newer admin config"
           return installedModules;
         };
 
+        const originalCompareAndSetAppState = app.datastore.compareAndSetAppState.bind(
+          app.datastore
+        );
+        let concurrentCompareAndSetUpdateInjected = false;
+        app.datastore.compareAndSetAppState = async (
+          key: string,
+          expectedValue: unknown,
+          nextValue: unknown
+        ) => {
+          if (key === "adminConsoleConfig" && !concurrentCompareAndSetUpdateInjected) {
+            concurrentCompareAndSetUpdateInjected = true;
+            await app.datastore.setAppState("adminConsoleConfig", {
+              defaults: {
+                activeModuleIds: ["demo.concurrent"],
+                totalPlayers: 3,
+                turnTimeoutHours: 48
+              },
+              maintenance: { staleLobbyDays: 45, auditLogLimit: 88 },
+              updatedAt: "2026-08-01T00:45:00.000Z",
+              updatedBy: null
+            });
+          }
+          return originalCompareAndSetAppState(key, expectedValue, nextValue);
+        };
+
         const response = await callApp(
           app,
           "GET",
@@ -1206,19 +1258,19 @@ register("read-time default migration preserves a concurrent newer admin config"
           authHeaders(adminSessionToken)
         );
         assert.equal(response.statusCode, 200, JSON.stringify(response.payload));
-        assert.equal(response.payload.config.defaults.totalPlayers, 4);
-        assert.equal(response.payload.config.defaults.turnTimeoutHours, 72);
+        assert.equal(response.payload.config.defaults.totalPlayers, 3);
+        assert.equal(response.payload.config.defaults.turnTimeoutHours, 48);
         assert.deepEqual(response.payload.config.defaults.activeModuleIds, ["core.base"]);
-        assert.equal(response.payload.config.maintenance.staleLobbyDays, 31);
-        assert.equal(response.payload.config.maintenance.auditLogLimit, 77);
-        assert.equal(response.payload.config.updatedAt, "2026-08-01T00:30:00.000Z");
+        assert.equal(response.payload.config.maintenance.staleLobbyDays, 45);
+        assert.equal(response.payload.config.maintenance.auditLogLimit, 88);
+        assert.equal(response.payload.config.updatedAt, "2026-08-01T00:45:00.000Z");
 
         const persisted = await app.datastore.getAppState("adminConsoleConfig");
-        assert.equal(persisted.defaults.totalPlayers, 4);
-        assert.equal(persisted.defaults.turnTimeoutHours, 72);
+        assert.equal(persisted.defaults.totalPlayers, 3);
+        assert.equal(persisted.defaults.turnTimeoutHours, 48);
         assert.deepEqual(persisted.defaults.activeModuleIds, ["core.base"]);
-        assert.equal(persisted.maintenance.staleLobbyDays, 31);
-        assert.equal(persisted.updatedAt, "2026-08-01T00:30:00.000Z");
+        assert.equal(persisted.maintenance.staleLobbyDays, 45);
+        assert.equal(persisted.updatedAt, "2026-08-01T00:45:00.000Z");
       } finally {
         if (typeof originalVercelEnvironment === "undefined") {
           delete process.env.VERCEL_ENV;

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -72,6 +72,21 @@ function authHeaders(sessionToken: string): HeaderMap {
   };
 }
 
+async function activateSeparateGame(app: any, sessionToken: string): Promise<void> {
+  const response = await callApp(
+    app,
+    "POST",
+    "/api/games",
+    {
+      name: "Active cache fixture",
+      totalPlayers: 2,
+      players: [{ type: "human" }, { type: "ai" }]
+    },
+    authHeaders(sessionToken)
+  );
+  assert.equal(response.statusCode, 201, JSON.stringify(response.payload));
+}
+
 function writeJson(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
@@ -1044,6 +1059,7 @@ register(
         storedGame.state.diceRuleSetId = "standard";
         storedGame.updatedAt = new Date().toISOString();
         await app.datastore.updateGame(storedGame);
+        await activateSeparateGame(app, adminSessionToken);
 
         const repairResponse = await callApp(
           app,
@@ -1051,12 +1067,13 @@ register(
           "/api/admin/games/action",
           {
             gameId,
-            action: "repair-game-config"
+            action: "repair-game-config",
+            confirmation: gameId
           },
           authHeaders(adminSessionToken)
         );
 
-        assert.equal(repairResponse.statusCode, 200);
+        assert.equal(repairResponse.statusCode, 200, JSON.stringify(repairResponse.payload));
         assert.equal(repairResponse.payload.rawState.gameConfig.diceRuleSetId, "demo-barrage");
         assert.equal(repairResponse.payload.rawState.gameConfig.diceRuleSetName, "Demo Barrage");
         assert.equal(repairResponse.payload.rawState.diceRuleSetId, "demo-barrage");
@@ -1064,6 +1081,227 @@ register(
     );
   }
 );
+
+register("admin previews and repairs a finished game with an orphaned runtime module", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Orphan repair fixture",
+        totalPlayers: 2,
+        players: [{ type: "human" }, { type: "ai" }]
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(createGameResponse.statusCode, 201);
+
+    const gameId = createGameResponse.payload.game.id;
+    const storedGame = await app.datastore.findGameById(gameId);
+    assert.ok(storedGame);
+    storedGame.state.phase = "finished";
+    storedGame.state.turnPhase = "finished";
+    storedGame.state.gameConfig.activeModules = [
+      { id: "core.base", version: "1.0.0" },
+      { id: "demo.defaults", version: "1.0.0" }
+    ];
+    storedGame.state.gameConfig.contentProfileId = "demo.defaults.content";
+    storedGame.state.gameConfig.gameplayProfileId = "demo.defaults.gameplay";
+    storedGame.state.gameConfig.uiProfileId = "demo.defaults.ui";
+    storedGame.state.gameConfig.scenarioSetup = {
+      logMessage: "Persisted scenario output",
+      territoryBonuses: [{ territoryId: "aurora", armies: 1 }]
+    };
+    storedGame.updatedAt = new Date().toISOString();
+    await app.datastore.updateGame(storedGame);
+    await activateSeparateGame(app, adminSessionToken);
+
+    const preservedBefore = JSON.parse(
+      JSON.stringify({
+        players: storedGame.state.players,
+        territories: storedGame.state.territories,
+        hands: storedGame.state.hands,
+        turnPhase: storedGame.state.turnPhase,
+        currentTurnIndex: storedGame.state.currentTurnIndex,
+        winnerId: storedGame.state.winnerId,
+        versionInfo: storedGame.state.versionInfo,
+        scenarioSetup: storedGame.state.gameConfig.scenarioSetup
+      })
+    );
+
+    const detailResponse = await callApp(
+      app,
+      "GET",
+      `/api/admin/games/${gameId}`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(detailResponse.statusCode, 200, JSON.stringify(detailResponse.payload));
+    assert.equal(detailResponse.payload.repairPreview.status, "safe");
+    assert.deepEqual(detailResponse.payload.repairPreview.orphanedModuleIds, ["demo.defaults"]);
+    assert.deepEqual(detailResponse.payload.repairPreview.relatedProfileIds, [
+      "demo.defaults.content",
+      "demo.defaults.gameplay",
+      "demo.defaults.ui"
+    ]);
+    assert.deepEqual(
+      detailResponse.payload.repairPreview.changes.map((change: any) => change.path),
+      [
+        "gameConfig.activeModules",
+        "gameConfig.contentProfileId",
+        "gameConfig.gameplayProfileId",
+        "gameConfig.uiProfileId"
+      ]
+    );
+    assert.equal(
+      detailResponse.payload.game.issues[0].message.includes("demo.defaults.content"),
+      true
+    );
+
+    const unconfirmedResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/games/action",
+      {
+        gameId,
+        action: "repair-game-config"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(unconfirmedResponse.statusCode, 400);
+
+    const repairResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/games/action",
+      {
+        gameId,
+        action: "repair-game-config",
+        confirmation: gameId
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(repairResponse.statusCode, 200, JSON.stringify(repairResponse.payload));
+    assert.equal(repairResponse.payload.repairPreview.status, "safe");
+    assert.deepEqual(repairResponse.payload.rawState.gameConfig.activeModules, [
+      { id: "core.base", version: "1.0.0" }
+    ]);
+    assert.equal(repairResponse.payload.rawState.gameConfig.contentProfileId, null);
+    assert.equal(repairResponse.payload.rawState.gameConfig.gameplayProfileId, null);
+    assert.equal(repairResponse.payload.rawState.gameConfig.uiProfileId, null);
+    assert.deepEqual(
+      JSON.parse(
+        JSON.stringify({
+          players: repairResponse.payload.rawState.players,
+          territories: repairResponse.payload.rawState.territories,
+          hands: repairResponse.payload.rawState.hands,
+          turnPhase: repairResponse.payload.rawState.turnPhase,
+          currentTurnIndex: repairResponse.payload.rawState.currentTurnIndex,
+          winnerId: repairResponse.payload.rawState.winnerId,
+          versionInfo: repairResponse.payload.rawState.versionInfo,
+          scenarioSetup: repairResponse.payload.rawState.gameConfig.scenarioSetup
+        })
+      ),
+      preservedBefore
+    );
+
+    const maintenanceResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/maintenance",
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(maintenanceResponse.statusCode, 200);
+    assert.equal(maintenanceResponse.payload.summary.orphanedModuleReferences, 0);
+    assert.equal(maintenanceResponse.payload.summary.invalidGames, 0);
+
+    const auditResponse = await callApp(
+      app,
+      "GET",
+      "/api/admin/audit",
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(auditResponse.statusCode, 200);
+    assert.equal(
+      auditResponse.payload.entries.some(
+        (entry: any) =>
+          entry.action === "game.repair-game-config" &&
+          entry.result === "success" &&
+          entry.details.orphanedModuleIds.includes("demo.defaults")
+      ),
+      true
+    );
+    assert.equal(
+      auditResponse.payload.entries.some(
+        (entry: any) => entry.action === "game.repair-game-config" && entry.result === "failure"
+      ),
+      true
+    );
+  });
+});
+
+register("admin orphan repair fails closed for a live game", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const createGameResponse = await callApp(
+      app,
+      "POST",
+      "/api/games",
+      {
+        name: "Live orphan fixture",
+        totalPlayers: 2,
+        players: [{ type: "human" }, { type: "ai" }]
+      },
+      authHeaders(adminSessionToken)
+    );
+    const gameId = createGameResponse.payload.game.id;
+    const storedGame = await app.datastore.findGameById(gameId);
+    assert.ok(storedGame);
+    storedGame.state.phase = "active";
+    storedGame.state.gameConfig.activeModules = [
+      { id: "core.base", version: "1.0.0" },
+      { id: "demo.defaults", version: "1.0.0" }
+    ];
+    storedGame.updatedAt = new Date().toISOString();
+    await app.datastore.updateGame(storedGame);
+
+    const detailResponse = await callApp(
+      app,
+      "GET",
+      `/api/admin/games/${gameId}`,
+      {},
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(detailResponse.statusCode, 200);
+    assert.equal(detailResponse.payload.repairPreview.status, "blocked");
+    assert.equal(
+      detailResponse.payload.repairPreview.blockers.some((blocker: string) =>
+        blocker.includes("finished games")
+      ),
+      true
+    );
+
+    const repairResponse = await callApp(
+      app,
+      "POST",
+      "/api/admin/games/action",
+      {
+        gameId,
+        action: "repair-game-config",
+        confirmation: gameId
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(repairResponse.statusCode, 400);
+    const unchangedGame = await app.datastore.findGameById(gameId);
+    assert.deepEqual(unchangedGame?.state.gameConfig.activeModules, [
+      { id: "core.base", version: "1.0.0" },
+      { id: "demo.defaults", version: "1.0.0" }
+    ]);
+  });
+});
 
 register(
   "admin console routes expose operational reads, maintenance validation, termination, and audit history",

--- a/tests/gameplay/regression/check-no-js-sources.test.cts
+++ b/tests/gameplay/regression/check-no-js-sources.test.cts
@@ -140,6 +140,32 @@ register("check-no-js-sources consente config JSON in .github nel repo tracciato
   });
 });
 
+register("check-no-js-sources consente migration SQL versionate di Supabase", () => {
+  withTrackedTempRepo((repoDir) => {
+    writeFile(
+      repoDir,
+      "package.json",
+      JSON.stringify({
+        name: "allowlist-supabase-migration",
+        private: true
+      })
+    );
+    writeFile(
+      repoDir,
+      "supabase/migrations/202608060001_add_atomic_app_state_compare_and_set.sql",
+      "select 1;\n"
+    );
+    runGit(["add", "."], repoDir);
+
+    const output = execFileSync(process.execPath, [builtScriptPath], {
+      cwd: repoDir,
+      encoding: "utf8"
+    });
+
+    assert.match(output, /Tracked repository sources satisfy the TS-complete allowlist\./);
+  });
+});
+
 register("check-no-js-sources rifiuta file js tracciati fuori allowlist", () => {
   withTrackedTempRepo((repoDir) => {
     writeFile(

--- a/tests/gameplay/regression/module-runtime.test.cts
+++ b/tests/gameplay/regression/module-runtime.test.cts
@@ -4,6 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const { createApp } = require("../../../backend/server.cjs");
+const { assertPersistentModuleIdAllowed } = require("../../../backend/module-runtime.cjs");
 const { moduleEntriesForSelection } = require("../../../backend/module-runtime-contributions.cjs");
 const {
   listCoreBaseMapSummaries,
@@ -67,6 +68,23 @@ register("module runtime selection accetta una baseline core configurabile", () 
   assert.deepEqual(
     selectedModules.map((moduleEntry: { id: string }) => moduleEntry.id),
     ["core.alt", "demo.extra"]
+  );
+});
+
+register("Vercel deployments reject development-only module ids before persistence", () => {
+  assert.doesNotThrow(() =>
+    assertPersistentModuleIdAllowed("demo.defaults", { VERCEL_ENV: "development" })
+  );
+  assert.doesNotThrow(() =>
+    assertPersistentModuleIdAllowed("community.weather", { VERCEL_ENV: "production" })
+  );
+  assert.throws(
+    () => assertPersistentModuleIdAllowed("demo.defaults", { VERCEL_ENV: "production" }),
+    /Development-only module/
+  );
+  assert.throws(
+    () => assertPersistentModuleIdAllowed("test.fixture", { VERCEL_ENV: "preview" }),
+    /Development-only module/
   );
 });
 

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -257,6 +257,13 @@ register("Supabase datastore ignores public keys and requires the service role k
 
 register("Supabase schema enables RLS and revokes browser role table access", () => {
   const schemaSql = getSupabaseSchemaSql();
+  const migrationSql = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "supabase/migrations/202608060001_add_atomic_app_state_compare_and_set.sql"
+    ),
+    "utf8"
+  );
 
   ["users", "sessions", "games", "app_state"].forEach((table) => {
     assert.match(schemaSql, new RegExp(`alter table public\\.${table} enable row level security;`));
@@ -273,6 +280,14 @@ register("Supabase schema enables RLS and revokes browser role table access", ()
   assert.match(schemaSql, /create or replace function public\.netrisk_compare_and_set_app_state/);
   assert.match(
     schemaSql,
+    /grant execute on function public\.netrisk_compare_and_set_app_state\(text, text, text\) to service_role;/
+  );
+  assert.match(
+    migrationSql,
+    /create or replace function public\.netrisk_compare_and_set_app_state/
+  );
+  assert.match(
+    migrationSql,
     /grant execute on function public\.netrisk_compare_and_set_app_state\(text, text, text\) to service_role;/
   );
 });

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -60,6 +60,51 @@ register("Supabase auth lookup uses a case-insensitive exact filter", async () =
   }
 });
 
+register("Supabase app-state compare-and-set uses the atomic service-role RPC", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestUrl = "";
+  let requestInit: RequestInit | undefined;
+
+  globalThis.fetch = async (input: unknown, init?: RequestInit) => {
+    requestUrl = String(input || "");
+    requestInit = init;
+    return new Response("true", {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  };
+
+  try {
+    const datastore = createSupabaseDatastore({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseServiceRoleKey: "service-role-key"
+    });
+    const updated = await datastore.compareAndSetAppState(
+      "adminConsoleConfig",
+      { defaults: { totalPlayers: 3 } },
+      { defaults: { totalPlayers: 4 } }
+    );
+
+    assert.equal(updated, true);
+    assert.equal(
+      requestUrl,
+      "https://example.supabase.co/rest/v1/rpc/netrisk_compare_and_set_app_state"
+    );
+    assert.equal(requestInit?.method, "POST");
+    assert.deepEqual(JSON.parse(String(requestInit?.body || "{}")), {
+      app_state_key: "adminConsoleConfig",
+      expected_value_json: JSON.stringify({ defaults: { totalPlayers: 3 } }),
+      next_value_json: JSON.stringify({ defaults: { totalPlayers: 4 } })
+    });
+    assert.equal(
+      (requestInit?.headers as Record<string, string>).Authorization,
+      "Bearer service-role-key"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 register("Supabase connection check probes core REST tables without exposing secrets", async () => {
   const requestedUrls: string[] = [];
   const requestedHeaders: Array<Record<string, string>> = [];
@@ -224,6 +269,11 @@ register("Supabase schema enables RLS and revokes browser role table access", ()
   assert.match(
     schemaSql,
     /revoke all on table public\.users, public\.sessions, public\.games, public\.app_state from authenticated;/
+  );
+  assert.match(schemaSql, /create or replace function public\.netrisk_compare_and_set_app_state/);
+  assert.match(
+    schemaSql,
+    /grant execute on function public\.netrisk_compare_and_set_app_state\(text, text, text\) to service_role;/
   );
 });
 

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -44,8 +44,15 @@ register("module version manifest centrally lists current functional modules", (
 
   assert.equal(getFunctionalModuleVersion("maps")?.version, "1.0.0");
   assert.equal(getFunctionalModuleVersion("admin-console")?.version, "1.1.0");
+  assert.equal(getFunctionalModuleVersion("module-runtime")?.version, "1.2.0");
+  assert.equal(getFunctionalModuleVersion("public-state")?.version, "1.3.0");
+  assert.equal(getFunctionalModuleVersion("datastore")?.version, "1.1.0");
   assert.equal(
     getFunctionalModuleVersion("admin-console")?.ownerPaths.includes("backend/admin-console.cts"),
+    true
+  );
+  assert.equal(
+    getFunctionalModuleVersion("datastore")?.ownerPaths.includes("backend/datastore-supabase.cts"),
     true
   );
   assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.patch), true);

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -43,6 +43,11 @@ register("module version manifest centrally lists current functional modules", (
   assert.equal(moduleIds.includes("public-state"), true);
 
   assert.equal(getFunctionalModuleVersion("maps")?.version, "1.0.0");
+  assert.equal(getFunctionalModuleVersion("admin-console")?.version, "1.1.0");
+  assert.equal(
+    getFunctionalModuleVersion("admin-console")?.ownerPaths.includes("backend/admin-console.cts"),
+    true
+  );
   assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.patch), true);
   assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.minor), true);
   assert.equal(Boolean(MODULE_VERSION_BUMP_RULES.major), true);

--- a/tests/gameplay/shared/version-registry.test.cts
+++ b/tests/gameplay/shared/version-registry.test.cts
@@ -35,6 +35,7 @@ function cleanupSqliteFiles(dbFile: string) {
 
 register("version manifest exports the central compatibility fields", () => {
   assert.equal(apiVersion, "1.1.0");
+  assert.equal(datastoreSchemaVersion, 2);
   assert.deepEqual(versionManifest, {
     appVersion,
     engineVersion,

--- a/tests/gameplay/shared/version-registry.test.cts
+++ b/tests/gameplay/shared/version-registry.test.cts
@@ -34,6 +34,7 @@ function cleanupSqliteFiles(dbFile: string) {
 }
 
 register("version manifest exports the central compatibility fields", () => {
+  assert.equal(apiVersion, "1.1.0");
   assert.deepEqual(versionManifest, {
     appVersion,
     engineVersion,


### PR DESCRIPTION
Fixes #369

## What changed

- add a read-only admin repair preview for unavailable runtime modules and related profile IDs
- require typed game-ID confirmation and fail closed for live games, missing core, or unresolved retained selections
- preserve valid map, rules, runtime themes, pieces, players, turn state, winner, version metadata, and scenario output
- record successful and failed repair attempts in the admin audit log
- block demo/test/fixture module IDs from being enabled or persisted in Vercel preview and production
- migrate old development-only catalog/default selections without disrupting modules still referenced by live games
- re-run persistent cleanup after the final active game finishes, including in an already-warm process
- derive orphaned profile and preset ownership from installed manifests, including disabled/incompatible modules
- atomically compare-and-set app state so concurrent Vercel instances cannot overwrite newer admin configuration or unrelated module catalog changes
- advance the central API compatibility version to 1.1.0
- record minor versions for module-runtime 1.2.0, public-state 1.3.0, datastore 1.1.0, and admin-console 1.1.0
- add backend, contract, React integration, regression, database, and browser acceptance coverage
- bump the application release to 0.1.059

## Root cause

A finished production game still references the removed `demo.defaults@1.0.0` module and its content/gameplay/UI profile IDs. The previous repair action normalized legacy root fields but could not preview or safely remove orphaned runtime references. Persistent cleanup also used unconditional whole-record writes, which could revert concurrent updates from another Vercel instance.

## Validation

- `npm run test:all` — 173 React + 167 backend + 505 gameplay tests passed
- focused admin React integration — 13/13 passed
- admin repair regressions include installed-manifest ownership, post-finish cleanup, runtime-theme preservation, fail-closed preset handling, complete preview reconciliation, live-game preservation, and concurrent-config safety
- multi-instance regressions inject stale CAS races for both admin config and module catalog and verify newer unrelated data is preserved\n- live core-only legacy normalization regression proves every non-finished repair is blocked without a persisted version or state change\n- live grandfathered development-module regression proves new-game options hide the module, preset, and profile while the internal runtime remains enabled
- tracked Supabase migration installs the CAS RPC for upgrades; datastore schema compatibility is version 2
- CI source allowlist accepts timestamped tracked Supabase migrations, locked by a regression test\n- Supabase CAS migration applied; transactional database UAT confirmed stale rejection/current acceptance and rolled back its temporary row
- Supabase function permissions verified: service role allowed, anon/authenticated denied
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run typecheck:frontend`
- `npm run typecheck:react-shell`
- release gate 0.1.059
- functional module versioning gate
- `git diff --check`

Merge remains blocked pending exact-head CI, exact-head Vercel preview verification, browser UAT, and a positive Codex review for `f297a149e5f856313ce71ac644cbdea46ad88d63`.