### PR TITLE
fix(admin): atomically clean up stale lobbies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.060 - 2026-08-06
+
+- Replaced stale-lobby phase mutation with atomic deletion guarded by game ID, version, and update timestamp so concurrent activity is never removed.
+- Added an exact maintenance candidate report with the configured age threshold and immediate post-cleanup revalidation.
+- Added per-lobby removed, skipped, and failed results to the admin UI and persistent maintenance audit trail.
+- Added SQLite, Supabase, API, and React regressions for stale, recent, active, finished, concurrent-change, and deletion-failure cases.
+- Advanced the additive admin maintenance API contract to 1.2.0 and the admin-console, datastore, and public-state module versions.
+
 ## 0.1.059 - 2026-08-06
 
 - Added a guarded admin preview and repair flow for finished games with orphaned runtime module and profile references while preserving valid gameplay state and selections.

--- a/backend/admin-console.cts
+++ b/backend/admin-console.cts
@@ -181,8 +181,15 @@ type AdminConsoleOptions = {
         };
     datastore: {
       listGames(): Promise<RawGameRecord[]> | RawGameRecord[];
+      findGameById?(gameId: string): Promise<RawGameRecord | null> | RawGameRecord | null;
+      deleteGameIfUnchanged?(
+        gameId: string,
+        expectedVersion: number,
+        expectedUpdatedAt: string
+      ): Promise<boolean> | boolean;
     };
   };
+  onGameDeleted?(gameId: string): Promise<void> | void;
   loadGameContext(gameId: string | null): Promise<GameContext>;
   persistGameContext(gameContext: GameContext, expectedVersion?: number | null): Promise<unknown>;
   broadcastGame(gameContext: GameContext): void;
@@ -359,6 +366,15 @@ function isStale(updatedAt: string | null | undefined, staleLobbyDays: number): 
 
   const ageMs = Date.now() - parsed.getTime();
   return ageMs > staleLobbyDays * 24 * 60 * 60 * 1000;
+}
+
+function staleAgeDays(updatedAt: string | null | undefined): number {
+  const parsed = new Date(String(updatedAt || ""));
+  if (Number.isNaN(parsed.getTime())) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor((Date.now() - parsed.getTime()) / (24 * 60 * 60 * 1000)));
 }
 
 function ensureGameConfig(state: GameState): Record<string, unknown> {
@@ -1699,8 +1715,20 @@ function createAdminConsole(options: AdminConsoleOptions) {
       )
     );
     const issues = enrichedGames.flatMap((game) => game.issues);
+    const eligibleStaleLobbies = enrichedGames
+      .filter((game) => game.phase === "lobby" && game.stale)
+      .map((game) => ({
+        id: game.id,
+        name: game.name,
+        version:
+          Number.isInteger(game.version) && Number(game.version) > 0 ? Number(game.version) : 1,
+        updatedAt: game.updatedAt,
+        ageDays: staleAgeDays(game.updatedAt)
+      }));
 
     return {
+      staleLobbyDays: config.maintenance.staleLobbyDays,
+      eligibleStaleLobbies,
       summary: {
         totalGames: enrichedGames.length,
         staleLobbies: enrichedGames.filter((game) => game.stale).length,
@@ -1739,6 +1767,7 @@ function createAdminConsole(options: AdminConsoleOptions) {
         ok: true,
         report,
         affectedGameIds: [],
+        cleanup: null,
         audit
       };
     }
@@ -1748,48 +1777,62 @@ function createAdminConsole(options: AdminConsoleOptions) {
     }
 
     const config = await loadConfigRecord();
-    const games = await listGames({ status: "lobby" });
-    const staleGames = games.games.filter(
-      (game) => game.stale || game.issues.some((issue) => issue.code === "stale-lobby")
-    );
-    const affectedGameIds: string[] = [];
+    const initialReport = await getMaintenanceReport();
+    const eligibleGameIds = initialReport.eligibleStaleLobbies.map((game) => game.id);
+    const removedGameIds: string[] = [];
+    const skippedGames: Array<{ gameId: string; reason: string }> = [];
+    const failedGames: Array<{ gameId: string; reason: string }> = [];
 
-    for (const game of staleGames) {
-      const context = await options.loadGameContext(game.id);
-      if (!context?.gameId) {
-        continue;
-      }
-
-      if (String(context.state?.phase || "") !== "lobby") {
-        continue;
-      }
-
-      const nextState = safeClone(context.state);
-      nextState.phase = "finished";
-      nextState.adminMeta = {
-        ...(nextState.adminMeta && typeof nextState.adminMeta === "object"
-          ? (nextState.adminMeta as Record<string, unknown>)
-          : {}),
-        lastAction: "cleanup-stale-lobbies",
-        actedAt: new Date().toISOString(),
-        actedBy: {
-          id: actor.id,
-          username: actor.username
+    for (const candidate of initialReport.eligibleStaleLobbies) {
+      try {
+        if (
+          typeof options.gameSessions.datastore.findGameById !== "function" ||
+          typeof options.gameSessions.datastore.deleteGameIfUnchanged !== "function"
+        ) {
+          throw new Error("Il datastore non supporta la cancellazione atomica delle lobby.");
         }
-      };
 
-      await options.persistGameContext(
-        {
-          ...context,
-          state: nextState
-        },
-        context.version
-      );
-      options.broadcastGame({
-        ...context,
-        state: nextState
-      });
-      affectedGameIds.push(game.id);
+        const current = await maybeResolve(
+          options.gameSessions.datastore.findGameById(candidate.id)
+        );
+        if (!current) {
+          skippedGames.push({ gameId: candidate.id, reason: "already-removed" });
+          continue;
+        }
+        if (String(current.state?.phase || "") !== "lobby") {
+          skippedGames.push({ gameId: candidate.id, reason: "phase-changed" });
+          continue;
+        }
+        if (!isStale(current.updatedAt, config.maintenance.staleLobbyDays)) {
+          skippedGames.push({ gameId: candidate.id, reason: "no-longer-stale" });
+          continue;
+        }
+
+        const currentVersion =
+          Number.isInteger(current.version) && Number(current.version) > 0
+            ? Number(current.version)
+            : 1;
+        const deleted = await maybeResolve(
+          options.gameSessions.datastore.deleteGameIfUnchanged(
+            current.id,
+            currentVersion,
+            current.updatedAt
+          )
+        );
+        if (!deleted) {
+          skippedGames.push({ gameId: candidate.id, reason: "changed-during-cleanup" });
+          continue;
+        }
+
+        removedGameIds.push(candidate.id);
+        try {
+          await maybeResolve(options.onGameDeleted?.(candidate.id));
+        } catch (error) {
+          console.error("Failed to clear runtime state after stale lobby deletion:", error);
+        }
+      } catch (_error) {
+        failedGames.push({ gameId: candidate.id, reason: "delete-failed" });
+      }
     }
 
     const report = await getMaintenanceReport();
@@ -1799,17 +1842,26 @@ function createAdminConsole(options: AdminConsoleOptions) {
       targetType: "maintenance",
       targetId: "cleanup-stale-lobbies",
       targetLabel: "Stale lobby cleanup",
-      result: "success",
+      result: failedGames.length ? "failure" : "success",
       details: {
         staleLobbyDays: config.maintenance.staleLobbyDays,
-        affectedGameIds
+        eligibleGameIds,
+        removedGameIds,
+        skippedGames,
+        failedGames
       }
     });
 
     return {
       ok: true,
       report,
-      affectedGameIds,
+      affectedGameIds: removedGameIds,
+      cleanup: {
+        eligibleGameIds,
+        removedGameIds,
+        skippedGames,
+        failedGames
+      },
       audit
     };
   }

--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -635,6 +635,29 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
         await datastore.setActiveGameId(null);
       }
     },
+    async deleteGameIfUnchanged(
+      gameId: string,
+      expectedVersion: number,
+      expectedUpdatedAt: string
+    ) {
+      await ensureInitialized();
+      const deletedRows = await request(
+        `/games${toQueryString({
+          id: `eq.${gameId}`,
+          version: `eq.${expectedVersion}`,
+          updated_at: `eq.${expectedUpdatedAt}`
+        })}`,
+        {
+          method: "DELETE",
+          prefer: "return=representation"
+        }
+      );
+      const deleted = Array.isArray(deletedRows) && deletedRows.length === 1;
+      if (deleted && (await datastore.getActiveGameId()) === gameId) {
+        await datastore.setActiveGameId(null);
+      }
+      return deleted;
+    },
     async getActiveGameId() {
       await ensureInitialized();
       const row = await selectOne<AppStateRow>("app_state", { key: "eq.activeGameId" });

--- a/backend/datastore-supabase.cts
+++ b/backend/datastore-supabase.cts
@@ -653,8 +653,12 @@ function createSupabaseDatastore(options: SupabaseDatastoreOptions = {}) {
         }
       );
       const deleted = Array.isArray(deletedRows) && deletedRows.length === 1;
-      if (deleted && (await datastore.getActiveGameId()) === gameId) {
-        await datastore.setActiveGameId(null);
+      if (deleted) {
+        try {
+          await datastore.compareAndSetAppState("activeGameId", gameId, null);
+        } catch (error) {
+          console.error("Failed to clear active game after deleting a stale lobby:", error);
+        }
       }
       return deleted;
     },

--- a/backend/datastore.cts
+++ b/backend/datastore.cts
@@ -70,6 +70,10 @@ type Statement<Row> = {
   run(...args: unknown[]): unknown;
 };
 
+type StatementRunResult = {
+  changes?: number | bigint;
+};
+
 type DatastoreOptions = {
   driver?: string;
   dbFile?: string;
@@ -272,6 +276,9 @@ function createDatastore(options: DatastoreOptions = {}) {
       "UPDATE games SET name = ?, version = ?, creator_user_id = ?, state_json = ?, updated_at = ? WHERE id = ?"
     ) as Statement<unknown>,
     deleteGame: db.prepare("DELETE FROM games WHERE id = ?") as Statement<unknown>,
+    deleteGameIfUnchanged: db.prepare(
+      "DELETE FROM games WHERE id = ? AND version = ? AND updated_at = ?"
+    ) as Statement<unknown>,
     getAppState: db.prepare(
       "SELECT value_json FROM app_state WHERE key = ?"
     ) as Statement<AppStateRow | null>,
@@ -533,6 +540,20 @@ function createDatastore(options: DatastoreOptions = {}) {
         if (activeGameId === gameId) {
           statements.setAppState.run("activeGameId", JSON.stringify(null));
         }
+      });
+    },
+    deleteGameIfUnchanged(gameId: string, expectedVersion: number, expectedUpdatedAt: string) {
+      return transaction(() => {
+        const result = statements.deleteGameIfUnchanged.run(
+          gameId,
+          expectedVersion,
+          expectedUpdatedAt
+        ) as StatementRunResult;
+        const deleted = Number(result.changes || 0) === 1;
+        if (deleted && datastore.getActiveGameId() === gameId) {
+          statements.setAppState.run("activeGameId", JSON.stringify(null));
+        }
+        return deleted;
       });
     },
     getActiveGameId() {

--- a/backend/game-session-store.cts
+++ b/backend/game-session-store.cts
@@ -80,6 +80,11 @@ interface GameSessionStoreOptions {
     getActiveGameId(): string | null | Promise<string | null>;
     updateGame(entry: GameEntry): GameEntry | Promise<GameEntry>;
     deleteGame?(gameId: string): void | Promise<void>;
+    deleteGameIfUnchanged?(
+      gameId: string,
+      expectedVersion: number,
+      expectedUpdatedAt: string
+    ): boolean | Promise<boolean>;
   };
   dbFile?: string;
   dataFile?: string;

--- a/backend/server.cts
+++ b/backend/server.cts
@@ -442,6 +442,18 @@ function createApp(options: CreateAppOptions = {}) {
     loadGameContext,
     persistGameContext,
     broadcastGame,
+    onGameDeleted(gameId: string) {
+      const clients = clientsByGameId.get(gameId);
+      clients?.forEach((client) => client.res.end());
+      clientsByGameId.delete(gameId);
+      if (gameId === activeGameId) {
+        activeGameId = null;
+        activeGameVersion = null;
+        activeGameName = null;
+        activeGameCreatorUserId = null;
+        replaceState(createInitialState());
+      }
+    },
     createConfiguredInitialState,
     moduleRuntime,
     authoredModules

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -17,7 +17,7 @@ The NetRisk administrator area lives at `/admin`, with `/react/admin` kept as th
 - `Configurations`: global admin defaults, enabled modules, profiles, runtime defaults, and maintenance thresholds
 - `Runtime / Modules`: module catalog management through the existing module admin tooling
 - `Content Studio`: constrained authoring for gameplay modules; supports validated maps and `victory-objectives`
-- `Maintenance`: validation report and guarded cleanup/repair actions
+- `Maintenance`: validation report with the configured stale threshold, exact eligible lobby list, and guarded cleanup/repair actions
 - `System Health`: diagnostics view for module references, game snapshots, stale lobbies, and maintenance findings
 - `Audit Log`: persistent log of admin mutations with actor, action, target, and result
 
@@ -53,6 +53,8 @@ Notes:
 - Content Studio maps and objective modules are schema-validated server-side before publish/enable and never execute arbitrary uploaded code
 - authored maps cannot be disabled while referenced by active games or admin defaults
 - game repair preserves runtime-resolved IDs while synchronizing stale top-level snapshot fields
+- stale-lobby cleanup deletes only a row that is still a lobby, still older than the configured threshold, and still has the version/timestamp inspected immediately before deletion
+- cleanup revalidates the report immediately and audits exact eligible, removed, skipped, and failed game IDs
 - cleanup and destructive actions are audit logged on both success and failure paths where applicable
 
 ## Regression coverage
@@ -66,4 +68,5 @@ Notable backend regressions covered today:
 
 - create-game requests that provide an explicit `ruleSetId` but omit `pieceSetId` still preserve valid admin defaults for piece sets
 - destructive admin actions fail closed without explicit confirmation and emit audit entries on the failure path
+- stale, recent, active, and finished fixtures verify cleanup eligibility; concurrent phase/version/timestamp changes verify that live lobbies are skipped
 - anonymous and authenticated non-admin callers receive `AUTH_REQUIRED` or `ADMIN_ONLY` on protected admin mutations

--- a/e2e/smoke/admin-stale-lobby-cleanup.spec.ts
+++ b/e2e/smoke/admin-stale-lobby-cleanup.spec.ts
@@ -129,7 +129,9 @@ test("admin removes only an eligible stale lobby and refreshes health and audit"
   });
 
   await page.goto("/admin/system-health");
-  await expect(page.getByText("Stale lobbies", { exact: true }).locator("..")).toContainText("OK");
+  await expect(page.getByText("Stale lobbies", { exact: true }).locator("..")).toContainText(
+    "All clear"
+  );
 
   await page.goto("/admin/audit");
   await expect(page.getByText("maintenance.cleanup-stale-lobbies")).toBeVisible();

--- a/e2e/smoke/admin-stale-lobby-cleanup.spec.ts
+++ b/e2e/smoke/admin-stale-lobby-cleanup.spec.ts
@@ -1,0 +1,137 @@
+const { test, expect } = require("@playwright/test");
+const { DatabaseSync } = require("node:sqlite");
+
+const {
+  attachSessionCookie,
+  createAuthenticatedSession,
+  resetGame,
+  uniqueUser
+} = require("../support/game-helpers");
+
+function withE2eDatabase(run) {
+  const dbFile = process.env.E2E_DB_FILE;
+  expect(dbFile).toBeTruthy();
+
+  const db = new DatabaseSync(dbFile);
+  try {
+    return run(db);
+  } finally {
+    db.close();
+  }
+}
+
+function promoteUserToAdmin(username) {
+  withE2eDatabase((db) => {
+    const result = db
+      .prepare("UPDATE users SET role = 'admin' WHERE lower(username) = lower(?)")
+      .run(username);
+    expect(result.changes).toBe(1);
+  });
+}
+
+function insertGameFixtures(prefix) {
+  const staleUpdatedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+  const recentUpdatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const fixtures = [
+    {
+      id: `${prefix}-stale`,
+      name: `${prefix} stale lobby`,
+      phase: "lobby",
+      updatedAt: staleUpdatedAt
+    },
+    {
+      id: `${prefix}-recent`,
+      name: `${prefix} recent lobby`,
+      phase: "lobby",
+      updatedAt: recentUpdatedAt
+    },
+    {
+      id: `${prefix}-active`,
+      name: `${prefix} active game`,
+      phase: "active",
+      updatedAt: staleUpdatedAt
+    },
+    {
+      id: `${prefix}-finished`,
+      name: `${prefix} finished game`,
+      phase: "finished",
+      updatedAt: staleUpdatedAt
+    }
+  ];
+
+  withE2eDatabase((db) => {
+    const insert = db.prepare(
+      "INSERT INTO games (id, name, version, creator_user_id, state_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    );
+    for (const fixture of fixtures) {
+      const state = {
+        phase: fixture.phase,
+        players: [],
+        territories: {},
+        hands: {},
+        gameConfig: {}
+      };
+      const result = insert.run(
+        fixture.id,
+        fixture.name,
+        4,
+        null,
+        JSON.stringify(state),
+        staleUpdatedAt,
+        fixture.updatedAt
+      );
+      expect(result.changes).toBe(1);
+    }
+  });
+
+  return fixtures;
+}
+
+test("admin removes only an eligible stale lobby and refreshes health and audit", async ({
+  page
+}) => {
+  await resetGame(page);
+
+  const adminUsername = uniqueUser("admin_stale_uat");
+  const sessionToken = await createAuthenticatedSession(page, adminUsername);
+  promoteUserToAdmin(adminUsername);
+  const prefix = uniqueUser("stale_cleanup_uat");
+  const fixtures = insertGameFixtures(prefix);
+  const staleFixture = fixtures[0];
+  await attachSessionCookie(page, sessionToken);
+
+  await page.goto("/admin/maintenance");
+  await expect(page.getByTestId("admin-route-page")).toBeVisible();
+  await expect(page.getByText("Stale after 7 days")).toBeVisible();
+  const candidateName = page.getByText(staleFixture.name, { exact: true });
+  await expect(candidateName).toBeVisible();
+  await expect(candidateName.locator("..")).toContainText(staleFixture.id);
+  await expect(page.getByText(fixtures[1].name, { exact: true })).toHaveCount(0);
+  await expect(page.getByText(fixtures[2].name, { exact: true })).toHaveCount(0);
+  await expect(page.getByText(fixtures[3].name, { exact: true })).toHaveCount(0);
+
+  page.once("dialog", async (dialog) => {
+    expect(dialog.type()).toBe("prompt");
+    expect(dialog.message()).toBe("Type cleanup-stale-lobbies to confirm cleanup.");
+    await dialog.accept("cleanup-stale-lobbies");
+  });
+  await page.getByRole("button", { name: "Cleanup stale lobbies" }).click();
+
+  await expect(page.getByText(/removed 1 · skipped 0 · failed 0/)).toBeVisible();
+  await expect(candidateName).toHaveCount(0);
+  await expect(page.getByText("No stale lobbies are currently eligible.")).toBeVisible();
+
+  withE2eDatabase((db) => {
+    expect(db.prepare("SELECT id FROM games WHERE id = ?").get(staleFixture.id)).toBeUndefined();
+    for (const fixture of fixtures.slice(1)) {
+      expect(db.prepare("SELECT id FROM games WHERE id = ?").get(fixture.id)).toBeTruthy();
+    }
+  });
+
+  await page.goto("/admin/system-health");
+  await expect(page.getByText("Stale lobbies", { exact: true }).locator("..")).toContainText("OK");
+
+  await page.goto("/admin/audit");
+  await expect(page.getByText("maintenance.cleanup-stale-lobbies")).toBeVisible();
+  await expect(page.getByText("success", { exact: true })).toBeVisible();
+});

--- a/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
+++ b/frontend/react-shell/src/__tests__/admin-route.integration.test.tsx
@@ -531,6 +531,16 @@ function createGameOptionsResponse(): GameOptionsResponse {
 
 function createMaintenanceReport(): AdminMaintenanceReport {
   return {
+    staleLobbyDays: 7,
+    eligibleStaleLobbies: [
+      {
+        id: "game-2",
+        name: "Stale test lobby",
+        version: 3,
+        updatedAt: "2026-07-20T10:00:00.000Z",
+        ageDays: 17
+      }
+    ],
     summary: {
       totalGames: 4,
       staleLobbies: 1,
@@ -1003,6 +1013,12 @@ describe("Admin route integration", () => {
       ok: true,
       report,
       affectedGameIds: ["game-2"],
+      cleanup: {
+        eligibleGameIds: ["game-2", "game-race"],
+        removedGameIds: ["game-2"],
+        skippedGames: [{ gameId: "game-race", reason: "phase-changed" }],
+        failedGames: []
+      },
       audit: createAuditEntry({
         action: "maintenance.cleanup-stale-lobbies",
         targetType: "maintenance",
@@ -1018,6 +1034,9 @@ describe("Admin route integration", () => {
     const { user } = renderReactShell("/react/admin/maintenance");
 
     await screen.findByText("Validation and repair operations");
+    const candidateName = await screen.findByText("Stale test lobby");
+    expect(candidateName.closest("li")).toHaveTextContent("game-2");
+    expect(candidateName.closest("li")).toHaveTextContent("17 days old");
 
     await user.click(screen.getByRole("button", { name: "Cleanup stale lobbies" }));
 
@@ -1035,6 +1054,7 @@ describe("Admin route integration", () => {
         expect.anything()
       );
     });
+    expect(await screen.findByText(/removed 1 · skipped 1 · failed 0/)).toBeInTheDocument();
   });
 
   it("loads the content studio editor, shows preview data, and saves a draft", async () => {

--- a/frontend/react-shell/src/admin-route.tsx
+++ b/frontend/react-shell/src/admin-route.tsx
@@ -2245,7 +2245,7 @@ function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext 
             type="button"
             className="ghost-action admin-danger-action"
             onClick={handleCleanup}
-            disabled={actionMutation.isPending}
+            disabled={actionMutation.isPending || !reportQuery.data?.eligibleStaleLobbies.length}
           >
             Cleanup stale lobbies
           </button>
@@ -2256,6 +2256,7 @@ function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext 
           <div className="admin-toolbar-summary">
             <span className="chip">{reportQuery.data?.summary.totalGames || 0} games checked</span>
             <span className="chip">{reportQuery.data?.issues.length || 0} findings</span>
+            <span className="chip">Stale after {reportQuery.data?.staleLobbyDays || 0} days</span>
             <span className="chip">{actionMutation.isPending ? "Operation running" : "Idle"}</span>
           </div>
         </div>
@@ -2275,8 +2276,17 @@ function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext 
           <p className="status-label">Last operation</p>
           <h2>{actionMutation.data.audit.action}</h2>
           <p className="status-copy">
-            Result {actionMutation.data.audit.result} · affected games{" "}
-            {actionMutation.data.affectedGameIds.length}
+            Result {actionMutation.data.audit.result}
+            {actionMutation.data.cleanup ? (
+              <>
+                {" "}
+                · removed {actionMutation.data.cleanup.removedGameIds.length} · skipped{" "}
+                {actionMutation.data.cleanup.skippedGames.length} · failed{" "}
+                {actionMutation.data.cleanup.failedGames.length}
+              </>
+            ) : (
+              <> · validation complete</>
+            )}
           </p>
         </section>
       ) : null}
@@ -2310,6 +2320,11 @@ function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext 
               hint="Candidates for cleanup"
             />
             <AdminMetric
+              label="Stale threshold"
+              value={`${reportQuery.data.staleLobbyDays} days`}
+              hint="Configured inactivity window"
+            />
+            <AdminMetric
               label="Invalid games"
               value={reportQuery.data.summary.invalidGames}
               tone={reportQuery.data.summary.invalidGames > 0 ? "danger" : "success"}
@@ -2324,6 +2339,27 @@ function MaintenanceSection({ frameContext }: { frameContext: AdminFrameContext 
           </div>
 
           <div className="grid-shell admin-maintenance-grid">
+            <section className="card-panel admin-card-span">
+              <div className="card-header">
+                <div>
+                  <p className="status-label">Cleanup candidates</p>
+                  <h2>Exact stale lobbies eligible for removal</h2>
+                </div>
+              </div>
+              {reportQuery.data.eligibleStaleLobbies.length ? (
+                <ul className="admin-note-list">
+                  {reportQuery.data.eligibleStaleLobbies.map((game) => (
+                    <li key={game.id}>
+                      <strong>{game.name}</strong> · {game.id} · {game.ageDays} days old · version{" "}
+                      {game.version} · updated {new Date(game.updatedAt).toLocaleString()}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="status-copy">No stale lobbies are currently eligible.</p>
+              )}
+            </section>
+
             <section className="card-panel admin-card-span">
               <div className="card-header">
                 <div>

--- a/frontend/src/generated/shared-runtime-validation.mts
+++ b/frontend/src/generated/shared-runtime-validation.mts
@@ -1720,6 +1720,16 @@ export const adminConfigUpdateResponseSchema = objectSchema({
 export type AdminConfigUpdateResponse = z.infer<typeof adminConfigUpdateResponseSchema>;
 
 export const adminMaintenanceReportSchema = objectSchema({
+  staleLobbyDays: z.number().int().min(1).max(365),
+  eligibleStaleLobbies: z.array(
+    objectSchema({
+      id: z.string().min(1),
+      name: z.string().min(1),
+      version: z.number().int().positive(),
+      updatedAt: z.string().min(1),
+      ageDays: z.number().int().nonnegative()
+    })
+  ),
   summary: objectSchema({
     totalGames: z.number().int(),
     staleLobbies: z.number().int(),
@@ -1742,6 +1752,22 @@ export const adminMaintenanceActionResponseSchema = objectSchema({
   ok: z.literal(true),
   report: adminMaintenanceReportSchema,
   affectedGameIds: z.array(z.string().min(1)),
+  cleanup: objectSchema({
+    eligibleGameIds: z.array(z.string().min(1)),
+    removedGameIds: z.array(z.string().min(1)),
+    skippedGames: z.array(
+      objectSchema({
+        gameId: z.string().min(1),
+        reason: z.string().min(1)
+      })
+    ),
+    failedGames: z.array(
+      objectSchema({
+        gameId: z.string().min(1),
+        reason: z.string().min(1)
+      })
+    )
+  }).nullable(),
   audit: adminAuditEntrySchema
 });
 

--- a/scripts/run-tests.cts
+++ b/scripts/run-tests.cts
@@ -2723,7 +2723,7 @@ register("frontend API client valida sessione, profilo e lobby list al boundary"
       assert.equal(profile.profile.gamesPlayed, 3);
       assert.equal(games.games[0].id, "game-1");
       assert.equal(versionInfo.compatible, true);
-      assert.equal(versionInfo.apiVersion, "1.1.0");
+      assert.equal(versionInfo.apiVersion, "1.2.0");
     }
   );
 

--- a/shared/api-contracts.cts
+++ b/shared/api-contracts.cts
@@ -382,6 +382,14 @@ export interface AdminConfigUpdateResponseContract {
 }
 
 export interface AdminMaintenanceReportContract {
+  staleLobbyDays: number;
+  eligibleStaleLobbies: Array<{
+    id: string;
+    name: string;
+    version: number;
+    updatedAt: string;
+    ageDays: number;
+  }>;
   summary: {
     totalGames: number;
     staleLobbies: number;
@@ -395,6 +403,12 @@ export interface AdminMaintenanceActionResponseContract {
   ok: boolean;
   report: AdminMaintenanceReportContract;
   affectedGameIds: string[];
+  cleanup: {
+    eligibleGameIds: string[];
+    removedGameIds: string[];
+    skippedGames: Array<{ gameId: string; reason: string }>;
+    failedGames: Array<{ gameId: string; reason: string }>;
+  } | null;
   audit: AdminAuditEntryContract;
 }
 

--- a/shared/module-versions.cts
+++ b/shared/module-versions.cts
@@ -264,7 +264,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "admin-console",
     name: "Admin Console",
     kind: "admin",
-    version: "1.1.0",
+    version: "1.2.0",
     description: "Admin routes and operational admin workflows.",
     ownerPaths: [
       "backend/admin-console.cts",
@@ -277,7 +277,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "datastore",
     name: "Datastore",
     kind: "platform",
-    version: "1.1.0",
+    version: "1.2.0",
     description:
       "Game/session persistence, app state persistence, backups, and datastore schema use.",
     ownerPaths: [
@@ -294,7 +294,7 @@ export const functionalModuleVersions: readonly FunctionalModuleVersion[] = Obje
     id: "public-state",
     name: "Public Game State",
     kind: "platform",
-    version: "1.3.0",
+    version: "1.4.0",
     description: "Public/read API game state contracts, snapshots, and shared game models.",
     ownerPaths: [
       "shared/api-contracts.cts",

--- a/shared/runtime-validation.cts
+++ b/shared/runtime-validation.cts
@@ -1719,6 +1719,16 @@ export const adminConfigUpdateResponseSchema = objectSchema({
 export type AdminConfigUpdateResponse = z.infer<typeof adminConfigUpdateResponseSchema>;
 
 export const adminMaintenanceReportSchema = objectSchema({
+  staleLobbyDays: z.number().int().min(1).max(365),
+  eligibleStaleLobbies: z.array(
+    objectSchema({
+      id: z.string().min(1),
+      name: z.string().min(1),
+      version: z.number().int().positive(),
+      updatedAt: z.string().min(1),
+      ageDays: z.number().int().nonnegative()
+    })
+  ),
   summary: objectSchema({
     totalGames: z.number().int(),
     staleLobbies: z.number().int(),
@@ -1741,6 +1751,22 @@ export const adminMaintenanceActionResponseSchema = objectSchema({
   ok: z.literal(true),
   report: adminMaintenanceReportSchema,
   affectedGameIds: z.array(z.string().min(1)),
+  cleanup: objectSchema({
+    eligibleGameIds: z.array(z.string().min(1)),
+    removedGameIds: z.array(z.string().min(1)),
+    skippedGames: z.array(
+      objectSchema({
+        gameId: z.string().min(1),
+        reason: z.string().min(1)
+      })
+    ),
+    failedGames: z.array(
+      objectSchema({
+        gameId: z.string().min(1),
+        reason: z.string().min(1)
+      })
+    )
+  }).nullable(),
   audit: adminAuditEntrySchema
 });
 

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,6 +1,6 @@
-export const appVersion = "0.1.059";
+export const appVersion = "0.1.060";
 export const engineVersion = "1.0.0";
-export const apiVersion = "1.1.0";
+export const apiVersion = "1.2.0";
 export const datastoreSchemaVersion = 2;
 export const saveGameSchemaVersion = 1;
 export const moduleApiVersion = "1.0.0";

--- a/tests/gameplay/regression/admin-console-routes.test.cts
+++ b/tests/gameplay/regression/admin-console-routes.test.cts
@@ -3153,9 +3153,189 @@ register(
   }
 );
 
-register("stale lobby cleanup skips games that become active before mutation", async () => {
-  const persistedStates: Array<{ gameId: string; phase: string }> = [];
-  const broadcastStates: Array<{ gameId: string; phase: string }> = [];
+register(
+  "stale lobby cleanup deletes only eligible lobbies and immediately revalidates the report",
+  async () => {
+    await withAdminApp(async ({ app, adminSessionToken }) => {
+      const now = Date.now();
+      const staleUpdatedAt = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString();
+      const recentUpdatedAt = new Date(now - 2 * 60 * 60 * 1000).toISOString();
+      const fixtures = [
+        { id: "stale-lobby", phase: "lobby", updatedAt: staleUpdatedAt },
+        { id: "recent-lobby", phase: "lobby", updatedAt: recentUpdatedAt },
+        { id: "active-game", phase: "active", updatedAt: staleUpdatedAt },
+        { id: "finished-game", phase: "finished", updatedAt: staleUpdatedAt }
+      ];
+
+      for (const fixture of fixtures) {
+        await app.datastore.createGame({
+          id: fixture.id,
+          name: fixture.id,
+          version: 4,
+          creatorUserId: null,
+          state: {
+            phase: fixture.phase,
+            players: [],
+            territories: {},
+            hands: {},
+            gameConfig: {}
+          },
+          createdAt: staleUpdatedAt,
+          updatedAt: fixture.updatedAt
+        });
+      }
+
+      const reportBefore = await callApp(
+        app,
+        "GET",
+        "/api/admin/maintenance",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(reportBefore.statusCode, 200, JSON.stringify(reportBefore.payload));
+      assert.equal(reportBefore.payload.staleLobbyDays, 7);
+      assert.deepEqual(
+        reportBefore.payload.eligibleStaleLobbies.map((game: any) => game.id),
+        ["stale-lobby"]
+      );
+
+      const cleanup = await callApp(
+        app,
+        "POST",
+        "/api/admin/maintenance",
+        {
+          action: "cleanup-stale-lobbies",
+          confirmation: "cleanup-stale-lobbies"
+        },
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(cleanup.statusCode, 200, JSON.stringify(cleanup.payload));
+      assert.deepEqual(cleanup.payload.cleanup, {
+        eligibleGameIds: ["stale-lobby"],
+        removedGameIds: ["stale-lobby"],
+        skippedGames: [],
+        failedGames: []
+      });
+      assert.equal(cleanup.payload.report.summary.staleLobbies, 0);
+      assert.deepEqual(cleanup.payload.report.eligibleStaleLobbies, []);
+      assert.equal(await app.datastore.findGameById("stale-lobby"), null);
+      assert.equal((await app.datastore.findGameById("recent-lobby"))?.state.phase, "lobby");
+      assert.equal((await app.datastore.findGameById("active-game"))?.state.phase, "active");
+      assert.equal((await app.datastore.findGameById("finished-game"))?.state.phase, "finished");
+
+      const audit = await callApp(
+        app,
+        "GET",
+        "/api/admin/audit",
+        undefined,
+        authHeaders(adminSessionToken)
+      );
+      assert.equal(audit.statusCode, 200);
+      const cleanupAudit = audit.payload.entries.find(
+        (entry: any) => entry.action === "maintenance.cleanup-stale-lobbies"
+      );
+      assert.deepEqual(cleanupAudit.details.removedGameIds, ["stale-lobby"]);
+      assert.deepEqual(cleanupAudit.details.skippedGames, []);
+      assert.deepEqual(cleanupAudit.details.failedGames, []);
+    });
+  }
+);
+
+register("stale lobby cleanup skips a lobby changed during atomic deletion", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const staleUpdatedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    await app.datastore.createGame({
+      id: "changed-lobby",
+      name: "changed-lobby",
+      version: 2,
+      creatorUserId: null,
+      state: {
+        phase: "lobby",
+        players: [],
+        territories: {},
+        hands: {},
+        gameConfig: {}
+      },
+      createdAt: staleUpdatedAt,
+      updatedAt: staleUpdatedAt
+    });
+
+    const atomicDelete = app.datastore.deleteGameIfUnchanged.bind(app.datastore);
+    app.datastore.deleteGameIfUnchanged = async (
+      gameId: string,
+      expectedVersion: number,
+      expectedUpdatedAt: string
+    ) => {
+      const current = await app.datastore.findGameById(gameId);
+      await app.datastore.updateGame({
+        ...current,
+        version: Number(current.version) + 1,
+        updatedAt: new Date().toISOString()
+      });
+      return atomicDelete(gameId, expectedVersion, expectedUpdatedAt);
+    };
+
+    const cleanup = await callApp(
+      app,
+      "POST",
+      "/api/admin/maintenance",
+      {
+        action: "cleanup-stale-lobbies",
+        confirmation: "cleanup-stale-lobbies"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(cleanup.statusCode, 200, JSON.stringify(cleanup.payload));
+    assert.deepEqual(cleanup.payload.cleanup.removedGameIds, []);
+    assert.deepEqual(cleanup.payload.cleanup.skippedGames, [
+      { gameId: "changed-lobby", reason: "changed-during-cleanup" }
+    ]);
+    assert.equal(cleanup.payload.cleanup.failedGames.length, 0);
+    assert.equal((await app.datastore.findGameById("changed-lobby"))?.version, 3);
+  });
+});
+
+register("stale lobby cleanup reports and audits individual deletion failures", async () => {
+  await withAdminApp(async ({ app, adminSessionToken }) => {
+    const staleUpdatedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    await app.datastore.createGame({
+      id: "failed-lobby",
+      name: "failed-lobby",
+      version: 1,
+      creatorUserId: null,
+      state: { phase: "lobby", players: [], gameConfig: {} },
+      createdAt: staleUpdatedAt,
+      updatedAt: staleUpdatedAt
+    });
+    app.datastore.deleteGameIfUnchanged = async () => {
+      throw new Error("simulated datastore outage");
+    };
+
+    const cleanup = await callApp(
+      app,
+      "POST",
+      "/api/admin/maintenance",
+      {
+        action: "cleanup-stale-lobbies",
+        confirmation: "cleanup-stale-lobbies"
+      },
+      authHeaders(adminSessionToken)
+    );
+    assert.equal(cleanup.statusCode, 200, JSON.stringify(cleanup.payload));
+    assert.deepEqual(cleanup.payload.cleanup.failedGames, [
+      { gameId: "failed-lobby", reason: "delete-failed" }
+    ]);
+    assert.equal(cleanup.payload.audit.result, "failure");
+    assert.deepEqual(cleanup.payload.audit.details.failedGames, [
+      { gameId: "failed-lobby", reason: "delete-failed" }
+    ]);
+    assert.equal((await app.datastore.findGameById("failed-lobby"))?.state.phase, "lobby");
+  });
+});
+
+register("stale lobby cleanup skips games that become active before deletion", async () => {
+  let deleteAttempts = 0;
+  const staleUpdatedAt = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
   const adminConsole = createAdminConsole({
     datastore: {
       listUsers() {
@@ -3200,7 +3380,7 @@ register("stale lobby cleanup skips games that become active before mutation", a
             version: 1,
             phase: "lobby",
             playerCount: 1,
-            updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+            updatedAt: staleUpdatedAt
           }
         ];
       },
@@ -3212,7 +3392,7 @@ register("stale lobby cleanup skips games that become active before mutation", a
             version: 1,
             phase: "lobby",
             playerCount: 1,
-            updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+            updatedAt: staleUpdatedAt
           },
           state: {
             phase: "lobby",
@@ -3232,7 +3412,7 @@ register("stale lobby cleanup skips games that become active before mutation", a
               version: 1,
               creatorUserId: null,
               createdAt: new Date().toISOString(),
-              updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+              updatedAt: staleUpdatedAt,
               state: {
                 phase: "lobby",
                 players: [],
@@ -3242,6 +3422,27 @@ register("stale lobby cleanup skips games that become active before mutation", a
               }
             }
           ];
+        },
+        findGameById() {
+          return {
+            id: "game-race",
+            name: "Race Lobby",
+            version: 2,
+            creatorUserId: null,
+            createdAt: staleUpdatedAt,
+            updatedAt: new Date().toISOString(),
+            state: {
+              phase: "active",
+              players: [],
+              territories: {},
+              hands: {},
+              gameConfig: {}
+            }
+          };
+        },
+        deleteGameIfUnchanged() {
+          deleteAttempts += 1;
+          return true;
         }
       }
     },
@@ -3259,19 +3460,10 @@ register("stale lobby cleanup skips games that become active before mutation", a
         }
       };
     },
-    persistGameContext(gameContext: any) {
-      persistedStates.push({
-        gameId: gameContext.gameId,
-        phase: String(gameContext.state?.phase || "")
-      });
-      return null;
+    persistGameContext() {
+      throw new Error("persistGameContext should not be used by cleanup");
     },
-    broadcastGame(gameContext: any) {
-      broadcastStates.push({
-        gameId: gameContext.gameId,
-        phase: String(gameContext.state?.phase || "")
-      });
-    },
+    broadcastGame() {},
     createConfiguredInitialState() {
       return {
         state: {
@@ -3334,6 +3526,8 @@ register("stale lobby cleanup skips games that become active before mutation", a
   );
 
   assert.deepEqual(actionResponse.affectedGameIds, []);
-  assert.deepEqual(persistedStates, []);
-  assert.deepEqual(broadcastStates, []);
+  assert.equal(deleteAttempts, 0);
+  assert.deepEqual(actionResponse.cleanup?.skippedGames, [
+    { gameId: "game-race", reason: "phase-changed" }
+  ]);
 });

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -119,6 +119,12 @@ register("Supabase stale-lobby deletion uses exact optimistic-concurrency filter
         headers: { "content-type": "application/json" }
       });
     }
+    if (url.endsWith("/rpc/netrisk_compare_and_set_app_state")) {
+      return new Response("true", {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
     return new Response("[]", {
       status: 200,
       headers: { "content-type": "application/json" }
@@ -146,8 +152,59 @@ register("Supabase stale-lobby deletion uses exact optimistic-concurrency filter
       (deleteRequest.init?.headers as Record<string, string>).Prefer,
       "return=representation"
     );
+    const compareAndSetRequest = requests.find((request) =>
+      request.url.endsWith("/rpc/netrisk_compare_and_set_app_state")
+    );
+    assert.equal(compareAndSetRequest?.init?.method, "POST");
+    assert.deepEqual(JSON.parse(String(compareAndSetRequest?.init?.body || "{}")), {
+      app_state_key: "activeGameId",
+      expected_value_json: JSON.stringify("stale-lobby"),
+      next_value_json: JSON.stringify(null)
+    });
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+register("Supabase stale-lobby deletion preserves success when pointer cleanup fails", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+  const errors: unknown[][] = [];
+
+  globalThis.fetch = async (input: unknown) => {
+    const url = String(input || "");
+    if (url.includes("/games?")) {
+      return new Response(JSON.stringify([{ id: "stale-lobby" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
+    return new Response(JSON.stringify({ message: "simulated app-state outage" }), {
+      status: 503,
+      headers: { "content-type": "application/json" }
+    });
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args);
+  };
+
+  try {
+    const datastore = createSupabaseDatastore({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseServiceRoleKey: "service-role-key"
+    });
+    const deleted = await datastore.deleteGameIfUnchanged(
+      "stale-lobby",
+      4,
+      "2026-07-20T10:00:00.000Z"
+    );
+
+    assert.equal(deleted, true);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0]?.[0]), /Failed to clear active game/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
   }
 });
 

--- a/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
+++ b/tests/gameplay/regression/tooling-and-supabase-regressions.test.cts
@@ -105,6 +105,52 @@ register("Supabase app-state compare-and-set uses the atomic service-role RPC", 
   }
 });
 
+register("Supabase stale-lobby deletion uses exact optimistic-concurrency filters", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const expectedUpdatedAt = "2026-07-20T10:00:00.000Z";
+
+  globalThis.fetch = async (input: unknown, init?: RequestInit) => {
+    const url = String(input || "");
+    requests.push({ url, init });
+    if (url.includes("/games?")) {
+      return new Response(JSON.stringify([{ id: "stale-lobby" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
+    return new Response("[]", {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    });
+  };
+
+  try {
+    const datastore = createSupabaseDatastore({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseServiceRoleKey: "service-role-key"
+    });
+    const deleted = await datastore.deleteGameIfUnchanged("stale-lobby", 4, expectedUpdatedAt);
+
+    assert.equal(deleted, true);
+    const deleteRequest = requests.find((request) => request.init?.method === "DELETE");
+    if (!deleteRequest) {
+      throw new Error("Expected an atomic Supabase DELETE request.");
+    }
+    const deleteUrl = new URL(deleteRequest.url);
+    assert.equal(deleteUrl.pathname, "/rest/v1/games");
+    assert.equal(deleteUrl.searchParams.get("id"), "eq.stale-lobby");
+    assert.equal(deleteUrl.searchParams.get("version"), "eq.4");
+    assert.equal(deleteUrl.searchParams.get("updated_at"), `eq.${expectedUpdatedAt}`);
+    assert.equal(
+      (deleteRequest.init?.headers as Record<string, string>).Prefer,
+      "return=representation"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 register("Supabase connection check probes core REST tables without exposing secrets", async () => {
   const requestedUrls: string[] = [];
   const requestedHeaders: Array<Record<string, string>> = [];

--- a/tests/gameplay/shared/module-versions.test.cts
+++ b/tests/gameplay/shared/module-versions.test.cts
@@ -43,10 +43,10 @@ register("module version manifest centrally lists current functional modules", (
   assert.equal(moduleIds.includes("public-state"), true);
 
   assert.equal(getFunctionalModuleVersion("maps")?.version, "1.0.0");
-  assert.equal(getFunctionalModuleVersion("admin-console")?.version, "1.1.0");
+  assert.equal(getFunctionalModuleVersion("admin-console")?.version, "1.2.0");
   assert.equal(getFunctionalModuleVersion("module-runtime")?.version, "1.2.0");
-  assert.equal(getFunctionalModuleVersion("public-state")?.version, "1.3.0");
-  assert.equal(getFunctionalModuleVersion("datastore")?.version, "1.1.0");
+  assert.equal(getFunctionalModuleVersion("public-state")?.version, "1.4.0");
+  assert.equal(getFunctionalModuleVersion("datastore")?.version, "1.2.0");
   assert.equal(
     getFunctionalModuleVersion("admin-console")?.ownerPaths.includes("backend/admin-console.cts"),
     true

--- a/tests/gameplay/shared/version-registry.test.cts
+++ b/tests/gameplay/shared/version-registry.test.cts
@@ -34,7 +34,7 @@ function cleanupSqliteFiles(dbFile: string) {
 }
 
 register("version manifest exports the central compatibility fields", () => {
-  assert.equal(apiVersion, "1.1.0");
+  assert.equal(apiVersion, "1.2.0");
   assert.equal(datastoreSchemaVersion, 2);
   assert.deepEqual(versionManifest, {
     appVersion,


### PR DESCRIPTION
## Summary
- delete only stale lobby rows that still match the re-read ID, phase, age, version, and timestamp
- expose the configured threshold and exact eligible lobby list in Maintenance
- return and audit exact removed, skipped, and failed results, then immediately revalidate Maintenance/System Health
- add isolated SQLite/Supabase/API/React/Playwright coverage for stale, recent, active, finished, race, and failure cases

## Verification
- `npm run test:all` — 173 React, 167 backend, 509 gameplay tests passed
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run typecheck:frontend`
- `npm run typecheck:react-shell`
- `npm run release:check`
- `npm run check:module-versioning`
- Playwright UAT scenario added; preview browser execution pending the Vercel deployment (the local image lacks the pinned Chromium binary)

Closes #370