### PR TITLE
Fix mobile map fit and add pinch-to-zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 NetRisk uses the application version from `shared/version-manifest.cts` as the release source of truth. Every merge to `main` must include a new app version and a changelog entry for that version.
 
+## 0.1.061 - 2026-08-06
+
+- Added fit-to-view zoom for horizontally cropped mobile maps so the complete board can be displayed on screen.
+- Added native two-pointer pinch-to-zoom while preserving one-pointer panning, mouse wheel zoom, and the existing zoom controls.
+- Added unit and mobile browser regressions for minimum-scale calculation, full-board visibility, and pinch gesture behavior.
+
 ## 0.1.060 - 2026-08-06
 
 - Replaced stale-lobby phase mutation with atomic deletion guarded by game ID, version, and update timestamp so concurrent activity is never removed.

--- a/docs/mobile-map-gestures.md
+++ b/docs/mobile-map-gestures.md
@@ -1,0 +1,10 @@
+# Mobile map gestures
+
+On phone-sized game screens, the map keeps the cropped tactical view by default while allowing the complete board to fit inside the viewport.
+
+- Pinch with two fingers to zoom in or out around the gesture midpoint.
+- Drag with one finger to pan while zoomed.
+- Use the plus and minus controls as accessible alternatives.
+- Use the focus control to center the map and fit the complete board on screen.
+
+The supported mobile acceptance viewports are 360 × 780, 390 × 844, and 430 × 932.

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -564,6 +564,119 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
   }
 });
 
+test("mobile map can fit the whole board and supports two-finger pinch zoom", async ({ page }) => {
+  await page.setViewportSize(mobileViewports[0]);
+  await openWorldClassicGame(page);
+
+  const surface = page.locator("[data-map-surface]");
+  await expect(surface).toBeVisible();
+  const initialScale = Number(await surface.getAttribute("data-map-scale"));
+  const minimumScale = Number(await surface.getAttribute("data-map-min-scale"));
+  expect(initialScale).toBeCloseTo(1, 3);
+  expect(minimumScale).toBeGreaterThanOrEqual(0.5);
+  expect(minimumScale).toBeLessThan(1);
+
+  await page.locator("[data-map-control='focus']").click();
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeCloseTo(minimumScale, 3);
+
+  const fittedLayout = await page.evaluate(() => {
+    const surfaceElement = document.querySelector("[data-map-surface]");
+    const board = document.querySelector(".game-map-stage .map-board");
+    if (!surfaceElement || !board) {
+      throw new Error("Missing map surface or board");
+    }
+
+    const surfaceRect = surfaceElement.getBoundingClientRect();
+    const boardRect = board.getBoundingClientRect();
+    return {
+      boardHeight: boardRect.height,
+      boardWidth: boardRect.width,
+      surfaceHeight: surfaceRect.height,
+      surfaceWidth: surfaceRect.width
+    };
+  });
+  expect(fittedLayout.boardWidth).toBeLessThanOrEqual(fittedLayout.surfaceWidth + 1);
+  expect(fittedLayout.boardHeight).toBeLessThanOrEqual(fittedLayout.surfaceHeight + 1);
+
+  await page.evaluate(() => {
+    const surfaceElement = document.querySelector("[data-map-surface]");
+    if (!surfaceElement) {
+      throw new Error("Missing map surface");
+    }
+
+    const rect = surfaceElement.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const dispatchTouchPointer = (type, pointerId, clientX, clientY) => {
+      surfaceElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          button: 0,
+          buttons: type === "pointerup" ? 0 : 1,
+          clientX,
+          clientY,
+          isPrimary: pointerId === 41,
+          pointerId,
+          pointerType: "touch"
+        })
+      );
+    };
+
+    dispatchTouchPointer("pointerdown", 41, centerX - 40, centerY);
+    dispatchTouchPointer("pointerdown", 42, centerX + 40, centerY);
+    dispatchTouchPointer("pointermove", 41, centerX - 80, centerY);
+    dispatchTouchPointer("pointermove", 42, centerX + 80, centerY);
+    dispatchTouchPointer("pointerup", 41, centerX - 80, centerY);
+    dispatchTouchPointer("pointerup", 42, centerX + 80, centerY);
+  });
+
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeGreaterThan(minimumScale + 0.2);
+  const zoomedScale = Number(await surface.getAttribute("data-map-scale"));
+
+  await page.evaluate(() => {
+    const surfaceElement = document.querySelector("[data-map-surface]");
+    if (!surfaceElement) {
+      throw new Error("Missing map surface");
+    }
+
+    const rect = surfaceElement.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const dispatchTouchPointer = (type, pointerId, clientX, clientY) => {
+      surfaceElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          button: 0,
+          buttons: type === "pointerup" ? 0 : 1,
+          clientX,
+          clientY,
+          isPrimary: pointerId === 51,
+          pointerId,
+          pointerType: "touch"
+        })
+      );
+    };
+
+    dispatchTouchPointer("pointerdown", 51, centerX - 80, centerY);
+    dispatchTouchPointer("pointerdown", 52, centerX + 80, centerY);
+    dispatchTouchPointer("pointermove", 51, centerX - 10, centerY);
+    dispatchTouchPointer("pointermove", 52, centerX + 10, centerY);
+    dispatchTouchPointer("pointerup", 51, centerX - 10, centerY);
+    dispatchTouchPointer("pointerup", 52, centerX + 10, centerY);
+  });
+
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeLessThan(zoomedScale);
+  await expect
+    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+    .toBeCloseTo(minimumScale, 3);
+});
+
 test("mobile attack sheet keeps primary actions visible and expands only secondary actions", async ({
   page
 }) => {

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -564,117 +564,111 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
   }
 });
 
+async function pinchMap(page, { endHalfDistance, pointerId, startHalfDistance }) {
+  await page.evaluate(
+    ({
+      endHalfDistance: endDistance,
+      pointerId: firstPointerId,
+      startHalfDistance: startDistance
+    }) => {
+      const surfaceElement = document.querySelector("[data-map-surface]");
+      if (!surfaceElement) {
+        throw new Error("Missing map surface");
+      }
+
+      const rect = surfaceElement.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const dispatchTouchPointer = (type, currentPointerId, clientX) => {
+        surfaceElement.dispatchEvent(
+          new PointerEvent(type, {
+            bubbles: true,
+            button: 0,
+            buttons: type === "pointerup" ? 0 : 1,
+            clientX,
+            clientY: centerY,
+            isPrimary: currentPointerId === firstPointerId,
+            pointerId: currentPointerId,
+            pointerType: "touch"
+          })
+        );
+      };
+
+      dispatchTouchPointer("pointerdown", firstPointerId, centerX - startDistance);
+      dispatchTouchPointer("pointerdown", firstPointerId + 1, centerX + startDistance);
+      dispatchTouchPointer("pointermove", firstPointerId, centerX - endDistance);
+      dispatchTouchPointer("pointermove", firstPointerId + 1, centerX + endDistance);
+      dispatchTouchPointer("pointerup", firstPointerId, centerX - endDistance);
+      dispatchTouchPointer("pointerup", firstPointerId + 1, centerX + endDistance);
+    },
+    { endHalfDistance, pointerId, startHalfDistance }
+  );
+}
+
 test("mobile map can fit the whole board and supports two-finger pinch zoom", async ({ page }) => {
   await page.setViewportSize(mobileViewports[0]);
   await openWorldClassicGame(page);
 
-  const surface = page.locator("[data-map-surface]");
-  await expect(surface).toBeVisible();
-  const initialScale = Number(await surface.getAttribute("data-map-scale"));
-  const minimumScale = Number(await surface.getAttribute("data-map-min-scale"));
-  expect(initialScale).toBeCloseTo(1, 3);
-  expect(minimumScale).toBeGreaterThanOrEqual(0.5);
-  expect(minimumScale).toBeLessThan(1);
-
-  await page.locator("[data-map-control='focus']").click();
-  await expect
-    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
-    .toBeCloseTo(minimumScale, 3);
-
-  const fittedLayout = await page.evaluate(() => {
-    const surfaceElement = document.querySelector("[data-map-surface]");
-    const board = document.querySelector(".game-map-stage .map-board");
-    if (!surfaceElement || !board) {
-      throw new Error("Missing map surface or board");
+  for (const [viewportIndex, viewport] of mobileViewports.entries()) {
+    if (viewportIndex > 0) {
+      await page.setViewportSize(viewport);
+      await page.reload();
+      await expect(page.locator(".map-board.has-custom-background")).toBeVisible({
+        timeout: 15000
+      });
     }
 
-    const surfaceRect = surfaceElement.getBoundingClientRect();
-    const boardRect = board.getBoundingClientRect();
-    return {
-      boardHeight: boardRect.height,
-      boardWidth: boardRect.width,
-      surfaceHeight: surfaceRect.height,
-      surfaceWidth: surfaceRect.width
-    };
-  });
-  expect(fittedLayout.boardWidth).toBeLessThanOrEqual(fittedLayout.surfaceWidth + 1);
-  expect(fittedLayout.boardHeight).toBeLessThanOrEqual(fittedLayout.surfaceHeight + 1);
+    const surface = page.locator("[data-map-surface]");
+    await expect(surface).toBeVisible();
+    const initialScale = Number(await surface.getAttribute("data-map-scale"));
+    const minimumScale = Number(await surface.getAttribute("data-map-min-scale"));
+    expect(initialScale).toBeCloseTo(1, 3);
+    expect(minimumScale).toBeGreaterThan(0);
+    expect(minimumScale).toBeLessThan(1);
 
-  await page.evaluate(() => {
-    const surfaceElement = document.querySelector("[data-map-surface]");
-    if (!surfaceElement) {
-      throw new Error("Missing map surface");
-    }
+    await page.locator("[data-map-control='focus']").click();
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+      .toBeCloseTo(minimumScale, 3);
 
-    const rect = surfaceElement.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-    const dispatchTouchPointer = (type, pointerId, clientX, clientY) => {
-      surfaceElement.dispatchEvent(
-        new PointerEvent(type, {
-          bubbles: true,
-          button: 0,
-          buttons: type === "pointerup" ? 0 : 1,
-          clientX,
-          clientY,
-          isPrimary: pointerId === 41,
-          pointerId,
-          pointerType: "touch"
-        })
-      );
-    };
+    const fittedLayout = await page.evaluate(() => {
+      const surfaceElement = document.querySelector("[data-map-surface]");
+      const board = document.querySelector(".game-map-stage .map-board");
+      if (!surfaceElement || !board) {
+        throw new Error("Missing map surface or board");
+      }
 
-    dispatchTouchPointer("pointerdown", 41, centerX - 40, centerY);
-    dispatchTouchPointer("pointerdown", 42, centerX + 40, centerY);
-    dispatchTouchPointer("pointermove", 41, centerX - 80, centerY);
-    dispatchTouchPointer("pointermove", 42, centerX + 80, centerY);
-    dispatchTouchPointer("pointerup", 41, centerX - 80, centerY);
-    dispatchTouchPointer("pointerup", 42, centerX + 80, centerY);
-  });
+      const surfaceRect = surfaceElement.getBoundingClientRect();
+      const boardRect = board.getBoundingClientRect();
+      return {
+        boardHeight: boardRect.height,
+        boardWidth: boardRect.width,
+        surfaceHeight: surfaceRect.height,
+        surfaceWidth: surfaceRect.width
+      };
+    });
+    expect(fittedLayout.boardWidth).toBeLessThanOrEqual(fittedLayout.surfaceWidth + 1);
+    expect(fittedLayout.boardHeight).toBeLessThanOrEqual(fittedLayout.surfaceHeight + 1);
 
-  await expect
-    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
-    .toBeGreaterThan(minimumScale + 0.2);
-  const zoomedScale = Number(await surface.getAttribute("data-map-scale"));
+    const pointerId = 41 + viewportIndex * 20;
+    await pinchMap(page, { endHalfDistance: 80, pointerId, startHalfDistance: 40 });
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+      .toBeGreaterThan(minimumScale + 0.2);
+    const zoomedScale = Number(await surface.getAttribute("data-map-scale"));
 
-  await page.evaluate(() => {
-    const surfaceElement = document.querySelector("[data-map-surface]");
-    if (!surfaceElement) {
-      throw new Error("Missing map surface");
-    }
-
-    const rect = surfaceElement.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-    const dispatchTouchPointer = (type, pointerId, clientX, clientY) => {
-      surfaceElement.dispatchEvent(
-        new PointerEvent(type, {
-          bubbles: true,
-          button: 0,
-          buttons: type === "pointerup" ? 0 : 1,
-          clientX,
-          clientY,
-          isPrimary: pointerId === 51,
-          pointerId,
-          pointerType: "touch"
-        })
-      );
-    };
-
-    dispatchTouchPointer("pointerdown", 51, centerX - 80, centerY);
-    dispatchTouchPointer("pointerdown", 52, centerX + 80, centerY);
-    dispatchTouchPointer("pointermove", 51, centerX - 10, centerY);
-    dispatchTouchPointer("pointermove", 52, centerX + 10, centerY);
-    dispatchTouchPointer("pointerup", 51, centerX - 10, centerY);
-    dispatchTouchPointer("pointerup", 52, centerX + 10, centerY);
-  });
-
-  await expect
-    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
-    .toBeLessThan(zoomedScale);
-  await expect
-    .poll(async () => Number(await surface.getAttribute("data-map-scale")))
-    .toBeCloseTo(minimumScale, 3);
+    await pinchMap(page, {
+      endHalfDistance: 10,
+      pointerId: pointerId + 10,
+      startHalfDistance: 80
+    });
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+      .toBeLessThan(zoomedScale);
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+      .toBeCloseTo(minimumScale, 3);
+  }
 });
 
 test("mobile attack sheet keeps primary actions visible and expands only secondary actions", async ({

--- a/e2e/00-visual/mobile-game-shell.spec.ts
+++ b/e2e/00-visual/mobile-game-shell.spec.ts
@@ -564,11 +564,16 @@ test("mobile game shell keeps the map-first sheet layout playable", async ({ pag
   }
 });
 
-async function pinchMap(page, { endHalfDistance, pointerId, startHalfDistance }) {
+async function pinchMap(
+  page,
+  { endCenterOffsetX = 0, endHalfDistance, pointerId, startCenterOffsetX = 0, startHalfDistance }
+) {
   await page.evaluate(
     ({
+      endCenterOffsetX: endOffsetX,
       endHalfDistance: endDistance,
       pointerId: firstPointerId,
+      startCenterOffsetX: startOffsetX,
       startHalfDistance: startDistance
     }) => {
       const surfaceElement = document.querySelector("[data-map-surface]");
@@ -579,6 +584,8 @@ async function pinchMap(page, { endHalfDistance, pointerId, startHalfDistance })
       const rect = surfaceElement.getBoundingClientRect();
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
+      const startCenterX = centerX + startOffsetX;
+      const endCenterX = centerX + endOffsetX;
       const dispatchTouchPointer = (type, currentPointerId, clientX) => {
         surfaceElement.dispatchEvent(
           new PointerEvent(type, {
@@ -594,14 +601,54 @@ async function pinchMap(page, { endHalfDistance, pointerId, startHalfDistance })
         );
       };
 
-      dispatchTouchPointer("pointerdown", firstPointerId, centerX - startDistance);
-      dispatchTouchPointer("pointerdown", firstPointerId + 1, centerX + startDistance);
-      dispatchTouchPointer("pointermove", firstPointerId, centerX - endDistance);
-      dispatchTouchPointer("pointermove", firstPointerId + 1, centerX + endDistance);
-      dispatchTouchPointer("pointerup", firstPointerId, centerX - endDistance);
-      dispatchTouchPointer("pointerup", firstPointerId + 1, centerX + endDistance);
+      dispatchTouchPointer("pointerdown", firstPointerId, startCenterX - startDistance);
+      dispatchTouchPointer("pointerdown", firstPointerId + 1, startCenterX + startDistance);
+      dispatchTouchPointer("pointermove", firstPointerId, endCenterX - endDistance);
+      dispatchTouchPointer("pointermove", firstPointerId + 1, endCenterX + endDistance);
+      dispatchTouchPointer("pointerup", firstPointerId, endCenterX - endDistance);
+      dispatchTouchPointer("pointerup", firstPointerId + 1, endCenterX + endDistance);
     },
-    { endHalfDistance, pointerId, startHalfDistance }
+    {
+      endCenterOffsetX,
+      endHalfDistance,
+      pointerId,
+      startCenterOffsetX,
+      startHalfDistance
+    }
+  );
+}
+
+async function dragMap(page, { deltaY, pointerId }) {
+  await page.evaluate(
+    ({ deltaY: verticalDelta, pointerId: currentPointerId }) => {
+      const surfaceElement = document.querySelector("[data-map-surface]");
+      if (!surfaceElement) {
+        throw new Error("Missing map surface");
+      }
+
+      const rect = surfaceElement.getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2;
+      const startClientY = rect.top + rect.height / 2;
+      const dispatchTouchPointer = (type, clientY) => {
+        surfaceElement.dispatchEvent(
+          new PointerEvent(type, {
+            bubbles: true,
+            button: 0,
+            buttons: type === "pointerup" ? 0 : 1,
+            clientX,
+            clientY,
+            isPrimary: true,
+            pointerId: currentPointerId,
+            pointerType: "touch"
+          })
+        );
+      };
+
+      dispatchTouchPointer("pointerdown", startClientY);
+      dispatchTouchPointer("pointermove", startClientY + verticalDelta);
+      dispatchTouchPointer("pointerup", startClientY + verticalDelta);
+    },
+    { deltaY, pointerId }
   );
 }
 
@@ -625,6 +672,7 @@ test("mobile map can fit the whole board and supports two-finger pinch zoom", as
     expect(initialScale).toBeCloseTo(1, 3);
     expect(minimumScale).toBeGreaterThan(0);
     expect(minimumScale).toBeLessThan(1);
+    await expect(page.getByRole("button", { name: "Adatta mappa alla schermata" })).toBeVisible();
 
     await page.locator("[data-map-control='focus']").click();
     await expect
@@ -640,15 +688,33 @@ test("mobile map can fit the whole board and supports two-finger pinch zoom", as
 
       const surfaceRect = surfaceElement.getBoundingClientRect();
       const boardRect = board.getBoundingClientRect();
+      const viewportTop = Number(surfaceElement.getAttribute("data-map-viewport-top"));
+      const viewportBottom = Number(surfaceElement.getAttribute("data-map-viewport-bottom"));
       return {
+        boardBottom: boardRect.bottom,
         boardHeight: boardRect.height,
+        boardLeft: boardRect.left,
+        boardRight: boardRect.right,
+        boardTop: boardRect.top,
+        surfaceBottom: surfaceRect.bottom,
         boardWidth: boardRect.width,
         surfaceHeight: surfaceRect.height,
+        surfaceLeft: surfaceRect.left,
+        surfaceRight: surfaceRect.right,
+        surfaceSafeBottom: surfaceRect.top + viewportBottom,
+        surfaceSafeTop: surfaceRect.top + viewportTop,
+        surfaceTop: surfaceRect.top,
         surfaceWidth: surfaceRect.width
       };
     });
     expect(fittedLayout.boardWidth).toBeLessThanOrEqual(fittedLayout.surfaceWidth + 1);
     expect(fittedLayout.boardHeight).toBeLessThanOrEqual(fittedLayout.surfaceHeight + 1);
+    expect(fittedLayout.boardLeft).toBeGreaterThanOrEqual(fittedLayout.surfaceLeft - 1);
+    expect(fittedLayout.boardRight).toBeLessThanOrEqual(fittedLayout.surfaceRight + 1);
+    expect(fittedLayout.boardTop).toBeGreaterThanOrEqual(fittedLayout.surfaceTop - 1);
+    expect(fittedLayout.boardBottom).toBeLessThanOrEqual(fittedLayout.surfaceBottom + 1);
+    expect(fittedLayout.boardTop).toBeGreaterThanOrEqual(fittedLayout.surfaceSafeTop - 1);
+    expect(fittedLayout.boardBottom).toBeLessThanOrEqual(fittedLayout.surfaceSafeBottom + 1);
 
     const pointerId = 41 + viewportIndex * 20;
     await pinchMap(page, { endHalfDistance: 80, pointerId, startHalfDistance: 40 });
@@ -656,6 +722,27 @@ test("mobile map can fit the whole board and supports two-finger pinch zoom", as
       .poll(async () => Number(await surface.getAttribute("data-map-scale")))
       .toBeGreaterThan(minimumScale + 0.2);
     const zoomedScale = Number(await surface.getAttribute("data-map-scale"));
+    const symmetricPinchTranslateX = Number(await surface.getAttribute("data-map-translate-x"));
+    expect(Math.abs(symmetricPinchTranslateX)).toBeLessThanOrEqual(1);
+
+    const beforeVerticalDrag = Number(await surface.getAttribute("data-map-translate-y"));
+    await dragMap(page, { deltaY: 60, pointerId: pointerId + 2 });
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-translate-y")))
+      .toBeGreaterThan(beforeVerticalDrag + 20);
+
+    await pinchMap(page, {
+      endCenterOffsetX: 30,
+      endHalfDistance: 60,
+      pointerId: pointerId + 4,
+      startHalfDistance: 60
+    });
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-scale")))
+      .toBeCloseTo(zoomedScale, 3);
+    await expect
+      .poll(async () => Number(await surface.getAttribute("data-map-translate-x")))
+      .toBeGreaterThan(symmetricPinchTranslateX + 20);
 
     await pinchMap(page, {
       endHalfDistance: 10,

--- a/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
+++ b/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampViewportTranslation,
   calculateFittedBoardSize,
   calculateMinimumViewportScale
 } from "@react-shell/gameplay-map-viewport";
@@ -61,5 +62,24 @@ describe("GameplayMapViewport fitting", () => {
     expect(frame.width).toBeGreaterThan(390);
     expect(frame.width).toBeLessThanOrEqual(390 * 1.9);
     expect(frame.height).toBeLessThanOrEqual(640);
+  });
+
+  it("clamps panning around an off-center safe-area anchor", () => {
+    const translation = clampViewportTranslation({
+      anchorX: 195,
+      anchorY: 289,
+      boardHeight: 641,
+      boardWidth: 975,
+      scale: 1,
+      surfaceHeight: 786,
+      surfaceWidth: 390,
+      translateX: 0,
+      translateY: 500,
+      viewportBottom: 466,
+      viewportTop: 112
+    });
+
+    expect(translation.x).toBe(0);
+    expect(translation.y).toBeCloseTo(143.5, 5);
   });
 });

--- a/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
+++ b/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { calculateFittedBoardSize } from "@react-shell/gameplay-map-viewport";
+import {
+  calculateFittedBoardSize,
+  calculateMinimumViewportScale
+} from "@react-shell/gameplay-map-viewport";
 
 describe("GameplayMapViewport fitting", () => {
   it("keeps portrait maps within the available height when horizontal crop is enabled", () => {
@@ -14,6 +17,36 @@ describe("GameplayMapViewport fitting", () => {
 
     expect(frame.width).toBeLessThan(390);
     expect(frame.height).toBeLessThanOrEqual(640);
+  });
+
+  it("calculates the scale needed to reveal a horizontally cropped mobile board", () => {
+    expect(
+      calculateMinimumViewportScale({
+        boardHeight: 616,
+        boardWidth: 741,
+        surfaceHeight: 616,
+        surfaceWidth: 390
+      })
+    ).toBeCloseTo(390 / 741, 5);
+  });
+
+  it("keeps desktop boards at the default scale and caps extreme fit ratios", () => {
+    expect(
+      calculateMinimumViewportScale({
+        boardHeight: 500,
+        boardWidth: 760,
+        surfaceHeight: 500,
+        surfaceWidth: 760
+      })
+    ).toBe(1);
+    expect(
+      calculateMinimumViewportScale({
+        boardHeight: 500,
+        boardWidth: 2000,
+        surfaceHeight: 500,
+        surfaceWidth: 390
+      })
+    ).toBe(0.5);
   });
 
   it("allows horizontal crop for wide maps that can still fit vertically", () => {

--- a/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
+++ b/frontend/react-shell/src/__tests__/gameplay-map-viewport.test.ts
@@ -30,7 +30,7 @@ describe("GameplayMapViewport fitting", () => {
     ).toBeCloseTo(390 / 741, 5);
   });
 
-  it("keeps desktop boards at the default scale and caps extreme fit ratios", () => {
+  it("keeps desktop boards at the default scale and preserves the full-board fit ratio", () => {
     expect(
       calculateMinimumViewportScale({
         boardHeight: 500,
@@ -46,7 +46,7 @@ describe("GameplayMapViewport fitting", () => {
         surfaceHeight: 500,
         surfaceWidth: 390
       })
-    ).toBe(0.5);
+    ).toBeCloseTo(390 / 2000, 5);
   });
 
   it("allows horizontal crop for wide maps that can still fit vertically", () => {

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -18,7 +18,8 @@ import { t } from "@frontend-i18n";
 
 import { WarTableIcon } from "@react-shell/war-table-icons";
 
-const MAP_VIEWPORT_MIN_SCALE = 1;
+const MAP_VIEWPORT_DEFAULT_SCALE = 1;
+const MAP_VIEWPORT_ABSOLUTE_MIN_SCALE = 0.5;
 const MAP_VIEWPORT_MAX_SCALE = 3;
 const MAP_VIEWPORT_WHEEL_FACTOR = 1.18;
 const MAP_VIEWPORT_BUTTON_STEP = 0.2;
@@ -70,6 +71,24 @@ type FittedBoardSizeInput = {
   stagePaddingY: number;
 };
 
+type MinimumViewportScaleInput = {
+  boardHeight: number;
+  boardWidth: number;
+  surfaceHeight: number;
+  surfaceWidth: number;
+};
+
+type PointerPosition = {
+  clientX: number;
+  clientY: number;
+};
+
+type PinchState = {
+  pointerIds: [number, number];
+  startDistance: number;
+  startScale: number;
+};
+
 type GameplayMapViewportProps = {
   attackFromId: string;
   attackToId: string;
@@ -88,6 +107,27 @@ function clampNumber(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value));
 }
 
+export function calculateMinimumViewportScale({
+  boardHeight,
+  boardWidth,
+  surfaceHeight,
+  surfaceWidth
+}: MinimumViewportScaleInput): number {
+  if (surfaceWidth <= 0 || surfaceHeight <= 0 || boardWidth <= 0 || boardHeight <= 0) {
+    return MAP_VIEWPORT_DEFAULT_SCALE;
+  }
+
+  return clampNumber(
+    Math.min(
+      MAP_VIEWPORT_DEFAULT_SCALE,
+      surfaceWidth / boardWidth,
+      surfaceHeight / boardHeight
+    ),
+    MAP_VIEWPORT_ABSOLUTE_MIN_SCALE,
+    MAP_VIEWPORT_DEFAULT_SCALE
+  );
+}
+
 function clampTranslation(
   translateX: number,
   translateY: number,
@@ -101,8 +141,8 @@ function clampTranslation(
     return { x: translateX, y: translateY };
   }
 
-  const overflowX = Math.max(0, (boardWidth * scale) / 2);
-  const overflowY = Math.max(0, (boardHeight * scale) / 2);
+  const overflowX = Math.max(0, (boardWidth * scale - surfaceWidth) / 2);
+  const overflowY = Math.max(0, (boardHeight * scale - surfaceHeight) / 2);
 
   return {
     x: clampNumber(translateX, -overflowX, overflowX),
@@ -117,7 +157,13 @@ function normalizeViewport(
   boardWidth: number,
   boardHeight: number
 ): ViewportState {
-  const scale = clampNumber(viewport.scale, MAP_VIEWPORT_MIN_SCALE, MAP_VIEWPORT_MAX_SCALE);
+  const minimumScale = calculateMinimumViewportScale({
+    boardHeight,
+    boardWidth,
+    surfaceHeight,
+    surfaceWidth
+  });
+  const scale = clampNumber(viewport.scale, minimumScale, MAP_VIEWPORT_MAX_SCALE);
   const clampedTranslation = clampTranslation(
     viewport.translateX,
     viewport.translateY,
@@ -266,7 +312,7 @@ export function GameplayMapViewport({
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null);
   const viewportRef = useRef<ViewportState>({
-    scale: MAP_VIEWPORT_MIN_SCALE,
+    scale: MAP_VIEWPORT_DEFAULT_SCALE,
     translateX: 0,
     translateY: 0,
     isDragging: false
@@ -280,6 +326,8 @@ export function GameplayMapViewport({
     suppressClick: false,
     didDrag: false
   });
+  const activePointersRef = useRef<Map<number, PointerPosition>>(new Map());
+  const pinchStateRef = useRef<PinchState | null>(null);
   const [surfaceSize, setSurfaceSize] = useState({ width: 0, height: 0 });
   const [fittedBoardFrame, setFittedBoardFrame] = useState<{
     width: number;
@@ -287,7 +335,7 @@ export function GameplayMapViewport({
   } | null>(null);
   const [renderedBoardFrame, setRenderedBoardFrame] = useState<BoardFrame | null>(null);
   const [viewport, setViewport] = useState<ViewportState>({
-    scale: MAP_VIEWPORT_MIN_SCALE,
+    scale: MAP_VIEWPORT_DEFAULT_SCALE,
     translateX: 0,
     translateY: 0,
     isDragging: false
@@ -419,6 +467,40 @@ export function GameplayMapViewport({
 
   useEffect(() => {
     function handleWindowPointerMove(event: globalThis.PointerEvent): void {
+      if (activePointersRef.current.has(event.pointerId)) {
+        activePointersRef.current.set(event.pointerId, {
+          clientX: event.clientX,
+          clientY: event.clientY
+        });
+      }
+
+      const pinchState = pinchStateRef.current;
+      if (pinchState) {
+        const firstPointer = activePointersRef.current.get(pinchState.pointerIds[0]);
+        const secondPointer = activePointersRef.current.get(pinchState.pointerIds[1]);
+        if (!firstPointer || !secondPointer) {
+          return;
+        }
+
+        const distance = Math.hypot(
+          secondPointer.clientX - firstPointer.clientX,
+          secondPointer.clientY - firstPointer.clientY
+        );
+        if (distance <= 0 || pinchState.startDistance <= 0) {
+          return;
+        }
+
+        dragStateRef.current.didDrag = true;
+        dragStateRef.current.suppressClick = true;
+        zoomTo(
+          pinchState.startScale * (distance / pinchState.startDistance),
+          (firstPointer.clientX + secondPointer.clientX) / 2,
+          (firstPointer.clientY + secondPointer.clientY) / 2,
+          true
+        );
+        return;
+      }
+
       if (dragStateRef.current.pointerId !== event.pointerId) {
         return;
       }
@@ -436,8 +518,8 @@ export function GameplayMapViewport({
       dragStateRef.current.suppressClick = true;
       const nextSurfaceSize = currentSurfaceSize();
       const nextBoardSize = currentBoardSize();
-      setViewport((currentViewport) =>
-        normalizeViewport(
+      setViewport((currentViewport) => {
+        const nextViewport = normalizeViewport(
           {
             ...currentViewport,
             translateX: dragStateRef.current.startTranslateX + deltaX,
@@ -448,8 +530,10 @@ export function GameplayMapViewport({
           nextSurfaceSize.height,
           nextBoardSize.width,
           nextBoardSize.height
-        )
-      );
+        );
+        viewportRef.current = nextViewport;
+        return nextViewport;
+      });
     }
 
     function handleWindowPointerFinish(event: globalThis.PointerEvent): void {
@@ -461,6 +545,8 @@ export function GameplayMapViewport({
     window.addEventListener("pointercancel", handleWindowPointerFinish);
 
     return () => {
+      activePointersRef.current.clear();
+      pinchStateRef.current = null;
       window.removeEventListener("pointermove", handleWindowPointerMove);
       window.removeEventListener("pointerup", handleWindowPointerFinish);
       window.removeEventListener("pointercancel", handleWindowPointerFinish);
@@ -580,6 +666,8 @@ export function GameplayMapViewport({
   ]);
 
   useEffect(() => {
+    activePointersRef.current.clear();
+    pinchStateRef.current = null;
     dragStateRef.current = {
       pointerId: null,
       startClientX: 0,
@@ -590,7 +678,7 @@ export function GameplayMapViewport({
       didDrag: false
     };
     setViewport({
-      scale: MAP_VIEWPORT_MIN_SCALE,
+      scale: MAP_VIEWPORT_DEFAULT_SCALE,
       translateX: 0,
       translateY: 0,
       isDragging: false
@@ -603,7 +691,12 @@ export function GameplayMapViewport({
     snapshot.mapVisual?.aspectRatio?.width
   ]);
 
-  function zoomTo(nextScale: number, clientX: number, clientY: number): void {
+  function zoomTo(
+    nextScale: number,
+    clientX: number,
+    clientY: number,
+    isGestureActive = false
+  ): void {
     const surface = surfaceRef.current;
     const nextSurfaceSize = currentSurfaceSize();
     const nextBoardSize = currentBoardSize();
@@ -619,19 +712,32 @@ export function GameplayMapViewport({
         nextBoardSize.width,
         nextBoardSize.height
       );
-      const clampedScale = clampNumber(nextScale, MAP_VIEWPORT_MIN_SCALE, MAP_VIEWPORT_MAX_SCALE);
-      if (clampedScale <= MAP_VIEWPORT_MIN_SCALE + 0.001 && nextScale <= normalizedViewport.scale) {
-        return {
+      const minimumScale = calculateMinimumViewportScale({
+        boardHeight: nextBoardSize.height,
+        boardWidth: nextBoardSize.width,
+        surfaceHeight: nextSurfaceSize.height,
+        surfaceWidth: nextSurfaceSize.width
+      });
+      const clampedScale = clampNumber(nextScale, minimumScale, MAP_VIEWPORT_MAX_SCALE);
+      if (clampedScale <= minimumScale + 0.001 && nextScale <= normalizedViewport.scale) {
+        const nextViewport = {
           ...normalizedViewport,
-          scale: MAP_VIEWPORT_MIN_SCALE,
+          scale: minimumScale,
           translateX: 0,
           translateY: 0,
-          isDragging: false
+          isDragging: isGestureActive
         };
+        viewportRef.current = nextViewport;
+        return nextViewport;
       }
 
       if (Math.abs(clampedScale - normalizedViewport.scale) < 0.001) {
-        return normalizedViewport;
+        const nextViewport = {
+          ...normalizedViewport,
+          isDragging: isGestureActive
+        };
+        viewportRef.current = nextViewport;
+        return nextViewport;
       }
 
       const surfaceRect = surface.getBoundingClientRect();
@@ -643,19 +749,20 @@ export function GameplayMapViewport({
       const contentY = (localY - currentCenterY) / normalizedViewport.scale;
       const nextTranslateX = localX - nextSurfaceSize.width / 2 - contentX * clampedScale;
       const nextTranslateY = localY - nextSurfaceSize.height / 2 - contentY * clampedScale;
-
-      return normalizeViewport(
+      const nextViewport = normalizeViewport(
         {
           scale: clampedScale,
           translateX: nextTranslateX,
           translateY: nextTranslateY,
-          isDragging: false
+          isDragging: isGestureActive
         },
         nextSurfaceSize.width,
         nextSurfaceSize.height,
         nextBoardSize.width,
         nextBoardSize.height
       );
+      viewportRef.current = nextViewport;
+      return nextViewport;
     });
   }
 
@@ -665,18 +772,31 @@ export function GameplayMapViewport({
       return;
     }
 
+    const nextSurfaceSize = currentSurfaceSize();
+    const nextBoardSize = currentBoardSize();
+    const minimumScale = calculateMinimumViewportScale({
+      boardHeight: nextBoardSize.height,
+      boardWidth: nextBoardSize.width,
+      surfaceHeight: nextSurfaceSize.height,
+      surfaceWidth: nextSurfaceSize.width
+    });
+
     if (
       direction === -1 &&
-      viewport.scale <= MAP_VIEWPORT_MIN_SCALE + 0.001 &&
+      viewport.scale <= minimumScale + 0.001 &&
       Math.hypot(viewport.translateX, viewport.translateY) > 1
     ) {
-      setViewport((currentViewport) => ({
-        ...currentViewport,
-        scale: MAP_VIEWPORT_MIN_SCALE,
-        translateX: 0,
-        translateY: 0,
-        isDragging: false
-      }));
+      setViewport((currentViewport) => {
+        const nextViewport = {
+          ...currentViewport,
+          scale: minimumScale,
+          translateX: 0,
+          translateY: 0,
+          isDragging: false
+        };
+        viewportRef.current = nextViewport;
+        return nextViewport;
+      });
       return;
     }
 
@@ -688,8 +808,51 @@ export function GameplayMapViewport({
     );
   }
 
+  function startPinchGesture(): boolean {
+    const pointers = Array.from(activePointersRef.current.entries()).slice(0, 2);
+    if (pointers.length < 2) {
+      return false;
+    }
+
+    const [[firstPointerId, firstPointer], [secondPointerId, secondPointer]] = pointers;
+    const startDistance = Math.hypot(
+      secondPointer.clientX - firstPointer.clientX,
+      secondPointer.clientY - firstPointer.clientY
+    );
+    if (startDistance <= 0) {
+      return false;
+    }
+
+    pinchStateRef.current = {
+      pointerIds: [firstPointerId, secondPointerId],
+      startDistance,
+      startScale: viewportRef.current.scale
+    };
+    dragStateRef.current.pointerId = null;
+    dragStateRef.current.didDrag = true;
+    dragStateRef.current.suppressClick = true;
+    setViewport((currentViewport) => {
+      const nextViewport = {
+        ...currentViewport,
+        isDragging: true
+      };
+      viewportRef.current = nextViewport;
+      return nextViewport;
+    });
+    return true;
+  }
+
   function handlePointerDown(event: PointerEvent<HTMLDivElement>): void {
-    if (event.button !== 0) {
+    if (event.pointerType !== "touch" && event.button !== 0) {
+      return;
+    }
+
+    viewportRef.current = viewport;
+    activePointersRef.current.set(event.pointerId, {
+      clientX: event.clientX,
+      clientY: event.clientY
+    });
+    if (activePointersRef.current.size >= 2 && startPinchGesture()) {
       return;
     }
 
@@ -702,23 +865,69 @@ export function GameplayMapViewport({
       suppressClick: false,
       didDrag: false
     };
-    viewportRef.current = viewport;
   }
 
   function finishPointer(pointerId: number): void {
+    activePointersRef.current.delete(pointerId);
+
+    if (pinchStateRef.current) {
+      pinchStateRef.current = null;
+      dragStateRef.current.suppressClick = true;
+      dragStateRef.current.didDrag = true;
+
+      if (activePointersRef.current.size >= 2 && startPinchGesture()) {
+        return;
+      }
+
+      const remainingPointer = activePointersRef.current.entries().next().value as
+        | [number, PointerPosition]
+        | undefined;
+      const currentViewport = viewportRef.current;
+      dragStateRef.current = remainingPointer
+        ? {
+            pointerId: remainingPointer[0],
+            startClientX: remainingPointer[1].clientX,
+            startClientY: remainingPointer[1].clientY,
+            startTranslateX: currentViewport.translateX,
+            startTranslateY: currentViewport.translateY,
+            suppressClick: true,
+            didDrag: true
+          }
+        : {
+            pointerId: null,
+            startClientX: 0,
+            startClientY: 0,
+            startTranslateX: currentViewport.translateX,
+            startTranslateY: currentViewport.translateY,
+            suppressClick: true,
+            didDrag: true
+          };
+      setViewport((currentState) => {
+        const nextViewport = {
+          ...currentState,
+          isDragging: false
+        };
+        viewportRef.current = nextViewport;
+        return nextViewport;
+      });
+      return;
+    }
+
     if (dragStateRef.current.pointerId !== pointerId) {
       return;
     }
 
     dragStateRef.current.pointerId = null;
-    setViewport((currentViewport) =>
-      currentViewport.isDragging
+    setViewport((currentViewport) => {
+      const nextViewport = currentViewport.isDragging
         ? {
             ...currentViewport,
             isDragging: false
           }
-        : currentViewport
-    );
+        : currentViewport;
+      viewportRef.current = nextViewport;
+      return nextViewport;
+    });
   }
 
   function handleTerritoryClick(territoryId: string): void {
@@ -730,9 +939,17 @@ export function GameplayMapViewport({
     onTerritorySelect(territoryId);
   }
 
+  const viewportSize = currentSurfaceSize();
+  const boardSize = currentBoardSize();
+  const minimumScale = calculateMinimumViewportScale({
+    boardHeight: boardSize.height,
+    boardWidth: boardSize.width,
+    surfaceHeight: viewportSize.height,
+    surfaceWidth: viewportSize.width
+  });
   const hasViewportOffset = Math.hypot(viewport.translateX, viewport.translateY) > 1;
   const connectionBadgeClassName =
-    viewport.scale > MAP_VIEWPORT_MIN_SCALE + 0.001 || hasViewportOffset
+    Math.abs(viewport.scale - MAP_VIEWPORT_DEFAULT_SCALE) > 0.001 || hasViewportOffset
       ? viewport.isDragging
         ? "map-board-surface is-zoomed is-dragging"
         : "map-board-surface is-zoomed"
@@ -766,8 +983,6 @@ export function GameplayMapViewport({
         }
       : {})
   } as CSSProperties;
-  const viewportSize = currentSurfaceSize();
-  const boardSize = currentBoardSize();
   const markerBoardFrame =
     renderedBoardFrame ||
     ({
@@ -805,7 +1020,7 @@ export function GameplayMapViewport({
             aria-label={t("game.map.zoomOut")}
             title={t("game.map.zoomOut")}
             onClick={() => zoomByStep(-1)}
-            disabled={viewport.scale <= MAP_VIEWPORT_MIN_SCALE + 0.001 && !hasViewportOffset}
+            disabled={viewport.scale <= minimumScale + 0.001 && !hasViewportOffset}
           >
             <span aria-hidden="true">-</span>
           </button>
@@ -816,11 +1031,15 @@ export function GameplayMapViewport({
             aria-label={t("game.map.reset")}
             title={t("game.map.reset")}
             onClick={() =>
-              setViewport({
-                scale: MAP_VIEWPORT_MIN_SCALE,
-                translateX: 0,
-                translateY: 0,
-                isDragging: false
+              setViewport(() => {
+                const nextViewport = {
+                  scale: minimumScale,
+                  translateX: 0,
+                  translateY: 0,
+                  isDragging: false
+                };
+                viewportRef.current = nextViewport;
+                return nextViewport;
               })
             }
           >
@@ -833,6 +1052,7 @@ export function GameplayMapViewport({
           className={connectionBadgeClassName}
           data-map-surface=""
           data-map-scale={viewport.scale.toFixed(3)}
+          data-map-min-scale={minimumScale.toFixed(3)}
           data-map-node-scale={nodeScale.toFixed(4)}
           data-map-translate-x={viewport.translateX.toFixed(2)}
           data-map-translate-y={viewport.translateY.toFixed(2)}

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -19,7 +19,6 @@ import { t } from "@frontend-i18n";
 import { WarTableIcon } from "@react-shell/war-table-icons";
 
 const MAP_VIEWPORT_DEFAULT_SCALE = 1;
-const MAP_VIEWPORT_ABSOLUTE_MIN_SCALE = 0.5;
 const MAP_VIEWPORT_MAX_SCALE = 3;
 const MAP_VIEWPORT_WHEEL_FACTOR = 1.18;
 const MAP_VIEWPORT_BUTTON_STEP = 0.2;
@@ -117,10 +116,10 @@ export function calculateMinimumViewportScale({
     return MAP_VIEWPORT_DEFAULT_SCALE;
   }
 
-  return clampNumber(
-    Math.min(MAP_VIEWPORT_DEFAULT_SCALE, surfaceWidth / boardWidth, surfaceHeight / boardHeight),
-    MAP_VIEWPORT_ABSOLUTE_MIN_SCALE,
-    MAP_VIEWPORT_DEFAULT_SCALE
+  return Math.min(
+    MAP_VIEWPORT_DEFAULT_SCALE,
+    surfaceWidth / boardWidth,
+    surfaceHeight / boardHeight
   );
 }
 

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -77,6 +77,27 @@ type MinimumViewportScaleInput = {
   surfaceWidth: number;
 };
 
+type ClampViewportTranslationInput = MinimumViewportScaleInput & {
+  anchorX: number;
+  anchorY: number;
+  scale: number;
+  translateX: number;
+  translateY: number;
+  viewportBottom?: number;
+  viewportLeft?: number;
+  viewportRight?: number;
+  viewportTop?: number;
+};
+
+type ViewportGeometry = {
+  anchorX: number;
+  anchorY: number;
+  viewportBottom: number;
+  viewportLeft: number;
+  viewportRight: number;
+  viewportTop: number;
+};
+
 type PointerPosition = {
   clientX: number;
   clientY: number;
@@ -84,8 +105,20 @@ type PointerPosition = {
 
 type PinchState = {
   pointerIds: [number, number];
+  startClientX: number;
+  startClientY: number;
   startDistance: number;
   startScale: number;
+  startTranslateX: number;
+  startTranslateY: number;
+};
+
+type ZoomOrigin = {
+  clientX: number;
+  clientY: number;
+  scale: number;
+  translateX: number;
+  translateY: number;
 };
 
 type GameplayMapViewportProps = {
@@ -123,25 +156,37 @@ export function calculateMinimumViewportScale({
   );
 }
 
-function clampTranslation(
-  translateX: number,
-  translateY: number,
-  scale: number,
-  surfaceWidth: number,
-  surfaceHeight: number,
-  boardWidth: number,
-  boardHeight: number
-): { x: number; y: number } {
+export function clampViewportTranslation({
+  anchorX,
+  anchorY,
+  boardHeight,
+  boardWidth,
+  scale,
+  surfaceHeight,
+  surfaceWidth,
+  translateX,
+  translateY,
+  viewportBottom = surfaceHeight,
+  viewportLeft = 0,
+  viewportRight = surfaceWidth,
+  viewportTop = 0
+}: ClampViewportTranslationInput): { x: number; y: number } {
   if (surfaceWidth <= 0 || surfaceHeight <= 0 || boardWidth <= 0 || boardHeight <= 0) {
     return { x: translateX, y: translateY };
   }
 
-  const overflowX = Math.max(0, (boardWidth * scale - surfaceWidth) / 2);
-  const overflowY = Math.max(0, (boardHeight * scale - surfaceHeight) / 2);
+  const horizontalBounds = [
+    viewportRight - anchorX - (boardWidth * scale) / 2,
+    viewportLeft + (boardWidth * scale) / 2 - anchorX
+  ];
+  const verticalBounds = [
+    viewportBottom - anchorY - (boardHeight * scale) / 2,
+    viewportTop + (boardHeight * scale) / 2 - anchorY
+  ];
 
   return {
-    x: clampNumber(translateX, -overflowX, overflowX),
-    y: clampNumber(translateY, -overflowY, overflowY)
+    x: clampNumber(translateX, Math.min(...horizontalBounds), Math.max(...horizontalBounds)),
+    y: clampNumber(translateY, Math.min(...verticalBounds), Math.max(...verticalBounds))
   };
 }
 
@@ -150,24 +195,39 @@ function normalizeViewport(
   surfaceWidth: number,
   surfaceHeight: number,
   boardWidth: number,
-  boardHeight: number
+  boardHeight: number,
+  geometry?: ViewportGeometry
 ): ViewportState {
+  const resolvedGeometry = geometry || {
+    anchorX: surfaceWidth / 2,
+    anchorY: surfaceHeight / 2,
+    viewportBottom: surfaceHeight,
+    viewportLeft: 0,
+    viewportRight: surfaceWidth,
+    viewportTop: 0
+  };
   const minimumScale = calculateMinimumViewportScale({
     boardHeight,
     boardWidth,
-    surfaceHeight,
-    surfaceWidth
+    surfaceHeight: resolvedGeometry.viewportBottom - resolvedGeometry.viewportTop,
+    surfaceWidth: resolvedGeometry.viewportRight - resolvedGeometry.viewportLeft
   });
   const scale = clampNumber(viewport.scale, minimumScale, MAP_VIEWPORT_MAX_SCALE);
-  const clampedTranslation = clampTranslation(
-    viewport.translateX,
-    viewport.translateY,
-    scale,
-    surfaceWidth,
-    surfaceHeight,
+  const clampedTranslation = clampViewportTranslation({
+    anchorX: resolvedGeometry.anchorX,
+    anchorY: resolvedGeometry.anchorY,
+    boardHeight,
     boardWidth,
-    boardHeight
-  );
+    scale,
+    surfaceHeight,
+    surfaceWidth,
+    translateX: viewport.translateX,
+    translateY: viewport.translateY,
+    viewportBottom: resolvedGeometry.viewportBottom,
+    viewportLeft: resolvedGeometry.viewportLeft,
+    viewportRight: resolvedGeometry.viewportRight,
+    viewportTop: resolvedGeometry.viewportTop
+  });
 
   return {
     scale,
@@ -303,6 +363,7 @@ export function GameplayMapViewport({
   onTerritorySelect
 }: GameplayMapViewportProps) {
   const mapRef = useRef<HTMLDivElement | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
   const boardRef = useRef<HTMLDivElement | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null);
@@ -356,6 +417,36 @@ export function GameplayMapViewport({
     return {
       width: fittedBoardFrame?.width || 0,
       height: fittedBoardFrame?.height || 0
+    };
+  }
+
+  function currentViewportGeometry(
+    currentSurfaceWidth: number,
+    currentSurfaceHeight: number
+  ): ViewportGeometry {
+    const surface = surfaceRef.current;
+    let safeTop = 0;
+    let safeBottom = 0;
+    if (surface) {
+      const surfaceStyles = window.getComputedStyle(surface);
+      safeTop = readCssLengthPixelValue(surface, surfaceStyles, "--game-map-safe-top");
+      safeBottom = readCssLengthPixelValue(surface, surfaceStyles, "--game-map-safe-bottom");
+    }
+    const viewportTop = clampNumber(safeTop, 0, currentSurfaceHeight);
+    const viewportBottom = clampNumber(
+      currentSurfaceHeight - safeBottom,
+      viewportTop,
+      currentSurfaceHeight
+    );
+    const anchor = anchorRef.current;
+
+    return {
+      anchorX: anchor?.offsetLeft ?? currentSurfaceWidth / 2,
+      anchorY: anchor?.offsetTop ?? (viewportTop + viewportBottom) / 2,
+      viewportBottom,
+      viewportLeft: 0,
+      viewportRight: currentSurfaceWidth,
+      viewportTop
     };
   }
 
@@ -491,7 +582,14 @@ export function GameplayMapViewport({
           pinchState.startScale * (distance / pinchState.startDistance),
           (firstPointer.clientX + secondPointer.clientX) / 2,
           (firstPointer.clientY + secondPointer.clientY) / 2,
-          true
+          true,
+          {
+            clientX: pinchState.startClientX,
+            clientY: pinchState.startClientY,
+            scale: pinchState.startScale,
+            translateX: pinchState.startTranslateX,
+            translateY: pinchState.startTranslateY
+          }
         );
         return;
       }
@@ -513,6 +611,10 @@ export function GameplayMapViewport({
       dragStateRef.current.suppressClick = true;
       const nextSurfaceSize = currentSurfaceSize();
       const nextBoardSize = currentBoardSize();
+      const nextViewportGeometry = currentViewportGeometry(
+        nextSurfaceSize.width,
+        nextSurfaceSize.height
+      );
       setViewport((currentViewport) => {
         const nextViewport = normalizeViewport(
           {
@@ -524,7 +626,8 @@ export function GameplayMapViewport({
           nextSurfaceSize.width,
           nextSurfaceSize.height,
           nextBoardSize.width,
-          nextBoardSize.height
+          nextBoardSize.height,
+          nextViewportGeometry
         );
         viewportRef.current = nextViewport;
         return nextViewport;
@@ -549,16 +652,24 @@ export function GameplayMapViewport({
   }, []);
 
   useEffect(() => {
-    setViewport((currentViewport) =>
-      normalizeViewport(
+    setViewport((currentViewport) => {
+      const nextViewportGeometry = currentViewportGeometry(surfaceSize.width, surfaceSize.height);
+      return normalizeViewport(
         currentViewport,
         surfaceSize.width,
         surfaceSize.height,
         currentBoardSize().width,
-        currentBoardSize().height
-      )
-    );
-  }, [fittedBoardFrame?.height, fittedBoardFrame?.width, surfaceSize.height, surfaceSize.width]);
+        currentBoardSize().height,
+        nextViewportGeometry
+      );
+    });
+  }, [
+    commandDockSheetState,
+    fittedBoardFrame?.height,
+    fittedBoardFrame?.width,
+    surfaceSize.height,
+    surfaceSize.width
+  ]);
 
   useLayoutEffect(() => {
     measureRenderedBoardFrame();
@@ -690,7 +801,8 @@ export function GameplayMapViewport({
     nextScale: number,
     clientX: number,
     clientY: number,
-    isGestureActive = false
+    isGestureActive = false,
+    origin?: ZoomOrigin
   ): void {
     const surface = surfaceRef.current;
     const nextSurfaceSize = currentSurfaceSize();
@@ -698,35 +810,55 @@ export function GameplayMapViewport({
     if (!surface || nextSurfaceSize.width <= 0 || nextSurfaceSize.height <= 0) {
       return;
     }
+    const nextViewportGeometry = currentViewportGeometry(
+      nextSurfaceSize.width,
+      nextSurfaceSize.height
+    );
 
     setViewport((currentViewport) => {
+      const sourceViewport = origin
+        ? {
+            scale: origin.scale,
+            translateX: origin.translateX,
+            translateY: origin.translateY,
+            isDragging: true
+          }
+        : currentViewport;
       const normalizedViewport = normalizeViewport(
-        currentViewport,
+        sourceViewport,
         nextSurfaceSize.width,
         nextSurfaceSize.height,
         nextBoardSize.width,
-        nextBoardSize.height
+        nextBoardSize.height,
+        nextViewportGeometry
       );
       const minimumScale = calculateMinimumViewportScale({
         boardHeight: nextBoardSize.height,
         boardWidth: nextBoardSize.width,
-        surfaceHeight: nextSurfaceSize.height,
-        surfaceWidth: nextSurfaceSize.width
+        surfaceHeight: nextViewportGeometry.viewportBottom - nextViewportGeometry.viewportTop,
+        surfaceWidth: nextViewportGeometry.viewportRight - nextViewportGeometry.viewportLeft
       });
       const clampedScale = clampNumber(nextScale, minimumScale, MAP_VIEWPORT_MAX_SCALE);
       if (clampedScale <= minimumScale + 0.001 && nextScale <= normalizedViewport.scale) {
-        const nextViewport = {
-          ...normalizedViewport,
-          scale: minimumScale,
-          translateX: 0,
-          translateY: 0,
-          isDragging: isGestureActive
-        };
+        const nextViewport = normalizeViewport(
+          {
+            ...normalizedViewport,
+            scale: minimumScale,
+            translateX: 0,
+            translateY: 0,
+            isDragging: isGestureActive
+          },
+          nextSurfaceSize.width,
+          nextSurfaceSize.height,
+          nextBoardSize.width,
+          nextBoardSize.height,
+          nextViewportGeometry
+        );
         viewportRef.current = nextViewport;
         return nextViewport;
       }
 
-      if (Math.abs(clampedScale - normalizedViewport.scale) < 0.001) {
+      if (!origin && Math.abs(clampedScale - normalizedViewport.scale) < 0.001) {
         const nextViewport = {
           ...normalizedViewport,
           isDragging: isGestureActive
@@ -738,12 +870,14 @@ export function GameplayMapViewport({
       const surfaceRect = surface.getBoundingClientRect();
       const localX = clientX - surfaceRect.left;
       const localY = clientY - surfaceRect.top;
-      const currentCenterX = nextSurfaceSize.width / 2 + normalizedViewport.translateX;
-      const currentCenterY = nextSurfaceSize.height / 2 + normalizedViewport.translateY;
-      const contentX = (localX - currentCenterX) / normalizedViewport.scale;
-      const contentY = (localY - currentCenterY) / normalizedViewport.scale;
-      const nextTranslateX = localX - nextSurfaceSize.width / 2 - contentX * clampedScale;
-      const nextTranslateY = localY - nextSurfaceSize.height / 2 - contentY * clampedScale;
+      const originLocalX = (origin?.clientX ?? clientX) - surfaceRect.left;
+      const originLocalY = (origin?.clientY ?? clientY) - surfaceRect.top;
+      const currentCenterX = nextViewportGeometry.anchorX + normalizedViewport.translateX;
+      const currentCenterY = nextViewportGeometry.anchorY + normalizedViewport.translateY;
+      const contentX = (originLocalX - currentCenterX) / normalizedViewport.scale;
+      const contentY = (originLocalY - currentCenterY) / normalizedViewport.scale;
+      const nextTranslateX = localX - nextViewportGeometry.anchorX - contentX * clampedScale;
+      const nextTranslateY = localY - nextViewportGeometry.anchorY - contentY * clampedScale;
       const nextViewport = normalizeViewport(
         {
           scale: clampedScale,
@@ -754,7 +888,8 @@ export function GameplayMapViewport({
         nextSurfaceSize.width,
         nextSurfaceSize.height,
         nextBoardSize.width,
-        nextBoardSize.height
+        nextBoardSize.height,
+        nextViewportGeometry
       );
       viewportRef.current = nextViewport;
       return nextViewport;
@@ -769,11 +904,15 @@ export function GameplayMapViewport({
 
     const nextSurfaceSize = currentSurfaceSize();
     const nextBoardSize = currentBoardSize();
+    const nextViewportGeometry = currentViewportGeometry(
+      nextSurfaceSize.width,
+      nextSurfaceSize.height
+    );
     const minimumScale = calculateMinimumViewportScale({
       boardHeight: nextBoardSize.height,
       boardWidth: nextBoardSize.width,
-      surfaceHeight: nextSurfaceSize.height,
-      surfaceWidth: nextSurfaceSize.width
+      surfaceHeight: nextViewportGeometry.viewportBottom - nextViewportGeometry.viewportTop,
+      surfaceWidth: nextViewportGeometry.viewportRight - nextViewportGeometry.viewportLeft
     });
 
     if (
@@ -782,13 +921,20 @@ export function GameplayMapViewport({
       Math.hypot(viewport.translateX, viewport.translateY) > 1
     ) {
       setViewport((currentViewport) => {
-        const nextViewport = {
-          ...currentViewport,
-          scale: minimumScale,
-          translateX: 0,
-          translateY: 0,
-          isDragging: false
-        };
+        const nextViewport = normalizeViewport(
+          {
+            ...currentViewport,
+            scale: minimumScale,
+            translateX: 0,
+            translateY: 0,
+            isDragging: false
+          },
+          nextSurfaceSize.width,
+          nextSurfaceSize.height,
+          nextBoardSize.width,
+          nextBoardSize.height,
+          nextViewportGeometry
+        );
         viewportRef.current = nextViewport;
         return nextViewport;
       });
@@ -820,8 +966,12 @@ export function GameplayMapViewport({
 
     pinchStateRef.current = {
       pointerIds: [firstPointerId, secondPointerId],
+      startClientX: (firstPointer.clientX + secondPointer.clientX) / 2,
+      startClientY: (firstPointer.clientY + secondPointer.clientY) / 2,
       startDistance,
-      startScale: viewportRef.current.scale
+      startScale: viewportRef.current.scale,
+      startTranslateX: viewportRef.current.translateX,
+      startTranslateY: viewportRef.current.translateY
     };
     dragStateRef.current.pointerId = null;
     dragStateRef.current.didDrag = true;
@@ -936,13 +1086,33 @@ export function GameplayMapViewport({
 
   const viewportSize = currentSurfaceSize();
   const boardSize = currentBoardSize();
+  const viewportGeometry = currentViewportGeometry(viewportSize.width, viewportSize.height);
   const minimumScale = calculateMinimumViewportScale({
     boardHeight: boardSize.height,
     boardWidth: boardSize.width,
-    surfaceHeight: viewportSize.height,
-    surfaceWidth: viewportSize.width
+    surfaceHeight: viewportGeometry.viewportBottom - viewportGeometry.viewportTop,
+    surfaceWidth: viewportGeometry.viewportRight - viewportGeometry.viewportLeft
   });
-  const hasViewportOffset = Math.hypot(viewport.translateX, viewport.translateY) > 1;
+  const fittedTranslation = clampViewportTranslation({
+    anchorX: viewportGeometry.anchorX,
+    anchorY: viewportGeometry.anchorY,
+    boardHeight: boardSize.height,
+    boardWidth: boardSize.width,
+    scale: minimumScale,
+    surfaceHeight: viewportSize.height,
+    surfaceWidth: viewportSize.width,
+    translateX: 0,
+    translateY: 0,
+    viewportBottom: viewportGeometry.viewportBottom,
+    viewportLeft: viewportGeometry.viewportLeft,
+    viewportRight: viewportGeometry.viewportRight,
+    viewportTop: viewportGeometry.viewportTop
+  });
+  const hasViewportOffset =
+    Math.hypot(
+      viewport.translateX - fittedTranslation.x,
+      viewport.translateY - fittedTranslation.y
+    ) > 1;
   const connectionBadgeClassName =
     Math.abs(viewport.scale - MAP_VIEWPORT_DEFAULT_SCALE) > 0.001 || hasViewportOffset
       ? viewport.isDragging
@@ -981,8 +1151,8 @@ export function GameplayMapViewport({
   const markerBoardFrame =
     renderedBoardFrame ||
     ({
-      left: viewportSize.width / 2 + viewport.translateX - (boardSize.width * viewport.scale) / 2,
-      top: viewportSize.height / 2 + viewport.translateY - (boardSize.height * viewport.scale) / 2,
+      left: viewportGeometry.anchorX + viewport.translateX - (boardSize.width * viewport.scale) / 2,
+      top: viewportGeometry.anchorY + viewport.translateY - (boardSize.height * viewport.scale) / 2,
       width: boardSize.width * viewport.scale,
       height: boardSize.height * viewport.scale
     } satisfies BoardFrame);
@@ -1023,16 +1193,29 @@ export function GameplayMapViewport({
             type="button"
             className="map-control-button"
             data-map-control="focus"
-            aria-label={t("game.map.reset")}
-            title={t("game.map.reset")}
+            aria-label={t("game.map.fit")}
+            title={t("game.map.fit")}
             onClick={() =>
               setViewport(() => {
-                const nextViewport = {
-                  scale: minimumScale,
-                  translateX: 0,
-                  translateY: 0,
-                  isDragging: false
-                };
+                const nextSurfaceSize = currentSurfaceSize();
+                const nextBoardSize = currentBoardSize();
+                const nextViewportGeometry = currentViewportGeometry(
+                  nextSurfaceSize.width,
+                  nextSurfaceSize.height
+                );
+                const nextViewport = normalizeViewport(
+                  {
+                    scale: minimumScale,
+                    translateX: 0,
+                    translateY: 0,
+                    isDragging: false
+                  },
+                  nextSurfaceSize.width,
+                  nextSurfaceSize.height,
+                  nextBoardSize.width,
+                  nextBoardSize.height,
+                  nextViewportGeometry
+                );
                 viewportRef.current = nextViewport;
                 return nextViewport;
               })
@@ -1051,6 +1234,8 @@ export function GameplayMapViewport({
           data-map-node-scale={nodeScale.toFixed(4)}
           data-map-translate-x={viewport.translateX.toFixed(2)}
           data-map-translate-y={viewport.translateY.toFixed(2)}
+          data-map-viewport-bottom={viewportGeometry.viewportBottom.toFixed(2)}
+          data-map-viewport-top={viewportGeometry.viewportTop.toFixed(2)}
           style={
             {
               aspectRatio: mapAspectRatio(snapshot),
@@ -1061,6 +1246,7 @@ export function GameplayMapViewport({
           onPointerDown={handlePointerDown}
         >
           <div
+            ref={anchorRef}
             className="map-board-anchor"
             data-map-anchor
             style={{

--- a/frontend/react-shell/src/gameplay-map-viewport.tsx
+++ b/frontend/react-shell/src/gameplay-map-viewport.tsx
@@ -118,11 +118,7 @@ export function calculateMinimumViewportScale({
   }
 
   return clampNumber(
-    Math.min(
-      MAP_VIEWPORT_DEFAULT_SCALE,
-      surfaceWidth / boardWidth,
-      surfaceHeight / boardHeight
-    ),
+    Math.min(MAP_VIEWPORT_DEFAULT_SCALE, surfaceWidth / boardWidth, surfaceHeight / boardHeight),
     MAP_VIEWPORT_ABSOLUTE_MIN_SCALE,
     MAP_VIEWPORT_DEFAULT_SCALE
   );

--- a/frontend/src/locales/de.mts
+++ b/frontend/src/locales/de.mts
@@ -374,6 +374,7 @@ export const de = Object.freeze({
   "game.meta.noOptionalModules": "Keine optionalen Module",
   "game.map.zoomIn": "Hineinzoomen",
   "game.map.zoomOut": "Herauszoomen",
+  "game.map.fit": "Karte an Ansicht anpassen",
   "game.map.reset": "Zuruecksetzen",
   "game.meta.access": "Zugang",
   "game.meta.accessCopy": "Registriere dich oder melde dich an, um der Lobby beizutreten.",

--- a/frontend/src/locales/en.mts
+++ b/frontend/src/locales/en.mts
@@ -650,6 +650,7 @@ export const en = Object.freeze({
   "game.meta.noOptionalModules": "No optional modules",
   "game.map.zoomIn": "Zoom in",
   "game.map.zoomOut": "Zoom out",
+  "game.map.fit": "Fit map to view",
   "game.map.reset": "Reset",
   "game.meta.access": "Access",
   "game.meta.accessCopy": "Register or log in to join the lobby.",

--- a/frontend/src/locales/es.mts
+++ b/frontend/src/locales/es.mts
@@ -371,6 +371,7 @@ export const es = Object.freeze({
   "game.meta.noOptionalModules": "Sin modulos opcionales",
   "game.map.zoomIn": "Acercar",
   "game.map.zoomOut": "Alejar",
+  "game.map.fit": "Ajustar mapa a la vista",
   "game.map.reset": "Restablecer",
   "game.meta.access": "Acceso",
   "game.meta.accessCopy": "Registrate o inicia sesion para unirte a la lobby.",

--- a/frontend/src/locales/it.mts
+++ b/frontend/src/locales/it.mts
@@ -654,6 +654,7 @@ export const it = Object.freeze({
   "game.meta.noOptionalModules": "Nessun modulo opzionale",
   "game.map.zoomIn": "Zoom avanti",
   "game.map.zoomOut": "Zoom indietro",
+  "game.map.fit": "Adatta mappa alla schermata",
   "game.map.reset": "Reset",
   "game.meta.access": "Access",
   "game.meta.accessCopy": "Registrati o accedi per entrare nella lobby.",

--- a/shared/version-manifest.cts
+++ b/shared/version-manifest.cts
@@ -1,4 +1,4 @@
-export const appVersion = "0.1.060";
+export const appVersion = "0.1.061";
 export const engineVersion = "1.0.0";
 export const apiVersion = "1.2.0";
 export const datastoreSchemaVersion = 2;


### PR DESCRIPTION
## Summary

- calculate a responsive minimum zoom so cropped mobile maps fit inside the visible safe area
- add native two-pointer pinch-to-zoom while preserving one-pointer pan, wheel zoom, and +/- controls
- derive pinch transforms from the gesture-start state so symmetric pinch does not drift
- clamp panning around the actual safe-area anchor, including command-dock insets
- label the fit control accurately in English, Italian, Spanish, and German
- add unit and mobile browser regression coverage across the supported phone viewports
- bump the app release to 0.1.061 and document the change

## Validation

- `npm run typecheck:react-shell`
- focused map viewport unit tests (5/5)
- `npm run test:all` (176 React + 167 application + 510 gameplay)
- `npm run release:check`
- `npm run format:check`
- production build and transfer budgets
- Playwright UAT at 360×780, 390×844, and 430×932:
  - full board fits inside the visible safe area
  - pinch-out and pinch-in work
  - symmetric pinch has no horizontal drift
  - moving the pinch midpoint pans in the same direction
  - one-finger vertical pan remains available inside safe-area bounds
  - the fit control has the correct accessible name

The first real-browser UAT correctly failed because the 0.5 zoom floor left a 487.5 px board inside a 390 px surface. The floor and the later Codex findings were fixed before this validation pass.

Vercel preview and an exact-head Codex review remain merge gates. GitHub Actions has not created pull-request runs for this connector-authored head, so that absence is tracked explicitly rather than reported as green.

Closes #363