### PR TITLE
Fix mobile map fit and add pinch-to-zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.061 - 2026-08-06
+
+- Added fit-to-view zoom for horizontally cropped mobile maps so the complete board can be displayed on screen.
+- Added native two-pointer pinch-to-zoom while preserving one-pointer panning, mouse wheel zoom, and the existing zoom controls.
+- Added unit and mobile browser regressions for minimum-scale calculation, full-board visibility, and pinch gesture behavior.
+
 ## 0.1.060 - 2026-08-06
 
 - Replaced stale-lobby phase mutation with atomic deletion guarded by game ID, version, and update timestamp so concurrent activity is never removed.

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -564,6 +564,119 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
   }
 });
 
+test("mobile map can fit the whole board and supports two-finger pinch zoom", async ({ page }) => {
+  await page.setViewportSize(mobileViewports[0]);
+  await openWorldClassicGame(page);
+
+  const surface = page.locator("[data-map-surface]");
+  await expect(surface).toBeVisible();
+  const initialScale = Number(await surface.getAttribute("data-map-scale"));
+  const minimumScale = Number(await surface.getAttribute("data-map-min-scale"));
+  expect(initialScale).toBeCloseTo(1, 3);
+  expect(minimumScale).toBeGreaterThanOrEqual(0.5);
+  expect(minimumScale).toBeLessThan(1);
+
+  await page.locator("[data-map-control='focus']").click();
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeCloseTo(minimumScale, 3);
+
+  const fittedLayout = await page.evaluate(() => {
+    const surfaceElement = document.querySelector("[data-map-surface]");
+    const board = document.querySelector(".game-map-stage .map-board");
+    if (!surfaceElement || !board) {
+      throw new Error("Missing map surface or board");
+    }
+
+    const surfaceRect = surfaceElement.getBoundingClientRect();
+    const boardRect = board.getBoundingClientRect();
+    return {
+      boardHeight: boardRect.height,
+      boardWidth: boardRect.width,
+      surfaceHeight: surfaceRect.height,
+      surfaceWidth: surfaceRect.width
+    };
+  });
+  expect(fittedLayout.boardWidth).toBeLessThanOrEqual(fittedLayout.surfaceWidth + 1);
+  expect(fittedLayout.boardHeight).toBeLessThanOrEqual(fittedLayout.surfaceHeight + 1);
+
+  await page.evaluate(() => {
+    const surfaceElement = document.querySelector("[data-map-surface]");
+    if (!surfaceElement) {
+      throw new Error("Missing map surface");
+    }
+
+    const rect = surfaceElement.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const dispatchTouchPointer = (type, pointerId, clientX, clientY) => {
+      surfaceElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          button: 0,
+          buttons: type === "pointerup" ? 0 : 1,
+          clientX,
+          clientY,
+          isPrimary: pointerId === 41,
+          pointerId,
+          pointerType: "touch"
+        })
+      );
+    };
+
+    dispatchTouchPointer("pointerdown", 41, centerX - 40, centerY);
+    dispatchTouchPointer("pointerdown", 42, centerX + 40, centerY);
+    dispatchTouchPointer("pointermove", 41, centerX - 80, centerY);
+    dispatchTouchPointer("pointermove", 42, centerX + 80, centerY);
+    dispatchTouchPointer("pointerup", 41, centerX - 80, centerY);
+    dispatchTouchPointer("pointerup", 42, centerX + 80, centerY);
+  });
+
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeGreaterThan(minimumScale + 0.2);
+  const zoomedScale = Number(await surface.getAttribute("data-map-scale"));
+
+  await page.evaluate(() => {
+    const surfaceElement = document.querySelector("[data-map-surface]");
+    if (!surfaceElement) {
+      throw new Error("Missing map surface");
+    }
+
+    const rect = surfaceElement.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const dispatchTouchPointer = (type, pointerId, clientX, clientY) => {
+      surfaceElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          button: 0,
+          buttons: type === "pointerup" ? 0 : 1,
+          clientX,
+          clientY,
+          isPrimary: pointerId === 51,
+          pointerId,
+          pointerType: "touch"
+        })
+      );
+    };
+
+    dispatchTouchPointer("pointerdown", 51, centerX - 80, centerY);
+    dispatchTouchPointer("pointerdown", 52, centerX + 80, centerY);
+    dispatchTouchPointer("pointermove", 51, centerX - 10, centerY);
+    dispatchTouchPointer("pointermove", 52, centerX + 10, centerY);
+    dispatchTouchPointer("pointerup", 51, centerX - 10, centerY);
+    dispatchTouchPointer("pointerup", 52, centerX + 10, centerY);
+  });
+
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeLessThan(zoomedScale);
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeCloseTo(minimumScale, 3);
+});
+
 test("mobile attack sheet keeps primary actions visible and expands only secondary actions", async ({
   page
 }) => {

--- a/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
+++ b/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { calculateFittedBoardSize } from "@react-shell/gameplay-map-viewport";
+import {
+  calculateFittedBoardSize,
+  calculateMinimumViewportScale
+} from "@react-shell/gameplay-map-viewport";
 
 describe("GameplayMapViewport fitting", () => {
   it("keeps portrait maps within the available height when horizontal crop is enabled", () => {
@@ -14,6 +17,36 @@ describe("GameplayMapViewport fitting", () => {
 
     expect(frame.width).toBeLessThan(390);
     expect(frame.height).toBeLessThanOrEqual(640);
+  });
+
+  it("calculates the scale needed to reveal a horizontally cropped mobile board", () => {
+    expect(
+      calculateMinimumViewportScale({
+        boardHeight: 616,
+        boardWidth: 741,
+        surfaceHeight: 616,
+        surfaceWidth: 390
+      })
+    ).toBeCloseTo(390 / 741, 5);
+  });
+
+  it("keeps desktop boards at the default scale and caps extreme fit ratios", () => {
+    expect(
+      calculateMinimumViewportScale({
+        boardHeight: 500,
+        boardWidth: 760,
+        surfaceHeight: 500,
+        surfaceWidth: 760
+      })
+    ).toBe(1);
+    expect(
+      calculateMinimumViewportScale({
+        boardHeight: 500,
+        boardWidth: 2000,
+        surfaceHeight: 500,
+        surfaceWidth: 390
+      })
+    ).toBe(0.5);
   });
 
   it("allows horizontal crop for wide maps that can still fit vertically", () => {

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -18,7 +18,8 @@ import { t } from "@frontend-i18n";
 
 import { WarTableIcon } from "@react-shell/war-table-icons";
 
-const MAP_VIEWPORT_MIN_SCALE = 1;
+const MAP_VIEWPORT_DEFAULT_SCALE = 1;
+const MAP_VIEWPORT_ABSOLUTE_MIN_SCALE = 0.5;
 const MAP_VIEWPORT_MAX_SCALE = 3;
 const MAP_VIEWPORT_WHEEL_FACTOR = 1.18;
 const MAP_VIEWPORT_BUTTON_STEP = 0.2;
@@ -70,6 +71,24 @@ type FittedBoardSizeInput = {
   stagePaddingY: number;
 };
 
+type MinimumViewportScaleInput = {
+  boardHeight: number;
+  boardWidth: number;
+  surfaceHeight: number;
+  surfaceWidth: number;
+};
+
+type PointerPosition = {
+  clientX: number;
+  clientY: number;
+};
+
+type PinchState = {
+  pointerIds: [number, number];
+  startDistance: number;
+  startScale: number;
+};
+
 type GameplayMapViewportProps = {
   attackFromId: string;
   attackToId: string;
@@ -88,6 +107,27 @@ function clampNumber(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value));
 }
 
+export function calculateMinimumViewportScale({
+  boardHeight,
+  boardWidth,
+  surfaceHeight,
+  surfaceWidth
+}: MinimumViewportScaleInput): number {
+  if (surfaceWidth <= 0 || surfaceHeight <= 0 || boardWidth <= 0 || boardHeight <= 0) {
+    return MAP_VIEWPORT_DEFAULT_SCALE;
+  }
+
+  return clampNumber(
+    Math.min(
+      MAP_VIEWPORT_DEFAULT_SCALE,
+      surfaceWidth / boardWidth,
+      surfaceHeight / boardHeight
+    ),
+    MAP_VIEWPORT_ABSOLUTE_MIN_SCALE,
+    MAP_VIEWPORT_DEFAULT_SCALE
+  );
+}
+
 function clampTranslation(
   translateX: number,
   translateY: number,
@@ -101,8 +141,8 @@ function clampTranslation(
     return { x: translateX, y: translateY };
   }
 
-  const overflowX = Math.max(0, (boardWidth * scale) / 2);
-  const overflowY = Math.max(0, (boardHeight * scale) / 2);
+  const overflowX = Math.max(0, (boardWidth * scale - surfaceWidth) / 2);
+  const overflowY = Math.max(0, (boardHeight * scale - surfaceHeight) / 2);
 
   return {
     x: clampNumber(translateX, -overflowX, overflowX),
@@ -117,7 +157,13 @@ function normalizeViewport(
   boardWidth: number,
   boardHeight: number
 ): ViewportState {
-  const scale = clampNumber(viewport.scale, MAP_VIEWPORT_MIN_SCALE, MAP_VIEWPORT_MAX_SCALE);
+  const minimumScale = calculateMinimumViewportScale({
+    boardHeight,
+    boardWidth,
+    surfaceHeight,
+    surfaceWidth
+  });
+  const scale = clampNumber(viewport.scale, minimumScale, MAP_VIEWPORT_MAX_SCALE);
   const clampedTranslation = clampTranslation(
     viewport.translateX,
     viewport.translateY,
@@ -266,7 +312,7 @@ export function GameplayMapViewport({
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null);
   const viewportRef = useRef<ViewportState>({
-    scale: MAP_VIEWPORT_MIN_SCALE,
+    scale: MAP_VIEWPORT_DEFAULT_SCALE,
     translateX: 0,
     translateY: 0,
     isDragging: false
@@ -280,6 +326,8 @@ export function GameplayMapViewport({
     suppressClick: false,
     didDrag: false
   });
+  const activePointersRef = useRef<Map<number, PointerPosition>>(new Map());
+  const pinchStateRef = useRef<PinchState | null>(null);
   const [surfaceSize, setSurfaceSize] = useState({ width: 0, height: 0 });
   const [fittedBoardFrame, setFittedBoardFrame] = useState<{
     width: number;
@@ -287,7 +335,7 @@ export function GameplayMapViewport({
   } | null>(null);
   const [renderedBoardFrame, setRenderedBoardFrame] = useState<BoardFrame | null>(null);
   const [viewport, setViewport] = useState<ViewportState>({
-    scale: MAP_VIEWPORT_MIN_SCALE,
+    scale: MAP_VIEWPORT_DEFAULT_SCALE,
     translateX: 0,
     translateY: 0,
     isDragging: false
@@ -419,6 +467,40 @@ export function GameplayMapViewport({
 
   useEffect(() => {
     function handleWindowPointerMove(event: globalThis.PointerEvent): void {
+      if (activePointersRef.current.has(event.pointerId)) {
+        activePointersRef.current.set(event.pointerId, {
+          clientX: event.clientX,
+          clientY: event.clientY
+        });
+      }
+
+      const pinchState = pinchStateRef.current;
+      if (pinchState) {
+        const firstPointer = activePointersRef.current.get(pinchState.pointerIds[0]);
+        const secondPointer = activePointersRef.current.get(pinchState.pointerIds[1]);
+        if (!firstPointer || !secondPointer) {
+          return;
+        }
+
+        const distance = Math.hypot(
+          secondPointer.clientX - firstPointer.clientX,
+          secondPointer.clientY - firstPointer.clientY
+        );
+        if (distance <= 0 || pinchState.startDistance <= 0) {
+          return;
+        }
+
+        dragStateRef.current.didDrag = true;
+        dragStateRef.current.suppressClick = true;
+        zoomTo(
+          pinchState.startScale * (distance / pinchState.startDistance),
+          (firstPointer.clientX + secondPointer.clientX) / 2,
+          (firstPointer.clientY + secondPointer.clientY) / 2,
+          true
+        );
+        return;
+      }
+
       if (dragStateRef.current.pointerId !== event.pointerId) {
         return;
       }
@@ -436,8 +518,8 @@ export function GameplayMapViewport({
       dragStateRef.current.suppressClick = true;
       const nextSurfaceSize = currentSurfaceSize();
       const nextBoardSize = currentBoardSize();
-      setViewport((currentViewport) =>
-        normalizeViewport(
+      setViewport((currentViewport) => {
+        const nextViewport = normalizeViewport(
           {
             ...currentViewport,
             translateX: dragStateRef.current.startTranslateX + deltaX,
@@ -448,8 +530,10 @@ export function GameplayMapViewport({
           nextSurfaceSize.height,
           nextBoardSize.width,
           nextBoardSize.height
-        )
-      );
+        );
+        viewportRef.current = nextViewport;
+        return nextViewport;
+      });
     }
 
     function handleWindowPointerFinish(event: globalThis.PointerEvent): void {
@@ -461,6 +545,8 @@ export function GameplayMapViewport({
     window.addEventListener("pointercancel", handleWindowPointerFinish);
 
     return () => {
+      activePointersRef.current.clear();
+      pinchStateRef.current = null;
       window.removeEventListener("pointermove", handleWindowPointerMove);
       window.removeEventListener("pointerup", handleWindowPointerFinish);
       window.removeEventListener("pointercancel", handleWindowPointerFinish);
@@ -580,6 +666,8 @@ export function GameplayMapViewport({
   ]);
 
   useEffect(() => {
+    activePointersRef.current.clear();
+    pinchStateRef.current = null;
     dragStateRef.current = {
       pointerId: null,
       startClientX: 0,
@@ -590,7 +678,7 @@ export function GameplayMapViewport({
       didDrag: false
     };
     setViewport({
-      scale: MAP_VIEWPORT_MIN_SCALE,
+      scale: MAP_VIEWPORT_DEFAULT_SCALE,
       translateX: 0,
       translateY: 0,
       isDragging: false
@@ -603,7 +691,12 @@ export function GameplayMapViewport({
     snapshot.mapVisual?.aspectRatio?.width
   ]);
 
-  function zoomTo(nextScale: number, clientX: number, clientY: number): void {
+  function zoomTo(
+    nextScale: number,
+    clientX: number,
+    clientY: number,
+    isGestureActive = false
+  ): void {
     const surface = surfaceRef.current;
     const nextSurfaceSize = currentSurfaceSize();
     const nextBoardSize = currentBoardSize();
@@ -619,19 +712,32 @@ export function GameplayMapViewport({
         nextBoardSize.width,
         nextBoardSize.height
       );
-      const clampedScale = clampNumber(nextScale, MAP_VIEWPORT_MIN_SCALE, MAP_VIEWPORT_MAX_SCALE);
-      if (clampedScale <= MAP_VIEWPORT_MIN_SCALE + 0.001 && nextScale <= normalizedViewport.scale) {
-        return {
+      const minimumScale = calculateMinimumViewportScale({
+        boardHeight: nextBoardSize.height,
+        boardWidth: nextBoardSize.width,
+        surfaceHeight: nextSurfaceSize.height,
+        surfaceWidth: nextSurfaceSize.width
+      });
+      const clampedScale = clampNumber(nextScale, minimumScale, MAP_VIEWPORT_MAX_SCALE);
+      if (clampedScale <= minimumScale + 0.001 && nextScale <= normalizedViewport.scale) {
+        const nextViewport = {
           ...normalizedViewport,
-          scale: MAP_VIEWPORT_MIN_SCALE,
+          scale: minimumScale,
           translateX: 0,
           translateY: 0,
-          isDragging: false
+          isDragging: isGestureActive
         };
+        viewportRef.current = nextViewport;
+        return nextViewport;
       }
 
       if (Math.abs(clampedScale - normalizedViewport.scale) < 0.001) {
-        return normalizedViewport;
+        const nextViewport = {
+          ...normalizedViewport,
+          isDragging: isGestureActive
+        };
+        viewportRef.current = nextViewport;
+        return nextViewport;
       }
 
       const surfaceRect = surface.getBoundingClientRect();
@@ -643,19 +749,20 @@ export function GameplayMapViewport({
       const contentY = (localY - currentCenterY) / normalizedViewport.scale;
       const nextTranslateX = localX - nextSurfaceSize.width / 2 - contentX * clampedScale;
       const nextTranslateY = localY - nextSurfaceSize.height / 2 - contentY * clampedScale;
-
-      return normalizeViewport(
+      const nextViewport = normalizeViewport(
         {
           scale: clampedScale,
           translateX: nextTranslateX,
           translateY: nextTranslateY,
-          isDragging: false
+          isDragging: isGestureActive
         },
         nextSurfaceSize.width,
         nextSurfaceSize.height,
         nextBoardSize.width,
         nextBoardSize.height
       );
+      viewportRef.current = nextViewport;
+      return nextViewport;
     });
   }
 
@@ -665,18 +772,31 @@ export function GameplayMapViewport({
       return;
     }
 
+    const nextSurfaceSize = currentSurfaceSize();
+    const nextBoardSize = currentBoardSize();
+    const minimumScale = calculateMinimumViewportScale({
+      boardHeight: nextBoardSize.height,
+      boardWidth: nextBoardSize.width,
+      surfaceHeight: nextSurfaceSize.height,
+      surfaceWidth: nextSurfaceSize.width
+    });
+
     if (
       direction === -1 &&
-      viewport.scale <= MAP_VIEWPORT_MIN_SCALE + 0.001 &&
+      viewport.scale <= minimumScale + 0.001 &&
       Math.hypot(viewport.translateX, viewport.translateY) > 1
     ) {
-      setViewport((currentViewport) => ({
-        ...currentViewport,
-        scale: MAP_VIEWPORT_MIN_SCALE,
-        translateX: 0,
-        translateY: 0,
-        isDragging: false
-      }));
+      setViewport((currentViewport) => {
+        const nextViewport = {
+          ...currentViewport,
+          scale: minimumScale,
+          translateX: 0,
+          translateY: 0,
+          isDragging: false
+        };
+        viewportRef.current = nextViewport;
+        return nextViewport;
+      });
       return;
     }
 
@@ -688,8 +808,51 @@ export function GameplayMapViewport({
     );
   }
 
+  function startPinchGesture(): boolean {
+    const pointers = Array.from(activePointersRef.current.entries()).slice(0, 2);
+    if (pointers.length < 2) {
+      return false;
+    }
+
+    const [[firstPointerId, firstPointer], [secondPointerId, secondPointer]] = pointers;
+    const startDistance = Math.hypot(
+      secondPointer.clientX - firstPointer.clientX,
+      secondPointer.clientY - firstPointer.clientY
+    );
+    if (startDistance <= 0) {
+      return false;
+    }
+
+    pinchStateRef.current = {
+      pointerIds: [firstPointerId, secondPointerId],
+      startDistance,
+      startScale: viewportRef.current.scale
+    };
+    dragStateRef.current.pointerId = null;
+    dragStateRef.current.didDrag = true;
+    dragStateRef.current.suppressClick = true;
+    setViewport((currentViewport) => {
+      const nextViewport = {
+        ...currentViewport,
+        isDragging: true
+      };
+      viewportRef.current = nextViewport;
+      return nextViewport;
+    });
+    return true;
+  }
+
   function handlePointerDown(event: PointerEvent<HTMLDivElement>): void {
-    if (event.button !== 0) {
+    if (event.pointerType !== "touch" && event.button !== 0) {
+      return;
+    }
+
+    viewportRef.current = viewport;
+    activePointersRef.current.set(event.pointerId, {
+      clientX: event.clientX,
+      clientY: event.clientY
+    });
+    if (activePointersRef.current.size >= 2 && startPinchGesture()) {
       return;
     }
 
@@ -702,23 +865,69 @@ export function GameplayMapViewport({
       suppressClick: false,
       didDrag: false
     };
-    viewportRef.current = viewport;
   }
 
   function finishPointer(pointerId: number): void {
+    activePointersRef.current.delete(pointerId);
+
+    if (pinchStateRef.current) {
+      pinchStateRef.current = null;
+      dragStateRef.current.suppressClick = true;
+      dragStateRef.current.didDrag = true;
+
+      if (activePointersRef.current.size >= 2 && startPinchGesture()) {
+        return;
+      }
+
+      const remainingPointer = activePointersRef.current.entries().next().value as
+        | [number, PointerPosition]
+        | undefined;
+      const currentViewport = viewportRef.current;
+      dragStateRef.current = remainingPointer
+        ? {
+            pointerId: remainingPointer[0],
+            startClientX: remainingPointer[1].clientX,
+            startClientY: remainingPointer[1].clientY,
+            startTranslateX: currentViewport.translateX,
+            startTranslateY: currentViewport.translateY,
+            suppressClick: true,
+            didDrag: true
+          }
+        : {
+            pointerId: null,
+            startClientX: 0,
+            startClientY: 0,
+            startTranslateX: currentViewport.translateX,
+            startTranslateY: currentViewport.translateY,
+            suppressClick: true,
+            didDrag: true
+          };
+      setViewport((currentState) => {
+        const nextViewport = {
+          ...currentState,
+          isDragging: false
+        };
+        viewportRef.current = nextViewport;
+        return nextViewport;
+      });
+      return;
+    }
+
     if (dragStateRef.current.pointerId !== pointerId) {
       return;
     }
 
     dragStateRef.current.pointerId = null;
-    setViewport((currentViewport) =>
-      currentViewport.isDragging
+    setViewport((currentViewport) => {
+      const nextViewport = currentViewport.isDragging
         ? {
             ...currentViewport,
             isDragging: false
           }
-        : currentViewport
-    );
+        : currentViewport;
+      viewportRef.current = nextViewport;
+      return nextViewport;
+    });
   }
 
   function handleTerritoryClick(territoryId: string): void {
@@ -730,9 +939,17 @@ export function GameplayMapViewport({
     onTerritorySelect(territoryId);
   }
 
+  const viewportSize = currentSurfaceSize();
+  const boardSize = currentBoardSize();
+  const minimumScale = calculateMinimumViewportScale({
+    boardHeight: boardSize.height,
+    boardWidth: boardSize.width,
+    surfaceHeight: viewportSize.height,
+    surfaceWidth: viewportSize.width
+  });
   const hasViewportOffset = Math.hypot(viewport.translateX, viewport.translateY) > 1;
   const connectionBadgeClassName =
-    viewport.scale > MAP_VIEWPORT_MIN_SCALE + 0.001 || hasViewportOffset
+    Math.abs(viewport.scale - MAP_VIEWPORT_DEFAULT_SCALE) > 0.001 || hasViewportOffset
       ? viewport.isDragging
         ? "map-board-surface is-zoomed is-dragging"
         : "map-board-surface is-zoomed"
@@ -766,8 +983,6 @@ export function GameplayMapViewport({
         }
       : {})
   } as CSSProperties;
-  const viewportSize = currentSurfaceSize();
-  const boardSize = currentBoardSize();
   const markerBoardFrame =
     renderedBoardFrame ||
     ({
@@ -805,7 +1020,7 @@ export function GameplayMapViewport({
             aria-label={t("game.map.zoomOut")}
             title={t("game.map.zoomOut")}
             onClick={() => zoomByStep(-1)}
-            disabled={viewport.scale <= MAP_VIEWPORT_MIN_SCALE + 0.001 && !hasViewportOffset}
+            disabled={viewport.scale <= minimumScale + 0.001 && !hasViewportOffset}
           >
             <span aria-hidden="true">-</span>
           </button>
@@ -816,11 +1031,15 @@ export function GameplayMapViewport({
             aria-label={t("game.map.reset")}
             title={t("game.map.reset")}
             onClick={() =>
-              setViewport({
-                scale: MAP_VIEWPORT_MIN_SCALE,
-                translateX: 0,
-                translateY: 0,
-                isDragging: false
+              setViewport(() => {
+                const nextViewport = {
+                  scale: minimumScale,
+                  translateX: 0,
+                  translateY: 0,
+                  isDragging: false
+                };
+                viewportRef.current = nextViewport;
+                return nextViewport;
               })
             }
           >
@@ -833,6 +1052,7 @@ export function GameplayMapViewport({
           className={connectionBadgeClassName}
           data-map-surface=""
           data-map-scale={viewport.scale.toFixed(3)}
+          data-map-min-scale={minimumScale.toFixed(3)}
           data-map-node-scale={nodeScale.toFixed(4)}
           data-map-translate-x={viewport.translateX.toFixed(2)}
           data-map-translate-y={viewport.translateY.toFixed(2)}

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -118,11 +118,7 @@ export function calculateMinimumViewportScale({
   }
 
   return clampNumber(
-    Math.min(
-      MAP_VIEWPORT_DEFAULT_SCALE,
-      surfaceWidth / boardWidth,
-      surfaceHeight / boardHeight
-    ),
+    Math.min(MAP_VIEWPORT_DEFAULT_SCALE, surfaceWidth / boardWidth, surfaceHeight / boardHeight),
     MAP_VIEWPORT_ABSOLUTE_MIN_SCALE,
     MAP_VIEWPORT_DEFAULT_SCALE
   );

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.060";
+export const appVersion = "0.1.061";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.2.0";
 export const datastoreSchemaVersion = 2;


### PR DESCRIPTION
## Summary

- calculate a responsive minimum zoom so horizontally cropped mobile maps can be fully visible
- add native two-pointer pinch-to-zoom while preserving one-pointer pan, wheel zoom, and +/- controls
- make the focus control fit the entire board and expose the computed minimum scale for browser assertions
- add unit and mobile browser regression coverage
- bump the app release to 0.1.061 and document the change

## Local validation

- `npm run typecheck:react-shell`
- focused map viewport unit tests (4/4)
- `npm run test:react` (175/175)
- targeted ESLint
- `npm run test:all` (175 React + 167 application + 510 gameplay)
- `npm run release:check`
- `npm run format:check`
- production build and transfer budgets

The targeted Playwright test is committed for CI. Local execution reached the Playwright preflight but the pinned browser download was unavailable in this environment; the preview deployment will also receive manual mobile UAT before merge.

Closes #363